### PR TITLE
Limit how often endpoint messages can be processed:

### DIFF
--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -782,9 +782,13 @@ public:
         // Must be handshaked!
         assert(slot->state() == Slot::active);
 
-        preprocess(slot, list);
-
         clock_type::time_point const now(m_clock.now());
+
+        // Limit how often we accept new endpoints
+        if (slot->whenAcceptEndpoints > now)
+            return;
+
+        preprocess(slot, list);
 
         for (auto const& ep : list)
         {


### PR DESCRIPTION
The peer discovery protocol depends on peers exchanging messages listing IP addresses for other peers.

Under normal circumstances, these messages should not be sent frequently; the existing code would track the earliest time a new message should be processed, but did not actually enforce that limit.

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
