### PR TITLE
refactor NegativeUNL class - use PublicKey instead of NodeID

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -89,7 +89,7 @@ RCLConsensus::Adaptor::Adaptor(
     , valCookie_{rand_int<std::uint64_t>(
           1,
           std::numeric_limits<std::uint64_t>::max())}
-    , nUnlVote_(validatorKeys_.nodeID, j_)
+    , nUnlVote_(validatorKeys_.masterPublicKey, j_)
 {
     assert(valCookie_ != 0);
 

--- a/src/ripple/app/misc/NegativeUNLVote.cpp
+++ b/src/ripple/app/misc/NegativeUNLVote.cpp
@@ -23,8 +23,8 @@
 
 namespace ripple {
 
-NegativeUNLVote::NegativeUNLVote(NodeID const& myId, beast::Journal j)
-    : myId_(myId), j_(j)
+NegativeUNLVote::NegativeUNLVote(PublicKey const& myValPubKey, beast::Journal j)
+    : myValPubKey_(myValPubKey), j_(j)
 {
 }
 
@@ -41,20 +41,9 @@ NegativeUNLVote::doVoting(
     // -- pick one to disable and one to re-enable if any
     // -- if found candidates, add ttUNL_MODIFY Tx
 
-    // Build NodeID set for internal use.
-    // Build NodeID to PublicKey map for lookup before creating ttUNL_MODIFY Tx.
-    hash_set<NodeID> unlNodeIDs;
-    hash_map<NodeID, PublicKey> nidToKeyMap;
-    for (auto const& k : unlKeys)
-    {
-        auto nid = calcNodeID(k);
-        nidToKeyMap.emplace(nid, k);
-        unlNodeIDs.emplace(nid);
-    }
-
     // Build a reliability score table of validators
-    if (std::optional<hash_map<NodeID, std::uint32_t>> scoreTable =
-            buildScoreTable(prevLedger, unlNodeIDs, validations))
+    if (std::optional<hash_map<PublicKey, std::uint32_t>> scoreTable =
+            buildScoreTable(prevLedger, unlKeys, validations))
     {
         // build next negUnl
         auto negUnlKeys = prevLedger->negativeUNL();
@@ -65,39 +54,28 @@ NegativeUNLVote::doVoting(
         if (negUnlToReEnable)
             negUnlKeys.erase(*negUnlToReEnable);
 
-        hash_set<NodeID> negUnlNodeIDs;
-        for (auto const& k : negUnlKeys)
-        {
-            auto nid = calcNodeID(k);
-            negUnlNodeIDs.emplace(nid);
-            if (!nidToKeyMap.count(nid))
-            {
-                nidToKeyMap.emplace(nid, k);
-            }
-        }
-
         auto const seq = prevLedger->info().seq + 1;
         purgeNewValidators(seq);
 
         // Process the table and find all candidates to disable or to re-enable
         auto const candidates =
-            findAllCandidates(unlNodeIDs, negUnlNodeIDs, *scoreTable);
+            findAllCandidates(unlKeys, negUnlKeys, *scoreTable);
 
         // Pick one to disable and one to re-enable if any, add ttUNL_MODIFY Tx
         if (!candidates.toDisableCandidates.empty())
         {
             auto n =
                 choose(prevLedger->info().hash, candidates.toDisableCandidates);
-            assert(nidToKeyMap.count(n));
-            addTx(seq, nidToKeyMap[n], ToDisable, initialSet);
+            assert(unlKeys.count(n));
+            addTx(seq, n, ToDisable, initialSet);
         }
 
         if (!candidates.toReEnableCandidates.empty())
         {
             auto n = choose(
                 prevLedger->info().hash, candidates.toReEnableCandidates);
-            assert(nidToKeyMap.count(n));
-            addTx(seq, nidToKeyMap[n], ToReEnable, initialSet);
+            assert(negUnlKeys.count(n));
+            addTx(seq, n, ToReEnable, initialSet);
         }
     }
 }
@@ -114,7 +92,6 @@ NegativeUNLVote::addTx(
         obj.setFieldU32(sfLedgerSequence, seq);
         obj.setFieldVL(sfUNLModifyValidator, vp.slice());
     });
-
     uint256 txID = negUnlTx.getTransactionID();
     Serializer s;
     negUnlTx.add(s);
@@ -135,29 +112,28 @@ NegativeUNLVote::addTx(
     }
 }
 
-NodeID
+PublicKey
 NegativeUNLVote::choose(
     uint256 const& randomPadData,
-    std::vector<NodeID> const& candidates)
+    std::vector<PublicKey> const& candidates)
 {
     assert(!candidates.empty());
-    static_assert(NodeID::bytes <= uint256::bytes);
-    NodeID randomPad = NodeID::fromVoid(randomPadData.data());
-    NodeID txNodeID = candidates[0];
+    PublicKey chosenValPubKey = candidates[0];
     for (int j = 1; j < candidates.size(); ++j)
     {
-        if ((candidates[j] ^ randomPad) < (txNodeID ^ randomPad))
+        if ((*candidates[j].data() ^ *randomPadData.data()) <
+            (*chosenValPubKey.data() ^ *randomPadData.data()))
         {
-            txNodeID = candidates[j];
+            chosenValPubKey = candidates[j];
         }
     }
-    return txNodeID;
+    return chosenValPubKey;
 }
 
-std::optional<hash_map<NodeID, std::uint32_t>>
+std::optional<hash_map<PublicKey, std::uint32_t>>
 NegativeUNLVote::buildScoreTable(
     std::shared_ptr<Ledger const> const& prevLedger,
-    hash_set<NodeID> const& unl,
+    hash_set<PublicKey> const& unl,
     RCLValidations& validations)
 {
     // Find agreed validation messages received for
@@ -187,7 +163,7 @@ NegativeUNLVote::buildScoreTable(
     }
 
     // have enough ledger ancestors, build the score table
-    hash_map<NodeID, std::uint32_t> scoreTable;
+    hash_map<PublicKey, std::uint32_t> scoreTable;
     for (auto const& k : unl)
     {
         scoreTable[k] = 0;
@@ -200,15 +176,16 @@ NegativeUNLVote::buildScoreTable(
         for (auto const& v : validations.getTrustedForLedger(
                  ledgerAncestors[numAncestors - 1 - i]))
         {
-            if (scoreTable.count(v->getNodeID()))
-                ++scoreTable[v->getNodeID()];
+            if (scoreTable.count(v->getSignerMasterPublic()))
+                ++scoreTable[v->getSignerMasterPublic()];
         }
     }
 
     // Return false if the validation message history or local node's
     // participation in the history is not good.
     auto const myValidationCount = [&]() -> std::uint32_t {
-        if (auto const it = scoreTable.find(myId_); it != scoreTable.end())
+        if (auto const it = scoreTable.find(myValPubKey_);
+            it != scoreTable.end())
             return it->second;
         return 0;
     }();
@@ -240,9 +217,9 @@ NegativeUNLVote::buildScoreTable(
 
 NegativeUNLVote::Candidates const
 NegativeUNLVote::findAllCandidates(
-    hash_set<NodeID> const& unl,
-    hash_set<NodeID> const& negUnl,
-    hash_map<NodeID, std::uint32_t> const& scoreTable)
+    hash_set<PublicKey> const& unl,
+    hash_set<PublicKey> const& negUnl,
+    hash_map<PublicKey, std::uint32_t> const& scoreTable)
 {
     // Compute if need to find more validators to disable
     auto const canAdd = [&]() -> bool {
@@ -255,7 +232,8 @@ NegativeUNLVote::findAllCandidates(
                 ++negativeListed;
         }
         bool const result = negativeListed < maxNegativeListed;
-        JLOG(j_.trace()) << "N-UNL: nodeId " << myId_ << " lowWaterMark "
+        JLOG(j_.trace()) << "N-UNL: Validator Public Key: "
+                         << myValPubKey_.slice() << " lowWaterMark "
                          << negativeUNLLowWaterMark << " highWaterMark "
                          << negativeUNLHighWaterMark << " canAdd " << result
                          << " negativeListed " << negativeListed
@@ -264,9 +242,10 @@ NegativeUNLVote::findAllCandidates(
     }();
 
     Candidates candidates;
-    for (auto const& [nodeId, score] : scoreTable)
+    for (auto const& [valPubKey, score] : scoreTable)
     {
-        JLOG(j_.trace()) << "N-UNL: node " << nodeId << " score " << score;
+        JLOG(j_.trace()) << "N-UNL: node " << valPubKey.slice() << " score "
+                         << score;
 
         // Find toDisable Candidates: check if
         //  (1) canAdd,
@@ -274,19 +253,22 @@ NegativeUNLVote::findAllCandidates(
         //  (3) is not in negUnl, and
         //  (4) is not a new validator.
         if (canAdd && score < negativeUNLLowWaterMark &&
-            !negUnl.count(nodeId) && !newValidators_.count(nodeId))
+            !negUnl.count(valPubKey) &&
+            !newValidators_.count(calcNodeID(valPubKey)))
         {
-            JLOG(j_.trace()) << "N-UNL: toDisable candidate " << nodeId;
-            candidates.toDisableCandidates.push_back(nodeId);
+            JLOG(j_.trace())
+                << "N-UNL: toDisable candidate " << valPubKey.slice();
+            candidates.toDisableCandidates.push_back(valPubKey);
         }
 
         // Find toReEnable Candidates: check if
         //  (1) has more than negativeUNLHighWaterMark validations,
         //  (2) is in negUnl
-        if (score > negativeUNLHighWaterMark && negUnl.count(nodeId))
+        if (score > negativeUNLHighWaterMark && negUnl.count(valPubKey))
         {
-            JLOG(j_.trace()) << "N-UNL: toReEnable candidate " << nodeId;
-            candidates.toReEnableCandidates.push_back(nodeId);
+            JLOG(j_.trace())
+                << "N-UNL: toReEnable candidate " << valPubKey.slice();
+            candidates.toReEnableCandidates.push_back(valPubKey);
         }
     }
 

--- a/src/ripple/app/misc/NegativeUNLVote.h
+++ b/src/ripple/app/misc/NegativeUNLVote.h
@@ -88,10 +88,10 @@ public:
     /**
      * Constructor
      *
-     * @param myId the NodeID of the local node
+     * @param myValPubKey the PublicKey of the local node
      * @param j log
      */
-    NegativeUNLVote(NodeID const& myId, beast::Journal j);
+    NegativeUNLVote(PublicKey const& myValPubKey, beast::Journal j);
     ~NegativeUNLVote() = default;
 
     /**
@@ -124,7 +124,7 @@ public:
     newValidators(LedgerIndex seq, hash_set<NodeID> const& nowTrusted);
 
 private:
-    NodeID const myId_;
+    PublicKey const myValPubKey_;
     beast::Journal j_;
     mutable std::mutex mutex_;
     hash_map<NodeID, LedgerIndex> newValidators_;
@@ -134,8 +134,8 @@ private:
      */
     struct Candidates
     {
-        std::vector<NodeID> toDisableCandidates;
-        std::vector<NodeID> toReEnableCandidates;
+        std::vector<PublicKey> toDisableCandidates;
+        std::vector<PublicKey> toReEnableCandidates;
     };
 
     /**
@@ -162,8 +162,10 @@ private:
      * @param candidates the vector of candidates
      * @return the picked candidate
      */
-    NodeID
-    choose(uint256 const& randomPadData, std::vector<NodeID> const& candidates);
+    PublicKey
+    choose(
+        uint256 const& randomPadData,
+        std::vector<PublicKey> const& candidates);
 
     /**
      * Build a reliability measurement score table of validators' validation
@@ -179,10 +181,10 @@ private:
      * @return the built scoreTable or empty optional if table could not be
      * built
      */
-    std::optional<hash_map<NodeID, std::uint32_t>>
+    std::optional<hash_map<PublicKey, std::uint32_t>>
     buildScoreTable(
         std::shared_ptr<Ledger const> const& prevLedger,
-        hash_set<NodeID> const& unl,
+        hash_set<PublicKey> const& unl,
         RCLValidations& validations);
 
     /**
@@ -196,9 +198,9 @@ private:
      */
     Candidates const
     findAllCandidates(
-        hash_set<NodeID> const& unl,
-        hash_set<NodeID> const& negUnl,
-        hash_map<NodeID, std::uint32_t> const& scoreTable);
+        hash_set<PublicKey> const& unl,
+        hash_set<PublicKey> const& negUnl,
+        hash_map<PublicKey, std::uint32_t> const& scoreTable);
 
     /**
      * Purge validators that are not new anymore.

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -603,7 +603,7 @@ PeerImp::fail(std::string const& reason)
         return post(
             strand_,
             std::bind(
-                (void (Peer::*)(std::string const&)) & PeerImp::fail,
+                (void(Peer::*)(std::string const&)) & PeerImp::fail,
                 shared_from_this(),
                 reason));
     if (journal_.active(beast::severities::kWarning) && socket_.is_open())
@@ -2546,6 +2546,9 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
                     return calcNodeID(
                         app_.validatorManifests().getMasterKey(pk));
                 },
+                [this](PublicKey const& pk) {
+                    return app_.validatorManifests().getMasterKey(pk);
+                },
                 false);
             val->setSeen(closeTime);
         }
@@ -2605,7 +2608,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
 #ifdef DEBUG
                 ret += " " +
                     std::to_string(val->getFieldU32(sfLedgerSequence)) + ": " +
-                    to_string(val->getNodeID());
+                    to_string(val->getSignerPublic());
 #endif
 
                 return ret;

--- a/src/ripple/protocol/PublicKey.h
+++ b/src/ripple/protocol/PublicKey.h
@@ -129,12 +129,10 @@ public:
     {
         return slice();
     }
-};
 
-/** Print the public key to a stream.
- */
-std::ostream&
-operator<<(std::ostream& os, PublicKey const& pk);
+    friend std::string
+    to_string(PublicKey const&);
+};
 
 inline bool
 operator==(PublicKey const& lhs, PublicKey const& rhs)

--- a/src/ripple/protocol/impl/PublicKey.cpp
+++ b/src/ripple/protocol/impl/PublicKey.cpp
@@ -28,11 +28,10 @@
 
 namespace ripple {
 
-std::ostream&
-operator<<(std::ostream& os, PublicKey const& pk)
+std::string
+to_string(PublicKey const& pk)
 {
-    os << strHex(pk);
-    return os;
+    return strHex(pk);
 }
 
 template <>

--- a/src/test/app/ValidatorKeys_test.cpp
+++ b/src/test/app/ValidatorKeys_test.cpp
@@ -23,9 +23,8 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>
-#include <test/jtx/Env.h>
-
 #include <string>
+#include <test/unit_test/SuiteJournal.h>
 
 namespace ripple {
 namespace test {
@@ -76,14 +75,7 @@ public:
     void
     run() override
     {
-        // We're only using Env for its Journal.  That Journal gives better
-        // coverage in unit tests.
-        test::jtx::Env env{
-            *this,
-            test::jtx::envconfig(),
-            nullptr,
-            beast::severities::kDisabled};
-        beast::Journal journal{env.app().journal("ValidatorKeys_test")};
+        SuiteJournal journal("ValidatorKeys_test", *this);
 
         // Keys/ID when using [validation_seed]
         SecretKey const seedSecretKey =

--- a/src/test/protocol/STValidation_test.cpp
+++ b/src/test/protocol/STValidation_test.cpp
@@ -185,12 +185,22 @@ public:
     {
         testcase("Deserialization");
 
+        std::array<std::uint8_t, 33> const testPubKeyData{
+            0x03, 0x33, 0x07, 0x57, 0xF4, 0xE7, 0x12, 0xF6, 0x8B, 0x39, 0x11,
+            0xC0, 0x8B, 0x0A, 0x05, 0x9E, 0x9C, 0xE2, 0x61, 0x55, 0xC7, 0xE5,
+            0xDB, 0xC6, 0xDC, 0xB6, 0xD6, 0x5E, 0x22, 0x3B, 0xD9, 0x85, 0x60};
+
+        PublicKey const testPubKey(makeSlice(testPubKeyData));
+
         try
         {
             SerialIter sit{payload8};
 
             auto val = std::make_shared<STValidation>(
-                sit, [](PublicKey const& pk) { return calcNodeID(pk); }, true);
+                sit,
+                [](PublicKey const& pk) { return calcNodeID(pk); },
+                [&testPubKey](PublicKey const& pk) { return testPubKey; },
+                true);
 
             BEAST_EXPECT(val);
             BEAST_EXPECT(val->isFieldPresent(sfLedgerSequence));


### PR DESCRIPTION
Summary of changes:

- refactor NegativeUNL class to use PublicKey instead of NodeID 
- modify the constructors of STValidation to include masterPubKey_ 
- major changes to unit tests of NegativeUNL and STValidation



- [ x] Refactor (non-breaking change that only restructures code)
- [ x] Tests (You added tests for code that already exists, or your new feature included in this PR)
