### PR TITLE
`TemporalTxValidity`: Implement temporal transaction validity rules:

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -691,6 +691,7 @@ target_sources (rippled PRIVATE
   src/test/app/SetRegularKey_test.cpp
   src/test/app/SetTrust_test.cpp
   src/test/app/Taker_test.cpp
+  src/test/app/TemporalTxValidity_test.cpp
   src/test/app/TheoreticalQuality_test.cpp
   src/test/app/Ticket_test.cpp
   src/test/app/Transaction_ordering_test.cpp

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -135,6 +135,9 @@ public:
     checkFee(PreclaimContext const& ctx, FeeUnit64 baseFee);
 
     static NotTEC
+    checkTemporalTxValidity(PreclaimContext const& ctx);
+
+    static NotTEC
     checkSign(PreclaimContext const& ctx);
 
     // Returns the fee in fee units, not scaled for load.

--- a/src/ripple/app/tx/impl/applySteps.cpp
+++ b/src/ripple/app/tx/impl/applySteps.cpp
@@ -171,6 +171,11 @@ invoke_preclaim(PreclaimContext const& ctx)
 
         if (result != tesSUCCESS)
             return result;
+
+        result = T::checkTemporalTxValidity(ctx);
+
+        if (result != tesSUCCESS)
+            return result;
     }
 
     return T::preclaim(ctx);

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -116,6 +116,7 @@ class FeatureCollections
         "TicketBatch",
         "FlowSortStrands",
         "fixSTAmountCanonicalize",
+        "TemporalTxValidity",
     };
 
     std::vector<uint256> features;
@@ -376,6 +377,7 @@ extern uint256 const featureNegativeUNL;
 extern uint256 const featureTicketBatch;
 extern uint256 const featureFlowSortStrands;
 extern uint256 const fixSTAmountCanonicalize;
+extern uint256 const featureTemporalTxValidity;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -392,6 +392,8 @@ extern SF_UINT32 const sfSignerListID;
 extern SF_UINT32 const sfSettleDelay;
 extern SF_UINT32 const sfTicketCount;
 extern SF_UINT32 const sfTicketSequence;
+extern SF_UINT32 const sfNotValidBefore;
+extern SF_UINT32 const sfNotValidAfter;
 
 // 64-bit integers
 extern SF_UINT64 const sfIndexNext;

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -119,6 +119,7 @@ enum TEMcodes : TERUnderlyingType {
     temUNKNOWN,    // An internal intermediate result; should never be returned.
 
     temSEQ_AND_TICKET,
+    temBAD_TEMPORAL_VALIDITY,
 };
 
 //------------------------------------------------------------------------------
@@ -161,6 +162,8 @@ enum TEFcodes : TERUnderlyingType {
     tefINVARIANT_FAILED,
     tefTOO_BIG,
     tefNO_TICKET,
+    tefTOO_EARLY,
+    tefTOO_LATE
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -135,6 +135,7 @@ detail::supportedAmendments()
         "TicketBatch",
         "FlowSortStrands",
         "fixSTAmountCanonicalize",
+        "TemporalTxValidity",
     };
     return supported;
 }
@@ -190,7 +191,8 @@ uint256 const
     featureNegativeUNL              = *getRegisteredFeature("NegativeUNL"),
     featureTicketBatch              = *getRegisteredFeature("TicketBatch"),
     featureFlowSortStrands          = *getRegisteredFeature("FlowSortStrands"),
-    fixSTAmountCanonicalize         = *getRegisteredFeature("fixSTAmountCanonicalize");
+    fixSTAmountCanonicalize         = *getRegisteredFeature("fixSTAmountCanonicalize"),
+    featureTemporalTxValidity       = *getRegisteredFeature("TemporalTxValidity");
 
 // The following amendments have been active for at least two years. Their
 // pre-amendment code has been removed and the identifiers are deprecated.

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -139,6 +139,8 @@ CONSTRUCT_TYPED_SFIELD(sfSignerListID,          "SignerListID",         UINT32, 
 CONSTRUCT_TYPED_SFIELD(sfSettleDelay,           "SettleDelay",          UINT32,    39);
 CONSTRUCT_TYPED_SFIELD(sfTicketCount,           "TicketCount",          UINT32,    40);
 CONSTRUCT_TYPED_SFIELD(sfTicketSequence,        "TicketSequence",       UINT32,    41);
+CONSTRUCT_TYPED_SFIELD(sfNotValidBefore,        "NotValidBefore",       UINT32,    42);
+CONSTRUCT_TYPED_SFIELD(sfNotValidAfter,         "NotValidAfter",        UINT32,    43);
 
 // 64-bit integers
 CONSTRUCT_TYPED_SFIELD(sfIndexNext,             "IndexNext",            UINT64,     1);

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -101,6 +101,9 @@ transResults()
         MAKE_ERROR(tefINVARIANT_FAILED,       "Fee claim violated invariants for the transaction."),
         MAKE_ERROR(tefTOO_BIG,                "Transaction affects too many items."),
         MAKE_ERROR(tefNO_TICKET,              "Ticket is not in ledger."),
+        MAKE_ERROR(tefTOO_EARLY,              "The transaction is not valid yet."),
+        MAKE_ERROR(tefTOO_LATE,               "The transaction is no longer valid."),
+
 
         MAKE_ERROR(telLOCAL_ERROR,            "Local failure."),
         MAKE_ERROR(telBAD_DOMAIN,             "Domain too long."),
@@ -153,6 +156,7 @@ transResults()
         MAKE_ERROR(temCANNOT_PREAUTH_SELF,    "Malformed: An account may not preauthorize itself."),
         MAKE_ERROR(temINVALID_COUNT,          "Malformed: Count field outside valid range."),
         MAKE_ERROR(temSEQ_AND_TICKET,         "Transaction contains a TicketSequence and a non-zero Sequence."),
+        MAKE_ERROR(temBAD_TEMPORAL_VALIDITY,  "Malformed: The specified temporal validity restrictions are invalid."),
 
         MAKE_ERROR(terRETRY,                  "Retry transaction."),
         MAKE_ERROR(terFUNDS_SPENT,            "DEPRECATED."),

--- a/src/ripple/protocol/impl/TxFormats.cpp
+++ b/src/ripple/protocol/impl/TxFormats.cpp
@@ -55,6 +55,8 @@ TxFormats::TxFormats()
             {sfClearFlag, soeOPTIONAL},
             {sfTickSize, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -65,6 +67,8 @@ TxFormats::TxFormats()
             {sfQualityIn, soeOPTIONAL},
             {sfQualityOut, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -76,6 +80,8 @@ TxFormats::TxFormats()
             {sfExpiration, soeOPTIONAL},
             {sfOfferSequence, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -84,6 +90,8 @@ TxFormats::TxFormats()
         {
             {sfOfferSequence, soeREQUIRED},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -92,6 +100,8 @@ TxFormats::TxFormats()
         {
             {sfRegularKey, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -106,6 +116,8 @@ TxFormats::TxFormats()
             {sfDestinationTag, soeOPTIONAL},
             {sfDeliverMin, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -119,6 +131,8 @@ TxFormats::TxFormats()
             {sfFinishAfter, soeOPTIONAL},
             {sfDestinationTag, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -130,6 +144,8 @@ TxFormats::TxFormats()
             {sfFulfillment, soeOPTIONAL},
             {sfCondition, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -139,6 +155,8 @@ TxFormats::TxFormats()
             {sfOwner, soeREQUIRED},
             {sfOfferSequence, soeREQUIRED},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -175,6 +193,8 @@ TxFormats::TxFormats()
         {
             {sfTicketCount, soeREQUIRED},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -186,6 +206,8 @@ TxFormats::TxFormats()
             {sfSignerQuorum, soeREQUIRED},
             {sfSignerEntries, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -199,6 +221,8 @@ TxFormats::TxFormats()
             {sfCancelAfter, soeOPTIONAL},
             {sfDestinationTag, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -209,6 +233,8 @@ TxFormats::TxFormats()
             {sfAmount, soeREQUIRED},
             {sfExpiration, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -221,6 +247,8 @@ TxFormats::TxFormats()
             {sfSignature, soeOPTIONAL},
             {sfPublicKey, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -233,6 +261,8 @@ TxFormats::TxFormats()
             {sfDestinationTag, soeOPTIONAL},
             {sfInvoiceID, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -243,6 +273,8 @@ TxFormats::TxFormats()
             {sfAmount, soeOPTIONAL},
             {sfDeliverMin, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -251,6 +283,8 @@ TxFormats::TxFormats()
         {
             {sfCheckID, soeREQUIRED},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -260,6 +294,8 @@ TxFormats::TxFormats()
             {sfDestination, soeREQUIRED},
             {sfDestinationTag, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 
@@ -269,6 +305,8 @@ TxFormats::TxFormats()
             {sfAuthorize, soeOPTIONAL},
             {sfUnauthorize, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfNotValidBefore, soeOPTIONAL},
+            {sfNotValidAfter, soeOPTIONAL},
         },
         commonFields);
 }

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -597,6 +597,9 @@ JSS(warnings);                // out: server_info, server_state
 JSS(workers);
 JSS(write_load);   // out: GetCounts
 JSS(NegativeUNL);  // out: ValidatorList; ledger type
+JSS(NotValidAfter);
+JSS(NotValidBefore);
+
 #undef JSS
 
 }  // namespace jss

--- a/src/test/app/TemporalTxValidity_test.cpp
+++ b/src/test/app/TemporalTxValidity_test.cpp
@@ -1,0 +1,126 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/protocol/Feature.h>
+#include <ripple/protocol/jss.h>
+#include <test/jtx.h>
+
+namespace ripple {
+namespace test {
+
+struct TemporalTxValidity_test : public beast::unit_test::suite
+{
+    std::uint32_t
+    nettime(jtx::Env& env)
+    {
+        return static_cast<std::uint32_t>(
+            env.closed()->info().closeTime.time_since_epoch().count());
+    }
+
+    void
+    run() override
+    {
+        using namespace jtx;
+
+        Account const alice{"alice"};
+        Account const bob{"bob"};
+
+        {
+            testcase("TemporalTxValidity: Amendment Not Enabled");
+
+            Env env(*this, supported_amendments() - featureTemporalTxValidity);
+            env.fund(XRP(1000000), alice);
+            env.close();
+
+            {  // Nothing special
+                env(pay(alice, bob, XRP(5000)), ter(tesSUCCESS));
+                env.close();
+            }
+
+            {  // NotValidAfter field - not supported
+                auto tx = pay(alice, bob, XRP(5000));
+                tx[jss::NotValidAfter] = 20034;
+                env(tx, ter(temMALFORMED));
+                env.close();
+            }
+
+            {  // NotValidBefore field - not supported
+                auto tx = pay(alice, bob, XRP(5000));
+                tx[jss::NotValidBefore] = 21576;
+                env(tx, ter(temMALFORMED));
+                env.close();
+            }
+
+            {  // NotValidBefore field - not supported
+                auto tx = pay(alice, bob, XRP(5000));
+                tx[jss::NotValidAfter] = 20034;
+                tx[jss::NotValidBefore] = 21576;
+                env(tx, ter(temMALFORMED));
+            }
+        }
+
+        {
+            testcase("Temporal Validity: Amendment Enabled");
+
+            Env env(*this, supported_amendments() | featureTemporalTxValidity);
+            env.fund(XRP(1000000), alice);
+            env.close(std::chrono::seconds{60});
+
+            {  // Nothing special
+                env(pay(alice, bob, XRP(5000)), ter(tesSUCCESS));
+                env.close(std::chrono::seconds{60});
+            }
+
+            {  // Invalid: before >= after
+                auto tx = pay(alice, bob, XRP(5001));
+                tx[jss::NotValidBefore] = nettime(env) + 10;
+                tx[jss::NotValidAfter] = nettime(env) - 10;
+                env(tx, ter(temBAD_TEMPORAL_VALIDITY));
+                env.close(std::chrono::seconds{60});
+            }
+
+            {  // Too soon: the transaction can't execute yet
+                auto tx = pay(alice, bob, XRP(5002));
+                tx[jss::NotValidBefore] = nettime(env) + 10;
+                env(tx, ter(tefTOO_EARLY));
+                env.close(std::chrono::seconds{60});
+            }
+
+            {  // Too late: the transaction can't execute anymore
+                auto tx = pay(alice, bob, XRP(5003));
+                tx[jss::NotValidAfter] = nettime(env) - 10;
+                env(tx, ter(tefTOO_LATE));
+                env.close(std::chrono::seconds{60});
+            }
+
+            { // Executes within validity period
+                auto tx = pay(alice, bob, XRP(5004));
+                tx[jss::NotValidBefore] = nettime(env) - 10;
+                tx[jss::NotValidAfter] = nettime(env) + 10;
+                env(tx, ter(tesSUCCESS));
+                env.close();
+            }
+        }
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(TemporalTxValidity, app, ripple);
+
+}  // namespace test
+}  // namespace ripple


### PR DESCRIPTION
## High Level Overview of Change

This commit introduces the `TemporalTxValidity` amendment which, if enabled, makes it possible for a transaction to control the time period during which the transaction should be considered valid.
    
This feature can be especially useful for transactions that use tickets instead of sequence numbers.
    
Two new optional fields are introduced that can be used with any submitted transactions:
    
1. The `NotValidBefore` field specifies the point in time before which the transaction should be rejected.
2. The `NotValidAfter` field specifies the point in time after which the transaction should be rejected.
    
Both fields specify the time as [seconds after the "Ripple epoch"](https://xrpl.org/basic-data-types.html#specifying-time) and one or both may be present, with the restriction that if both are used then the `NotValidAfter` time must be strictly greater than the `NotValidBefore` time.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Amendment
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [X] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [X] Documentation Updates
- [ ] Release

## Test Plan

Unit tests are included with this code, but it would be nice to add integration tests that exercise the code more.
