### PR TITLE
Proposed 1.9.3

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,38 @@ This document contains the release notes for `rippled`, the reference server imp
  
 Have new ideas? Need help with setting up your node? Come visit us [here](https://github.com/xrplf/rippled/issues/new/choose)
 
+# Introducing XRP Ledger version 1.9.3
+
+Version 1.9.3 of `rippled`, the reference server implementation of the XRP Ledger protocol is now available. This release corrects minor technical flaws with the code that loads configured amendment votes after a startup and the copy constructor of `PublicKey`.
+
+## Install / Upgrade
+
+On supported platforms, see the [instructions on installing or updating `rippled`](https://xrpl.org/install-rippled.html).
+
+## Changelog
+
+## Contributions
+
+This releases contains the following bug fixes:
+
+- **Change by-value to by-reference to persist vote**: A minor technical flaw, caused by use of a copy instead of a reference, resulted in operator-configured "yes" votes to not be properly loaded after a restart. ([#4256](https://github.com/XRPLF/rippled/pull/4256))
+- **Properly handle self-assignment of PublicKey**: The `PublicKey` copy assignment operator mishandled the case where a `PublicKey` would be assigned to itself, and could result in undefined behavior. 
+
+### GitHub
+
+The public source code repository for `rippled` is hosted on GitHub at <https://github.com/XRPLF/rippled>.
+
+We welcome contributions, big and small, and invite everyone to join the community of XRP Ledger developers and help us build the Internet of Value.
+
+### Credits
+
+The following people contributed directly to this release:
+
+- Howard Hinnant <howard@ripple.com>
+- Crypto Brad Garlinghouse <cryptobradgarlinghouse@protonmail.com>
+- Wo Jake <87929946+wojake@users.noreply.github.com>
+
+
 # Introducing XRP Ledger version 1.9.2
 
 Version 1.9.2 of `rippled`, the reference server implementation of the XRP Ledger protocol, is now available. This release includes several fixes and improvements, including a second new fix amendment to correct a bug in Non-Fungible Tokens (NFTs) code, a new API method for order book changes, less noisy logging, and other small fixes.

--- a/src/ripple/app/misc/impl/AmendmentTable.cpp
+++ b/src/ripple/app/misc/impl/AmendmentTable.cpp
@@ -425,7 +425,7 @@ AmendmentTableImpl::AmendmentTableImpl(
             }
             else  // up-vote
             {
-                auto s = add(amend_hash, lock);
+                AmendmentState& s = add(amend_hash, lock);
 
                 JLOG(j_.debug()) << "Amendment {" << *amendment_name << ", "
                                  << amend_hash << "} is upvoted.";

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "1.9.2"
+char const* const versionString = "1.9.3"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -52,7 +52,7 @@ enum class Supported : bool { no = false, yes };
 // enabled using run-time conditionals based on the state of the amendment.
 // There is value in retaining that conditional code for some time after
 // the amendment is enabled to make it simple to replay old transactions.
-// However, once an Amendment has been enabled for, say, more than two years
+// However, once an amendment has been enabled for, say, more than two years
 // then retaining that conditional code has less value since it is
 // uncommon to replay such old transactions.
 //
@@ -61,10 +61,15 @@ enum class Supported : bool { no = false, yes };
 // 2018 needs to happen on an older version of the server code.  There's
 // a log message in Application.cpp that warns about replaying old ledgers.
 //
-// At some point in the future someone may wish to remove Amendment
-// conditional code for Amendments that were enabled after January 2018.
+// At some point in the future someone may wish to remove amendment
+// conditional code for amendments that were enabled after January 2018.
 // When that happens then the log message in Application.cpp should be
 // updated.
+//
+// Generally, amendments which introduce new features should be set as
+// "DefaultVote::no" whereas in rare cases, amendments that fix critical
+// bugs should be set as "DefaultVote::yes", if off-chain consensus is
+// reached amongst reviewers, validator operators, and other participants.
 
 class FeatureCollections
 {

--- a/src/ripple/protocol/impl/PublicKey.cpp
+++ b/src/ripple/protocol/impl/PublicKey.cpp
@@ -24,7 +24,6 @@
 #include <ripple/protocol/impl/secp256k1.h>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <ed25519-donna/ed25519.h>
-#include <type_traits>
 
 namespace ripple {
 
@@ -186,14 +185,18 @@ PublicKey::PublicKey(PublicKey const& other) : size_(other.size_)
 {
     if (size_)
         std::memcpy(buf_, other.buf_, size_);
-};
+}
 
 PublicKey&
 PublicKey::operator=(PublicKey const& other)
 {
-    size_ = other.size_;
-    if (size_)
-        std::memcpy(buf_, other.buf_, size_);
+    if (this != &other)
+    {
+        size_ = other.size_;
+        if (size_)
+            std::memcpy(buf_, other.buf_, size_);
+    }
+
     return *this;
 }
 


### PR DESCRIPTION
This release corrects a minor technical flaw that could cause servers to incorrectly process a request to vote in support for an amendment during server startup. A minor technical fix in the copy constructor of `PublicKey` is also included.

If merged, this will:

- close #4254
- close #4256
- close #4263