### PR TITLE
Change by-value to by-reference to persist vote

### DIFF
--- a/src/ripple/app/misc/impl/AmendmentTable.cpp
+++ b/src/ripple/app/misc/impl/AmendmentTable.cpp
@@ -425,7 +425,7 @@ AmendmentTableImpl::AmendmentTableImpl(
             }
             else  // up-vote
             {
-                auto s = add(amend_hash, lock);
+                AmendmentState& s = add(amend_hash, lock);
 
                 JLOG(j_.debug()) << "Amendment {" << *amendment_name << ", "
                                  << amend_hash << "} is upvoted.";


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

Simple bug fix for persisting votes.

### Context of Change

This is a fix to a recent fix.  It simply changes a value variable to a reference variable.  I missed this because I only tested an amendment with a default vote of yes, and the bug only is exposed only with amendments with a default vote of no.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->


## Test Plan

This was tested by starting rippled and issuing the following commands on the command line:

```
rippled feature
```
Observe some amendment with a default vote of no, such as `NonFungibleTokensV1_1`, is vetoed.

Unveto the amendment with:
```
rippled feature NonFungibleTokensV1_1 accept
```
Stop rippled:
```
rippled stop
```
Restart rippled and:
```
rippled feature
```
Note that the amendment now is listed with `"vetoed" : false`.

Amendments with a default vote of no can be found in the source file: `src/ripple/protocol/impl/Feature.cpp`.

<!--
## Future Tasks
For future tasks related to PR.
-->
