### PR TITLE
Correctly use the configured network_id parameter

### DIFF
--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1312,6 +1312,7 @@ public:
         };
 
         auto const count = jvParams.size();
+        
         for (auto const& command : commands)
         {
             if (strMethod == command.name)

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1213,10 +1213,6 @@ public:
         Json::Value jvParams,
         bool allowAnyCommand)
     {
-        // creating an instance of MyTimer. This instance is destroyed at the end of the parseCommand function.
-        // The duration of existence of this object is used as a proxy 
-        // to measure the time-taken for searching through commands array
-
         if (auto stream = j_.trace())
         {
             stream << "Method: '" << strMethod << "'";
@@ -1231,6 +1227,9 @@ public:
             int maxParams;
         };
 
+        // FIXME: replace this with a function-static std::map and the lookup
+        // code with std::map::find when the problem with magic statics on
+        // Visual Studio is fixed.
         constexpr static Command commands[]{
             // Request-response methods
             // - Returns an error, or the request.

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1230,7 +1230,7 @@ public:
         // FIXME: replace this with a function-static std::map and the lookup
         // code with std::map::find when the problem with magic statics on
         // Visual Studio is fixed.
-        static Command const commands[]{
+        static Command const commands[] = {
             // Request-response methods
             // - Returns an error, or the request.
             // - To modify the method, provide a new method in the request.

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1230,7 +1230,7 @@ public:
         // FIXME: replace this with a function-static std::map and the lookup
         // code with std::map::find when the problem with magic statics on
         // Visual Studio is fixed.
-        constexpr static Command commands[]{
+        static Command const commands[]{
             // Request-response methods
             // - Returns an error, or the request.
             // - To modify the method, provide a new method in the request.

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1312,7 +1312,7 @@ public:
         };
 
         auto const count = jvParams.size();
-        
+
         for (auto const& command : commands)
         {
             if (strMethod == command.name)

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -49,24 +49,6 @@
 #include <type_traits>
 #include <unordered_map>
 
-// the below variable keeps track of number of invocations of the MyTimer destructor.
-static std::atomic_int64_t numOfCalls = {};
-
-// @Scott Schurr: The above variable is not correctly tracking the number of invocations of the destructor.
-// I tried placing the increment operation within the constructor, setting numOfCalls as a static variable of the class.
-// But none of these methods help in counting the calls.
-// But when I run ./rippled --unittest, I can observe non-zero values for numOfCalls. (It increases with successive unit tests as expected)
-
-class MyTimer
-{
-public:
-    ~MyTimer()
-    {
-        numOfCalls++;
-        std::cerr << "Destructor: Total calls: " << numOfCalls << std::endl;
-    }
-};
-
 namespace ripple {
 
 class RPCParser;
@@ -1235,8 +1217,6 @@ public:
         // The duration of existence of this object is used as a proxy 
         // to measure the time-taken for searching through commands array
 
-        MyTimer();
-
         if (auto stream = j_.trace())
         {
             stream << "Method: '" << strMethod << "'";
@@ -1251,7 +1231,7 @@ public:
             int maxParams;
         };
 
-        constexpr static Command modified_commands[]{
+        constexpr static Command commands[]{
             // Request-response methods
             // - Returns an error, or the request.
             // - To modify the method, provide a new method in the request.
@@ -1333,7 +1313,7 @@ public:
         };
 
         auto const count = jvParams.size();
-        for (auto const& command : modified_commands)
+        for (auto const& command : commands)
         {
             if (strMethod == command.name)
             {

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -391,7 +391,7 @@ public:
     std::optional<std::uint32_t>
     networkID() const override
     {
-        return networkID_;
+        return setup_.networkID;
     }
 
     Json::Value


### PR DESCRIPTION
The existing code would correctly parse the network_id parameter from the configuration
file, but it would not properly store it inside the overlay, which means that the server would
ignore the configured value for some operations. This commit corrects this flaw.