### PR TITLE
Avoid unnecessary copying and dynamic memory allocations

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -211,15 +211,10 @@ RCLConsensus::Adaptor::propose(RCLCxPeerPos::Proposal const& proposal)
     prop.set_nodepubkey(
         validatorKeys_.publicKey.data(), validatorKeys_.publicKey.size());
 
-    auto signingHash = sha512Half(
-        HashPrefix::proposal,
-        std::uint32_t(proposal.proposeSeq()),
-        proposal.closeTime().time_since_epoch().count(),
-        proposal.prevLedger(),
-        proposal.position());
-
     auto sig = signDigest(
-        validatorKeys_.publicKey, validatorKeys_.secretKey, signingHash);
+        validatorKeys_.publicKey,
+        validatorKeys_.secretKey,
+        proposal.signingHash());
 
     prop.set_signature(sig.data(), sig.size());
 

--- a/src/ripple/app/consensus/RCLCxPeerPos.h
+++ b/src/ripple/app/consensus/RCLCxPeerPos.h
@@ -28,6 +28,7 @@
 #include <ripple/protocol/HashPrefix.h>
 #include <ripple/protocol/PublicKey.h>
 #include <ripple/protocol/SecretKey.h>
+#include <boost/container/static_vector.hpp>
 #include <chrono>
 #include <cstdint>
 #include <string>
@@ -61,10 +62,6 @@ public:
         uint256 const& suppress,
         Proposal&& proposal);
 
-    //! Create the signing hash for the proposal
-    uint256
-    signingHash() const;
-
     //! Verify the signing hash of the proposal
     bool
     checkSign() const;
@@ -73,27 +70,27 @@ public:
     Slice
     signature() const
     {
-        return data_->signature_;
+        return {signature_.data(), signature_.size()};
     }
 
     //! Public key of peer that sent the proposal
     PublicKey const&
     publicKey() const
     {
-        return data_->publicKey_;
+        return publicKey_;
     }
 
     //! Unique id used by hash router to suppress duplicates
     uint256 const&
     suppressionID() const
     {
-        return data_->suppression_;
+        return suppression_;
     }
 
     Proposal const&
     proposal() const
     {
-        return data_->proposal_;
+        return proposal_;
     }
 
     //! JSON representation of proposal
@@ -101,21 +98,10 @@ public:
     getJson() const;
 
 private:
-    struct Data : public CountedObject<Data>
-    {
-        PublicKey publicKey_;
-        Buffer signature_;
-        uint256 suppression_;
-        Proposal proposal_;
-
-        Data(
-            PublicKey const& publicKey,
-            Slice const& signature,
-            uint256 const& suppress,
-            Proposal&& proposal);
-    };
-
-    std::shared_ptr<Data> data_;
+    PublicKey publicKey_;
+    uint256 suppression_;
+    Proposal proposal_;
+    boost::container::static_vector<std::uint8_t, 72> signature_;
 
     template <class Hasher>
     void

--- a/src/ripple/protocol/impl/PublicKey.cpp
+++ b/src/ripple/protocol/impl/PublicKey.cpp
@@ -221,6 +221,8 @@ verifyDigest(
     Slice const& sig,
     bool mustBeFullyCanonical) noexcept
 {
+    if (sig.size() == 0)
+        return false;
     if (publicKeyType(publicKey) != KeyType::secp256k1)
         LogicError("sign: secp256k1 required for digest signing");
     auto const canonicality = ecdsaCanonicality(sig);


### PR DESCRIPTION
This commit implements an optimization that @chennakeshava1998 and I identified; this commit reduces unnecessary dynamic memory allocations when processing proposals.