### PR TITLE
Specify source type for stored UNLs

### DIFF
--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -518,7 +518,9 @@ JSS(snapshot);                  // in: Subscribe
 JSS(source_account);            // in: PathRequest, RipplePathFind
 JSS(source_amount);             // in: PathRequest, RipplePathFind
 JSS(source_currencies);         // in: PathRequest, RipplePathFind
+JSS(source_peer);               // out: ValidatorSites
 JSS(source_tag);                // out: AccountChannels
+JSS(source_uri);                // out: ValidatorSites
 JSS(stand_alone);               // out: NetworkOPs
 JSS(start);                     // in: TxHistory
 JSS(started);

--- a/src/ripple/rpc/handlers/Validators.cpp
+++ b/src/ripple/rpc/handlers/Validators.cpp
@@ -31,7 +31,7 @@ doValidators(RPC::JsonContext& context)
     if (context.app.config().reporting())
         return rpcError(rpcREPORTING_UNSUPPORTED);
 
-    return context.app.validators().getJson();
+    return context.app.validators().getJson(context);
 }
 
 }  // namespace ripple

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -476,7 +476,7 @@ private:
         testcase("Apply list");
         using namespace std::chrono_literals;
 
-        std::string const siteUri = "testApplyList.test";
+        std::string const siteUri = "http://testApplyList.test";
 
         auto checkAvailable =
             [this](
@@ -926,7 +926,7 @@ private:
         testcase("GetAvailable");
         using namespace std::chrono_literals;
 
-        std::string const siteUri = "testApplyList.test";
+        std::string const siteUri = "http://testApplyList.test";
 
         ManifestCache manifests;
         jtx::Env env(*this);
@@ -1062,7 +1062,7 @@ private:
     {
         testcase("Update trusted");
 
-        std::string const siteUri = "testUpdateTrusted.test";
+        std::string const siteUri = "http://testUpdateTrusted.test";
 
         PublicKey emptyLocalKeyOuter;
         ManifestCache manifestsOuter;
@@ -1615,7 +1615,7 @@ private:
     {
         testcase("Expires");
 
-        std::string const siteUri = "testExpires.test";
+        std::string const siteUri = "http://testExpires.test";
 
         jtx::Env env(*this);
         auto& app = env.app();


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

This pull request resolves  #3949 by specifying the source of stored validator lists as displayed in the response to the rpc command `validators`.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

<!--
### Context of Change
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

## Before / After

This change introduces two field names to replace an existing name. Consequently, this change may compel updates to applications that expect the old name. Specifically `uri` will become either `source_uri` or `source_peer` depending on the source of the validator list.

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

## Test Plan
Unit tests and integration tests were conducted to confirm expected behavior.

<!--
## Future Tasks
For future tasks related to PR.
-->
