### PR TITLE
[TRIVIAL] Lower log level of "addPathsForType" log message:

### DIFF
--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -796,8 +796,8 @@ Pathfinder::addPathsForType(
     PathType const& pathType,
     std::function<bool(void)> const& continueCallback)
 {
-    JLOG(j_.warn()) << "addPathsForType "
-                    << CollectionAndDelimiter(pathType, ", ");
+    JLOG(j_.debug()) << "addPathsForType "
+                     << CollectionAndDelimiter(pathType, ", ");
     // See if the set of paths for this type already exists.
     auto it = mPaths.find(pathType);
     if (it != mPaths.end())


### PR DESCRIPTION
## High Level Overview of Change

Per #4177, the log level for Pathfinder:WRN addPathsForType appears to be too verbose. It should be downgraded from warning to debug or trace level.

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)

## Test Plan

* Run rippled with the log level set to "WRN" for all components.
* Submit a `path_find` request
* With version 1.9.1, there will be many messages starting with "Pathfinder:WRN addPathsForType"
* With this change, there won't be any of those messages.
