### PR TITLE
fix for issue 3383

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2323,8 +2323,8 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
     if (!app_.config().SERVER_DOMAIN.empty())
         info[jss::server_domain] = app_.config().SERVER_DOMAIN;
 
-    if (!app_.config().reporting())
-        if (auto const netid = app_.overlay().networkID())
+    // If network ID is configured, return it in the server_info output.
+    if (auto const netid = app_.overlay().networkID())
             info[jss::network_id] = static_cast<Json::UInt>(*netid);
 
     info[jss::build_version] = BuildInfo::getVersionString();

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -125,8 +125,6 @@ private:
     // Peer IDs expecting to receive a last link notification
     std::set<std::uint32_t> csIDs_;
 
-    std::optional<std::uint32_t> networkID_;
-
     reduce_relay::Slots<UptimeClock> slots_;
 
     // Transaction reduce-relay metrics
@@ -391,7 +389,7 @@ public:
     std::optional<std::uint32_t>
     networkID() const override
     {
-        return networkID_;
+        return setup_.networkID;
     }
 
     Json::Value


### PR DESCRIPTION
- correctly set networkID value in OverlayImpl
- return networkID in server_info output

This fix implements the second proposed solution in this comment thread: https://github.com/XRPLF/rippled/issues/3383#issue-609222880