### PR TITLE
Building RocksDB is optional

### DIFF
--- a/Builds/CMake/deps/Rocksdb.cmake
+++ b/Builds/CMake/deps/Rocksdb.cmake
@@ -2,7 +2,7 @@
    NIH dep: rocksdb
 #]===================================================================]
 
-option(use_rocksdb "build rocksdb" OFF)
+option(use_rocksdb "build rocksdb" ON)
 
 if(NOT use_rocksdb)
   return()

--- a/Builds/CMake/deps/Rocksdb.cmake
+++ b/Builds/CMake/deps/Rocksdb.cmake
@@ -2,6 +2,12 @@
    NIH dep: rocksdb
 #]===================================================================]
 
+option(use_rocksdb "build rocksdb" OFF)
+
+if(NOT use_rocksdb)
+  return()
+endif()
+
 add_library (rocksdb_lib UNKNOWN IMPORTED GLOBAL)
 set_target_properties (rocksdb_lib
   PROPERTIES INTERFACE_COMPILE_DEFINITIONS RIPPLE_ROCKSDB_AVAILABLE=1)


### PR DESCRIPTION
## High Level Overview of Change

RocksDB is not a hard requirement for rippled and there's been requests for this as many people have no need.


- [x] New feature (non-breaking change which adds functionality)
