### PR TITLE
TaggedCache: Fix swept object memory release which can occur within the …

### DIFF
--- a/src/ripple/basics/TaggedCache.h
+++ b/src/ripple/basics/TaggedCache.h
@@ -727,7 +727,7 @@ private:
         clock_type::time_point const& when_expire,
         clock_type::time_point const& now,
         typename KeyOnlyCacheType::map_type& partition,
-        SweptPointersVector& stuffToSweep,
+        SweptPointersVector&,
         std::atomic<int>& allRemovals)
     {
         return std::thread([&, this]() {

--- a/src/ripple/basics/TaggedCache.h
+++ b/src/ripple/basics/TaggedCache.h
@@ -247,7 +247,8 @@ public:
                     now,
                     m_cache.map()[p],
                     allStuffToSweep[p],
-                    allRemovals));
+                    allRemovals,
+                    lock));
             }
             for (std::thread& worker : workers)
                 worker.join();
@@ -655,7 +656,8 @@ private:
         [[maybe_unused]] clock_type::time_point const& now,
         typename KeyValueCacheType::map_type& partition,
         SweptPointersVector& stuffToSweep,
-        std::atomic<int>& allRemovals)
+        std::atomic<int>& allRemovals,
+        std::lock_guard<std::recursive_mutex> const&)
     {
         return std::thread([&, this]() {
             int cacheRemovals = 0;
@@ -728,7 +730,8 @@ private:
         clock_type::time_point const& now,
         typename KeyOnlyCacheType::map_type& partition,
         SweptPointersVector&,
-        std::atomic<int>& allRemovals)
+        std::atomic<int>& allRemovals,
+        std::lock_guard<std::recursive_mutex> const&)
     {
         return std::thread([&, this]() {
             int cacheRemovals = 0;


### PR DESCRIPTION
…lock

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

When a `std::shared_ptr` is destructed, even if there is no other `shared_ptr` referencing the same object, the object memory is not necessarily released. This is because `std::weak_ptr ` referencing the same object still need to reference the control block, and the control block is deleted only when the last `std::weak_ptr` is deleted.

When the object is allocated with `std::make_shared`, both the control block and the object are allocated within the same malloc block, and that malloc block is released only when no `std::shared_ptr` **or** `std::weak_ptr` reference it. Many commonly used objects are allocated with std::make_shared, including the SHAMap tree nodes.

As a result, the release of the memory used by many objects is still occurring within the lock in the `TaggedCache` (because it occurs when the `std::weak_ptr` is destructed).

> Note: even prior to this change, the destructor for the shared objects is indeed called outside the lock, since the object destructor is called when the last strong reference (by `shared_ptr`) is destructed. It is only the actual memory release which occurred within the lock when the `std::weak_ptr` is destroyed.

### Context of Change

This is a performance issue. It has very likely been present for a very long time.
I think this change should increase rippled's performance, as the TaggedCache lock will be held for a shorter time.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

This change gathers both pointer types ( `std::shared_ptr` and `std::weak_ptr`) in vectors which are destroyed outside of the lock, ensuring that the memory deallocation occurs outside the lock, for both object memory and control block, regardless of whether they are allocated together or not.

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

I ran the unittests (no failure), and verified that rippled syncs correctly. In my opinion the change is simple and straightforward enough that it is unlikely to cause any problem.

<!--
## Future Tasks
For future tasks related to PR.
-->
