### PR TITLE
Implement fee scaling based on the size of the memos

### DIFF
--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -152,7 +152,17 @@ Transactor::calculateBaseFee(ReadView const& view, STTx const& tx)
     std::size_t const signerCount =
         tx.isFieldPresent(sfSigners) ? tx.getFieldArray(sfSigners).size() : 0;
 
-    return baseFee + (signerCount * baseFee);
+    std::uint32_t memoCount = 0;
+
+    if (tx.isFieldPresent(sfMemos) &&
+        view.rules().enabled(featureMemoFeeScaling))
+    {
+        Serializer s(2048);
+        tx.getFieldArray(sfMemos).add(s);
+        memoCount = 1 + static_cast<std::uint32_t>(s.size() / 32);
+    }
+
+    return baseFee * (1 + signerCount + memoCount);
 }
 
 XRPAmount

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -74,7 +74,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 50;
+static constexpr std::size_t numFeatures = 51;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -338,6 +338,7 @@ extern uint256 const featureExpandedSignerList;
 extern uint256 const fixNFTokenDirV1;
 extern uint256 const fixNFTokenNegOffer;
 extern uint256 const featureNonFungibleTokensV1_1;
+extern uint256 const featureMemoFeeScaling;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -442,6 +442,7 @@ REGISTER_FEATURE(ExpandedSignerList,            Supported::yes, DefaultVote::no)
 REGISTER_FIX    (fixNFTokenDirV1,               Supported::yes, DefaultVote::no);
 REGISTER_FIX    (fixNFTokenNegOffer,            Supported::yes, DefaultVote::no);
 REGISTER_FEATURE(NonFungibleTokensV1_1,         Supported::yes, DefaultVote::no);
+REGISTER_FEATURE(MemoFeeScaling,                Supported::yes, DefaultVote::yes);
 
 // The following amendments have been active for at least two years. Their
 // pre-amendment code has been removed and the identifiers are deprecated.

--- a/src/test/app/AccountTxPaging_test.cpp
+++ b/src/test/app/AccountTxPaging_test.cpp
@@ -735,7 +735,7 @@ class AccountTxPaging_test : public beast::unit_test::suite
         auto const baseFee = env.current()->fees().base;
         env(noop(alice),
             msig(gw),
-            fee(2 * baseFee),
+            fee(3 * baseFee),
             memo("data", "format", "type"));
         env.close();
 
@@ -753,7 +753,7 @@ class AccountTxPaging_test : public beast::unit_test::suite
                      txns[txns.size() - 1]->getJson(JsonOptions::none);
                  return BEAST_EXPECT(res.has_account_set()) &&
                      BEAST_EXPECT(res.has_fee()) &&
-                     BEAST_EXPECT(res.fee().drops() == 20) &&
+                     BEAST_EXPECT(res.fee().drops() == 30) &&
                      BEAST_EXPECT(res.memos_size() == 1) &&
                      BEAST_EXPECT(res.memos(0).has_memo_data()) &&
                      BEAST_EXPECT(res.memos(0).memo_data().value() == "data") &&

--- a/src/test/jtx/Env_test.cpp
+++ b/src/test/jtx/Env_test.cpp
@@ -619,7 +619,8 @@ public:
         env(noop("alice"), memo("data", "format", "type"), fee(100));
         env(noop("alice"),
             memo("data1", "format1", "type1"),
-            memo("data2", "format2", "type2"), fee(250));
+            memo("data2", "format2", "type2"), 
+            fee(250));
     }
 
     void

--- a/src/test/jtx/Env_test.cpp
+++ b/src/test/jtx/Env_test.cpp
@@ -610,16 +610,16 @@ public:
         using namespace jtx;
         Env env(*this);
         env.fund(XRP(10000), "alice");
-        env(noop("alice"), memodata("data"));
-        env(noop("alice"), memoformat("format"));
-        env(noop("alice"), memotype("type"));
-        env(noop("alice"), memondata("format", "type"));
-        env(noop("alice"), memonformat("data", "type"));
-        env(noop("alice"), memontype("data", "format"));
-        env(noop("alice"), memo("data", "format", "type"));
+        env(noop("alice"), memodata("data"), fee(100));
+        env(noop("alice"), memoformat("format"), fee(100));
+        env(noop("alice"), memotype("type"), fee(100));
+        env(noop("alice"), memondata("format", "type"), fee(100));
+        env(noop("alice"), memonformat("data", "type"), fee(100));
+        env(noop("alice"), memontype("data", "format"), fee(100));
+        env(noop("alice"), memo("data", "format", "type"), fee(100));
         env(noop("alice"),
             memo("data1", "format1", "type1"),
-            memo("data2", "format2", "type2"));
+            memo("data2", "format2", "type2"), fee(250));
     }
 
     void

--- a/src/test/rpc/Tx_test.cpp
+++ b/src/test/rpc/Tx_test.cpp
@@ -568,7 +568,7 @@ class Tx_test : public beast::unit_test::suite
         for (int i = 0; i < 14; ++i)
         {
             auto const baseFee = env.current()->fees().base;
-            auto txfee = fee(i + (2 * baseFee));
+            auto txfee = fee(i + (10 * baseFee));
             auto lls = last_ledger_seq(i + startLegSeq + 20);
             auto dsttag = dtag(i * 456);
             auto srctag = stag(i * 321);


### PR DESCRIPTION
A revision of #3007 to  scale the fees for transactions with many memos which is csauing a spamming problem. It may be better to just change the coe to change by the size of the transaction instead which works for other expensive things too likea lot of paths.