### PR TITLE
Proposed 1.9.2-rc1

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -156,6 +156,7 @@ install (
     src/ripple/basics/MathUtilities.h
     src/ripple/basics/safe_cast.h
     src/ripple/basics/Slice.h
+    src/ripple/basics/spinlock.h
     src/ripple/basics/StringUtilities.h
     src/ripple/basics/ThreadSafetyAnalysis.h
     src/ripple/basics/ToString.h

--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -157,6 +157,7 @@ install (
     src/ripple/basics/safe_cast.h
     src/ripple/basics/Slice.h
     src/ripple/basics/StringUtilities.h
+    src/ripple/basics/ThreadSafetyAnalysis.h
     src/ripple/basics/ToString.h
     src/ripple/basics/UnorderedContainers.h
     src/ripple/basics/XRPAmount.h

--- a/Builds/CMake/RippledDocs.cmake
+++ b/Builds/CMake/RippledDocs.cmake
@@ -31,7 +31,7 @@ if (tests)
     # find_path sets a CACHE variable, so don't try using a "local" variable.
     find_path (${variable} "${name}" ${ARGN})
     if (NOT ${variable})
-      message (WARNING "could not find ${name}")
+      message (NOTICE "could not find ${name}")
     else ()
       message (STATUS "found ${name}: ${${variable}}/${name}")
     endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,12 @@ if(Git_FOUND)
     endif()
 endif() #git
 
+if (thread_safety_analysis)
+  add_compile_options(-Wthread-safety -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -DRIPPLE_ENABLE_THREAD_SAFETY_ANNOTATIONS)
+  add_compile_options("-stdlib=libc++")
+  add_link_options("-stdlib=libc++")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/Builds/CMake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/Builds/CMake/deps")
 

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2323,10 +2323,6 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
     if (!app_.config().SERVER_DOMAIN.empty())
         info[jss::server_domain] = app_.config().SERVER_DOMAIN;
 
-    if (!app_.config().reporting())
-        if (auto const netid = app_.overlay().networkID())
-            info[jss::network_id] = static_cast<Json::UInt>(*netid);
-
     info[jss::build_version] = BuildInfo::getVersionString();
 
     info[jss::server_state] = strOperatingMode(admin);
@@ -2469,6 +2465,9 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
 
     if (!app_.config().reporting())
     {
+        if (auto const netid = app_.overlay().networkID())
+            info[jss::network_id] = static_cast<Json::UInt>(*netid);
+
         auto const escalationMetrics =
             app_.getTxQ().getMetrics(*app_.openLedger().current());
 

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -919,7 +919,10 @@ void
 NetworkOPsImp::setStateTimer()
 {
     setHeartbeatTimer();
-    setClusterTimer();
+
+    // Only do this work if a cluster is configured
+    if (app_.cluster().size() != 0)
+        setClusterTimer();
 }
 
 void
@@ -972,6 +975,7 @@ void
 NetworkOPsImp::setClusterTimer()
 {
     using namespace std::chrono_literals;
+
     setTimer(
         clusterTimer_,
         10s,
@@ -1057,7 +1061,11 @@ NetworkOPsImp::processHeartbeatTimer()
 void
 NetworkOPsImp::processClusterTimer()
 {
+    if (app_.cluster().size() == 0)
+        return;
+
     using namespace std::chrono_literals;
+
     bool const update = app_.cluster().update(
         app_.nodeIdentity().first,
         "",

--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -796,8 +796,8 @@ Pathfinder::addPathsForType(
     PathType const& pathType,
     std::function<bool(void)> const& continueCallback)
 {
-    JLOG(j_.warn()) << "addPathsForType "
-                    << CollectionAndDelimiter(pathType, ", ");
+    JLOG(j_.debug()) << "addPathsForType "
+                     << CollectionAndDelimiter(pathType, ", ");
     // See if the set of paths for this type already exists.
     auto it = mPaths.find(pathType);
     if (it != mPaths.end())

--- a/src/ripple/app/rdb/impl/Wallet.cpp
+++ b/src/ripple/app/rdb/impl/Wallet.cpp
@@ -254,7 +254,10 @@ readAmendments(
 
     soci::transaction tr(session);
     std::string sql =
-        "SELECT AmendmentHash, AmendmentName, Veto FROM FeatureVotes";
+        "SELECT AmendmentHash, AmendmentName, Veto FROM "
+        "( SELECT AmendmentHash, AmendmentName, Veto, RANK() OVER "
+        "(  PARTITION BY AmendmentHash ORDER BY ROWID DESC ) "
+        "as rnk FROM FeatureVotes ) WHERE rnk = 1";
     // SOCI requires boost::optional (not std::optional) as parameters.
     boost::optional<std::string> amendment_hash;
     boost::optional<std::string> amendment_name;

--- a/src/ripple/app/reporting/P2pProxy.cpp
+++ b/src/ripple/app/reporting/P2pProxy.cpp
@@ -72,7 +72,7 @@ shouldForwardToP2p(RPC::JsonContext& context)
     if (params.isMember(jss::ledger_index))
     {
         auto indexValue = params[jss::ledger_index];
-        if (!indexValue.isNumeric())
+        if (indexValue.isString())
         {
             auto index = indexValue.asString();
             return index == "current" || index == "closed";

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -728,7 +728,7 @@ CreateOffer::flowCross(
         // additional path with XRP as the intermediate between two books.
         // This second path we have to build ourselves.
         STPathSet paths;
-        if (!takerAmount.in.native() & !takerAmount.out.native())
+        if (!takerAmount.in.native() && !takerAmount.out.native())
         {
             STPath path;
             path.emplace_back(std::nullopt, xrpCurrency(), std::nullopt);

--- a/src/ripple/basics/Slice.h
+++ b/src/ripple/basics/Slice.h
@@ -48,7 +48,8 @@ private:
     std::size_t size_ = 0;
 
 public:
-    using const_iterator = std::uint8_t const*;
+    using value_type = std::uint8_t;
+    using const_iterator = value_type const*;
 
     /** Default constructed Slice has length 0. */
     Slice() noexcept = default;
@@ -75,13 +76,13 @@ public:
         This may be zero for an empty range.
     */
     /** @{ */
-    std::size_t
+    [[nodiscard]] std::size_t
     size() const noexcept
     {
         return size_;
     }
 
-    std::size_t
+    [[nodiscard]] std::size_t
     length() const noexcept
     {
         return size_;

--- a/src/ripple/basics/ThreadSafetyAnalysis.h
+++ b/src/ripple/basics/ThreadSafetyAnalysis.h
@@ -1,0 +1,63 @@
+#ifndef RIPPLE_BASICS_THREAD_SAFTY_ANALYSIS_H_INCLUDED
+#define RIPPLE_BASICS_THREAD_SAFTY_ANALYSIS_H_INCLUDED
+
+#ifdef RIPPLE_ENABLE_THREAD_SAFETY_ANNOTATIONS
+#define THREAD_ANNOTATION_ATTRIBUTE__(x) __attribute__((x))
+#else
+#define THREAD_ANNOTATION_ATTRIBUTE__(x)  // no-op
+#endif
+
+#define CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
+
+#define SCOPED_CAPABILITY THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+
+#define GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
+
+#define PT_GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
+
+#define ACQUIRED_BEFORE(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(acquired_before(__VA_ARGS__))
+
+#define ACQUIRED_AFTER(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
+
+#define REQUIRES(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+
+#define REQUIRES_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+
+#define ACQUIRE(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
+
+#define ACQUIRE_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
+
+#define RELEASE(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
+
+#define RELEASE_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
+
+#define RELEASE_GENERIC(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(release_generic_capability(__VA_ARGS__))
+
+#define TRY_ACQUIRE(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
+
+#define TRY_ACQUIRE_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_shared_capability(__VA_ARGS__))
+
+#define EXCLUDES(...) THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+
+#define ASSERT_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(assert_capability(x))
+
+#define ASSERT_SHARED_CAPABILITY(x) \
+    THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_capability(x))
+
+#define RETURN_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+
+#define NO_THREAD_SAFETY_ANALYSIS \
+    THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
+
+#endif

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -26,6 +26,7 @@
 #define RIPPLE_BASICS_BASE_UINT_H_INCLUDED
 
 #include <ripple/basics/Expected.h>
+#include <ripple/basics/Slice.h>
 #include <ripple/basics/contract.h>
 #include <ripple/basics/hardened_hash.h>
 #include <ripple/basics/strHex.h>
@@ -53,6 +54,11 @@ struct is_contiguous_container<
         decltype(std::declval<Container const>().size()),
         decltype(std::declval<Container const>().data()),
         typename Container::value_type>> : std::true_type
+{
+};
+
+template <>
+struct is_contiguous_container<Slice> : std::true_type
 {
 };
 

--- a/src/ripple/basics/impl/StringUtilities.cpp
+++ b/src/ripple/basics/impl/StringUtilities.cpp
@@ -90,6 +90,13 @@ parseUrl(parsedURL& pUrl, std::string const& strUrl)
     if (!port.empty())
     {
         pUrl.port = beast::lexicalCast<std::uint16_t>(port);
+
+        // For inputs larger than 2^32-1 (65535), lexicalCast returns 0.
+        // parseUrl returns false for such inputs.
+        if (pUrl.port == 0)
+        {
+            return false;
+        }
     }
     pUrl.path = smMatch[6];
 

--- a/src/ripple/basics/spinlock.h
+++ b/src/ripple/basics/spinlock.h
@@ -1,0 +1,223 @@
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright 2022, Nikolaos D. Bougalis <nikb@bougalis.net>
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#ifndef RIPPLE_BASICS_SPINLOCK_H_INCLUDED
+#define RIPPLE_BASICS_SPINLOCK_H_INCLUDED
+
+#include <atomic>
+#include <cassert>
+#include <limits>
+#include <type_traits>
+
+#ifndef __aarch64__
+#include <immintrin.h>
+#endif
+
+namespace ripple {
+
+namespace detail {
+/** Inform the processor that we are in a tight spin-wait loop.
+
+    Spinlocks caught in tight loops can result in the processor's pipeline
+    filling up with comparison operations, resulting in a misprediction at
+    the time the lock is finally acquired, necessitating pipeline flushing
+    which is ridiculously expensive and results in very high latency.
+
+    This function instructs the processor to "pause" for some architecture
+    specific amount of time, to prevent this.
+ */
+inline void
+spin_pause() noexcept
+{
+#ifdef __aarch64__
+    asm volatile("yield");
+#else
+    _mm_pause();
+#endif
+}
+
+}  // namespace detail
+
+/** @{ */
+/** Classes to handle arrays of spinlocks packed into a single atomic integer:
+
+    Packed spinlocks allow for tremendously space-efficient lock-sharding
+    but they come at a cost.
+
+    First, the implementation is necessarily low-level and uses advanced
+    features like memory ordering and highly platform-specific tricks to
+    maximize performance. This imposes a significant and ongoing cost to
+    developers.
+
+    Second, and perhaps most important, is that the packing of multiple
+    locks into a single integer which, albeit space-efficient, also has
+    performance implications stemming from data dependencies, increased
+    cache-coherency traffic between processors and heavier loads on the
+    processor's load/store units.
+
+    To be sure, these locks can have advantages but they are definitely
+    not general purpose locks and should not be thought of or used that
+    way. The use cases for them are likely few and far between; without
+    a compelling reason to use them, backed by profiling data, it might
+    be best to use one of the standard locking primitives instead. Note
+    that in most common platforms, `std::mutex` is so heavily optimized
+    that it can, usually, outperform spinlocks.
+
+    @tparam T An unsigned integral type (e.g. std::uint16_t)
+ */
+
+/** A class that grabs a single packed spinlock from an atomic integer.
+
+    This class meets the requirements of Lockable:
+        https://en.cppreference.com/w/cpp/named_req/Lockable
+ */
+template <class T>
+class packed_spinlock
+{
+    // clang-format off
+    static_assert(std::is_unsigned_v<T>);
+    static_assert(std::atomic<T>::is_always_lock_free);
+    static_assert(
+        std::is_same_v<decltype(std::declval<std::atomic<T>&>().fetch_or(0)), T> &&
+        std::is_same_v<decltype(std::declval<std::atomic<T>&>().fetch_and(0)), T>,
+        "std::atomic<T>::fetch_and(T) and std::atomic<T>::fetch_and(T) are required by packed_spinlock");
+    // clang-format on
+
+private:
+    std::atomic<T>& bits_;
+    T const mask_;
+
+public:
+    packed_spinlock(packed_spinlock const&) = delete;
+    packed_spinlock&
+    operator=(packed_spinlock const&) = delete;
+
+    /** A single spinlock packed inside the specified atomic
+
+        @param lock The atomic integer inside which the spinlock is packed.
+        @param index The index of the spinlock this object acquires.
+
+        @note For performance reasons, you should strive to have `lock` be
+              on a cacheline by itself.
+     */
+    packed_spinlock(std::atomic<T>& lock, int index)
+        : bits_(lock), mask_(static_cast<T>(1) << index)
+    {
+        assert(index >= 0 && (mask_ != 0));
+    }
+
+    [[nodiscard]] bool
+    try_lock()
+    {
+        return (bits_.fetch_or(mask_, std::memory_order_acquire) & mask_) == 0;
+    }
+
+    void
+    lock()
+    {
+        while (!try_lock())
+        {
+            // The use of relaxed memory ordering here is intentional and
+            // serves to help reduce cache coherency traffic during times
+            // of contention by avoiding writes that would definitely not
+            // result in the lock being acquired.
+            while ((bits_.load(std::memory_order_relaxed) & mask_) != 0)
+                detail::spin_pause();
+        }
+    }
+
+    void
+    unlock()
+    {
+        bits_.fetch_and(~mask_, std::memory_order_release);
+    }
+};
+
+/** A spinlock implemented on top of an atomic integer.
+
+    @note Using `packed_spinlock` and `spinlock` against the same underlying
+          atomic integer can result in `spinlock` not being able to actually
+          acquire the lock during periods of high contention, because of how
+          the two locks operate: `spinlock` will spin trying to grab all the
+          bits at once, whereas any given `packed_spinlock` will only try to
+          grab one bit at a time. Caveat emptor.
+
+    This class meets the requirements of Lockable:
+        https://en.cppreference.com/w/cpp/named_req/Lockable
+ */
+template <class T>
+class spinlock
+{
+    static_assert(std::is_unsigned_v<T>);
+    static_assert(std::atomic<T>::is_always_lock_free);
+
+private:
+    std::atomic<T>& lock_;
+
+public:
+    spinlock(spinlock const&) = delete;
+    spinlock&
+    operator=(spinlock const&) = delete;
+
+    /** Grabs the
+
+        @param lock The atomic integer to spin against.
+
+        @note For performance reasons, you should strive to have `lock` be
+              on a cacheline by itself.
+     */
+    spinlock(std::atomic<T>& lock) : lock_(lock)
+    {
+    }
+
+    [[nodiscard]] bool
+    try_lock()
+    {
+        T expected = 0;
+
+        return lock_.compare_exchange_weak(
+            expected,
+            std::numeric_limits<T>::max(),
+            std::memory_order_acquire,
+            std::memory_order_relaxed);
+    }
+
+    void
+    lock()
+    {
+        while (!try_lock())
+        {
+            // The use of relaxed memory ordering here is intentional and
+            // serves to help reduce cache coherency traffic during times
+            // of contention by avoiding writes that would definitely not
+            // result in the lock being acquired.
+            while (lock_.load(std::memory_order_relaxed) != 0)
+                detail::spin_pause();
+        }
+    }
+
+    void
+    unlock()
+    {
+        lock_.store(0, std::memory_order_release);
+    }
+};
+/** @} */
+
+}  // namespace ripple
+
+#endif

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -125,8 +125,6 @@ private:
     // Peer IDs expecting to receive a last link notification
     std::set<std::uint32_t> csIDs_;
 
-    std::optional<std::uint32_t> networkID_;
-
     reduce_relay::Slots<UptimeClock> slots_;
 
     // Transaction reduce-relay metrics
@@ -391,7 +389,7 @@ public:
     std::optional<std::uint32_t>
     networkID() const override
     {
-        return networkID_;
+        return setup_.networkID;
     }
 
     Json::Value

--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -782,9 +782,13 @@ public:
         // Must be handshaked!
         assert(slot->state() == Slot::active);
 
-        preprocess(slot, list);
-
         clock_type::time_point const now(m_clock.now());
+
+        // Limit how often we accept new endpoints
+        if (slot->whenAcceptEndpoints > now)
+            return;
+
+        preprocess(slot, list);
 
         for (auto const& ep : list)
         {

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -74,7 +74,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 49;
+static constexpr std::size_t numFeatures = 50;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -337,6 +337,7 @@ extern uint256 const featureNonFungibleTokensV1;
 extern uint256 const featureExpandedSignerList;
 extern uint256 const fixNFTokenDirV1;
 extern uint256 const fixNFTokenNegOffer;
+extern uint256 const featureNonFungibleTokensV1_1;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -74,7 +74,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 48;
+static constexpr std::size_t numFeatures = 49;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -336,6 +336,7 @@ extern uint256 const featureCheckCashMakesTrustLine;
 extern uint256 const featureNonFungibleTokensV1;
 extern uint256 const featureExpandedSignerList;
 extern uint256 const fixNFTokenDirV1;
+extern uint256 const fixNFTokenNegOffer;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "1.9.1"
+char const* const versionString = "1.9.2-rc1"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -431,7 +431,7 @@ REGISTER_FEATURE(RequireFullyCanonicalSig,      Supported::yes, DefaultVote::yes
 REGISTER_FIX    (fix1781,                       Supported::yes, DefaultVote::yes);
 REGISTER_FEATURE(HardenedValidations,           Supported::yes, DefaultVote::yes);
 REGISTER_FIX    (fixAmendmentMajorityCalc,      Supported::yes, DefaultVote::yes);
-REGISTER_FEATURE(NegativeUNL,                   Supported::yes, DefaultVote::no);
+REGISTER_FEATURE(NegativeUNL,                   Supported::yes, DefaultVote::yes);
 REGISTER_FEATURE(TicketBatch,                   Supported::yes, DefaultVote::yes);
 REGISTER_FEATURE(FlowSortStrands,               Supported::yes, DefaultVote::yes);
 REGISTER_FIX    (fixSTAmountCanonicalize,       Supported::yes, DefaultVote::yes);
@@ -440,6 +440,7 @@ REGISTER_FEATURE(CheckCashMakesTrustLine,       Supported::yes, DefaultVote::no)
 REGISTER_FEATURE(NonFungibleTokensV1,           Supported::yes, DefaultVote::no);
 REGISTER_FEATURE(ExpandedSignerList,            Supported::yes, DefaultVote::no);
 REGISTER_FIX    (fixNFTokenDirV1,               Supported::yes, DefaultVote::no);
+REGISTER_FIX    (fixNFTokenNegOffer,            Supported::yes, DefaultVote::no);
 
 // The following amendments have been active for at least two years. Their
 // pre-amendment code has been removed and the identifiers are deprecated.

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -441,6 +441,7 @@ REGISTER_FEATURE(NonFungibleTokensV1,           Supported::yes, DefaultVote::no)
 REGISTER_FEATURE(ExpandedSignerList,            Supported::yes, DefaultVote::no);
 REGISTER_FIX    (fixNFTokenDirV1,               Supported::yes, DefaultVote::no);
 REGISTER_FIX    (fixNFTokenNegOffer,            Supported::yes, DefaultVote::no);
+REGISTER_FEATURE(NonFungibleTokensV1_1,         Supported::yes, DefaultVote::no);
 
 // The following amendments have been active for at least two years. Their
 // pre-amendment code has been removed and the identifiers are deprecated.

--- a/src/ripple/protocol/impl/Rules.cpp
+++ b/src/ripple/protocol/impl/Rules.cpp
@@ -17,9 +17,8 @@
 */
 //==============================================================================
 
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/Rules.h>
-
-#include <ripple/protocol/Indexes.h>
 
 namespace ripple {
 
@@ -40,9 +39,8 @@ public:
         std::unordered_set<uint256, beast::uhash<>> const& presets,
         std::optional<uint256> const& digest,
         STVector256 const& amendments)
-        : presets_(presets)
+        : presets_(presets), digest_(digest)
     {
-        digest_ = digest;
         set_.reserve(amendments.size());
         set_.insert(amendments.begin(), amendments.end());
     }
@@ -83,6 +81,18 @@ bool
 Rules::enabled(uint256 const& feature) const
 {
     assert(impl_);
+
+    // The functionality of the "NonFungibleTokensV1_1" amendment is
+    // precisely the functionality of the following three amendments
+    // so if their status is ever queried individually, we inject an
+    // extra check here to simplify the checking elsewhere.
+    if (feature == featureNonFungibleTokensV1 ||
+        feature == fixNFTokenNegOffer || feature == fixNFTokenDirV1)
+    {
+        if (impl_->enabled(featureNonFungibleTokensV1_1))
+            return true;
+    }
+
     return impl_->enabled(feature);
 }
 

--- a/src/ripple/protocol/impl/Rules.cpp
+++ b/src/ripple/protocol/impl/Rules.cpp
@@ -39,7 +39,7 @@ public:
         std::unordered_set<uint256, beast::uhash<>> const& presets,
         std::optional<uint256> const& digest,
         STVector256 const& amendments)
-        : presets_(presets), digest_(digest)
+        : digest_(digest), presets_(presets)
     {
         set_.reserve(amendments.size());
         set_.insert(amendments.begin(), amendments.end());

--- a/src/ripple/rpc/BookChanges.h
+++ b/src/ripple/rpc/BookChanges.h
@@ -18,7 +18,7 @@
 //==============================================================================
 
 #ifndef RIPPLE_RPC_BOOKCHANGES_H_INCLUDED
-#define RIPPLE_RPC_BOOKCAHNGES_H_INCLUDED
+#define RIPPLE_RPC_BOOKCHANGES_H_INCLUDED
 
 namespace Json {
 class Value;

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -873,9 +873,23 @@ ServerHandlerImp::processRequest(
             params,
             {user, forwardedFor}};
         Json::Value result;
+
         auto start = std::chrono::system_clock::now();
-        RPC::doCommand(context, result);
+
+        try
+        {
+            RPC::doCommand(context, result);
+        }
+        catch (std::exception const& ex)
+        {
+            result = RPC::make_error(rpcINTERNAL);
+            JLOG(m_journal.error()) << "Internal error : " << ex.what()
+                                    << " when processing request: "
+                                    << Json::Compact{Json::Value{params}};
+        }
+
         auto end = std::chrono::system_clock::now();
+
         logDuration(params, end - start, m_journal);
 
         usage.charge(loadType);

--- a/src/test/app/LedgerLoad_test.cpp
+++ b/src/test/app/LedgerLoad_test.cpp
@@ -21,11 +21,12 @@
 #include <ripple/beast/utility/temp_dir.h>
 #include <ripple/protocol/SField.h>
 #include <ripple/protocol/jss.h>
+#include <test/jtx.h>
+#include <test/jtx/Env.h>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <fstream>
-#include <test/jtx.h>
-#include <test/jtx/Env.h>
 
 namespace ripple {
 
@@ -111,7 +112,9 @@ class LedgerLoad_test : public beast::unit_test::suite
         Env env(
             *this,
             envconfig(
-                ledgerConfig, sd.dbPath, sd.ledgerFile, Config::LOAD_FILE));
+                ledgerConfig, sd.dbPath, sd.ledgerFile, Config::LOAD_FILE),
+            nullptr,
+            beast::severities::kDisabled);
         auto jrb = env.rpc("ledger", "current", "full")[jss::result];
         BEAST_EXPECT(
             sd.ledger[jss::ledger][jss::accountState].size() ==
@@ -129,7 +132,9 @@ class LedgerLoad_test : public beast::unit_test::suite
         except([&] {
             Env env(
                 *this,
-                envconfig(ledgerConfig, sd.dbPath, "", Config::LOAD_FILE));
+                envconfig(ledgerConfig, sd.dbPath, "", Config::LOAD_FILE),
+                nullptr,
+                beast::severities::kDisabled);
         });
 
         // file does not exist
@@ -137,10 +142,9 @@ class LedgerLoad_test : public beast::unit_test::suite
             Env env(
                 *this,
                 envconfig(
-                    ledgerConfig,
-                    sd.dbPath,
-                    "badfile.json",
-                    Config::LOAD_FILE));
+                    ledgerConfig, sd.dbPath, "badfile.json", Config::LOAD_FILE),
+                nullptr,
+                beast::severities::kDisabled);
         });
 
         // make a corrupted version of the ledger file (last 10 bytes removed).
@@ -168,7 +172,9 @@ class LedgerLoad_test : public beast::unit_test::suite
                     ledgerConfig,
                     sd.dbPath,
                     ledgerFileCorrupt.string(),
-                    Config::LOAD_FILE));
+                    Config::LOAD_FILE),
+                nullptr,
+                beast::severities::kDisabled);
         });
     }
 
@@ -183,7 +189,9 @@ class LedgerLoad_test : public beast::unit_test::suite
         boost::erase_all(ledgerHash, "\"");
         Env env(
             *this,
-            envconfig(ledgerConfig, sd.dbPath, ledgerHash, Config::LOAD));
+            envconfig(ledgerConfig, sd.dbPath, ledgerHash, Config::LOAD),
+            nullptr,
+            beast::severities::kDisabled);
         auto jrb = env.rpc("ledger", "current", "full")[jss::result];
         BEAST_EXPECT(jrb[jss::ledger][jss::accountState].size() == 97);
         BEAST_EXPECT(
@@ -199,7 +207,10 @@ class LedgerLoad_test : public beast::unit_test::suite
 
         // create a new env with the ledger "latest" specified for startup
         Env env(
-            *this, envconfig(ledgerConfig, sd.dbPath, "latest", Config::LOAD));
+            *this,
+            envconfig(ledgerConfig, sd.dbPath, "latest", Config::LOAD),
+            nullptr,
+            beast::severities::kDisabled);
         auto jrb = env.rpc("ledger", "current", "full")[jss::result];
         BEAST_EXPECT(
             sd.ledger[jss::ledger][jss::accountState].size() ==
@@ -213,7 +224,11 @@ class LedgerLoad_test : public beast::unit_test::suite
         using namespace test::jtx;
 
         // create a new env with specific ledger index at startup
-        Env env(*this, envconfig(ledgerConfig, sd.dbPath, "43", Config::LOAD));
+        Env env(
+            *this,
+            envconfig(ledgerConfig, sd.dbPath, "43", Config::LOAD),
+            nullptr,
+            beast::severities::kDisabled);
         auto jrb = env.rpc("ledger", "current", "full")[jss::result];
         BEAST_EXPECT(
             sd.ledger[jss::ledger][jss::accountState].size() ==

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -465,7 +465,7 @@ struct LedgerServer
         assert(param.initLedgers > 0);
         createAccounts(param.initAccounts);
         createLedgerHistory();
-        app.logs().threshold(beast::severities::Severity::kWarning);
+        app.logs().threshold(beast::severities::kWarning);
     }
 
     /**
@@ -567,7 +567,10 @@ public:
         PeerSetBehavior behavior = PeerSetBehavior::Good,
         InboundLedgersBehavior inboundBhvr = InboundLedgersBehavior::Good,
         PeerFeature peerFeature = PeerFeature::LedgerReplayEnabled)
-        : env(suite, jtx::envconfig(jtx::port_increment, 3))
+        : env(suite,
+              jtx::envconfig(jtx::port_increment, 3),
+              nullptr,
+              beast::severities::kDisabled)
         , app(env.app())
         , ledgerMaster(env.app().getLedgerMaster())
         , inboundLedgers(

--- a/src/test/app/NFTokenDir_test.cpp
+++ b/src/test/app/NFTokenDir_test.cpp
@@ -388,7 +388,12 @@ class NFTokenDir_test : public beast::unit_test::suite
         auto exerciseFixNFTokenDirV1 =
             [this,
              &features](std::initializer_list<std::string_view const> seeds) {
-                Env env{*this, features};
+                Env env{
+                    *this,
+                    envconfig(),
+                    features,
+                    nullptr,
+                    beast::severities::kDisabled};
 
                 // Eventually all of the NFTokens will be owned by buyer.
                 Account const buyer{"buyer"};

--- a/src/test/app/NFTokenDir_test.cpp
+++ b/src/test/app/NFTokenDir_test.cpp
@@ -1075,7 +1075,8 @@ public:
     {
         using namespace test::jtx;
         FeatureBitset const all{supported_amendments()};
-        FeatureBitset const fixNFTDir{fixNFTokenDirV1};
+        FeatureBitset const fixNFTDir{
+            fixNFTokenDirV1, featureNonFungibleTokensV1_1};
 
         testWithFeats(all - fixNFTDir);
         testWithFeats(all);

--- a/src/test/app/NFToken_test.cpp
+++ b/src/test/app/NFToken_test.cpp
@@ -96,7 +96,10 @@ class NFToken_test : public beast::unit_test::suite
         {
             // If the NFT amendment is not enabled, you should not be able
             // to create or burn NFTs.
-            Env env{*this, features - featureNonFungibleTokensV1};
+            Env env{
+                *this,
+                features - featureNonFungibleTokensV1 -
+                    featureNonFungibleTokensV1_1};
             Account const& master = env.master;
 
             BEAST_EXPECT(ownerCount(env, master) == 0);
@@ -4650,7 +4653,8 @@ class NFToken_test : public beast::unit_test::suite
 
         // Test both with and without fixNFTokenNegOffer
         for (auto const& tweakedFeatures :
-             {features - fixNFTokenNegOffer, features | fixNFTokenNegOffer})
+             {features - fixNFTokenNegOffer - featureNonFungibleTokensV1_1,
+              features | fixNFTokenNegOffer})
         {
             // There was a bug in the initial NFT implementation that
             // allowed offers to be placed with negative amounts.  Verify
@@ -4759,7 +4763,9 @@ class NFToken_test : public beast::unit_test::suite
         // Test what happens if NFTokenOffers are created with negative amounts
         // and then fixNFTokenNegOffer goes live.  What does an acceptOffer do?
         {
-            Env env{*this, features - fixNFTokenNegOffer};
+            Env env{
+                *this,
+                features - fixNFTokenNegOffer - featureNonFungibleTokensV1_1};
 
             env.fund(XRP(1000000), issuer, buyer, gw);
             env.close();
@@ -4844,7 +4850,8 @@ class NFToken_test : public beast::unit_test::suite
         // Test buy offers with a destination with and without
         // fixNFTokenNegOffer.
         for (auto const& tweakedFeatures :
-             {features - fixNFTokenNegOffer, features | fixNFTokenNegOffer})
+             {features - fixNFTokenNegOffer - featureNonFungibleTokensV1_1,
+              features | fixNFTokenNegOffer})
         {
             Env env{*this, tweakedFeatures};
 

--- a/src/test/app/NFToken_test.cpp
+++ b/src/test/app/NFToken_test.cpp
@@ -2666,7 +2666,7 @@ class NFToken_test : public beast::unit_test::suite
         env.close();
 
         // Test how adding a Destination field to an offer affects permissions
-        // for cancelling offers.
+        // for canceling offers.
         {
             uint256 const offerMinterToIssuer =
                 keylet::nftoffer(minter, env.seq(minter)).key;
@@ -2680,14 +2680,20 @@ class NFToken_test : public beast::unit_test::suite
                 token::destination(buyer),
                 txflags(tfSellNFToken));
 
-            // buy offers cannot contain a Destination, so this attempt fails.
+            uint256 const offerIssuerToMinter =
+                keylet::nftoffer(issuer, env.seq(issuer)).key;
             env(token::createOffer(issuer, nftokenID, drops(1)),
                 token::owner(minter),
-                token::destination(minter),
-                ter(temMALFORMED));
+                token::destination(minter));
+
+            uint256 const offerIssuerToBuyer =
+                keylet::nftoffer(issuer, env.seq(issuer)).key;
+            env(token::createOffer(issuer, nftokenID, drops(1)),
+                token::owner(minter),
+                token::destination(buyer));
 
             env.close();
-            BEAST_EXPECT(ownerCount(env, issuer) == 0);
+            BEAST_EXPECT(ownerCount(env, issuer) == 2);
             BEAST_EXPECT(ownerCount(env, minter) == 3);
             BEAST_EXPECT(ownerCount(env, buyer) == 0);
 
@@ -2702,8 +2708,12 @@ class NFToken_test : public beast::unit_test::suite
                 ter(tecNO_PERMISSION));
             env(token::cancelOffer(buyer, {offerMinterToIssuer}),
                 ter(tecNO_PERMISSION));
+            env(token::cancelOffer(buyer, {offerIssuerToMinter}),
+                ter(tecNO_PERMISSION));
+            env(token::cancelOffer(minter, {offerIssuerToBuyer}),
+                ter(tecNO_PERMISSION));
             env.close();
-            BEAST_EXPECT(ownerCount(env, issuer) == 0);
+            BEAST_EXPECT(ownerCount(env, issuer) == 2);
             BEAST_EXPECT(ownerCount(env, minter) == 3);
             BEAST_EXPECT(ownerCount(env, buyer) == 0);
 
@@ -2711,6 +2721,8 @@ class NFToken_test : public beast::unit_test::suite
             // cancel the offers.
             env(token::cancelOffer(buyer, {offerMinterToBuyer}));
             env(token::cancelOffer(minter, {offerMinterToIssuer}));
+            env(token::cancelOffer(buyer, {offerIssuerToBuyer}));
+            env(token::cancelOffer(issuer, {offerIssuerToMinter}));
             env.close();
             BEAST_EXPECT(ownerCount(env, issuer) == 0);
             BEAST_EXPECT(ownerCount(env, minter) == 1);
@@ -2720,7 +2732,7 @@ class NFToken_test : public beast::unit_test::suite
         // Test how adding a Destination field to a sell offer affects
         // accepting that offer.
         {
-            uint256 const offerMinterToBuyer =
+            uint256 const offerMinterSellsToBuyer =
                 keylet::nftoffer(minter, env.seq(minter)).key;
             env(token::createOffer(minter, nftokenID, drops(1)),
                 token::destination(buyer),
@@ -2732,7 +2744,7 @@ class NFToken_test : public beast::unit_test::suite
 
             // issuer cannot accept a sell offer where they are not the
             // destination.
-            env(token::acceptSellOffer(issuer, offerMinterToBuyer),
+            env(token::acceptSellOffer(issuer, offerMinterSellsToBuyer),
                 ter(tecNO_PERMISSION));
             env.close();
             BEAST_EXPECT(ownerCount(env, issuer) == 0);
@@ -2740,36 +2752,61 @@ class NFToken_test : public beast::unit_test::suite
             BEAST_EXPECT(ownerCount(env, buyer) == 0);
 
             // However buyer can accept the sell offer.
-            env(token::acceptSellOffer(buyer, offerMinterToBuyer));
+            env(token::acceptSellOffer(buyer, offerMinterSellsToBuyer));
             env.close();
             BEAST_EXPECT(ownerCount(env, issuer) == 0);
             BEAST_EXPECT(ownerCount(env, minter) == 0);
             BEAST_EXPECT(ownerCount(env, buyer) == 1);
         }
 
-        // You can't add a Destination field to a buy offer.
+        // Test how adding a Destination field to a buy offer affects
+        // accepting that offer.
         {
-            env(token::createOffer(minter, nftokenID, drops(1)),
-                token::owner(buyer),
-                token::destination(buyer),
-                ter(temMALFORMED));
-            env.close();
-            BEAST_EXPECT(ownerCount(env, issuer) == 0);
-            BEAST_EXPECT(ownerCount(env, minter) == 0);
-            BEAST_EXPECT(ownerCount(env, buyer) == 1);
-
-            // However without the Destination the buy offer works fine.
-            uint256 const offerMinterToBuyer =
+            uint256 const offerMinterBuysFromBuyer =
                 keylet::nftoffer(minter, env.seq(minter)).key;
             env(token::createOffer(minter, nftokenID, drops(1)),
-                token::owner(buyer));
+                token::owner(buyer),
+                token::destination(buyer));
+            env.close();
+            BEAST_EXPECT(ownerCount(env, issuer) == 0);
+            BEAST_EXPECT(ownerCount(env, minter) == 1);
+            BEAST_EXPECT(ownerCount(env, buyer) == 1);
+
+            // issuer cannot accept a buy offer where they are the
+            // destination.
+            env(token::acceptBuyOffer(issuer, offerMinterBuysFromBuyer),
+                ter(tecNO_PERMISSION));
             env.close();
             BEAST_EXPECT(ownerCount(env, issuer) == 0);
             BEAST_EXPECT(ownerCount(env, minter) == 1);
             BEAST_EXPECT(ownerCount(env, buyer) == 1);
 
             // Buyer accepts minter's offer.
-            env(token::acceptBuyOffer(buyer, offerMinterToBuyer));
+            env(token::acceptBuyOffer(buyer, offerMinterBuysFromBuyer));
+            env.close();
+            BEAST_EXPECT(ownerCount(env, issuer) == 0);
+            BEAST_EXPECT(ownerCount(env, minter) == 1);
+            BEAST_EXPECT(ownerCount(env, buyer) == 0);
+
+            // If a destination other than the NFToken owner is set, that
+            // destination must act as a broker.  The NFToken owner may not
+            // simply accept the offer.
+            uint256 const offerBuyerBuysFromMinter =
+                keylet::nftoffer(buyer, env.seq(buyer)).key;
+            env(token::createOffer(buyer, nftokenID, drops(1)),
+                token::owner(minter),
+                token::destination(broker));
+            env.close();
+            BEAST_EXPECT(ownerCount(env, issuer) == 0);
+            BEAST_EXPECT(ownerCount(env, minter) == 1);
+            BEAST_EXPECT(ownerCount(env, buyer) == 1);
+
+            env(token::acceptBuyOffer(minter, offerBuyerBuysFromMinter),
+                ter(tecNO_PERMISSION));
+            env.close();
+
+            // Clean up the unused offer.
+            env(token::cancelOffer(buyer, {offerBuyerBuysFromMinter}));
             env.close();
             BEAST_EXPECT(ownerCount(env, issuer) == 0);
             BEAST_EXPECT(ownerCount(env, minter) == 1);
@@ -2856,6 +2893,47 @@ class NFToken_test : public beast::unit_test::suite
             BEAST_EXPECT(ownerCount(env, issuer) == 1);
             BEAST_EXPECT(ownerCount(env, minter) == 1);
             BEAST_EXPECT(ownerCount(env, buyer) == 0);
+
+            // Clean out the unconsumed offer.
+            env(token::cancelOffer(issuer, {offerIssuerToBuyer}));
+            env.close();
+            BEAST_EXPECT(ownerCount(env, issuer) == 0);
+            BEAST_EXPECT(ownerCount(env, minter) == 1);
+            BEAST_EXPECT(ownerCount(env, buyer) == 0);
+        }
+
+        // Show that if a buy and a sell offer both have the same destination,
+        // then that destination can broker the offers.
+        {
+            uint256 const offerMinterToBroker =
+                keylet::nftoffer(minter, env.seq(minter)).key;
+            env(token::createOffer(minter, nftokenID, drops(1)),
+                token::destination(broker),
+                txflags(tfSellNFToken));
+
+            uint256 const offerBuyerToBroker =
+                keylet::nftoffer(buyer, env.seq(buyer)).key;
+            env(token::createOffer(buyer, nftokenID, drops(1)),
+                token::owner(minter),
+                token::destination(broker));
+
+            // Cannot broker offers when the sell destination is not the buyer
+            // or the broker.
+            env(token::brokerOffers(
+                    issuer, offerBuyerToBroker, offerMinterToBroker),
+                ter(tecNFTOKEN_BUY_SELL_MISMATCH));
+            env.close();
+            BEAST_EXPECT(ownerCount(env, issuer) == 0);
+            BEAST_EXPECT(ownerCount(env, minter) == 2);
+            BEAST_EXPECT(ownerCount(env, buyer) == 1);
+
+            // Broker is successful if they are the destination of both offers.
+            env(token::brokerOffers(
+                broker, offerBuyerToBroker, offerMinterToBroker));
+            env.close();
+            BEAST_EXPECT(ownerCount(env, issuer) == 0);
+            BEAST_EXPECT(ownerCount(env, minter) == 0);
+            BEAST_EXPECT(ownerCount(env, buyer) == 1);
         }
     }
 
@@ -4558,6 +4636,239 @@ class NFToken_test : public beast::unit_test::suite
     }
 
     void
+    testFixNFTokenNegOffer(FeatureBitset features)
+    {
+        // Exercise changes introduced by fixNFTokenNegOffer.
+        using namespace test::jtx;
+
+        testcase("fixNFTokenNegOffer");
+
+        Account const issuer{"issuer"};
+        Account const buyer{"buyer"};
+        Account const gw{"gw"};
+        IOU const gwXAU(gw["XAU"]);
+
+        // Test both with and without fixNFTokenNegOffer
+        for (auto const& tweakedFeatures :
+             {features - fixNFTokenNegOffer, features | fixNFTokenNegOffer})
+        {
+            // There was a bug in the initial NFT implementation that
+            // allowed offers to be placed with negative amounts.  Verify
+            // that fixNFTokenNegOffer addresses the problem.
+            Env env{*this, tweakedFeatures};
+
+            env.fund(XRP(1000000), issuer, buyer, gw);
+            env.close();
+
+            env(trust(issuer, gwXAU(2000)));
+            env(trust(buyer, gwXAU(2000)));
+            env.close();
+
+            env(pay(gw, issuer, gwXAU(1000)));
+            env(pay(gw, buyer, gwXAU(1000)));
+            env.close();
+
+            // Create an NFT that we'll make XRP offers for.
+            uint256 const nftID0{
+                token::getNextID(env, issuer, 0u, tfTransferable)};
+            env(token::mint(issuer, 0), txflags(tfTransferable));
+            env.close();
+
+            // Create an NFT that we'll make IOU offers for.
+            uint256 const nftID1{
+                token::getNextID(env, issuer, 1u, tfTransferable)};
+            env(token::mint(issuer, 1), txflags(tfTransferable));
+            env.close();
+
+            TER const offerCreateTER = tweakedFeatures[fixNFTokenNegOffer]
+                ? static_cast<TER>(temBAD_AMOUNT)
+                : static_cast<TER>(tesSUCCESS);
+
+            // Make offers with negative amounts for the NFTs
+            uint256 const sellNegXrpOfferIndex =
+                keylet::nftoffer(issuer, env.seq(issuer)).key;
+            env(token::createOffer(issuer, nftID0, XRP(-2)),
+                txflags(tfSellNFToken),
+                ter(offerCreateTER));
+            env.close();
+
+            uint256 const sellNegIouOfferIndex =
+                keylet::nftoffer(issuer, env.seq(issuer)).key;
+            env(token::createOffer(issuer, nftID1, gwXAU(-2)),
+                txflags(tfSellNFToken),
+                ter(offerCreateTER));
+            env.close();
+
+            uint256 const buyNegXrpOfferIndex =
+                keylet::nftoffer(buyer, env.seq(buyer)).key;
+            env(token::createOffer(buyer, nftID0, XRP(-1)),
+                token::owner(issuer),
+                ter(offerCreateTER));
+            env.close();
+
+            uint256 const buyNegIouOfferIndex =
+                keylet::nftoffer(buyer, env.seq(buyer)).key;
+            env(token::createOffer(buyer, nftID1, gwXAU(-1)),
+                token::owner(issuer),
+                ter(offerCreateTER));
+            env.close();
+
+            {
+                // Now try to accept the offers.
+                //  1. If fixNFTokenNegOffer is NOT enabled get tecINTERNAL.
+                //  2. If fixNFTokenNegOffer IS enabled get tecOBJECT_NOT_FOUND.
+                TER const offerAcceptTER = tweakedFeatures[fixNFTokenNegOffer]
+                    ? static_cast<TER>(tecOBJECT_NOT_FOUND)
+                    : static_cast<TER>(tecINTERNAL);
+
+                // Sell offers.
+                env(token::acceptSellOffer(buyer, sellNegXrpOfferIndex),
+                    ter(offerAcceptTER));
+                env.close();
+                env(token::acceptSellOffer(buyer, sellNegIouOfferIndex),
+                    ter(offerAcceptTER));
+                env.close();
+
+                // Buy offers.
+                env(token::acceptBuyOffer(issuer, buyNegXrpOfferIndex),
+                    ter(offerAcceptTER));
+                env.close();
+                env(token::acceptBuyOffer(issuer, buyNegIouOfferIndex),
+                    ter(offerAcceptTER));
+                env.close();
+            }
+            {
+                //  1. If fixNFTokenNegOffer is NOT enabled get tecSUCCESS.
+                //  2. If fixNFTokenNegOffer IS enabled get tecOBJECT_NOT_FOUND.
+                TER const offerAcceptTER = tweakedFeatures[fixNFTokenNegOffer]
+                    ? static_cast<TER>(tecOBJECT_NOT_FOUND)
+                    : static_cast<TER>(tesSUCCESS);
+
+                // Brokered offers.
+                env(token::brokerOffers(
+                        gw, buyNegXrpOfferIndex, sellNegXrpOfferIndex),
+                    ter(offerAcceptTER));
+                env.close();
+                env(token::brokerOffers(
+                        gw, buyNegIouOfferIndex, sellNegIouOfferIndex),
+                    ter(offerAcceptTER));
+                env.close();
+            }
+        }
+
+        // Test what happens if NFTokenOffers are created with negative amounts
+        // and then fixNFTokenNegOffer goes live.  What does an acceptOffer do?
+        {
+            Env env{*this, features - fixNFTokenNegOffer};
+
+            env.fund(XRP(1000000), issuer, buyer, gw);
+            env.close();
+
+            env(trust(issuer, gwXAU(2000)));
+            env(trust(buyer, gwXAU(2000)));
+            env.close();
+
+            env(pay(gw, issuer, gwXAU(1000)));
+            env(pay(gw, buyer, gwXAU(1000)));
+            env.close();
+
+            // Create an NFT that we'll make XRP offers for.
+            uint256 const nftID0{
+                token::getNextID(env, issuer, 0u, tfTransferable)};
+            env(token::mint(issuer, 0), txflags(tfTransferable));
+            env.close();
+
+            // Create an NFT that we'll make IOU offers for.
+            uint256 const nftID1{
+                token::getNextID(env, issuer, 1u, tfTransferable)};
+            env(token::mint(issuer, 1), txflags(tfTransferable));
+            env.close();
+
+            // Make offers with negative amounts for the NFTs
+            uint256 const sellNegXrpOfferIndex =
+                keylet::nftoffer(issuer, env.seq(issuer)).key;
+            env(token::createOffer(issuer, nftID0, XRP(-2)),
+                txflags(tfSellNFToken));
+            env.close();
+
+            uint256 const sellNegIouOfferIndex =
+                keylet::nftoffer(issuer, env.seq(issuer)).key;
+            env(token::createOffer(issuer, nftID1, gwXAU(-2)),
+                txflags(tfSellNFToken));
+            env.close();
+
+            uint256 const buyNegXrpOfferIndex =
+                keylet::nftoffer(buyer, env.seq(buyer)).key;
+            env(token::createOffer(buyer, nftID0, XRP(-1)),
+                token::owner(issuer));
+            env.close();
+
+            uint256 const buyNegIouOfferIndex =
+                keylet::nftoffer(buyer, env.seq(buyer)).key;
+            env(token::createOffer(buyer, nftID1, gwXAU(-1)),
+                token::owner(issuer));
+            env.close();
+
+            // Now the amendment passes.
+            env.enableFeature(fixNFTokenNegOffer);
+            env.close();
+
+            // All attempts to accept the offers with negative amounts
+            // should fail with temBAD_OFFER.
+            env(token::acceptSellOffer(buyer, sellNegXrpOfferIndex),
+                ter(temBAD_OFFER));
+            env.close();
+            env(token::acceptSellOffer(buyer, sellNegIouOfferIndex),
+                ter(temBAD_OFFER));
+            env.close();
+
+            // Buy offers.
+            env(token::acceptBuyOffer(issuer, buyNegXrpOfferIndex),
+                ter(temBAD_OFFER));
+            env.close();
+            env(token::acceptBuyOffer(issuer, buyNegIouOfferIndex),
+                ter(temBAD_OFFER));
+            env.close();
+
+            // Brokered offers.
+            env(token::brokerOffers(
+                    gw, buyNegXrpOfferIndex, sellNegXrpOfferIndex),
+                ter(temBAD_OFFER));
+            env.close();
+            env(token::brokerOffers(
+                    gw, buyNegIouOfferIndex, sellNegIouOfferIndex),
+                ter(temBAD_OFFER));
+            env.close();
+        }
+
+        // Test buy offers with a destination with and without
+        // fixNFTokenNegOffer.
+        for (auto const& tweakedFeatures :
+             {features - fixNFTokenNegOffer, features | fixNFTokenNegOffer})
+        {
+            Env env{*this, tweakedFeatures};
+
+            env.fund(XRP(1000000), issuer, buyer);
+
+            // Create an NFT that we'll make offers for.
+            uint256 const nftID{
+                token::getNextID(env, issuer, 0u, tfTransferable)};
+            env(token::mint(issuer, 0), txflags(tfTransferable));
+            env.close();
+
+            TER const offerCreateTER = tweakedFeatures[fixNFTokenNegOffer]
+                ? static_cast<TER>(tesSUCCESS)
+                : static_cast<TER>(temMALFORMED);
+
+            env(token::createOffer(buyer, nftID, drops(1)),
+                token::owner(issuer),
+                token::destination(issuer),
+                ter(offerCreateTER));
+            env.close();
+        }
+    }
+
+    void
     testWithFeats(FeatureBitset features)
     {
         testEnabled(features);
@@ -4584,6 +4895,7 @@ class NFToken_test : public beast::unit_test::suite
         testNFTokenWithTickets(features);
         testNFTokenDeleteAccount(features);
         testNftXxxOffers(features);
+        testFixNFTokenNegOffer(features);
     }
 
 public:

--- a/src/test/app/ValidatorKeys_test.cpp
+++ b/src/test/app/ValidatorKeys_test.cpp
@@ -23,8 +23,9 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>
+#include <test/jtx/Env.h>
+
 #include <string>
-#include <test/unit_test/SuiteJournal.h>
 
 namespace ripple {
 namespace test {
@@ -75,7 +76,14 @@ public:
     void
     run() override
     {
-        SuiteJournal journal("ValidatorKeys_test", *this);
+        // We're only using Env for its Journal.  That Journal gives better
+        // coverage in unit tests.
+        test::jtx::Env env{
+            *this,
+            test::jtx::envconfig(),
+            nullptr,
+            beast::severities::kDisabled};
+        beast::Journal journal{env.app().journal("ValidatorKeys_test")};
 
         // Keys/ID when using [validation_seed]
         SecretKey const seedSecretKey =

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -29,8 +29,9 @@
 #include <ripple/protocol/digest.h>
 #include <ripple/protocol/jss.h>
 #include <ripple/protocol/messages.h>
-#include <boost/beast/core/multi_buffer.hpp>
 #include <test/jtx.h>
+
+#include <boost/beast/core/multi_buffer.hpp>
 
 namespace ripple {
 namespace test {
@@ -217,7 +218,8 @@ private:
     {
         testcase("Config Load");
 
-        jtx::Env env(*this);
+        jtx::Env env(
+            *this, jtx::envconfig(), nullptr, beast::severities::kDisabled);
         auto& app = env.app();
         PublicKey emptyLocalKey;
         std::vector<std::string> const emptyCfgKeys;

--- a/src/test/app/ValidatorSite_test.cpp
+++ b/src/test/app/ValidatorSite_test.cpp
@@ -69,7 +69,7 @@ private:
 
         using namespace jtx;
 
-        Env env(*this);
+        Env env(*this, envconfig(), nullptr, beast::severities::kDisabled);
         auto trustedSites =
             std::make_unique<ValidatorSite>(env.app(), env.journal);
 
@@ -282,9 +282,6 @@ private:
             if (u.cfg.failFetch)
             {
                 using namespace std::chrono;
-                log << " -- Msg: "
-                    << myStatus[jss::last_refresh_message].asString()
-                    << std::endl;
                 std::stringstream nextRefreshStr{
                     myStatus[jss::next_refresh_time].asString()};
                 system_clock::time_point nextRefresh;
@@ -357,9 +354,6 @@ private:
                     sink.messages().str().find(u.expectMsg) !=
                         std::string::npos,
                     sink.messages().str());
-                log << " -- Msg: "
-                    << myStatus[jss::last_refresh_message].asString()
-                    << std::endl;
             }
         }
     }

--- a/src/test/basics/PerfLog_test.cpp
+++ b/src/test/basics/PerfLog_test.cpp
@@ -24,12 +24,13 @@
 #include <ripple/json/json_reader.h>
 #include <ripple/protocol/jss.h>
 #include <ripple/rpc/impl/Handler.h>
+#include <test/jtx/Env.h>
+
 #include <atomic>
 #include <chrono>
 #include <cmath>
 #include <random>
 #include <string>
-#include <test/jtx/Env.h>
 #include <thread>
 
 //------------------------------------------------------------------------------
@@ -44,7 +45,11 @@ class PerfLog_test : public beast::unit_test::suite
 
     // We're only using Env for its Journal.  That Journal gives better
     // coverage in unit tests.
-    test::jtx::Env env_{*this};
+    test::jtx::Env env_{
+        *this,
+        test::jtx::envconfig(),
+        nullptr,
+        beast::severities::kDisabled};
     beast::Journal j_{env_.app().journal("PerfLog_test")};
 
     struct Fixture

--- a/src/test/basics/StringUtilities_test.cpp
+++ b/src/test/basics/StringUtilities_test.cpp
@@ -289,6 +289,13 @@ public:
             BEAST_EXPECT(!parseUrl(pUrl, "nonsense"));
             BEAST_EXPECT(!parseUrl(pUrl, "://"));
             BEAST_EXPECT(!parseUrl(pUrl, ":///"));
+            BEAST_EXPECT(
+                !parseUrl(pUrl, "scheme://user:pass@domain:65536/abc:321"));
+            BEAST_EXPECT(!parseUrl(pUrl, "UPPER://domain:23498765/"));
+            BEAST_EXPECT(!parseUrl(pUrl, "UPPER://domain:0/"));
+            BEAST_EXPECT(!parseUrl(pUrl, "UPPER://domain:+7/"));
+            BEAST_EXPECT(!parseUrl(pUrl, "UPPER://domain:-7234/"));
+            BEAST_EXPECT(!parseUrl(pUrl, "UPPER://domain:@#$56!/"));
         }
 
         {

--- a/src/test/beast/beast_io_latency_probe_test.cpp
+++ b/src/test/beast/beast_io_latency_probe_test.cpp
@@ -200,9 +200,6 @@ class io_latency_probe_test : public beast::unit_test::suite,
                 duration_cast<milliseconds>(probe_duration).count()) /
             static_cast<size_t>(tt.getMean<milliseconds>());
 #endif
-        log << "expected_probe_count_min: " << expected_probe_count_min << "\n";
-        log << "expected_probe_count_max: " << expected_probe_count_max << "\n";
-
         test_sampler io_probe{interval, get_io_service()};
         io_probe.start();
         MyTimer timer{get_io_service(), probe_duration};

--- a/src/test/core/ClosureCounter_test.cpp
+++ b/src/test/core/ClosureCounter_test.cpp
@@ -19,9 +19,10 @@
 
 #include <ripple/beast/unit_test.h>
 #include <ripple/core/ClosureCounter.h>
+#include <test/jtx/Env.h>
+
 #include <atomic>
 #include <chrono>
-#include <test/jtx/Env.h>
 #include <thread>
 
 namespace ripple {
@@ -31,9 +32,14 @@ namespace test {
 
 class ClosureCounter_test : public beast::unit_test::suite
 {
-    // We're only using Env for its Journal.
-    jtx::Env env{*this};
-    beast::Journal j{env.app().journal("ClosureCounter_test")};
+    // We're only using Env for its Journal.  That Journal gives better
+    // coverage in unit tests.
+    test::jtx::Env env_{
+        *this,
+        jtx::envconfig(),
+        nullptr,
+        beast::severities::kDisabled};
+    beast::Journal j{env_.app().journal("ClosureCounter_test")};
 
     void
     testConstruction()

--- a/src/test/core/Config_test.cpp
+++ b/src/test/core/Config_test.cpp
@@ -154,7 +154,7 @@ public:
         rmDataDir_ = !exists(dataDir_);
         config_.setup(
             file_.string(),
-            /*bQuiet*/ true,
+            /* bQuiet */ true,
             /* bSilent */ false,
             /* bStandalone */ false);
     }
@@ -190,9 +190,6 @@ public:
             using namespace boost::filesystem;
             if (rmDataDir_)
                 rmDir(dataDir_);
-            else
-                test_.log << "Skipping rm dir: " << dataDir_.string()
-                          << std::endl;
         }
         catch (std::exception& e)
         {

--- a/src/test/jtx/Env_test.cpp
+++ b/src/test/jtx/Env_test.cpp
@@ -888,10 +888,14 @@ public:
     testExceptionalShutdown()
     {
         except([this] {
-            jtx::Env env{*this, jtx::envconfig([](std::unique_ptr<Config> cfg) {
-                             (*cfg).deprecatedClearSection("port_rpc");
-                             return cfg;
-                         })};
+            jtx::Env env{
+                *this,
+                jtx::envconfig([](std::unique_ptr<Config> cfg) {
+                    (*cfg).deprecatedClearSection("port_rpc");
+                    return cfg;
+                }),
+                nullptr,
+                beast::severities::kDisabled};
         });
         pass();
     }

--- a/src/test/ledger/View_test.cpp
+++ b/src/test/ledger/View_test.cpp
@@ -130,6 +130,8 @@ class View_test : public beast::unit_test::suite
     void
     testLedger()
     {
+        testcase("Ledger");
+
         using namespace jtx;
         Env env(*this);
         Config config;
@@ -165,6 +167,8 @@ class View_test : public beast::unit_test::suite
     void
     testMeta()
     {
+        testcase("Meta");
+
         using namespace jtx;
         Env env(*this);
         wipe(env.app().openLedger());
@@ -196,6 +200,8 @@ class View_test : public beast::unit_test::suite
     void
     testMetaSucc()
     {
+        testcase("Meta succ");
+
         using namespace jtx;
         Env env(*this);
         wipe(env.app().openLedger());
@@ -260,6 +266,8 @@ class View_test : public beast::unit_test::suite
     void
     testStacked()
     {
+        testcase("Stacked");
+
         using namespace jtx;
         Env env(*this);
         wipe(env.app().openLedger());
@@ -325,6 +333,8 @@ class View_test : public beast::unit_test::suite
     void
     testContext()
     {
+        testcase("Context");
+
         using namespace jtx;
         using namespace std::chrono;
         {
@@ -387,6 +397,8 @@ class View_test : public beast::unit_test::suite
     void
     testUpperAndLowerBound()
     {
+        testcase("Upper and lower bound");
+
         using namespace jtx;
         Env env(*this);
         Config config;
@@ -654,6 +666,8 @@ class View_test : public beast::unit_test::suite
     void
     testSles()
     {
+        testcase("Sles");
+
         using namespace jtx;
         Env env(*this);
         Config config;
@@ -786,6 +800,8 @@ class View_test : public beast::unit_test::suite
     void
     testFlags()
     {
+        testcase("Flags");
+
         using namespace jtx;
         Env env(*this);
 
@@ -949,6 +965,8 @@ class View_test : public beast::unit_test::suite
     void
     testTransferRate()
     {
+        testcase("Transfer rate");
+
         using namespace jtx;
         Env env(*this);
 
@@ -975,12 +993,14 @@ class View_test : public beast::unit_test::suite
         // construct and manage two different Env instances at the same
         // time.  So we can use two Env instances to produce mutually
         // incompatible ledgers.
+        testcase("Are compatible");
+
         using namespace jtx;
         auto const alice = Account("alice");
         auto const bob = Account("bob");
 
         // The first Env.
-        Env eA(*this);
+        Env eA(*this, envconfig(), nullptr, beast::severities::kDisabled);
 
         eA.fund(XRP(10000), alice);
         eA.close();
@@ -990,9 +1010,13 @@ class View_test : public beast::unit_test::suite
         eA.close();
         auto const rdViewA4 = eA.closed();
 
-        // The two Env's can't share the same ports, so modifiy the config
+        // The two Env's can't share the same ports, so modify the config
         // of the second Env to use higher port numbers
-        Env eB{*this, envconfig(port_increment, 3)};
+        Env eB{
+            *this,
+            envconfig(port_increment, 3),
+            nullptr,
+            beast::severities::kDisabled};
 
         // Make ledgers that are incompatible with the first ledgers.  Note
         // that bob is funded before alice.
@@ -1029,6 +1053,8 @@ class View_test : public beast::unit_test::suite
     void
     testRegressions()
     {
+        testcase("Regressions");
+
         using namespace jtx;
 
         // Create a ledger with 1 item, put a

--- a/src/test/overlay/short_read_test.cpp
+++ b/src/test/overlay/short_read_test.cpp
@@ -195,8 +195,6 @@ private:
             {
                 acceptor_.listen();
                 server_.endpoint_ = acceptor_.local_endpoint();
-                test_.log << "[server] up on port: " << server_.endpoint_.port()
-                          << std::endl;
             }
 
             void

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -1250,13 +1250,10 @@ class LedgerRPC_test : public beast::unit_test::suite
                                           // no amendments
         env.fund(XRP(10000), "alice");
         env.close();
-        log << env.closed()->info().hash;
         env.fund(XRP(10000), "bob");
         env.close();
-        log << env.closed()->info().hash;
         env.fund(XRP(10000), "jim");
         env.close();
-        log << env.closed()->info().hash;
         env.fund(XRP(10000), "jill");
 
         {

--- a/src/test/rpc/NodeToShardRPC_test.cpp
+++ b/src/test/rpc/NodeToShardRPC_test.cpp
@@ -276,7 +276,8 @@ public:
             sectionNode.set("ledgers_per_shard", "256");
             c->setupControl(true, true, true);
 
-            return jtx::Env(*this, std::move(c));
+            return jtx::Env(
+                *this, std::move(c), nullptr, beast::severities::kDisabled);
         }();
 
         std::uint8_t const numberOfShards = 10;

--- a/src/test/rpc/ShardArchiveHandler_test.cpp
+++ b/src/test/rpc/ShardArchiveHandler_test.cpp
@@ -173,7 +173,8 @@ public:
         }
         c->setupControl(true, true, true);
 
-        jtx::Env env(*this, std::move(c));
+        jtx::Env env(
+            *this, std::move(c), nullptr, beast::severities::kDisabled);
 
         std::uint8_t const numberOfDownloads = 10;
 
@@ -276,7 +277,8 @@ public:
             }
             c->setupControl(true, true, true);
 
-            jtx::Env env(*this, std::move(c));
+            jtx::Env env(
+                *this, std::move(c), nullptr, beast::severities::kDisabled);
 
             std::uint8_t const numberOfDownloads = 10;
 
@@ -380,7 +382,8 @@ public:
         }
         c->setupControl(true, true, true);
 
-        jtx::Env env(*this, std::move(c));
+        jtx::Env env(
+            *this, std::move(c), nullptr, beast::severities::kDisabled);
         std::uint8_t const numberOfDownloads = 10;
 
         // Create some ledgers so that the ShardArchiveHandler

--- a/src/test/server/Server_test.cpp
+++ b/src/test/server/Server_test.cpp
@@ -299,7 +299,6 @@ public:
         serverPort.back().port = 0;
         serverPort.back().protocol.insert("http");
         auto eps = s->ports(serverPort);
-        log << "server listening on port " << eps[0].port() << std::endl;
         test_request(eps[0]);
         test_keepalive(eps[0]);
         // s->close();

--- a/src/test/shamap/SHAMapSync_test.cpp
+++ b/src/test/shamap/SHAMapSync_test.cpp
@@ -184,7 +184,6 @@ public:
 
         BEAST_EXPECT(source.deepCompare(destination));
 
-        log << "Checking destination invariants..." << std::endl;
         destination.invariants();
     }
 };

--- a/src/test/unit_test/FileDirGuard.h
+++ b/src/test/unit_test/FileDirGuard.h
@@ -86,9 +86,6 @@ public:
 
             if (rmSubDir_)
                 rmDir(subDir_);
-            else
-                test_.log << "Skipping rm dir: " << subDir_.string()
-                          << std::endl;
         }
         catch (std::exception& e)
         {


### PR DESCRIPTION
Roll-up PR for **1.9.2-rc**, the first release candidate for **1.9.2**, which introduces a fix for the amendment voting persistence issue described in #4220, as well as a fix for "negative offers" for NFTs.

Primarily, this release will introduce a new amendment, **`NonFungibleTokensV1_1`** which is a combination of three amendments: **`NonFungibleTokensV1`**, **`fixNFTokenDirV1`** and **`fixNFTokenNegOffer`**. The maintainers of the reference implementation of the protocol recommend that operators that wish to vote for activation of the XLS-20 NFT enhancements vote in favor of **`NonFungibleTokensV1_1`** instead of **`NonFungibleTokensV1`**.

If merged, this release will:

- close #4166
- close #4173 
- close #4178 
- close #4180 
- close #4182
- close #4183 
- close #4188 
- close #4202
- close #4204 
- close #4213
- close #4215 
- close #4221 
- close #4222 