### PR TITLE
Implement changes for Issue 3417 

### DIFF
--- a/src/ripple/rpc/impl/Handler.h
+++ b/src/ripple/rpc/impl/Handler.h
@@ -39,8 +39,8 @@ namespace RPC {
 enum Condition {
     NO_CONDITION = 0,
     NEEDS_NETWORK_CONNECTION = 1,
-    NEEDS_CURRENT_LEDGER = 2 + NEEDS_NETWORK_CONNECTION,
-    NEEDS_CLOSED_LEDGER = 4 + NEEDS_NETWORK_CONNECTION,
+    NEEDS_CURRENT_LEDGER = 2 * NEEDS_NETWORK_CONNECTION,
+    NEEDS_CLOSED_LEDGER = 4 * NEEDS_NETWORK_CONNECTION,
 };
 
 struct Handler
@@ -94,20 +94,18 @@ conditionMet(Condition condition_required, T& context)
     }
 
     if (context.app.getOPs().isAmendmentBlocked() &&
-        (condition_required & NEEDS_CURRENT_LEDGER ||
-         condition_required & NEEDS_CLOSED_LEDGER))
+        (condition_required != NO_CONDITION))
     {
         return rpcAMENDMENT_BLOCKED;
     }
 
     if (context.app.getOPs().isUNLBlocked() &&
-        (condition_required & NEEDS_CURRENT_LEDGER ||
-         condition_required & NEEDS_CLOSED_LEDGER))
+        (condition_required != NO_CONDITION))
     {
         return rpcEXPIRED_VALIDATOR_LIST;
     }
 
-    if ((condition_required & NEEDS_NETWORK_CONNECTION) &&
+    if ((condition_required != NO_CONDITION) &&
         (context.netOps.getOperatingMode() < OperatingMode::SYNCING))
     {
         JLOG(context.j.info()) << "Insufficient network mode for RPC: "
@@ -119,7 +117,7 @@ conditionMet(Condition condition_required, T& context)
     }
 
     if (!context.app.config().standalone() &&
-        condition_required & NEEDS_CURRENT_LEDGER)
+        condition_required != NO_CONDITION)
     {
         if (context.ledgerMaster.getValidatedLedgerAge() >
             Tuning::maxValidatedLedgerAge)
@@ -143,7 +141,7 @@ conditionMet(Condition condition_required, T& context)
         }
     }
 
-    if ((condition_required & NEEDS_CLOSED_LEDGER) &&
+    if ((condition_required != NO_CONDITION) &&
         !context.ledgerMaster.getClosedLedger())
     {
         if (context.apiVersion == 1)


### PR DESCRIPTION
If merged, this code will:
- Implement the simplified condition evaluation
- removes the complex bitwise and(&) operator
- Implement the second proposed solution in Nik Bougalis's comment - https://github.com/XRPLF/rippled/issues/3417#issuecomment-635116233


I have tested this code change by performing RPC calls with the commands `server_info`, `server_state`, `peers` and `validation_info`. These commands worked as expected.