### PR TITLE
Add featureImmediateOfferKilled for tfImmediateOrCancel offers:

### DIFF
--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -1107,6 +1107,12 @@ CreateOffer::applyGuts(Sandbox& sb, Sandbox& sbCancel)
     if (bImmediateOrCancel)
     {
         JLOG(j_.trace()) << "Immediate or cancel: offer canceled";
+        if (!crossed && sb.rules().enabled(featureImmediateOfferKilled))
+            // If the ImmediateOfferKilled amendment is enabled, any
+            // ImmediateOrCancel offer that transfers absolutely no funds
+            // returns tecKILLED rather than tesSUCCESS.  Motivation for the
+            // change is here: https://github.com/ripple/rippled/issues/4115
+            return {tecKILLED, false};
         return {tesSUCCESS, true};
     }
 

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -74,7 +74,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 51;
+static constexpr std::size_t numFeatures = 52;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -338,6 +338,7 @@ extern uint256 const fixNFTokenDirV1;
 extern uint256 const fixNFTokenNegOffer;
 extern uint256 const featureNonFungibleTokensV1_1;
 extern uint256 const fixTrustLinesToSelf;
+extern uint256 const featureImmediateOfferKilled;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -448,6 +448,7 @@ REGISTER_FIX    (fixNFTokenDirV1,               Supported::yes, DefaultVote::no)
 REGISTER_FIX    (fixNFTokenNegOffer,            Supported::yes, DefaultVote::no);
 REGISTER_FEATURE(NonFungibleTokensV1_1,         Supported::yes, DefaultVote::no);
 REGISTER_FIX    (fixTrustLinesToSelf,           Supported::yes, DefaultVote::no);
+REGISTER_FEATURE(ImmediateOfferKilled,          Supported::yes, DefaultVote::no);
 
 // The following amendments have been active for at least two years. Their
 // pre-amendment code has been removed and the identifiers are deprecated.

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -77,7 +77,7 @@ transResults()
         MAKE_ERROR(tecINVARIANT_FAILED,              "One or more invariants for the transaction were not satisfied."),
         MAKE_ERROR(tecEXPIRED,                       "Expiration time is passed."),
         MAKE_ERROR(tecDUPLICATE,                     "Ledger object already exists."),
-        MAKE_ERROR(tecKILLED,                        "FillOrKill offer killed."),
+        MAKE_ERROR(tecKILLED,                        "No funds transferred and no offer created."),
         MAKE_ERROR(tecHAS_OBLIGATIONS,               "The account cannot be deleted since it has obligations."),
         MAKE_ERROR(tecTOO_SOON,                      "It is too early to attempt the requested operation. Please wait."),
         MAKE_ERROR(tecMAX_SEQUENCE_REACHED,          "The maximum sequence number was reached."),

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -950,9 +950,14 @@ public:
             env(pay(gw, alice, USD(1000)), ter(tesSUCCESS));
 
             // No cross:
-            env(offer(alice, XRP(1000), USD(1000)),
-                txflags(tfImmediateOrCancel),
-                ter(tesSUCCESS));
+            {
+                TER const expectedCode = features[featureImmediateOfferKilled]
+                    ? static_cast<TER>(tecKILLED)
+                    : static_cast<TER>(tesSUCCESS);
+                env(offer(alice, XRP(1000), USD(1000)),
+                    txflags(tfImmediateOrCancel),
+                    ter(expectedCode));
+            }
 
             env.require(
                 balance(alice, startBalance - f - f),
@@ -5165,11 +5170,12 @@ public:
         FeatureBitset const flowCross{featureFlowCross};
         FeatureBitset const takerDryOffer{fixTakerDryOfferRemoval};
         FeatureBitset const rmSmallIncreasedQOffers{fixRmSmallIncreasedQOffers};
+        FeatureBitset const immediateOfferKilled{featureImmediateOfferKilled};
 
-        testAll(all - takerDryOffer);
-        testAll(all - flowCross - takerDryOffer);
-        testAll(all - flowCross);
-        testAll(all - rmSmallIncreasedQOffers);
+        testAll(all - takerDryOffer - immediateOfferKilled);
+        testAll(all - flowCross - takerDryOffer - immediateOfferKilled);
+        testAll(all - flowCross - immediateOfferKilled);
+        testAll(all - rmSmallIncreasedQOffers - immediateOfferKilled);
         testAll(all);
         testFalseAssert();
     }
@@ -5184,11 +5190,12 @@ class Offer_manual_test : public Offer_test
         FeatureBitset const all{supported_amendments()};
         FeatureBitset const flowCross{featureFlowCross};
         FeatureBitset const f1513{fix1513};
+        FeatureBitset const immediateOfferKilled{featureImmediateOfferKilled};
         FeatureBitset const takerDryOffer{fixTakerDryOfferRemoval};
 
-        testAll(all - flowCross - f1513);
-        testAll(all - flowCross);
-        testAll(all - f1513);
+        testAll(all - flowCross - f1513 - immediateOfferKilled);
+        testAll(all - flowCross - immediateOfferKilled);
+        testAll(all - immediateOfferKilled);
         testAll(all);
 
         testAll(all - flowCross - takerDryOffer);


### PR DESCRIPTION

## High Level Overview of Change

Fixes https://github.com/ripple/rippled/issues/4115

### Context of Change

@mDuo13 noted:
> It's confusing and unintuitive to see an "immediate or cancel" transaction treated as "successful" when it did nothing because the "or cancel" part applied. A different result code makes it apparent at a glance what happened.

The approach taken to this fix reuses the `tecKILLED` code.  I hesitated on this because the descriptive text associated with `tecKILLED` needs to change when applied in this new context.  And that description change could not easily be protected by the amendment.  However @mDuo13 pointed out:

> ... no amendment is necessary for the description change. Per https://xrpl.org/transaction-results.html#immediate-response

So this gave us the leash to make make the change minimally invasive.  Even though, admittedly, it requires an amendment.

For me, the strongest motivation for this change is as follows (also from @mDuo13):

> A major benefit of this change is that you could write code to assume that, if the code is tesSUCCESS (and the transaction is post-amendment) then there will be balance changes of some kind in the metadata, and if the code is tecKILLED then you don't have to look at the metadata to know that no balance change occurred (other than burning the tx cost of course). 

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Amendment (Functionality waits for amendment to pass. Once passed may cause amendment blocking.)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR).

## Before / After

**Before**: an `OfferCreate` transaction with the `tfImmediateOrCancel` flag set that causes no funds to move returns `tesSUCCESS`.

**After:** an `OfferCreate` transaction with the `tfImmediateOrCancel` flag set that causes no funds to move returns `tecKILLED`.


