### PR TITLE
Improve AccountID string conversion caching

### DIFF
--- a/src/ripple/app/ledger/AcceptedLedger.cpp
+++ b/src/ripple/app/ledger/AcceptedLedger.cpp
@@ -31,11 +31,9 @@ AcceptedLedger::AcceptedLedger(
     transactions_.reserve(256);
 
     auto insertAll = [&](auto const& txns) {
-        auto const& idcache = app.accountIDCache();
-
         for (auto const& item : txns)
             transactions_.emplace_back(std::make_unique<AcceptedLedgerTx>(
-                ledger, item.first, item.second, idcache));
+                ledger, item.first, item.second));
     };
 
     if (app.config().reporting())

--- a/src/ripple/app/ledger/AcceptedLedgerTx.cpp
+++ b/src/ripple/app/ledger/AcceptedLedgerTx.cpp
@@ -28,8 +28,7 @@ namespace ripple {
 AcceptedLedgerTx::AcceptedLedgerTx(
     std::shared_ptr<ReadView const> const& ledger,
     std::shared_ptr<STTx const> const& txn,
-    std::shared_ptr<STObject const> const& met,
-    AccountIDCache const& accountCache)
+    std::shared_ptr<STObject const> const& met)
     : mTxn(txn)
     , mMeta(txn->getTransactionID(), ledger->seq(), *met)
     , mAffected(mMeta.getAffectedAccounts())
@@ -52,7 +51,7 @@ AcceptedLedgerTx::AcceptedLedgerTx(
     {
         Json::Value& affected = (mJson[jss::affected] = Json::arrayValue);
         for (auto const& account : mAffected)
-            affected.append(accountCache.toBase58(account));
+            affected.append(toBase58(account));
     }
 
     if (mTxn->getTxnType() == ttOFFER_CREATE)

--- a/src/ripple/app/ledger/AcceptedLedgerTx.h
+++ b/src/ripple/app/ledger/AcceptedLedgerTx.h
@@ -46,8 +46,7 @@ public:
     AcceptedLedgerTx(
         std::shared_ptr<ReadView const> const& ledger,
         std::shared_ptr<STTx const> const&,
-        std::shared_ptr<STObject const> const&,
-        AccountIDCache const&);
+        std::shared_ptr<STObject const> const&);
 
     std::shared_ptr<STTx const> const&
     getTxn() const

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -177,7 +177,6 @@ public:
     NodeStoreScheduler m_nodeStoreScheduler;
     std::unique_ptr<SHAMapStore> m_shaMapStore;
     PendingSaves pendingSaves_;
-    AccountIDCache accountIDCache_;
     std::optional<OpenLedger> openLedger_;
 
     NodeCache m_tempNodeCache;
@@ -326,8 +325,6 @@ public:
               *this,
               m_nodeStoreScheduler,
               logs_->journal("SHAMapStore")))
-
-        , accountIDCache_(128000)
 
         , m_tempNodeCache(
               "NodeCache",
@@ -485,6 +482,8 @@ public:
               config_->reporting() ? std::make_unique<ReportingETL>(*this)
                                    : nullptr)
     {
+        initAccountIdCache(config_->getValueFor(SizedItem::accountIdCacheSize));
+
         add(m_resourceManager.get());
 
         //
@@ -839,12 +838,6 @@ public:
     pendingSaves() override
     {
         return pendingSaves_;
-    }
-
-    AccountIDCache const&
-    accountIDCache() const override
-    {
-        return accountIDCache_;
     }
 
     OpenLedger&

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -89,7 +89,6 @@ class PathRequests;
 class PendingSaves;
 class PublicKey;
 class SecretKey;
-class AccountIDCache;
 class STLedgerEntry;
 class TimeKeeper;
 class TransactionMaster;
@@ -245,8 +244,6 @@ public:
     getSHAMapStore() = 0;
     virtual PendingSaves&
     pendingSaves() = 0;
-    virtual AccountIDCache const&
-    accountIDCache() const = 0;
     virtual OpenLedger&
     openLedger() = 0;
     virtual OpenLedger const&

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -552,9 +552,16 @@ PathRequest::findPaths(
             continueCallback);
         mContext[issue] = ps;
 
-        auto& sourceAccount = !isXRP(issue.account)
-            ? issue.account
-            : isXRP(issue.currency) ? xrpAccount() : *raSrcAccount;
+        auto const& sourceAccount = [&] {
+            if (!isXRP(issue.account))
+                return issue.account;
+
+            if (isXRP(issue.currency))
+                return xrpAccount();
+
+            return *raSrcAccount;
+        }();
+
         STAmount saMaxAmount = saSendMax.value_or(
             STAmount({issue.currency, sourceAccount}, 1u, 0, true));
 
@@ -675,10 +682,8 @@ PathRequest::doUpdate(
             destCurrencies.append(to_string(c));
     }
 
-    newStatus[jss::source_account] =
-        app_.accountIDCache().toBase58(*raSrcAccount);
-    newStatus[jss::destination_account] =
-        app_.accountIDCache().toBase58(*raDstAccount);
+    newStatus[jss::source_account] = toBase58(*raSrcAccount);
+    newStatus[jss::destination_account] = toBase58(*raDstAccount);
     newStatus[jss::destination_amount] = saDstAmount.getJson(JsonOptions::none);
     newStatus[jss::full_reply] = !fast;
 

--- a/src/ripple/app/rdb/backend/detail/Node.h
+++ b/src/ripple/app/rdb/backend/detail/Node.h
@@ -389,7 +389,6 @@ getNewestAccountTxsB(
  *        account which match given criteria starting from given marker
  *        and calls callback for each found transaction.
  * @param session Session with database.
- * @param idCache Account ID cache.
  * @param onUnsavedLedger Callback function to call on each found unsaved
  *        ledger within given range.
  * @param onTransaction Callback function to call on each found transaction.
@@ -408,7 +407,6 @@ getNewestAccountTxsB(
 std::pair<std::optional<RelationalDatabase::AccountTxMarker>, int>
 oldestAccountTxPage(
     soci::session& session,
-    AccountIDCache const& idCache,
     std::function<void(std::uint32_t)> const& onUnsavedLedger,
     std::function<
         void(std::uint32_t, std::string const&, Blob&&, Blob&&)> const&
@@ -422,7 +420,6 @@ oldestAccountTxPage(
  *        account which match given criteria starting from given marker
  *        and calls callback for each found transaction.
  * @param session Session with database.
- * @param idCache Account ID cache.
  * @param onUnsavedLedger Callback function to call on each found unsaved
  *        ledger within given range.
  * @param onTransaction Callback function to call on each found transaction.
@@ -441,7 +438,6 @@ oldestAccountTxPage(
 std::pair<std::optional<RelationalDatabase::AccountTxMarker>, int>
 newestAccountTxPage(
     soci::session& session,
-    AccountIDCache const& idCache,
     std::function<void(std::uint32_t)> const& onUnsavedLedger,
     std::function<
         void(std::uint32_t, std::string const&, Blob&&, Blob&&)> const&

--- a/src/ripple/app/rdb/backend/impl/SQLiteDatabase.cpp
+++ b/src/ripple/app/rdb/backend/impl/SQLiteDatabase.cpp
@@ -1322,7 +1322,6 @@ SQLiteDatabaseImp::oldestAccountTxPage(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const page_length(200);
-    auto& idCache = app_.accountIDCache();
     auto onUnsavedLedger =
         std::bind(saveLedgerAsync, std::ref(app_), std::placeholders::_1);
     AccountTxs ret;
@@ -1338,15 +1337,10 @@ SQLiteDatabaseImp::oldestAccountTxPage(AccountTxPageOptions const& options)
     if (existsTransaction())
     {
         auto db = checkoutTransaction();
-        auto newmarker = detail::oldestAccountTxPage(
-                             *db,
-                             idCache,
-                             onUnsavedLedger,
-                             onTransaction,
-                             options,
-                             0,
-                             page_length)
-                             .first;
+        auto newmarker =
+            detail::oldestAccountTxPage(
+                *db, onUnsavedLedger, onTransaction, options, 0, page_length)
+                .first;
         return {ret, newmarker};
     }
 
@@ -1363,7 +1357,6 @@ SQLiteDatabaseImp::oldestAccountTxPage(AccountTxPageOptions const& options)
                     return false;
                 auto [marker, total] = detail::oldestAccountTxPage(
                     session,
-                    idCache,
                     onUnsavedLedger,
                     onTransaction,
                     opt,
@@ -1391,7 +1384,6 @@ SQLiteDatabaseImp::newestAccountTxPage(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const page_length(200);
-    auto& idCache = app_.accountIDCache();
     auto onUnsavedLedger =
         std::bind(saveLedgerAsync, std::ref(app_), std::placeholders::_1);
     AccountTxs ret;
@@ -1407,15 +1399,10 @@ SQLiteDatabaseImp::newestAccountTxPage(AccountTxPageOptions const& options)
     if (existsTransaction())
     {
         auto db = checkoutTransaction();
-        auto newmarker = detail::newestAccountTxPage(
-                             *db,
-                             idCache,
-                             onUnsavedLedger,
-                             onTransaction,
-                             options,
-                             0,
-                             page_length)
-                             .first;
+        auto newmarker =
+            detail::newestAccountTxPage(
+                *db, onUnsavedLedger, onTransaction, options, 0, page_length)
+                .first;
         return {ret, newmarker};
     }
 
@@ -1432,7 +1419,6 @@ SQLiteDatabaseImp::newestAccountTxPage(AccountTxPageOptions const& options)
                     return false;
                 auto [marker, total] = detail::newestAccountTxPage(
                     session,
-                    idCache,
                     onUnsavedLedger,
                     onTransaction,
                     opt,
@@ -1460,7 +1446,6 @@ SQLiteDatabaseImp::oldestAccountTxPageB(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const page_length(500);
-    auto& idCache = app_.accountIDCache();
     auto onUnsavedLedger =
         std::bind(saveLedgerAsync, std::ref(app_), std::placeholders::_1);
     MetaTxsList ret;
@@ -1475,15 +1460,10 @@ SQLiteDatabaseImp::oldestAccountTxPageB(AccountTxPageOptions const& options)
     if (existsTransaction())
     {
         auto db = checkoutTransaction();
-        auto newmarker = detail::oldestAccountTxPage(
-                             *db,
-                             idCache,
-                             onUnsavedLedger,
-                             onTransaction,
-                             options,
-                             0,
-                             page_length)
-                             .first;
+        auto newmarker =
+            detail::oldestAccountTxPage(
+                *db, onUnsavedLedger, onTransaction, options, 0, page_length)
+                .first;
         return {ret, newmarker};
     }
 
@@ -1500,7 +1480,6 @@ SQLiteDatabaseImp::oldestAccountTxPageB(AccountTxPageOptions const& options)
                     return false;
                 auto [marker, total] = detail::oldestAccountTxPage(
                     session,
-                    idCache,
                     onUnsavedLedger,
                     onTransaction,
                     opt,
@@ -1528,7 +1507,6 @@ SQLiteDatabaseImp::newestAccountTxPageB(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const page_length(500);
-    auto& idCache = app_.accountIDCache();
     auto onUnsavedLedger =
         std::bind(saveLedgerAsync, std::ref(app_), std::placeholders::_1);
     MetaTxsList ret;
@@ -1543,15 +1521,10 @@ SQLiteDatabaseImp::newestAccountTxPageB(AccountTxPageOptions const& options)
     if (existsTransaction())
     {
         auto db = checkoutTransaction();
-        auto newmarker = detail::newestAccountTxPage(
-                             *db,
-                             idCache,
-                             onUnsavedLedger,
-                             onTransaction,
-                             options,
-                             0,
-                             page_length)
-                             .first;
+        auto newmarker =
+            detail::newestAccountTxPage(
+                *db, onUnsavedLedger, onTransaction, options, 0, page_length)
+                .first;
         return {ret, newmarker};
     }
 
@@ -1568,7 +1541,6 @@ SQLiteDatabaseImp::newestAccountTxPageB(AccountTxPageOptions const& options)
                     return false;
                 auto [marker, total] = detail::newestAccountTxPage(
                     session,
-                    idCache,
                     onUnsavedLedger,
                     onTransaction,
                     opt,

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -57,7 +57,8 @@ enum class SizedItem : std::size_t {
     lgrDBCache,
     openFinalLimit,
     burstSize,
-    ramSizeGB
+    ramSizeGB,
+    accountIdCacheSize,
 };
 
 //  This entire derived class is deprecated.

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -108,26 +108,27 @@ namespace ripple {
 
 // clang-format off
 // The configurable node sizes are "tiny", "small", "medium", "large", "huge"
-inline constexpr std::array<std::pair<SizedItem, std::array<int, 5>>, 12>
+inline constexpr std::array<std::pair<SizedItem, std::array<int, 5>>, 13>
 sizedItems
 {{
     // FIXME: We should document each of these items, explaining exactly
     //        what they control and whether there exists an explicit
     //        config option that can be used to override the default.
 
-    //                                tiny    small   medium    large     huge
-    {SizedItem::sweepInterval,   {{     10,      30,      60,      90,     120 }}},
-    {SizedItem::treeCacheSize,   {{ 262144,  524288, 2097152, 4194304, 8388608 }}},
-    {SizedItem::treeCacheAge,    {{     30,      60,      90,     120,     900 }}},
-    {SizedItem::ledgerSize,      {{     32,      32,      64,     256,     384 }}},
-    {SizedItem::ledgerAge,       {{     30,      60,     180,     300,     600 }}},
-    {SizedItem::ledgerFetch,     {{      2,       3,       4,       5,       8 }}},
-    {SizedItem::hashNodeDBCache, {{      4,      12,      24,      64,     128 }}},
-    {SizedItem::txnDBCache,      {{      4,      12,      24,      64,     128 }}},
-    {SizedItem::lgrDBCache,      {{      4,       8,      16,      32,     128 }}},
-    {SizedItem::openFinalLimit,  {{      8,      16,      32,      64,     128 }}},
-    {SizedItem::burstSize,       {{      4,       8,      16,      32,      48 }}},
-    {SizedItem::ramSizeGB,       {{      8,      12,      16,      24,      32 }}},
+    //                                   tiny    small   medium    large     huge
+    {SizedItem::sweepInterval,      {{     10,      30,      60,      90,     120 }}},
+    {SizedItem::treeCacheSize,      {{ 262144,  524288, 2097152, 4194304, 8388608 }}},
+    {SizedItem::treeCacheAge,       {{     30,      60,      90,     120,     900 }}},
+    {SizedItem::ledgerSize,         {{     32,      32,      64,     256,     384 }}},
+    {SizedItem::ledgerAge,          {{     30,      60,     180,     300,     600 }}},
+    {SizedItem::ledgerFetch,        {{      2,       3,       4,       5,       8 }}},
+    {SizedItem::hashNodeDBCache,    {{      4,      12,      24,      64,     128 }}},
+    {SizedItem::txnDBCache,         {{      4,      12,      24,      64,     128 }}},
+    {SizedItem::lgrDBCache,         {{      4,       8,      16,      32,     128 }}},
+    {SizedItem::openFinalLimit,     {{      8,      16,      32,      64,     128 }}},
+    {SizedItem::burstSize,          {{      4,       8,      16,      32,      48 }}},
+    {SizedItem::ramSizeGB,          {{      8,      12,      16,      24,      32 }}},
+    {SizedItem::accountIdCacheSize, {{  20047,   50053,   77081,  150061,  300007 }}}
 }};
 
 // Ensure that the order of entries in the table corresponds to the

--- a/src/ripple/protocol/AccountID.h
+++ b/src/ripple/protocol/AccountID.h
@@ -106,41 +106,20 @@ operator<<(std::ostream& os, AccountID const& x)
     return os;
 }
 
-//------------------------------------------------------------------------------
+/** Initialize the global cache used to map AccountID to base58 conversions.
 
-/** Caches the base58 representations of AccountIDs
+    The cache is optional and need not be initialized. But because conversion
+    is expensive (it requires a SHA-256 operation) in most cases the overhead
+    of the cache is worth the benefit.
 
-    This operation occurs with sufficient frequency to
-    justify having a cache. In the future, rippled should
-    require clients to receive "binary" results, where
-    AccountIDs are hex-encoded.
-*/
-class AccountIDCache
-{
-private:
-    std::mutex mutable mutex_;
-    std::size_t capacity_;
-    hash_map<AccountID, std::string> mutable m0_;
-    hash_map<AccountID, std::string> mutable m1_;
+    @param count The number of entries the cache should accomodate. Zero will
+                 disable the cache, releasing any memory associated with it.
 
-public:
-    AccountIDCache(AccountIDCache const&) = delete;
-    AccountIDCache&
-    operator=(AccountIDCache const&) = delete;
-
-    explicit AccountIDCache(std::size_t capacity);
-
-    /** Return ripple::toBase58 for the AccountID
-
-        Thread Safety:
-            Safe to call from any thread concurrently
-
-        @note This function intentionally returns a
-              copy for correctness.
-    */
-    std::string
-    toBase58(AccountID const&) const;
-};
+    @note The function will only initialize the cache the first time it is
+          invoked. Subsequent invocations do nothing.
+ */
+void
+initAccountIdCache(std::size_t count);
 
 }  // namespace ripple
 

--- a/src/ripple/rpc/handlers/AccountChannels.cpp
+++ b/src/ripple/rpc/handlers/AccountChannels.cpp
@@ -202,7 +202,7 @@ doAccountChannels(RPC::JsonContext& context)
             to_string(*marker) + "," + std::to_string(nextHint);
     }
 
-    result[jss::account] = context.app.accountIDCache().toBase58(accountID);
+    result[jss::account] = toBase58(accountID);
 
     for (auto const& item : visitData.items)
         addChannel(jsonChannels, *item);

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -215,7 +215,7 @@ doAccountInfo(RPC::JsonContext& context)
     }
     else
     {
-        result[jss::account] = context.app.accountIDCache().toBase58(accountID);
+        result[jss::account] = toBase58(accountID);
         RPC::inject_error(rpcACT_NOT_FOUND, result);
     }
 

--- a/src/ripple/rpc/handlers/AccountLines.cpp
+++ b/src/ripple/rpc/handlers/AccountLines.cpp
@@ -252,7 +252,7 @@ doAccountLines(RPC::JsonContext& context)
             to_string(*marker) + "," + std::to_string(nextHint);
     }
 
-    result[jss::account] = context.app.accountIDCache().toBase58(accountID);
+    result[jss::account] = toBase58(accountID);
 
     for (auto const& item : visitData.items)
         addLine(jsonLines, item);

--- a/src/ripple/rpc/handlers/AccountObjects.cpp
+++ b/src/ripple/rpc/handlers/AccountObjects.cpp
@@ -160,7 +160,7 @@ doAccountNFTs(RPC::JsonContext& context)
             cp = nullptr;
     }
 
-    result[jss::account] = context.app.accountIDCache().toBase58(accountID);
+    result[jss::account] = toBase58(accountID);
     context.loadType = Resource::feeMediumBurdenRPC;
     return result;
 }
@@ -275,7 +275,7 @@ doAccountObjects(RPC::JsonContext& context)
         result[jss::account_objects] = Json::arrayValue;
     }
 
-    result[jss::account] = context.app.accountIDCache().toBase58(accountID);
+    result[jss::account] = toBase58(accountID);
     context.loadType = Resource::feeMediumBurdenRPC;
     return result;
 }

--- a/src/ripple/rpc/handlers/AccountOffers.cpp
+++ b/src/ripple/rpc/handlers/AccountOffers.cpp
@@ -77,7 +77,7 @@ doAccountOffers(RPC::JsonContext& context)
     }
 
     // Get info on account.
-    result[jss::account] = context.app.accountIDCache().toBase58(accountID);
+    result[jss::account] = toBase58(accountID);
 
     if (!ledger->exists(keylet::account(accountID)))
         return rpcError(rpcACT_NOT_FOUND);

--- a/src/ripple/rpc/handlers/AccountTxOld.cpp
+++ b/src/ripple/rpc/handlers/AccountTxOld.cpp
@@ -149,7 +149,7 @@ doAccountTxOld(RPC::JsonContext& context)
 
         Json::Value ret(Json::objectValue);
 
-        ret[jss::account] = context.app.accountIDCache().toBase58(*raAccount);
+        ret[jss::account] = toBase58(*raAccount);
         Json::Value& jvTxns = (ret[jss::transactions] = Json::arrayValue);
 
         RelationalDatabase::AccountTxOptions options = {

--- a/src/ripple/rpc/handlers/GatewayBalances.cpp
+++ b/src/ripple/rpc/handlers/GatewayBalances.cpp
@@ -80,7 +80,7 @@ doGatewayBalances(RPC::JsonContext& context)
 
     context.loadType = Resource::feeHighBurdenRPC;
 
-    result[jss::account] = context.app.accountIDCache().toBase58(accountID);
+    result[jss::account] = toBase58(accountID);
 
     // Parse the specified hotwallet(s), if any
     std::set<AccountID> hotWallets;

--- a/src/ripple/rpc/handlers/NFTOffers.cpp
+++ b/src/ripple/rpc/handlers/NFTOffers.cpp
@@ -41,12 +41,10 @@ appendNftOfferJson(
 
     obj[jss::nft_offer_index] = to_string(offer->key());
     obj[jss::flags] = (*offer)[sfFlags];
-    obj[jss::owner] =
-        app.accountIDCache().toBase58(offer->getAccountID(sfOwner));
+    obj[jss::owner] = toBase58(offer->getAccountID(sfOwner));
 
     if (offer->isFieldPresent(sfDestination))
-        obj[jss::destination] =
-            app.accountIDCache().toBase58(offer->getAccountID(sfDestination));
+        obj[jss::destination] = toBase58(offer->getAccountID(sfDestination));
 
     if (offer->isFieldPresent(sfExpiration))
         obj[jss::expiration] = offer->getFieldU32(sfExpiration);

--- a/src/ripple/rpc/handlers/NoRippleCheck.cpp
+++ b/src/ripple/rpc/handlers/NoRippleCheck.cpp
@@ -40,7 +40,7 @@ fillTransaction(
     ReadView const& ledger)
 {
     txArray["Sequence"] = Json::UInt(sequence++);
-    txArray["Account"] = context.app.accountIDCache().toBase58(accountID);
+    txArray["Account"] = toBase58(accountID);
     auto& fees = ledger.fees();
     // Convert the reference transaction cost in fee units to drops
     // scaled to represent the current fee load.


### PR DESCRIPTION
Caching the base58check encoded version of an `AccountID` has performance advantages, because because of the computationally heavy cost associated with the conversion, which requires the application of SHA-256 twice.

This commit makes the cache significantly more efficient in terms of memory used: it maps an `AccountID` to `char*` instead of an `std::string` (eliminating the need for dynamic memory allocation and the fixed overhead of `std::string`) and effectively eliminates runtime allocation and deallocation of memory by grabbing a single, large block of memory at initialization.

The eviction policy is also improved and ensures that the cache, once full, will always remain full. Although not currently coded the structure of the cache is such that it can be used to easily evict the least-recently-used entry without additional overhead.

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
