### PR TITLE
Properly handle self-assignment of PublicKey

### DIFF
--- a/src/ripple/protocol/impl/PublicKey.cpp
+++ b/src/ripple/protocol/impl/PublicKey.cpp
@@ -24,7 +24,6 @@
 #include <ripple/protocol/impl/secp256k1.h>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <ed25519-donna/ed25519.h>
-#include <type_traits>
 
 namespace ripple {
 
@@ -186,14 +185,18 @@ PublicKey::PublicKey(PublicKey const& other) : size_(other.size_)
 {
     if (size_)
         std::memcpy(buf_, other.buf_, size_);
-};
+}
 
 PublicKey&
 PublicKey::operator=(PublicKey const& other)
 {
-    size_ = other.size_;
-    if (size_)
-        std::memcpy(buf_, other.buf_, size_);
+    if (this != &other)
+    {
+        size_ = other.size_;
+        if (size_)
+            std::memcpy(buf_, other.buf_, size_);
+    }
+
     return *this;
 }
 


### PR DESCRIPTION
The copy assignment function of the `PublicKey` behaves incorrectly if it does something `pk = pk;` 