### PR TITLE
Change the return type of mulDiv to std::optional

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2058,7 +2058,7 @@ NetworkOPsImp::pubServer()
                     f.em->openLedgerFeeLevel,
                     f.loadBaseServer,
                     f.em->referenceFeeLevel)
-                    .second);
+                    .value_or(ripple::muldiv_max));
 
             jvObj[jss::load_factor] = trunc32(loadFactor);
             jvObj[jss::load_factor_fee_escalation] =
@@ -2506,7 +2506,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
                 escalationMetrics.openLedgerFeeLevel,
                 loadBaseServer,
                 escalationMetrics.referenceFeeLevel)
-                .second;
+                .value_or(ripple::muldiv_max);
 
         auto const loadFactor = std::max(
             safe_cast<std::uint64_t>(loadFactorServer),

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -492,7 +492,7 @@ private:
             @param seriesSize Total number of transactions in the series to be
                 processed.
 
-            @return A `std::pair` as returned from @ref `mulDiv` indicating
+            @return A `std::pair` indicating
                 whether the calculation result overflows.
         */
         static std::pair<bool, FeeLevel64>
@@ -862,20 +862,15 @@ template <class T>
 XRPAmount
 toDrops(FeeLevel<T> const& level, XRPAmount baseFee)
 {
-    if (auto const drops = mulDiv(level, baseFee, TxQ::baseLevel); drops.first)
-        return drops.second;
-
-    return XRPAmount(STAmount::cMaxNativeN);
+    return mulDiv(level, baseFee, TxQ::baseLevel)
+        .value_or(XRPAmount(STAmount::cMaxNativeN));
 }
 
 inline FeeLevel64
 toFeeLevel(XRPAmount const& drops, XRPAmount const& baseFee)
 {
-    if (auto const feeLevel = mulDiv(drops, TxQ::baseLevel, baseFee);
-        feeLevel.first)
-        return feeLevel.second;
-
-    return FeeLevel64(std::numeric_limits<std::uint64_t>::max());
+    return mulDiv(drops, TxQ::baseLevel, baseFee)
+        .value_or(FeeLevel64(std::numeric_limits<std::uint64_t>::max()));
 }
 
 }  // namespace ripple

--- a/src/ripple/app/misc/impl/LoadFeeTrack.cpp
+++ b/src/ripple/app/misc/impl/LoadFeeTrack.cpp
@@ -109,9 +109,9 @@ scaleFeeLoad(
 
     auto const result = mulDiv(
         fee, feeFactor, safe_cast<std::uint64_t>(feeTrack.getLoadBase()));
-    if (!result.first)
+    if (!result)
         Throw<std::overflow_error>("scaleFeeLoad");
-    return result.second;
+    return *result;
 }
 
 }  // namespace ripple

--- a/src/ripple/basics/impl/mulDiv.cpp
+++ b/src/ripple/basics/impl/mulDiv.cpp
@@ -17,15 +17,13 @@
 */
 //==============================================================================
 
-#include <ripple/basics/contract.h>
 #include <ripple/basics/mulDiv.h>
 #include <boost/multiprecision/cpp_int.hpp>
-#include <limits>
-#include <utility>
+#include <optional>
 
 namespace ripple {
 
-std::pair<bool, std::uint64_t>
+std::optional<std::uint64_t>
 mulDiv(std::uint64_t value, std::uint64_t mul, std::uint64_t div)
 {
     using namespace boost::multiprecision;
@@ -35,12 +33,10 @@ mulDiv(std::uint64_t value, std::uint64_t mul, std::uint64_t div)
 
     result /= div;
 
-    auto constexpr limit = std::numeric_limits<std::uint64_t>::max();
+    if (result > ripple::muldiv_max)
+        return std::nullopt;
 
-    if (result > limit)
-        return {false, limit};
-
-    return {true, static_cast<std::uint64_t>(result)};
+    return static_cast<std::uint64_t>(result);
 }
 
 }  // namespace ripple

--- a/src/ripple/basics/mulDiv.h
+++ b/src/ripple/basics/mulDiv.h
@@ -21,9 +21,12 @@
 #define RIPPLE_BASICS_MULDIV_H_INCLUDED
 
 #include <cstdint>
+#include <limits>
+#include <optional>
 #include <utility>
 
 namespace ripple {
+auto constexpr muldiv_max = std::numeric_limits<std::uint64_t>::max();
 
 /** Return value*mul/div accurately.
     Computes the result of the multiplication and division in
@@ -31,14 +34,11 @@ namespace ripple {
     Throws:
         None
     Returns:
-        `std::pair`:
-            `first` is `false` if the calculation overflows,
-                `true` if the calculation is safe.
-            `second` is the result of the calculation if
-                `first` is `false`, max value of `uint64_t`
-                if `true`.
+        `std::optional`:
+            `std::nullopt` if the calculation overflows. Otherwise, `value * mul
+   / div`.
 */
-std::pair<bool, std::uint64_t>
+std::optional<std::uint64_t>
 mulDiv(std::uint64_t value, std::uint64_t mul, std::uint64_t div);
 
 }  // namespace ripple

--- a/src/ripple/rpc/handlers/Fee1.cpp
+++ b/src/ripple/rpc/handlers/Fee1.cpp
@@ -20,7 +20,6 @@
 #include <ripple/app/ledger/OpenLedger.h>
 #include <ripple/app/main/Application.h>
 #include <ripple/app/misc/TxQ.h>
-#include <ripple/basics/mulDiv.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/rpc/Context.h>

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -738,9 +738,9 @@ checkFee(
     auto const limit = [&]() {
         // Scale fee units to drops:
         auto const result = mulDiv(feeDefault, mult, div);
-        if (!result.first)
+        if (!result)
             Throw<std::overflow_error>("mulDiv");
-        return result.second;
+        return *result;
     }();
 
     if (fee > limit)

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -22,7 +22,6 @@
 #include <ripple/app/misc/TxQ.h>
 #include <ripple/app/tx/apply.h>
 #include <ripple/basics/Log.h>
-#include <ripple/basics/mulDiv.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/jss.h>
 #include <ripple/protocol/st.h>

--- a/src/test/basics/FeeUnits_test.cpp
+++ b/src/test/basics/FeeUnits_test.cpp
@@ -50,12 +50,17 @@ private:
             FeeLevel32 f{10};
             FeeLevel32 baseFee{100};
 
-            auto drops = mulDiv(baseFee, x, f).second;
+            auto drops = mulDiv(baseFee, x, f);
 
+            BEAST_EXPECT(drops);
             BEAST_EXPECT(drops.value() == 1000);
-            BEAST_EXPECT(
-                (std::is_same_v<decltype(drops)::unit_type, feeunit::dropTag>));
-            BEAST_EXPECT((std::is_same_v<decltype(drops), XRPAmount>));
+            BEAST_EXPECT((std::is_same_v<
+                          std::remove_reference_t<decltype(*drops)>::unit_type,
+                          feeunit::dropTag>));
+
+            BEAST_EXPECT((std::is_same_v<
+                          std::remove_reference_t<decltype(*drops)>,
+                          XRPAmount>));
         }
         {
             XRPAmount x{100};
@@ -70,12 +75,16 @@ private:
             FeeLevel64 f{10};
             FeeLevel64 baseFee{100};
 
-            auto drops = mulDiv(baseFee, x, f).second;
+            auto drops = mulDiv(baseFee, x, f);
 
+            BEAST_EXPECT(drops);
             BEAST_EXPECT(drops.value() == 1000);
-            BEAST_EXPECT(
-                (std::is_same_v<decltype(drops)::unit_type, feeunit::dropTag>));
-            BEAST_EXPECT((std::is_same_v<decltype(drops), XRPAmount>));
+            BEAST_EXPECT((std::is_same_v<
+                          std::remove_reference_t<decltype(*drops)>::unit_type,
+                          feeunit::dropTag>));
+            BEAST_EXPECT((std::is_same_v<
+                          std::remove_reference_t<decltype(*drops)>,
+                          XRPAmount>));
         }
         {
             FeeLevel64 x{1024};
@@ -91,12 +100,16 @@ private:
             XRPAmount basefee{10};
             FeeLevel64 referencefee{256};
 
-            auto drops = mulDiv(x, basefee, referencefee).second;
+            auto drops = mulDiv(x, basefee, referencefee);
 
+            BEAST_EXPECT(drops);
             BEAST_EXPECT(drops.value() == 40);
-            BEAST_EXPECT(
-                (std::is_same_v<decltype(drops)::unit_type, feeunit::dropTag>));
-            BEAST_EXPECT((std::is_same_v<decltype(drops), XRPAmount>));
+            BEAST_EXPECT((std::is_same_v<
+                          std::remove_reference_t<decltype(*drops)>::unit_type,
+                          feeunit::dropTag>));
+            BEAST_EXPECT((std::is_same_v<
+                          std::remove_reference_t<decltype(*drops)>,
+                          XRPAmount>));
         }
     }
 

--- a/src/test/basics/mulDiv_test.cpp
+++ b/src/test/basics/mulDiv_test.cpp
@@ -32,27 +32,27 @@ struct mulDiv_test : beast::unit_test::suite
         const std::uint64_t max32 = std::numeric_limits<std::uint32_t>::max();
 
         auto result = mulDiv(85, 20, 5);
-        BEAST_EXPECT(result.first && result.second == 340);
+        BEAST_EXPECT(result && *result == 340);
         result = mulDiv(20, 85, 5);
-        BEAST_EXPECT(result.first && result.second == 340);
+        BEAST_EXPECT(result && *result == 340);
 
         result = mulDiv(0, max - 1, max - 3);
-        BEAST_EXPECT(result.first && result.second == 0);
+        BEAST_EXPECT(result && *result == 0);
         result = mulDiv(max - 1, 0, max - 3);
-        BEAST_EXPECT(result.first && result.second == 0);
+        BEAST_EXPECT(result && *result == 0);
 
         result = mulDiv(max, 2, max / 2);
-        BEAST_EXPECT(result.first && result.second == 4);
+        BEAST_EXPECT(result && *result == 4);
         result = mulDiv(max, 1000, max / 1000);
-        BEAST_EXPECT(result.first && result.second == 1000000);
+        BEAST_EXPECT(result && *result == 1000000);
         result = mulDiv(max, 1000, max / 1001);
-        BEAST_EXPECT(result.first && result.second == 1001000);
+        BEAST_EXPECT(result && *result == 1001000);
         result = mulDiv(max32 + 1, max32 + 1, 5);
-        BEAST_EXPECT(result.first && result.second == 3689348814741910323);
+        BEAST_EXPECT(result && *result == 3689348814741910323);
 
         // Overflow
         result = mulDiv(max - 1, max - 2, 5);
-        BEAST_EXPECT(!result.first && result.second == max);
+        BEAST_EXPECT(!result);
     }
 };
 


### PR DESCRIPTION
- Previously, mulDiv had `std::pair<bool, uint64_t>` as the output type. 
- This PR changes the return type to std::optional
- The existing unit test cases pass with this change.
- This PR attempts to fix Issue 3495 (https://github.com/XRPLF/rippled/issues/3495)