### PR TITLE
remove deprecated fields in ledger command, fix for #3214

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerToJson.cpp
+++ b/src/ripple/app/ledger/impl/LedgerToJson.cpp
@@ -53,7 +53,6 @@ fillJson(Object& json, bool closed, LedgerInfo const& info, bool bFull)
 {
     json[jss::parent_hash] = to_string(info.parentHash);
     json[jss::ledger_index] = to_string(info.seq);
-    json[jss::seqNum] = to_string(info.seq);  // DEPRECATED
 
     if (closed)
     {
@@ -70,10 +69,6 @@ fillJson(Object& json, bool closed, LedgerInfo const& info, bool bFull)
     json[jss::account_hash] = to_string(info.accountHash);
     json[jss::total_coins] = to_string(info.drops);
 
-    // These next three are DEPRECATED.
-    json[jss::hash] = to_string(info.hash);
-    json[jss::totalCoins] = to_string(info.drops);
-    json[jss::accepted] = closed;
     json[jss::close_flags] = info.closeFlags;
 
     // Always show fields that contribute to the ledger hash

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -519,7 +519,6 @@ JSS(send_max);                  // in: PathRequest, RipplePathFind
 JSS(seq);                       // in: LedgerEntry;
                                 // out: NetworkOPs, RPCSub, AccountOffers,
                                 //      ValidatorList, ValidatorInfo, Manifest
-JSS(seqNum);                    // out: LedgerToJson
 JSS(sequence);                  // in: UNL
 JSS(sequence_count);            // out: AccountInfo
 JSS(server_domain);             // out: NetworkOPs
@@ -574,7 +573,6 @@ JSS(timeouts);                // out: InboundLedger
 JSS(track);                   // out: PeerImp
 JSS(traffic);                 // out: Overlay
 JSS(total);                   // out: counters
-JSS(totalCoins);              // out: LedgerToJson
 JSS(total_bytes_recv);        // out: Peers
 JSS(total_bytes_sent);        // out: Peers
 JSS(total_coins);             // out: LedgerToJson

--- a/src/test/app/SHAMapStore_test.cpp
+++ b/src/test/app/SHAMapStore_test.cpp
@@ -85,7 +85,8 @@ class SHAMapStore_test : public beast::unit_test::suite
         const std::string outTxHash = to_string(info.txHash);
 
         auto const& ledger = json[jss::result][jss::ledger];
-        return outHash == ledger[jss::ledger_hash].asString() && outSeq == seq &&
+        return outHash == ledger[jss::ledger_hash].asString() &&
+            outSeq == seq &&
             outParentHash == ledger[jss::parent_hash].asString() &&
             outDrops == ledger[jss::total_coins].asString() &&
             outCloseTime == ledger[jss::close_time].asUInt() &&

--- a/src/test/app/SHAMapStore_test.cpp
+++ b/src/test/app/SHAMapStore_test.cpp
@@ -85,7 +85,7 @@ class SHAMapStore_test : public beast::unit_test::suite
         const std::string outTxHash = to_string(info.txHash);
 
         auto const& ledger = json[jss::result][jss::ledger];
-        return outHash == ledger[jss::hash].asString() && outSeq == seq &&
+        return outHash == ledger[jss::ledger_hash].asString() && outSeq == seq &&
             outParentHash == ledger[jss::parent_hash].asString() &&
             outDrops == ledger[jss::total_coins].asString() &&
             outCloseTime == ledger[jss::close_time].asUInt() &&
@@ -111,9 +111,9 @@ class SHAMapStore_test : public beast::unit_test::suite
         BEAST_EXPECT(
             json.isMember(jss::result) &&
             json[jss::result].isMember(jss::ledger) &&
-            json[jss::result][jss::ledger].isMember(jss::hash) &&
-            json[jss::result][jss::ledger][jss::hash].isString());
-        return json[jss::result][jss::ledger][jss::hash].asString();
+            json[jss::result][jss::ledger].isMember(jss::ledger_hash) &&
+            json[jss::result][jss::ledger][jss::ledger_hash].isString());
+        return json[jss::result][jss::ledger][jss::ledger_hash].asString();
     }
 
     void

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -78,10 +78,6 @@ class LedgerRPC_test : public beast::unit_test::suite
                 env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::ledger][jss::closed] == true);
             BEAST_EXPECT(jrr[jss::ledger][jss::ledger_index] == "1");
-            BEAST_EXPECT(jrr[jss::ledger][jss::accepted] == true);
-            BEAST_EXPECT(
-                jrr[jss::ledger][jss::totalCoins] ==
-                env.balance(env.master).value().getText());
         }
 
         {
@@ -91,10 +87,6 @@ class LedgerRPC_test : public beast::unit_test::suite
                 env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::ledger][jss::closed] == true);
             BEAST_EXPECT(jrr[jss::ledger][jss::ledger_index] == "1");
-            BEAST_EXPECT(jrr[jss::ledger][jss::accepted] == true);
-            BEAST_EXPECT(
-                jrr[jss::ledger][jss::totalCoins] ==
-                env.balance(env.master).value().getText());
         }
 
         {


### PR DESCRIPTION
I removed the following fields from the ledger command - `accepted`, `seq`, `hash` and `totalCoins`.

Some of these variable names (`totalCoins`, `seq`) are used in managing the database but I don't think there is any redundancy in the creation/updation/deletion of the tables.