### PR TITLE
[TRIVIAL] Fix bitwise or on boolean operands warning / error

### DIFF
--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -728,7 +728,7 @@ CreateOffer::flowCross(
         // additional path with XRP as the intermediate between two books.
         // This second path we have to build ourselves.
         STPathSet paths;
-        if (!takerAmount.in.native() & !takerAmount.out.native())
+        if (!takerAmount.in.native() && !takerAmount.out.native())
         {
             STPath path;
             path.emplace_back(std::nullopt, xrpCurrency(), std::nullopt);


### PR DESCRIPTION
## High Level Overview of Change

I compile rippled with `-werr`. Clang 14 generated the following error.
```
src/ripple/app/tx/impl/CreateOffer.cpp:731:13: error: use of bitwise '&' with boolean operands [-Werror,-Wbitwise-instead-of-logical]
        if (!takerAmount.in.native() & !takerAmount.out.native())
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                     &&
src/ripple/app/tx/impl/CreateOffer.cpp:731:13: note: cast one or both operands to int to silence this warning
1 error generated.
```

### Context of Change

I updated to Ubuntu 22.04, which ships with clang 14. Building rippled on the new system failed because of this issue.

### Type of Change

- [X ] Refactor (non-breaking change that only restructures code)
