### PR TITLE
[TRIVIAL] Lower the message level for missing optional doc components

### DIFF
--- a/Builds/CMake/RippledDocs.cmake
+++ b/Builds/CMake/RippledDocs.cmake
@@ -31,7 +31,7 @@ if (tests)
     # find_path sets a CACHE variable, so don't try using a "local" variable.
     find_path (${variable} "${name}" ${ARGN})
     if (NOT ${variable})
-      message (WARNING "could not find ${name}")
+      message (NOTICE "could not find ${name}")
     else ()
       message (STATUS "found ${name}: ${${variable}}/${name}")
     endif ()


### PR DESCRIPTION
## High Level Overview of Change

If certain doc-related components are not available at build time, cmake will output warnings, which are noisy and annoying and completely unnecessary if one doesn't intend to build docs. I've observed this mostly on Windows where the components are less likely to already be available by default. This change lowers the message from a `WARNING` to a `NOTICE`, which is much less disruptive, but still informative.

### Type of Change

- [ X] Documentation Updates

 ## Before / After

### Before

```
[...]
1> [CMake] -- Pausing to download NuDB...
1> [CMake] -- Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR) (Required is at least version "3.8")
1> [CMake] -- using local protobuf build.
1> [CMake] -- Couldn't find protobuf_protoc_lib
1> [CMake] CMake Warning at Builds/CMake/RippledDocs.cmake:34 (message):
1> [CMake]   could not find plantuml.jar
1> [CMake] Call Stack (most recent call first):
1> [CMake]   Builds/CMake/RippledDocs.cmake:40 (verbose_find_path)
1> [CMake]   CMakeLists.txt:77 (include)
1> [CMake] 
1> [CMake] 
1> [CMake] CMake Warning at Builds/CMake/RippledDocs.cmake:34 (message):
1> [CMake]   could not find dot
1> [CMake] Call Stack (most recent call first):
1> [CMake]   Builds/CMake/RippledDocs.cmake:41 (verbose_find_path)
1> [CMake]   CMakeLists.txt:77 (include)
1> [CMake] 
1> [CMake] 
1> [CMake] -- Configuring done
[...]
```

### After

```
[...]
1> [CMake] -- Pausing to download NuDB...
1> [CMake] -- Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR) (Required is at least version "3.8")
1> [CMake] -- using local protobuf build.
1> [CMake] -- Couldn't find protobuf_protoc_lib
1> [CMake] could not find plantuml.jar
1> [CMake] could not find dot
1> [CMake] -- Configuring done
[...]
```
