### PR TITLE
Improve detection & handling of duplicate Node ID:

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -86,9 +86,11 @@ RCLConsensus::Adaptor::Adaptor(
     , inboundTransactions_{inboundTransactions}
     , j_(journal)
     , validatorKeys_(validatorKeys)
-    , valCookie_{rand_int<std::uint64_t>(
-          1,
-          std::numeric_limits<std::uint64_t>::max())}
+    , valCookie_(
+          1 +
+          rand_int(
+              crypto_prng(),
+              std::numeric_limits<std::uint64_t>::max() - 1))
     , nUnlVote_(validatorKeys_.nodeID, j_)
 {
     assert(valCookie_ != 0);

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -28,6 +28,7 @@
 #include <ripple/shamap/FullBelowCache.h>
 #include <ripple/shamap/TreeNodeCache.h>
 #include <boost/asio.hpp>
+#include <boost/program_options.hpp>
 #include <memory>
 #include <mutex>
 
@@ -136,13 +137,14 @@ public:
     virtual ~Application() = default;
 
     virtual bool
-    setup() = 0;
+    setup(boost::program_options::variables_map const& options) = 0;
+
     virtual void
     start(bool withTimers) = 0;
     virtual void
     run() = 0;
     virtual void
-    signalStop() = 0;
+    signalStop(std::string msg = "") = 0;
     virtual bool
     checkSigs() const = 0;
     virtual void
@@ -153,6 +155,10 @@ public:
     //
     // ---
     //
+
+    /** Returns a 64-bit instance identifier, generated at startup */
+    virtual std::uint64_t
+    instanceID() const = 0;
 
     virtual Logs&
     logs() = 0;

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -368,6 +368,10 @@ run(int argc, char** argv)
         "conf", po::value<std::string>(), "Specify the configuration file.")(
         "debug", "Enable normally suppressed debug logging")(
         "help,h", "Display this message.")(
+        "newnodeid", "Generate a new node identity for this server.")(
+        "nodeid",
+        po::value<std::string>(),
+        "Specify the node identity for this server.")(
         "quorum",
         po::value<std::size_t>(),
         "Override the minimum validation quorum.")(
@@ -752,7 +756,7 @@ run(int argc, char** argv)
         auto app = make_Application(
             std::move(config), std::move(logs), std::move(timeKeeper));
 
-        if (!app->setup())
+        if (!app->setup(vm))
             return -1;
 
         // With our configuration parsed, ensure we have

--- a/src/ripple/app/main/NodeIdentity.cpp
+++ b/src/ripple/app/main/NodeIdentity.cpp
@@ -20,27 +20,38 @@
 #include <ripple/app/main/Application.h>
 #include <ripple/app/main/NodeIdentity.h>
 #include <ripple/app/rdb/Wallet.h>
-#include <ripple/basics/Log.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>
-#include <boost/format.hpp>
 #include <boost/optional.hpp>
 
 namespace ripple {
 
 std::pair<PublicKey, SecretKey>
-getNodeIdentity(Application& app)
+getNodeIdentity(
+    Application& app,
+    boost::program_options::variables_map const& cmdline)
 {
-    // If a seed is specified in the configuration file use that directly.
-    if (app.config().exists(SECTION_NODE_SEED))
+    std::optional<Seed> seed;
+
+    if (cmdline.count("nodeid"))
     {
-        auto const seed = parseBase58<Seed>(
+        seed = parseGenericSeed(cmdline["nodeid"].as<std::string>(), false);
+
+        if (!seed)
+            Throw<std::runtime_error>("Invalid 'nodeid' in command line");
+    }
+    else if (app.config().exists(SECTION_NODE_SEED))
+    {
+        seed = parseBase58<Seed>(
             app.config().section(SECTION_NODE_SEED).lines().front());
 
         if (!seed)
-            Throw<std::runtime_error>("NodeIdentity: Bad [" SECTION_NODE_SEED
-                                      "] specified");
+            Throw<std::runtime_error>("Invalid [" SECTION_NODE_SEED
+                                      "] in configuration file");
+    }
 
+    if (seed)
+    {
         auto secretKey = generateSecretKey(KeyType::secp256k1, *seed);
         auto publicKey = derivePublicKey(KeyType::secp256k1, secretKey);
 
@@ -48,6 +59,10 @@ getNodeIdentity(Application& app)
     }
 
     auto db = app.getWalletDB().checkoutDb();
+
+    if (cmdline.count("newnodeid") != 0)
+        clearNodeIdentity(*db);
+
     return getNodeIdentity(*db);
 }
 

--- a/src/ripple/app/main/NodeIdentity.h
+++ b/src/ripple/app/main/NodeIdentity.h
@@ -23,13 +23,20 @@
 #include <ripple/app/main/Application.h>
 #include <ripple/protocol/PublicKey.h>
 #include <ripple/protocol/SecretKey.h>
+#include <boost/program_options.hpp>
 #include <utility>
 
 namespace ripple {
 
-/** The cryptographic credentials identifying this server instance. */
+/** The cryptographic credentials identifying this server instance.
+
+    @param app The application object
+    @param cmdline The command line parameters passed into the application.
+ */
 std::pair<PublicKey, SecretKey>
-getNodeIdentity(Application& app);
+getNodeIdentity(
+    Application& app,
+    boost::program_options::variables_map const& cmdline);
 
 }  // namespace ripple
 

--- a/src/ripple/app/rdb/Wallet.h
+++ b/src/ripple/app/rdb/Wallet.h
@@ -87,10 +87,19 @@ saveManifests(
 void
 addValidatorManifest(soci::session& session, std::string const& serialized);
 
-/**
- * @brief getNodeIdentity Returns the public and private keys of this node.
- * @param session Session with the database.
- * @return Pair of public and private keys.
+/** Delete any saved public/private key associated with this node. */
+void
+clearNodeIdentity(soci::session& session);
+
+/** Returns a stable public and private key for this node.
+
+    The node's public identity is defined by a secp256k1 keypair
+    that is (normally) randomly generated. This function will
+    return such a keypair, securely generating one if needed.
+
+    @param session Session with the database.
+
+    @return Pair of public and private secp256k1 keys.
  */
 std::pair<PublicKey, SecretKey>
 getNodeIdentity(soci::session& session);

--- a/src/ripple/app/rdb/impl/Wallet.cpp
+++ b/src/ripple/app/rdb/impl/Wallet.cpp
@@ -119,6 +119,12 @@ addValidatorManifest(soci::session& session, std::string const& serialized)
     tr.commit();
 }
 
+void
+clearNodeIdentity(soci::session& session)
+{
+    session << "DELETE FROM NodeIdentity;";
+}
+
 std::pair<PublicKey, SecretKey>
 getNodeIdentity(soci::session& session)
 {

--- a/src/ripple/overlay/README.md
+++ b/src/ripple/overlay/README.md
@@ -296,8 +296,8 @@ For more on the Peer Crawler, please visit https://xrpl.org/peer-crawler.html.
 If present, identifies the hash of the last ledger that the sending server
 considers to be closed.
 
-The value is presently encoded using **Base64** encoding, but implementations
-should support both **Base64** and **HEX** encoding for this value.
+The value is encoded as **HEX**, but implementations should support both
+**Base64** and **HEX** encoding for this value for legacy purposes.
     
 | Field Name          	|  Request          	| Response          	|
 |---------------------	|:-----------------:	|:-----------------:	|

--- a/src/ripple/overlay/impl/ProtocolVersion.cpp
+++ b/src/ripple/overlay/impl/ProtocolVersion.cpp
@@ -36,7 +36,6 @@ namespace ripple {
 // clang-format off
 constexpr ProtocolVersion const supportedProtocolList[]
 {
-    {2, 0},
     {2, 1},
     {2, 2}
 };

--- a/src/ripple/protocol/Seed.h
+++ b/src/ripple/protocol/Seed.h
@@ -116,9 +116,13 @@ template <>
 std::optional<Seed>
 parseBase58(std::string const& s);
 
-/** Attempt to parse a string as a seed */
+/** Attempt to parse a string as a seed.
+
+    @param str the string to parse
+    @param rfc1751 true if we should attempt RFC1751 style parsing (deprecated)
+ * */
 std::optional<Seed>
-parseGenericSeed(std::string const& str);
+parseGenericSeed(std::string const& str, bool rfc1751 = true);
 
 /** Encode a Seed in RFC1751 format */
 std::string

--- a/src/ripple/protocol/impl/Seed.cpp
+++ b/src/ripple/protocol/impl/Seed.cpp
@@ -87,7 +87,7 @@ parseBase58(std::string const& s)
 }
 
 std::optional<Seed>
-parseGenericSeed(std::string const& str)
+parseGenericSeed(std::string const& str, bool rfc1751)
 {
     if (str.empty())
         return std::nullopt;
@@ -111,6 +111,7 @@ parseGenericSeed(std::string const& str)
     if (auto seed = parseBase58<Seed>(str))
         return seed;
 
+    if (rfc1751)
     {
         std::string key;
         if (RFC1751::getKeyFromEnglish(key, str) == 1)

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -83,7 +83,7 @@ Env::AppBundle::AppBundle(
         std::move(config), std::move(logs), std::move(timeKeeper_));
     app = owned.get();
     app->logs().threshold(thresh);
-    if (!app->setup())
+    if (!app->setup({}))
         Throw<std::runtime_error>("Env::AppBundle: setup failed");
     timeKeeper->set(app->getLedgerMaster().getClosedLedger()->info().closeTime);
     app->start(false /*don't start timers*/);


### PR DESCRIPTION
Each node on the network is supposed to have a unique cryptographic identity. Typically, this identity is generated randomly at startup and stored for later reuse in the (poorly named) file `wallet.db`.

If the file is copied, it is possible for two nodes to share the same node identity. This is generally not desirable and existing servers will detect and reject connections to other servers that have the same key.

This commit achives three things:

1. It improves the detection code to pinpoint instances where two distinct servers with the same key connect with each other. In that case, servers will log an appropriate error and shut down pending intervention by the server's operator.
2. It makes it possible for server administrators to securely and easily generate new cryptographic identities for servers using the new `--newnodeid` command line arguments. When a server is started using this command, it will generate and save a random secure identity.
3. It makes it possible to configure the identity using a command line option, which makes it possible to derive it from data or parameters associated with the container or hardware where the instance is running by passing the `--nodeid` option, followed by a single argument identifying the infomation from which the node's identity is derived. For example, the following command will result in nodes with different hostnames having different node identities: `rippled --nodeid $HOSTNAME`

The last option is particularly useful for automated cloud-based deployments that minimize the need for storing state.

**Important note for server operators:**
Depending on variables outside of the the control of this code, such as operating system version or configuration, permissions, and more, it may be possible for other users or programs to be able to access the command line arguments of other processes on the system.

If you are operating in a shared environment, you should avoid using this option, preferring instead to use the [node_seed] option in the configuration file.

The commit also updates the minimum supported server protocol version to `XRPL/2.1`, which has been supported since version 1.5.0 and eliminates support for `XPRL/2.0`.
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
