### PR TITLE
removed inaccessible code paths outdated data formats

### DIFF
--- a/src/ripple/beast/utility/PropertyStream.h
+++ b/src/ripple/beast/utility/PropertyStream.h
@@ -78,12 +78,6 @@ protected:
     virtual void
     add(std::string const& key, unsigned char value);
     virtual void
-    add(std::string const& key, wchar_t value);
-#if 0
-    virtual void add (std::string const& key, char16_t value);
-    virtual void add (std::string const& key, char32_t value);
-#endif
-    virtual void
     add(std::string const& key, short value);
     virtual void
     add(std::string const& key, unsigned short value);
@@ -139,12 +133,6 @@ protected:
     add(signed char value);
     virtual void
     add(unsigned char value);
-    virtual void
-    add(wchar_t value);
-#if 0
-    virtual void add (char16_t value);
-    virtual void add (char32_t value);
-#endif
     virtual void
     add(short value);
     virtual void

--- a/src/ripple/beast/utility/src/beast_PropertyStream.cpp
+++ b/src/ripple/beast/utility/src/beast_PropertyStream.cpp
@@ -415,24 +415,6 @@ PropertyStream::add(std::string const& key, unsigned char value)
 }
 
 void
-PropertyStream::add(std::string const& key, wchar_t value)
-{
-    lexical_add(key, value);
-}
-
-#if 0
-void PropertyStream::add (std::string const& key, char16_t value)
-{
-    lexical_add (key, value);
-}
-
-void PropertyStream::add (std::string const& key, char32_t value)
-{
-    lexical_add (key, value);
-}
-#endif
-
-void
 PropertyStream::add(std::string const& key, short value)
 {
     lexical_add(key, value);
@@ -524,24 +506,6 @@ PropertyStream::add(unsigned char value)
 {
     lexical_add(value);
 }
-
-void
-PropertyStream::add(wchar_t value)
-{
-    lexical_add(value);
-}
-
-#if 0
-void PropertyStream::add (char16_t value)
-{
-    lexical_add (value);
-}
-
-void PropertyStream::add (char32_t value)
-{
-    lexical_add (value);
-}
-#endif
 
 void
 PropertyStream::add(short value)

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -642,11 +642,6 @@ PeerImp::gracefulClose()
     assert(socket_.is_open());
     assert(!gracefulClose_);
     gracefulClose_ = true;
-#if 0
-    // Flush messages
-    while(send_queue_.size() > 1)
-        send_queue_.pop_back();
-#endif
     if (send_queue_.size() > 0)
         return;
     setTimer();


### PR DESCRIPTION


This PR removes old inaccessible code-paths.
- certain portions of the code are marked with `#if 0 ... #endif`. These code portions never make it into the assembly stage and hence are removed.
- some functions accomodating the `wchar_t` data type have been removed in this PR.





- [ X ] Refactor (non-breaking change that only restructures code