### PR TITLE
Improve STVector256 deserialization

### DIFF
--- a/src/ripple/basics/Slice.h
+++ b/src/ripple/basics/Slice.h
@@ -48,6 +48,7 @@ private:
     std::size_t size_ = 0;
 
 public:
+    using value_type = std::uint8_t;
     using const_iterator = std::uint8_t const*;
 
     /** Default constructed Slice has length 0. */

--- a/src/ripple/basics/Slice.h
+++ b/src/ripple/basics/Slice.h
@@ -49,7 +49,7 @@ private:
 
 public:
     using value_type = std::uint8_t;
-    using const_iterator = std::uint8_t const*;
+    using const_iterator = value_type const*;
 
     /** Default constructed Slice has length 0. */
     Slice() noexcept = default;
@@ -76,13 +76,13 @@ public:
         This may be zero for an empty range.
     */
     /** @{ */
-    std::size_t
+    [[nodiscard]] std::size_t
     size() const noexcept
     {
         return size_;
     }
 
-    std::size_t
+    [[nodiscard]] std::size_t
     length() const noexcept
     {
         return size_;

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -26,6 +26,7 @@
 #define RIPPLE_BASICS_BASE_UINT_H_INCLUDED
 
 #include <ripple/basics/Expected.h>
+#include <ripple/basics/Slice.h>
 #include <ripple/basics/contract.h>
 #include <ripple/basics/hardened_hash.h>
 #include <ripple/basics/strHex.h>
@@ -53,6 +54,11 @@ struct is_contiguous_container<
         decltype(std::declval<Container const>().size()),
         decltype(std::declval<Container const>().data()),
         typename Container::value_type>> : std::true_type
+{
+};
+
+template <>
+struct is_contiguous_container<Slice> : std::true_type
 {
 };
 


### PR DESCRIPTION
The existing `STVector256` is not very optimal: it requires a lot of unnecessary copying. This commit fixes that _and_ improves detection improperly serialized values: now such values will result in an exception being raised (exceptions from that codepath are expected _and_ properly handled).

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
