### PR TITLE
Improve the `fixRmSmallIncreasedQOffers` amendment

### DIFF
--- a/src/ripple/app/tx/impl/OfferStream.cpp
+++ b/src/ripple/app/tx/impl/OfferStream.cpp
@@ -153,7 +153,11 @@ TOfferStreamBase<TIn, TOut>::shouldRmSmallIncreasedQOffer() const
             !std::is_same_v<TTakerGets, XRPAmount>,
         "Cannot have XRP/XRP offers");
 
-    if (!view_.rules().enabled(fixRmSmallIncreasedQOffers))
+
+    bool enabledVersion1 = view_.rules().enabled(fixRmSmallIncreasedQOffers);
+    bool enabledVersion2 = view_.rules().enabled(fixRmSmallIncreasedQOffersV2);
+
+    if (!enabledVersion1 && !enabledVersion2)
         return false;
 
     // Consider removing the offer if:
@@ -193,9 +197,19 @@ TOfferStreamBase<TIn, TOut>::shouldRmSmallIncreasedQOffer() const
         return ofrAmts;
     }();
 
-    if (effectiveAmounts.in > TTakerPays::minPositiveAmount())
-        return false;
 
+    if(enabledVersion2)
+    {
+        if (effectiveAmounts.in >= TTakerPays::minFundedOfferAmount())
+            return false;
+    }
+    else
+    {
+        if (effectiveAmounts.in > TTakerPays::minPositiveAmount())
+            return false;
+    }
+
+    
     Quality const effectiveQuality{effectiveAmounts};
     return effectiveQuality < offer_.quality();
 }

--- a/src/ripple/basics/IOUAmount.h
+++ b/src/ripple/basics/IOUAmount.h
@@ -132,6 +132,9 @@ public:
 
     static IOUAmount
     minPositiveAmount();
+
+    static IOUAmount
+    minFundedOfferAmount();
 };
 
 std::string

--- a/src/ripple/basics/XRPAmount.h
+++ b/src/ripple/basics/XRPAmount.h
@@ -244,6 +244,12 @@ public:
     {
         return XRPAmount{1};
     }
+
+    static XRPAmount
+    minFundedOfferAmount()
+    {
+        return XRPAmount{1000};
+    }
 };
 
 /** Number of drops per 1 XRP */

--- a/src/ripple/basics/impl/IOUAmount.cpp
+++ b/src/ripple/basics/impl/IOUAmount.cpp
@@ -40,6 +40,13 @@ IOUAmount::minPositiveAmount()
     return IOUAmount(minMantissa, minExponent);
 }
 
+IOUAmount
+IOUAmount::minFundedOfferAmount()
+{
+    return minPositiveAmount();
+}
+
+
 void
 IOUAmount::normalize()
 {

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -332,6 +332,7 @@ extern uint256 const featureTicketBatch;
 extern uint256 const featureFlowSortStrands;
 extern uint256 const fixSTAmountCanonicalize;
 extern uint256 const fixRmSmallIncreasedQOffers;
+extern uint256 const fixRmSmallIncreasedQOffersV2;
 extern uint256 const featureCheckCashMakesTrustLine;
 extern uint256 const featureNonFungibleTokensV1;
 extern uint256 const featureExpandedSignerList;

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -436,6 +436,7 @@ REGISTER_FEATURE(TicketBatch,                   Supported::yes, DefaultVote::yes
 REGISTER_FEATURE(FlowSortStrands,               Supported::yes, DefaultVote::yes);
 REGISTER_FIX    (fixSTAmountCanonicalize,       Supported::yes, DefaultVote::yes);
 REGISTER_FIX    (fixRmSmallIncreasedQOffers,    Supported::yes, DefaultVote::yes);
+REGISTER_FIX    (fixRmSmallIncreasedQOffersV2,  Supported::yes, DefaultVote::yes);
 REGISTER_FEATURE(CheckCashMakesTrustLine,       Supported::yes, DefaultVote::no);
 REGISTER_FEATURE(NonFungibleTokensV1,           Supported::yes, DefaultVote::no);
 REGISTER_FEATURE(ExpandedSignerList,            Supported::yes, DefaultVote::no);


### PR DESCRIPTION
This amendment fixes edge cases missed by its predecessor by increasing its threshold for IOU -> XRP offers.
https://github.com/XRPLF/XRPL-Standards/discussions/74


## High Level Overview of Change

This amendment introduces a new method called `minFundedOfferAmount` on both `XRPAmount` and `IOUAmount`. This method returns the newly elevated threshold for the `fixRmSmallIncreasedQOffers` logic.

### Type of Change

- [x] Bug fix
- [x] Breaking change



## Test Plan
An automated test script can be found at https://github.com/Mwni/xrpl-tests/tree/master/small-offers-quality. Ideally, this should be ran against a validator with, and without this amendment.