### PR TITLE
Add fix for CMake OpenSSL root parameter

### DIFF
--- a/Builds/CMake/deps/OpenSSL.cmake
+++ b/Builds/CMake/deps/OpenSSL.cmake
@@ -8,7 +8,9 @@
   OPENSSL_ROOT vars to this
 #]===============================================]
 if (NOT DEFINED OPENSSL_ROOT_DIR)
-  if (DEFINED ENV{OPENSSL_ROOT})
+  if (DEFINED OPENSSL_ROOT)
+    set (OPENSSL_ROOT_DIR "${OPENSSL_ROOT}")
+  elseif (DEFINED ENV{OPENSSL_ROOT})
     set (OPENSSL_ROOT_DIR $ENV{OPENSSL_ROOT})
   elseif (HOMEBREW)
     execute_process (COMMAND ${HOMEBREW} --prefix openssl


### PR DESCRIPTION
The documentation incorrectly instructs to use OPENSSL_ROOT instead of OPENSSL_ROOT_DIR when creating build files with CMake.

This change copies the variable OPENSSL_ROOT to OPENSSL_ROOT_DIR whenever only the former is defined. This is to 
- statisfy the fixed requirement by CMake of calling the path OPENSSL_ROOT_DIR
- fix the documentation
- stay in conformity with the naming convention of BOOST_ROOT.