### PR TITLE
Use strongly-typed AcctRoot class to internally represent account root ledger objects

### DIFF
--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -46,7 +46,7 @@ RCLValidatedLedger::RCLValidatedLedger(
     beast::Journal j)
     : ledgerID_{ledger->info().hash}, ledgerSeq_{ledger->seq()}, j_{j}
 {
-    auto const hashIndex = ledger->read(keylet::skip());
+    auto const hashIndex = ledger->readSLE(keylet::skip());
     if (hashIndex)
     {
         assert(hashIndex->getFieldU32(sfLastLedgerSequence) == (seq() - 1));

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -450,7 +450,7 @@ Ledger::succ(uint256 const& key, std::optional<uint256> const& last) const
 }
 
 std::shared_ptr<SLE const>
-Ledger::read(KeyletBase const& k) const
+Ledger::readSLE(KeyletBase const& k) const
 {
     if (k.key == beast::zero)
     {
@@ -626,7 +626,7 @@ Ledger::setup()
 
     try
     {
-        if (auto const sle = read(keylet::fees()))
+        if (auto const sle = readSLE(keylet::fees()))
         {
             bool oldFees = false;
             bool newFees = false;
@@ -697,7 +697,7 @@ Ledger::defaultFees(Config const& config)
 }
 
 std::shared_ptr<SLE>
-Ledger::peek(KeyletBase const& k) const
+Ledger::peekSLE(KeyletBase const& k) const
 {
     auto const& value = stateMap_.peekItem(k.key);
     if (!value)
@@ -712,7 +712,7 @@ hash_set<PublicKey>
 Ledger::negativeUNL() const
 {
     hash_set<PublicKey> negUnl;
-    if (auto sle = read(keylet::negativeUNL());
+    if (auto sle = readSLE(keylet::negativeUNL());
         sle && sle->isFieldPresent(sfDisabledValidators))
     {
         auto const& nUnlData = sle->getFieldArray(sfDisabledValidators);
@@ -737,7 +737,7 @@ Ledger::negativeUNL() const
 std::optional<PublicKey>
 Ledger::validatorToDisable() const
 {
-    if (auto sle = read(keylet::negativeUNL());
+    if (auto sle = readSLE(keylet::negativeUNL());
         sle && sle->isFieldPresent(sfValidatorToDisable))
     {
         auto d = sle->getFieldVL(sfValidatorToDisable);
@@ -752,7 +752,7 @@ Ledger::validatorToDisable() const
 std::optional<PublicKey>
 Ledger::validatorToReEnable() const
 {
-    if (auto sle = read(keylet::negativeUNL());
+    if (auto sle = readSLE(keylet::negativeUNL());
         sle && sle->isFieldPresent(sfValidatorToReEnable))
     {
         auto d = sle->getFieldVL(sfValidatorToReEnable);
@@ -767,7 +767,7 @@ Ledger::validatorToReEnable() const
 void
 Ledger::updateNegativeUNL()
 {
-    auto sle = peek(keylet::negativeUNL());
+    auto sle = peekSLE(keylet::negativeUNL());
     if (!sle)
         return;
 
@@ -902,7 +902,7 @@ Ledger::updateSkipList()
     if ((prevIndex & 0xff) == 0)
     {
         auto const k = keylet::skip(prevIndex);
-        auto sle = peek(k);
+        auto sle = peekSLE(k);
         std::vector<uint256> hashes;
 
         bool created;
@@ -929,7 +929,7 @@ Ledger::updateSkipList()
 
     // update record of past 256 ledger
     auto const k = keylet::skip();
-    auto sle = peek(k);
+    auto sle = peekSLE(k);
     std::vector<uint256> hashes;
     bool created;
     if (!sle)
@@ -1101,7 +1101,7 @@ finishLoadByIndexOrHash(
 
     assert(
         ledger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
-        ledger->read(keylet::fees()));
+        ledger->readSLE(keylet::fees()));
     ledger->setImmutable();
 
     JLOG(j.trace()) << "Loaded ledger: " << to_string(ledger->info().hash);

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -426,7 +426,7 @@ deserializeTxPlusMeta(SHAMapItem const& item)
 //------------------------------------------------------------------------------
 
 bool
-Ledger::exists(Keylet const& k) const
+Ledger::exists(KeyletBase const& k) const
 {
     // VFALCO NOTE Perhaps check the type for debug builds?
     return stateMap_.hasItem(k.key);
@@ -450,7 +450,7 @@ Ledger::succ(uint256 const& key, std::optional<uint256> const& last) const
 }
 
 std::shared_ptr<SLE const>
-Ledger::read(Keylet const& k) const
+Ledger::read(KeyletBase const& k) const
 {
     if (k.key == beast::zero)
     {
@@ -697,7 +697,7 @@ Ledger::defaultFees(Config const& config)
 }
 
 std::shared_ptr<SLE>
-Ledger::peek(Keylet const& k) const
+Ledger::peek(KeyletBase const& k) const
 {
     auto const& value = stateMap_.peekItem(k.key);
     if (!value)

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -173,7 +173,7 @@ public:
     }
 
     bool
-    exists(Keylet const& k) const override;
+    exists(KeyletBase const& k) const override;
 
     bool
     exists(uint256 const& key) const;
@@ -183,7 +183,7 @@ public:
         const override;
 
     std::shared_ptr<SLE const>
-    read(Keylet const& k) const override;
+    read(KeyletBase const& k) const override;
 
     std::unique_ptr<sles_type::iter_base>
     slesBegin() const override;
@@ -391,7 +391,7 @@ public:
     isVotingLedger() const;
 
     std::shared_ptr<SLE>
-    peek(Keylet const& k) const;
+    peek(KeyletBase const& k) const;
 
 private:
     class sles_iter_impl;

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -183,7 +183,7 @@ public:
         const override;
 
     std::shared_ptr<SLE const>
-    read(KeyletBase const& k) const override;
+    readSLE(KeyletBase const& k) const override;
 
     std::unique_ptr<sles_type::iter_base>
     slesBegin() const override;
@@ -391,7 +391,7 @@ public:
     isVotingLedger() const;
 
     std::shared_ptr<SLE>
-    peek(KeyletBase const& k) const;
+    peekSLE(KeyletBase const& k) const;
 
 private:
     class sles_iter_impl;

--- a/src/ripple/app/ledger/impl/BuildLedger.cpp
+++ b/src/ripple/app/ledger/impl/BuildLedger.cpp
@@ -77,7 +77,7 @@ buildLedgerImpl(
     // Accept ledger
     assert(
         built->info().seq < XRP_LEDGER_EARLIEST_FEES ||
-        built->read(keylet::fees()));
+        built->readSLE(keylet::fees()));
     built->setAccepted(closeTime, closeResolution, closeTimeCorrect);
 
     return built;

--- a/src/ripple/app/ledger/impl/InboundLedger.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedger.cpp
@@ -157,7 +157,7 @@ InboundLedger::init(ScopedLockType& collectionLock)
                            << " local store. " << hash_;
     assert(
         mLedger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
-        mLedger->read(keylet::fees()));
+        mLedger->readSLE(keylet::fees()));
     mLedger->setImmutable();
 
     if (mReason == Reason::HISTORY || mReason == Reason::SHARD)
@@ -421,7 +421,7 @@ InboundLedger::tryDB(NodeStore::Database& srcDB)
         complete_ = true;
         assert(
             mLedger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
-            mLedger->read(keylet::fees()));
+            mLedger->readSLE(keylet::fees()));
         mLedger->setImmutable();
     }
 }
@@ -521,7 +521,7 @@ InboundLedger::done()
     {
         assert(
             mLedger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
-            mLedger->read(keylet::fees()));
+            mLedger->readSLE(keylet::fees()));
         mLedger->setImmutable();
         switch (mReason)
         {

--- a/src/ripple/app/ledger/impl/LocalTxs.cpp
+++ b/src/ripple/app/ledger/impl/LocalTxs.cpp
@@ -156,7 +156,7 @@ public:
                 return true;
 
             AccountID const acctID = txn.getAccount();
-            auto const sleAcct = view.read(keylet::account(acctID));
+            auto const sleAcct = view.readSLE(keylet::account(acctID));
 
             if (!sleAcct)
                 return false;

--- a/src/ripple/app/ledger/impl/LocalTxs.cpp
+++ b/src/ripple/app/ledger/impl/LocalTxs.cpp
@@ -156,13 +156,12 @@ public:
                 return true;
 
             AccountID const acctID = txn.getAccount();
-            auto const sleAcct = view.readSLE(keylet::account(acctID));
+            auto const acctRoot = view.read(keylet::account(acctID));
 
-            if (!sleAcct)
+            if (!acctRoot)
                 return false;
 
-            SeqProxy const acctSeq =
-                SeqProxy::sequence(sleAcct->getFieldU32(sfSequence));
+            SeqProxy const acctSeq = SeqProxy::sequence(acctRoot->sequence());
             SeqProxy const seqProx = txn.getSeqProxy();
 
             if (seqProx.isSeq())

--- a/src/ripple/app/ledger/impl/SkipListAcquire.cpp
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.cpp
@@ -192,7 +192,7 @@ SkipListAcquire::retrieveSkipList(
     std::shared_ptr<Ledger const> const& ledger,
     ScopedLockType& sl)
 {
-    if (auto const hashIndex = ledger->read(keylet::skip());
+    if (auto const hashIndex = ledger->readSLE(keylet::skip());
         hashIndex && hashIndex->isFieldPresent(sfHashes))
     {
         auto const& slist = hashIndex->getFieldV256(sfHashes).value();

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1712,7 +1712,7 @@ ApplicationImp::startGenesisLedger()
     next->updateSkipList();
     assert(
         next->info().seq < XRP_LEDGER_EARLIEST_FEES ||
-        next->read(keylet::fees()));
+        next->readSLE(keylet::fees()));
     next->setImmutable();
     openLedger_.emplace(next, cachedSLEs_, logs_->journal("OpenLedger"));
     m_ledgerMaster->storeLedger(next);
@@ -1733,7 +1733,7 @@ ApplicationImp::getLastFullLedger()
 
         assert(
             ledger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
-            ledger->read(keylet::fees()));
+            ledger->readSLE(keylet::fees()));
         ledger->setImmutable();
 
         if (getLedgerMaster().haveLedger(seq))
@@ -1887,7 +1887,7 @@ ApplicationImp::loadLedgerFromFile(std::string const& name)
 
         assert(
             loadLedger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
-            loadLedger->read(keylet::fees()));
+            loadLedger->readSLE(keylet::fees()));
         loadLedger->setAccepted(
             closeTime, closeTimeResolution, !closeTimeEstimated);
 

--- a/src/ripple/app/misc/NegativeUNLVote.cpp
+++ b/src/ripple/app/misc/NegativeUNLVote.cpp
@@ -170,7 +170,7 @@ NegativeUNLVote::buildScoreTable(
     validations.setSeqToKeep(seq - 1, seq + FLAG_LEDGER_INTERVAL);
 
     // Find FLAG_LEDGER_INTERVAL (i.e. 256) previous ledger hashes
-    auto const hashIndex = prevLedger->read(keylet::skip());
+    auto const hashIndex = prevLedger->readSLE(keylet::skip());
     if (!hashIndex || !hashIndex->isFieldPresent(sfHashes))
     {
         JLOG(j_.debug()) << "N-UNL: ledger " << seq << " no history.";

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -3742,9 +3742,9 @@ NetworkOPsImp::subAccountHistoryStart(
     }
     if (accountId == genesisAccountId)
     {
-        if (auto const sleAcct = ledger->readSLE(accountKeylet); sleAcct)
+        if (auto const acctRoot = ledger->read(accountKeylet))
         {
-            if (sleAcct->getFieldU32(sfSequence) == 1)
+            if (acctRoot->sequence() == 1)
             {
                 JLOG(m_journal.debug())
                     << "subAccountHistoryStart, genesis account "

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1522,7 +1522,7 @@ NetworkOPsImp::getOwnerInfo(
 {
     Json::Value jvObjects(Json::objectValue);
     auto root = keylet::ownerDir(account);
-    auto sleNode = lpLedger->read(keylet::page(root));
+    auto sleNode = lpLedger->readSLE(keylet::page(root));
     if (sleNode)
     {
         std::uint64_t uNodeDir;
@@ -1531,7 +1531,7 @@ NetworkOPsImp::getOwnerInfo(
         {
             for (auto const& uDirEntry : sleNode->getFieldV256(sfIndexes))
             {
-                auto sleCur = lpLedger->read(keylet::child(uDirEntry));
+                auto sleCur = lpLedger->readSLE(keylet::child(uDirEntry));
                 assert(sleCur);
 
                 switch (sleCur->getType())
@@ -1568,7 +1568,7 @@ NetworkOPsImp::getOwnerInfo(
 
             if (uNodeDir)
             {
-                sleNode = lpLedger->read(keylet::page(root, uNodeDir));
+                sleNode = lpLedger->readSLE(keylet::page(root, uNodeDir));
                 assert(sleNode);
             }
         } while (uNodeDir);
@@ -3742,7 +3742,7 @@ NetworkOPsImp::subAccountHistoryStart(
     }
     if (accountId == genesisAccountId)
     {
-        if (auto const sleAcct = ledger->read(accountKeylet); sleAcct)
+        if (auto const sleAcct = ledger->readSLE(accountKeylet); sleAcct)
         {
             if (sleAcct->getFieldU32(sfSequence) == 1)
             {
@@ -4203,7 +4203,7 @@ NetworkOPsImp::getBookPage(
 
             auto const ledgerIndex = view.succ(uTipIndex, uBookEnd);
             if (ledgerIndex)
-                sleOfferDir = view.read(keylet::page(*ledgerIndex));
+                sleOfferDir = view.readSLE(keylet::page(*ledgerIndex));
             else
                 sleOfferDir.reset();
 
@@ -4228,7 +4228,7 @@ NetworkOPsImp::getBookPage(
 
         if (!bDone)
         {
-            auto sleOffer = view.read(keylet::offer(offerIndex));
+            auto sleOffer = view.readSLE(keylet::offer(offerIndex));
 
             if (sleOffer)
             {

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -306,7 +306,7 @@ public:
 
     /** Return the next sequence that would go in the TxQ for an account. */
     SeqProxy
-    nextQueuableSeq(std::shared_ptr<SLE const> const& sleAccount) const;
+    nextQueuableSeq(std::optional<AcctRootRd const> const& acctRoot) const;
 
     /** Returns fee metrics in reference fee level units.
      */
@@ -363,7 +363,7 @@ private:
     // Implementation for nextQueuableSeq().  The passed lock must be held.
     SeqProxy
     nextQueuableSeqImpl(
-        std::shared_ptr<SLE const> const& sleAccount,
+        std::optional<AcctRootRd const> const& acctRoot,
         std::lock_guard<std::mutex> const&) const;
 
     /**
@@ -812,7 +812,7 @@ private:
         STTx const&,
         ApplyFlags const,
         OpenView const&,
-        std::shared_ptr<SLE const> const& sleAccount,
+        std::optional<AcctRootRd const> const& acctRoot,
         AccountMap::iterator const&,
         std::optional<TxQAccount::TxMap::iterator> const&,
         std::lock_guard<std::mutex> const& lock);

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -742,7 +742,7 @@ TxQ::apply(
     // If the account is not currently in the ledger, don't queue its tx.
     auto const account = (*tx)[sfAccount];
     Keylet const accountKey{keylet::account(account)};
-    auto const sleAccount = view.read(accountKey);
+    auto const sleAccount = view.readSLE(accountKey);
     if (!sleAccount)
         return {terNO_ACCOUNT, false};
 
@@ -1109,7 +1109,7 @@ TxQ::apply(
             // Create the test view from the current view.
             multiTxn.emplace(view, flags);
 
-            auto const sleBump = multiTxn->applyView.peek(accountKey);
+            auto const sleBump = multiTxn->applyView.peekSLE(accountKey);
             if (!sleBump)
                 return {tefINTERNAL, false};
 
@@ -1661,7 +1661,7 @@ TxQ::tryDirectApply(
     beast::Journal j)
 {
     auto const account = (*tx)[sfAccount];
-    auto const sleAccount = view.read(keylet::account(account));
+    auto const sleAccount = view.readSLE(keylet::account(account));
 
     // Don't attempt to direct apply if the account is not in the ledger.
     if (!sleAccount)
@@ -1778,7 +1778,7 @@ TxQ::getTxRequiredFeeAndSeq(
     auto const baseFee = calculateBaseFee(view, *tx);
     auto const fee = FeeMetrics::scaleFeeLevel(snapshot, view);
 
-    auto const sle = view.read(keylet::account(account));
+    auto const sle = view.readSLE(keylet::account(account));
 
     std::uint32_t const accountSeq = sle ? (*sle)[sfSequence] : 0;
     std::uint32_t const availableSeq = nextQueuableSeqImpl(sle, lock).value();

--- a/src/ripple/app/paths/Credit.cpp
+++ b/src/ripple/app/paths/Credit.cpp
@@ -33,7 +33,7 @@ creditLimit(
 {
     STAmount result({currency, account});
 
-    auto sleRippleState = view.read(keylet::line(account, issuer, currency));
+    auto sleRippleState = view.readSLE(keylet::line(account, issuer, currency));
 
     if (sleRippleState)
     {
@@ -66,7 +66,7 @@ creditBalance(
 {
     STAmount result({currency, account});
 
-    auto sleRippleState = view.read(keylet::line(account, issuer, currency));
+    auto sleRippleState = view.readSLE(keylet::line(account, issuer, currency));
 
     if (sleRippleState)
     {

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -190,7 +190,7 @@ PathRequest::isValid(std::shared_ptr<RippleLineCache> const& crCache)
         return false;
     }
 
-    auto const sleDest = lrLedger->read(keylet::account(*raDstAccount));
+    auto const sleDest = lrLedger->readSLE(keylet::account(*raDstAccount));
 
     Json::Value& jvDestCur =
         (jvStatus[jss::destination_currencies] = Json::arrayValue);

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -190,12 +190,12 @@ PathRequest::isValid(std::shared_ptr<RippleLineCache> const& crCache)
         return false;
     }
 
-    auto const sleDest = lrLedger->readSLE(keylet::account(*raDstAccount));
+    auto const destAcctRoot = lrLedger->read(keylet::account(*raDstAccount));
 
     Json::Value& jvDestCur =
         (jvStatus[jss::destination_currencies] = Json::arrayValue);
 
-    if (!sleDest)
+    if (!destAcctRoot)
     {
         jvDestCur.append(Json::Value(systemCurrencyCode()));
         if (!saDstAmount.native())
@@ -215,7 +215,7 @@ PathRequest::isValid(std::shared_ptr<RippleLineCache> const& crCache)
     }
     else
     {
-        bool const disallowXRP(sleDest->getFlags() & lsfDisallowXRP);
+        bool const disallowXRP(destAcctRoot->isFlag(lsfDisallowXRP));
 
         auto usDestCurrID =
             accountDestCurrencies(*raDstAccount, crCache, !disallowXRP);
@@ -223,7 +223,7 @@ PathRequest::isValid(std::shared_ptr<RippleLineCache> const& crCache)
         for (auto const& currency : usDestCurrID)
             jvDestCur.append(to_string(currency));
         jvStatus[jss::destination_tag] =
-            (sleDest->getFlags() & lsfRequireDestTag);
+            destAcctRoot->isFlag(lsfRequireDestTag);
     }
 
     jvStatus[jss::ledger_hash] = to_string(lrLedger->info().hash);

--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -721,12 +721,12 @@ Pathfinder::getPathsOut(
     if (!inserted)
         return it->second;
 
-    auto sleAccount = mLedger->readSLE(keylet::account(account));
+    auto const acctRoot = mLedger->read(keylet::account(account));
 
-    if (!sleAccount)
+    if (!acctRoot)
         return 0;
 
-    int aFlags = sleAccount->getFieldU32(sfFlags);
+    int aFlags = acctRoot->flags();
     bool const bAuthRequired = (aFlags & lsfRequireAuth) != 0;
     bool const bFrozen = ((aFlags & lsfGlobalFreeze) != 0);
 
@@ -970,12 +970,12 @@ Pathfinder::addLink(
         else
         {
             // search for accounts to add
-            auto const sleEnd = mLedger->readSLE(keylet::account(uEndAccount));
+            auto const endAcctRoot =
+                mLedger->read(keylet::account(uEndAccount));
 
-            if (sleEnd)
+            if (endAcctRoot)
             {
-                bool const bRequireAuth(
-                    sleEnd->getFieldU32(sfFlags) & lsfRequireAuth);
+                bool const bRequireAuth(endAcctRoot->isFlag(lsfRequireAuth));
                 bool const bIsEndCurrency(
                     uEndCurrency == mDstAmount.getCurrency());
                 bool const bIsNoRippleOut(isNoRippleOut(currentPath));

--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -721,7 +721,7 @@ Pathfinder::getPathsOut(
     if (!inserted)
         return it->second;
 
-    auto sleAccount = mLedger->read(keylet::account(account));
+    auto sleAccount = mLedger->readSLE(keylet::account(account));
 
     if (!sleAccount)
         return 0;
@@ -888,7 +888,7 @@ Pathfinder::isNoRipple(
     Currency const& currency)
 {
     auto sleRipple =
-        mLedger->read(keylet::line(toAccount, fromAccount, currency));
+        mLedger->readSLE(keylet::line(toAccount, fromAccount, currency));
 
     auto const flag(
         (toAccount > fromAccount) ? lsfHighNoRipple : lsfLowNoRipple);
@@ -970,7 +970,7 @@ Pathfinder::addLink(
         else
         {
             // search for accounts to add
-            auto const sleEnd = mLedger->read(keylet::account(uEndAccount));
+            auto const sleEnd = mLedger->readSLE(keylet::account(uEndAccount));
 
             if (sleEnd)
             {

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -600,7 +600,7 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
             (offer.owner() != offer.issueIn().account))
         {
             auto const& issuerID = offer.issueIn().account;
-            auto const issuer = afView.read(keylet::account(issuerID));
+            auto const issuer = afView.readSLE(keylet::account(issuerID));
             if (issuer && ((*issuer)[sfFlags] & lsfRequireAuth))
             {
                 // Issuer requires authorization.  See if offer owner has that.
@@ -608,7 +608,7 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
                 auto const authFlag =
                     issuerID > ownerID ? lsfHighAuth : lsfLowAuth;
 
-                auto const line = afView.read(
+                auto const line = afView.readSLE(
                     keylet::line(ownerID, issuerID, offer.issueIn().currency));
 
                 if (!line || (((*line)[sfFlags] & authFlag) == 0))
@@ -1077,7 +1077,7 @@ BookStep<TIn, TOut, TDerived>::check(StrandContext const& ctx) const
     }
 
     auto issuerExists = [](ReadView const& view, Issue const& iss) -> bool {
-        return isXRP(iss.account) || view.read(keylet::account(iss.account));
+        return isXRP(iss.account) || view.readSLE(keylet::account(iss.account));
     };
 
     if (!issuerExists(ctx.view, book_.in) || !issuerExists(ctx.view, book_.out))
@@ -1093,7 +1093,8 @@ BookStep<TIn, TOut, TDerived>::check(StrandContext const& ctx) const
             auto const& view = ctx.view;
             auto const& cur = book_.in.account;
 
-            auto sle = view.read(keylet::line(*prev, cur, book_.in.currency));
+            auto sle =
+                view.readSLE(keylet::line(*prev, cur, book_.in.currency));
             if (!sle)
                 return terNO_LINE;
             if ((*sle)[sfFlags] &

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -600,8 +600,9 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
             (offer.owner() != offer.issueIn().account))
         {
             auto const& issuerID = offer.issueIn().account;
-            auto const issuer = afView.readSLE(keylet::account(issuerID));
-            if (issuer && ((*issuer)[sfFlags] & lsfRequireAuth))
+            if (auto const issuerAcctRoot =
+                    afView.read(keylet::account(issuerID));
+                issuerAcctRoot && issuerAcctRoot->isFlag(lsfRequireAuth))
             {
                 // Issuer requires authorization.  See if offer owner has that.
                 auto const& ownerID = offer.owner();
@@ -1077,7 +1078,7 @@ BookStep<TIn, TOut, TDerived>::check(StrandContext const& ctx) const
     }
 
     auto issuerExists = [](ReadView const& view, Issue const& iss) -> bool {
-        return isXRP(iss.account) || view.readSLE(keylet::account(iss.account));
+        return isXRP(iss.account) || view.read(keylet::account(iss.account));
     };
 
     if (!issuerExists(ctx.view, book_.in) || !issuerExists(ctx.view, book_.out))

--- a/src/ripple/app/paths/impl/DirectStep.cpp
+++ b/src/ripple/app/paths/impl/DirectStep.cpp
@@ -331,7 +331,7 @@ DirectIPaymentStep::quality(ReadView const& sb, QualityDirection qDir) const
     if (src_ == dst_)
         return QUALITY_ONE;
 
-    auto const sle = sb.read(keylet::line(dst_, src_, currency_));
+    auto const sle = sb.readSLE(keylet::line(dst_, src_, currency_));
 
     if (!sle)
         return QUALITY_ONE;
@@ -408,7 +408,8 @@ DirectIPaymentStep::check(
     // Since this is a payment a trust line must be present.  Perform all
     // trust line related checks.
     {
-        auto const sleLine = ctx.view.read(keylet::line(src_, dst_, currency_));
+        auto const sleLine =
+            ctx.view.readSLE(keylet::line(src_, dst_, currency_));
         if (!sleLine)
         {
             JLOG(j_.trace()) << "DirectStepI: No credit line. " << *this;
@@ -887,7 +888,7 @@ DirectStepI<TDerived>::check(StrandContext const& ctx) const
         return temBAD_PATH;
     }
 
-    auto const sleSrc = ctx.view.read(keylet::account(src_));
+    auto const sleSrc = ctx.view.readSLE(keylet::account(src_));
     if (!sleSrc)
     {
         JLOG(j_.warn())

--- a/src/ripple/app/paths/impl/StepChecks.h
+++ b/src/ripple/app/paths/impl/StepChecks.h
@@ -38,12 +38,10 @@ checkFreeze(
     assert(src != dst);
 
     // check freeze
-    if (auto sle = view.readSLE(keylet::account(dst)))
+    if (auto const acctRoot = view.read(keylet::account(dst));
+        acctRoot && acctRoot->isFlag(lsfGlobalFreeze))
     {
-        if (sle->isFlag(lsfGlobalFreeze))
-        {
-            return terNO_LINE;
-        }
+        return terNO_LINE;
     }
 
     if (auto sle = view.readSLE(keylet::line(src, dst, currency)))

--- a/src/ripple/app/paths/impl/StepChecks.h
+++ b/src/ripple/app/paths/impl/StepChecks.h
@@ -38,7 +38,7 @@ checkFreeze(
     assert(src != dst);
 
     // check freeze
-    if (auto sle = view.read(keylet::account(dst)))
+    if (auto sle = view.readSLE(keylet::account(dst)))
     {
         if (sle->isFlag(lsfGlobalFreeze))
         {
@@ -46,7 +46,7 @@ checkFreeze(
         }
     }
 
-    if (auto sle = view.read(keylet::line(src, dst, currency)))
+    if (auto sle = view.readSLE(keylet::line(src, dst, currency)))
     {
         if (sle->isFlag((dst > src) ? lsfHighFreeze : lsfLowFreeze))
         {
@@ -68,8 +68,8 @@ checkNoRipple(
     beast::Journal j)
 {
     // fetch the ripple lines into and out of this node
-    auto sleIn = view.read(keylet::line(prev, cur, currency));
-    auto sleOut = view.read(keylet::line(cur, next, currency));
+    auto sleIn = view.readSLE(keylet::line(prev, cur, currency));
+    auto sleOut = view.readSLE(keylet::line(cur, next, currency));
 
     if (!sleIn || !sleOut)
         return terNO_LINE;

--- a/src/ripple/app/paths/impl/StrandFlow.h
+++ b/src/ripple/app/paths/impl/StrandFlow.h
@@ -721,7 +721,7 @@ flow(
             SetUnion(ofrsToRmOnFail, ofrsToRm);
             for (auto const& o : ofrsToRm)
             {
-                if (auto ok = sb.peek(keylet::offer(o)))
+                if (auto ok = sb.peekSLE(keylet::offer(o)))
                     offerDelete(sb, ok, j);
             }
         }

--- a/src/ripple/app/paths/impl/XRPEndpointStep.cpp
+++ b/src/ripple/app/paths/impl/XRPEndpointStep.cpp
@@ -343,8 +343,7 @@ XRPEndpointStep<TDerived>::check(StrandContext const& ctx) const
         return temBAD_PATH;
     }
 
-    auto sleAcc = ctx.view.readSLE(keylet::account(acc_));
-    if (!sleAcc)
+    if (!ctx.view.read(keylet::account(acc_)))
     {
         JLOG(j_.warn()) << "XRPEndpointStep: can't send or receive XRP from "
                            "non-existent account: "

--- a/src/ripple/app/paths/impl/XRPEndpointStep.cpp
+++ b/src/ripple/app/paths/impl/XRPEndpointStep.cpp
@@ -202,7 +202,8 @@ private:
     static std::int32_t
     computeReserveReduction(StrandContext const& ctx, AccountID const& acc)
     {
-        if (ctx.isFirst && !ctx.view.read(keylet::line(acc, ctx.strandDeliver)))
+        if (ctx.isFirst &&
+            !ctx.view.readSLE(keylet::line(acc, ctx.strandDeliver)))
             return -1;
         return 0;
     }
@@ -342,7 +343,7 @@ XRPEndpointStep<TDerived>::check(StrandContext const& ctx) const
         return temBAD_PATH;
     }
 
-    auto sleAcc = ctx.view.read(keylet::account(acc_));
+    auto sleAcc = ctx.view.readSLE(keylet::account(acc_));
     if (!sleAcc)
     {
         JLOG(j_.warn()) << "XRPEndpointStep: can't send or receive XRP from "

--- a/src/ripple/app/reporting/ReportingETL.cpp
+++ b/src/ripple/app/reporting/ReportingETL.cpp
@@ -191,7 +191,7 @@ ReportingETL::flushLedger(std::shared_ptr<Ledger>& ledger)
 
     assert(
         ledger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
-        ledger->read(keylet::fees()));
+        ledger->readSLE(keylet::fees()));
     ledger->setImmutable(false);
     auto start = std::chrono::system_clock::now();
 

--- a/src/ripple/app/tx/impl/BookTip.cpp
+++ b/src/ripple/app/tx/impl/BookTip.cpp
@@ -58,7 +58,7 @@ BookTip::step(beast::Journal j)
         if (dirFirst(view_, *first_page, dir, di, m_index))
         {
             m_dir = dir->key();
-            m_entry = view_.peek(keylet::offer(m_index));
+            m_entry = view_.peekSLE(keylet::offer(m_index));
             m_quality = Quality(getQuality(*first_page));
             m_valid = true;
 

--- a/src/ripple/app/tx/impl/CancelCheck.cpp
+++ b/src/ripple/app/tx/impl/CancelCheck.cpp
@@ -53,7 +53,7 @@ CancelCheck::preflight(PreflightContext const& ctx)
 TER
 CancelCheck::preclaim(PreclaimContext const& ctx)
 {
-    auto const sleCheck = ctx.view.read(keylet::check(ctx.tx[sfCheckID]));
+    auto const sleCheck = ctx.view.readSLE(keylet::check(ctx.tx[sfCheckID]));
     if (!sleCheck)
     {
         JLOG(ctx.j.warn()) << "Check does not exist.";
@@ -88,7 +88,7 @@ CancelCheck::preclaim(PreclaimContext const& ctx)
 TER
 CancelCheck::doApply()
 {
-    auto const sleCheck = view().peek(keylet::check(ctx_.tx[sfCheckID]));
+    auto const sleCheck = view().peekSLE(keylet::check(ctx_.tx[sfCheckID]));
     if (!sleCheck)
     {
         // Error should have been caught in preclaim.
@@ -123,7 +123,7 @@ CancelCheck::doApply()
     }
 
     // If we succeeded, update the check owner's reserve.
-    auto const sleSrc = view().peek(keylet::account(srcId));
+    auto const sleSrc = view().peekSLE(keylet::account(srcId));
     adjustOwnerCount(view(), sleSrc, -1, viewJ);
 
     // Remove check from ledger.

--- a/src/ripple/app/tx/impl/CancelCheck.cpp
+++ b/src/ripple/app/tx/impl/CancelCheck.cpp
@@ -124,7 +124,7 @@ CancelCheck::doApply()
 
     // If we succeeded, update the check owner's reserve.
     auto srcAcctRoot = view().peek(keylet::account(srcId));
-    adjustOwnerCount(view(), srcAcctRoot, -1, viewJ);
+    adjustOwnerCount(view(), *srcAcctRoot, -1, viewJ);
 
     // Remove check from ledger.
     view().erase(sleCheck);

--- a/src/ripple/app/tx/impl/CancelCheck.cpp
+++ b/src/ripple/app/tx/impl/CancelCheck.cpp
@@ -123,8 +123,8 @@ CancelCheck::doApply()
     }
 
     // If we succeeded, update the check owner's reserve.
-    auto const sleSrc = view().peekSLE(keylet::account(srcId));
-    adjustOwnerCount(view(), sleSrc, -1, viewJ);
+    auto srcAcctRoot = view().peek(keylet::account(srcId));
+    adjustOwnerCount(view(), srcAcctRoot, -1, viewJ);
 
     // Remove check from ledger.
     view().erase(sleCheck);

--- a/src/ripple/app/tx/impl/CancelOffer.cpp
+++ b/src/ripple/app/tx/impl/CancelOffer.cpp
@@ -56,7 +56,7 @@ CancelOffer::preclaim(PreclaimContext const& ctx)
     auto const id = ctx.tx[sfAccount];
     auto const offerSequence = ctx.tx[sfOfferSequence];
 
-    auto const sle = ctx.view.read(keylet::account(id));
+    auto const sle = ctx.view.readSLE(keylet::account(id));
     if (!sle)
         return terNO_ACCOUNT;
 
@@ -77,11 +77,11 @@ CancelOffer::doApply()
 {
     auto const offerSequence = ctx_.tx[sfOfferSequence];
 
-    auto const sle = view().read(keylet::account(account_));
+    auto const sle = view().readSLE(keylet::account(account_));
     if (!sle)
         return tefINTERNAL;
 
-    if (auto sleOffer = view().peek(keylet::offer(account_, offerSequence)))
+    if (auto sleOffer = view().peekSLE(keylet::offer(account_, offerSequence)))
     {
         JLOG(j_.debug()) << "Trying to cancel offer #" << offerSequence;
         return offerDelete(view(), sleOffer, ctx_.app.journal("View"));

--- a/src/ripple/app/tx/impl/CancelOffer.cpp
+++ b/src/ripple/app/tx/impl/CancelOffer.cpp
@@ -56,11 +56,11 @@ CancelOffer::preclaim(PreclaimContext const& ctx)
     auto const id = ctx.tx[sfAccount];
     auto const offerSequence = ctx.tx[sfOfferSequence];
 
-    auto const sle = ctx.view.readSLE(keylet::account(id));
-    if (!sle)
+    auto const acctRoot = ctx.view.read(keylet::account(id));
+    if (!acctRoot)
         return terNO_ACCOUNT;
 
-    if ((*sle)[sfSequence] <= offerSequence)
+    if (acctRoot->sequence() <= offerSequence)
     {
         JLOG(ctx.j.trace()) << "Malformed transaction: "
                             << "Sequence " << offerSequence << " is invalid.";
@@ -77,8 +77,7 @@ CancelOffer::doApply()
 {
     auto const offerSequence = ctx_.tx[sfOfferSequence];
 
-    auto const sle = view().readSLE(keylet::account(account_));
-    if (!sle)
+    if (!view().read(keylet::account(account_)))
         return tefINTERNAL;
 
     if (auto sleOffer = view().peekSLE(keylet::offer(account_, offerSequence)))

--- a/src/ripple/app/tx/impl/CashCheck.cpp
+++ b/src/ripple/app/tx/impl/CashCheck.cpp
@@ -389,7 +389,7 @@ CashCheck::doApply()
                         issuer,                         // source
                         account_,                       // destination
                         trustLineKey.key,               // ledger index
-                        dstAcctRoot,                    // account to add to
+                        *dstAcctRoot,                   // account to add to
                         false,                          // authorize account
                         !dstAcctRoot->isFlag(lsfDefaultRipple),
                         false,                          // freeze trust line
@@ -404,7 +404,7 @@ CashCheck::doApply()
                 }
                 // clang-format on
 
-                psb.update(dstAcctRoot);
+                psb.update(*dstAcctRoot);
 
                 // Note that we _don't_ need to be careful about destroying
                 // the trust line if the check cashing fails.  The transaction
@@ -508,7 +508,7 @@ CashCheck::doApply()
 
     // If we succeeded, update the check owner's reserve.
     auto srcAcctRoot = psb.peek(keylet::account(srcId));
-    adjustOwnerCount(psb, srcAcctRoot, -1, viewJ);
+    adjustOwnerCount(psb, *srcAcctRoot, -1, viewJ);
 
     // Remove check from ledger.
     psb.erase(sleCheck);

--- a/src/ripple/app/tx/impl/Change.cpp
+++ b/src/ripple/app/tx/impl/Change.cpp
@@ -209,12 +209,16 @@ Change::activateTrustLinesToSelfFix()
         }
 
         if (tl->getFlags() & lsfLowReserve)
-            adjustOwnerCount(
-                sb, sb.peekSLE(keylet::account(lo.getIssuer())), -1, j_);
+        {
+            auto acctRootLo = sb.peek(keylet::account(lo.getIssuer()));
+            adjustOwnerCount(sb, acctRootLo, -1, j_);
+        }
 
         if (tl->getFlags() & lsfHighReserve)
-            adjustOwnerCount(
-                sb, sb.peekSLE(keylet::account(hi.getIssuer())), -1, j_);
+        {
+            auto acctRootHi = sb.peek(keylet::account(hi.getIssuer()));
+            adjustOwnerCount(sb, acctRootHi, -1, j_);
+        }
 
         sb.erase(tl);
 

--- a/src/ripple/app/tx/impl/Change.cpp
+++ b/src/ripple/app/tx/impl/Change.cpp
@@ -211,13 +211,13 @@ Change::activateTrustLinesToSelfFix()
         if (tl->getFlags() & lsfLowReserve)
         {
             auto acctRootLo = sb.peek(keylet::account(lo.getIssuer()));
-            adjustOwnerCount(sb, acctRootLo, -1, j_);
+            adjustOwnerCount(sb, *acctRootLo, -1, j_);
         }
 
         if (tl->getFlags() & lsfHighReserve)
         {
             auto acctRootHi = sb.peek(keylet::account(hi.getIssuer()));
-            adjustOwnerCount(sb, acctRootHi, -1, j_);
+            adjustOwnerCount(sb, *acctRootHi, -1, j_);
         }
 
         sb.erase(tl);

--- a/src/ripple/app/tx/impl/Change.cpp
+++ b/src/ripple/app/tx/impl/Change.cpp
@@ -166,7 +166,7 @@ Change::activateTrustLinesToSelfFix()
     JLOG(j_.warn()) << "fixTrustLinesToSelf amendment activation code starting";
 
     auto removeTrustLineToSelf = [this](Sandbox& sb, uint256 id) {
-        auto tl = sb.peek(keylet::child(id));
+        auto tl = sb.peekSLE(keylet::child(id));
 
         if (tl == nullptr)
         {
@@ -210,11 +210,11 @@ Change::activateTrustLinesToSelfFix()
 
         if (tl->getFlags() & lsfLowReserve)
             adjustOwnerCount(
-                sb, sb.peek(keylet::account(lo.getIssuer())), -1, j_);
+                sb, sb.peekSLE(keylet::account(lo.getIssuer())), -1, j_);
 
         if (tl->getFlags() & lsfHighReserve)
             adjustOwnerCount(
-                sb, sb.peek(keylet::account(hi.getIssuer())), -1, j_);
+                sb, sb.peekSLE(keylet::account(hi.getIssuer())), -1, j_);
 
         sb.erase(tl);
 
@@ -249,7 +249,7 @@ Change::applyAmendment()
 
     auto const k = keylet::amendments();
 
-    SLE::pointer amendmentObject = view().peek(k);
+    SLE::pointer amendmentObject = view().peekSLE(k);
 
     if (!amendmentObject)
     {
@@ -346,7 +346,7 @@ Change::applyFee()
 {
     auto const k = keylet::fees();
 
-    SLE::pointer feeObject = view().peek(k);
+    SLE::pointer feeObject = view().peekSLE(k);
 
     if (!feeObject)
     {
@@ -421,7 +421,7 @@ Change::applyUNLModify()
                     << " validator data:" << strHex(validator);
 
     auto const k = keylet::negativeUNL();
-    SLE::pointer negUnlObject = view().peek(k);
+    SLE::pointer negUnlObject = view().peekSLE(k);
     if (!negUnlObject)
     {
         negUnlObject = std::make_shared<SLE>(k);

--- a/src/ripple/app/tx/impl/CreateCheck.cpp
+++ b/src/ripple/app/tx/impl/CreateCheck.cpp
@@ -83,7 +83,7 @@ TER
 CreateCheck::preclaim(PreclaimContext const& ctx)
 {
     AccountID const dstId{ctx.tx[sfDestination]};
-    auto const sleDst = ctx.view.read(keylet::account(dstId));
+    auto const sleDst = ctx.view.readSLE(keylet::account(dstId));
     if (!sleDst)
     {
         JLOG(ctx.j.warn()) << "Destination account does not exist.";
@@ -125,7 +125,7 @@ CreateCheck::preclaim(PreclaimContext const& ctx)
             if (issuerId != srcId)
             {
                 // Check if the issuer froze the line
-                auto const sleTrust = ctx.view.read(
+                auto const sleTrust = ctx.view.readSLE(
                     keylet::line(srcId, issuerId, sendMax.getCurrency()));
                 if (sleTrust &&
                     sleTrust->isFlag(
@@ -139,7 +139,7 @@ CreateCheck::preclaim(PreclaimContext const& ctx)
             if (issuerId != dstId)
             {
                 // Check if dst froze the line.
-                auto const sleTrust = ctx.view.read(
+                auto const sleTrust = ctx.view.readSLE(
                     keylet::line(issuerId, dstId, sendMax.getCurrency()));
                 if (sleTrust &&
                     sleTrust->isFlag(
@@ -163,7 +163,7 @@ CreateCheck::preclaim(PreclaimContext const& ctx)
 TER
 CreateCheck::doApply()
 {
-    auto const sle = view().peek(keylet::account(account_));
+    auto const sle = view().peekSLE(keylet::account(account_));
     if (!sle)
         return tefINTERNAL;
 

--- a/src/ripple/app/tx/impl/CreateCheck.cpp
+++ b/src/ripple/app/tx/impl/CreateCheck.cpp
@@ -236,7 +236,7 @@ CreateCheck::doApply()
         sleCheck->setFieldU64(sfOwnerNode, *page);
     }
     // If we succeeded, the new entry counts against the creator's reserve.
-    adjustOwnerCount(view(), acctRoot, 1, viewJ);
+    adjustOwnerCount(view(), *acctRoot, 1, viewJ);
     return tesSUCCESS;
 }
 

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -1158,7 +1158,7 @@ CreateOffer::applyGuts(Sandbox& sb, Sandbox& sbCancel)
     }
 
     // Update owner count.
-    adjustOwnerCount(sb, creatorAcctRoot, 1, viewJ);
+    adjustOwnerCount(sb, *creatorAcctRoot, 1, viewJ);
 
     JLOG(j_.trace()) << "adding to book: " << to_string(saTakerPays.issue())
                      << " : " << to_string(saTakerGets.issue());

--- a/src/ripple/app/tx/impl/CreateTicket.cpp
+++ b/src/ripple/app/tx/impl/CreateTicket.cpp
@@ -57,14 +57,13 @@ TER
 CreateTicket::preclaim(PreclaimContext const& ctx)
 {
     auto const id = ctx.tx[sfAccount];
-    auto const sleAccountRoot = ctx.view.readSLE(keylet::account(id));
-    if (!sleAccountRoot)
+    auto const acctRoot = ctx.view.read(keylet::account(id));
+    if (!acctRoot)
         return terNO_ACCOUNT;
 
     // Make sure the TicketCreate would not cause the account to own
     // too many tickets.
-    std::uint32_t const curTicketCount =
-        (*sleAccountRoot)[~sfTicketCount].value_or(0u);
+    std::uint32_t const curTicketCount = acctRoot->ticketCount().value_or(0u);
     std::uint32_t const addedTickets = ctx.tx[sfTicketCount];
     std::uint32_t const consumedTickets =
         ctx.tx.getSeqProxy().isTicket() ? 1u : 0u;
@@ -84,9 +83,8 @@ CreateTicket::preclaim(PreclaimContext const& ctx)
 TER
 CreateTicket::doApply()
 {
-    SLE::pointer const sleAccountRoot =
-        view().peekSLE(keylet::account(account_));
-    if (!sleAccountRoot)
+    auto acctRoot = view().peek(keylet::account(account_));
+    if (!acctRoot)
         return tefINTERNAL;
 
     // Each ticket counts against the reserve of the issuing account, but we
@@ -94,8 +92,8 @@ CreateTicket::doApply()
     // reserve to pay fees.
     std::uint32_t const ticketCount = ctx_.tx[sfTicketCount];
     {
-        XRPAmount const reserve = view().fees().accountReserve(
-            sleAccountRoot->getFieldU32(sfOwnerCount) + ticketCount);
+        XRPAmount const reserve =
+            view().fees().accountReserve(acctRoot->ownerCount() + ticketCount);
 
         if (mPriorBalance < reserve)
             return tecINSUFFICIENT_RESERVE;
@@ -107,7 +105,7 @@ CreateTicket::doApply()
     // root sequence.  Before we got here to doApply(), the transaction
     // machinery already incremented the account root sequence if that
     // was appropriate.
-    std::uint32_t const firstTicketSeq = (*sleAccountRoot)[sfSequence];
+    std::uint32_t const firstTicketSeq = acctRoot->sequence();
 
     // Sanity check that the transaction machinery really did already
     // increment the account root Sequence.
@@ -140,17 +138,15 @@ CreateTicket::doApply()
     }
 
     // Update the record of the number of Tickets this account owns.
-    std::uint32_t const oldTicketCount =
-        (*(sleAccountRoot))[~sfTicketCount].value_or(0u);
-
-    sleAccountRoot->setFieldU32(sfTicketCount, oldTicketCount + ticketCount);
+    std::uint32_t const oldTicketCount = acctRoot->ticketCount().value_or(0u);
+    acctRoot->setTicketCount(oldTicketCount + ticketCount);
 
     // Every added Ticket counts against the creator's reserve.
-    adjustOwnerCount(view(), sleAccountRoot, ticketCount, viewJ);
+    adjustOwnerCount(view(), acctRoot, ticketCount, viewJ);
 
     // TicketCreate is the only transaction that can cause an account root's
     // Sequence field to increase by more than one.  October 2018.
-    sleAccountRoot->setFieldU32(sfSequence, firstTicketSeq + ticketCount);
+    acctRoot->setSequence(firstTicketSeq + ticketCount);
 
     return tesSUCCESS;
 }

--- a/src/ripple/app/tx/impl/CreateTicket.cpp
+++ b/src/ripple/app/tx/impl/CreateTicket.cpp
@@ -142,7 +142,7 @@ CreateTicket::doApply()
     acctRoot->setTicketCount(oldTicketCount + ticketCount);
 
     // Every added Ticket counts against the creator's reserve.
-    adjustOwnerCount(view(), acctRoot, ticketCount, viewJ);
+    adjustOwnerCount(view(), *acctRoot, ticketCount, viewJ);
 
     // TicketCreate is the only transaction that can cause an account root's
     // Sequence field to increase by more than one.  October 2018.

--- a/src/ripple/app/tx/impl/CreateTicket.cpp
+++ b/src/ripple/app/tx/impl/CreateTicket.cpp
@@ -57,7 +57,7 @@ TER
 CreateTicket::preclaim(PreclaimContext const& ctx)
 {
     auto const id = ctx.tx[sfAccount];
-    auto const sleAccountRoot = ctx.view.read(keylet::account(id));
+    auto const sleAccountRoot = ctx.view.readSLE(keylet::account(id));
     if (!sleAccountRoot)
         return terNO_ACCOUNT;
 
@@ -84,7 +84,8 @@ CreateTicket::preclaim(PreclaimContext const& ctx)
 TER
 CreateTicket::doApply()
 {
-    SLE::pointer const sleAccountRoot = view().peek(keylet::account(account_));
+    SLE::pointer const sleAccountRoot =
+        view().peekSLE(keylet::account(account_));
     if (!sleAccountRoot)
         return tefINTERNAL;
 

--- a/src/ripple/app/tx/impl/DeleteAccount.cpp
+++ b/src/ripple/app/tx/impl/DeleteAccount.cpp
@@ -164,7 +164,7 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
     AccountID const account{ctx.tx[sfAccount]};
     AccountID const dst{ctx.tx[sfDestination]};
 
-    auto sleDst = ctx.view.read(keylet::account(dst));
+    auto sleDst = ctx.view.readSLE(keylet::account(dst));
 
     if (!sleDst)
         return tecNO_DST;
@@ -180,7 +180,7 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
             return tecNO_PERMISSION;
     }
 
-    auto sleAccount = ctx.view.read(keylet::account(account));
+    auto sleAccount = ctx.view.readSLE(keylet::account(account));
     assert(sleAccount);
     if (!sleAccount)
         return terNO_ACCOUNT;
@@ -197,7 +197,7 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
         Keylet const first = keylet::nftpage_min(account);
         Keylet const last = keylet::nftpage_max(account);
 
-        auto const cp = ctx.view.read(Keylet(
+        auto const cp = ctx.view.readSLE(Keylet(
             ltNFTOKEN_PAGE,
             ctx.view.succ(first.key, last.key.next()).value_or(last.key)));
         if (cp)
@@ -252,7 +252,7 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
     {
         // Make sure any directory node types that we find are the kind
         // we can delete.
-        auto sleItem = ctx.view.read(keylet::child(dirEntry));
+        auto sleItem = ctx.view.readSLE(keylet::child(dirEntry));
         if (!sleItem)
         {
             // Directory node has an invalid index.  Bail out.
@@ -283,10 +283,10 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
 TER
 DeleteAccount::doApply()
 {
-    auto src = view().peek(keylet::account(account_));
+    auto src = view().peekSLE(keylet::account(account_));
     assert(src);
 
-    auto dst = view().peek(keylet::account(ctx_.tx[sfDestination]));
+    auto dst = view().peekSLE(keylet::account(ctx_.tx[sfDestination]));
     assert(dst);
 
     if (!src || !dst)
@@ -304,7 +304,7 @@ DeleteAccount::doApply()
         do
         {
             // Choose the right way to delete each directory node.
-            auto sleItem = view().peek(keylet::child(dirEntry));
+            auto sleItem = view().peekSLE(keylet::child(dirEntry));
             if (!sleItem)
             {
                 // Directory node has an invalid index.  Bail out.

--- a/src/ripple/app/tx/impl/DeleteAccount.cpp
+++ b/src/ripple/app/tx/impl/DeleteAccount.cpp
@@ -382,8 +382,8 @@ DeleteAccount::doApply()
     if (mSourceBalance > XRPAmount(0) && dstAcctRoot->isFlag(lsfPasswordSpent))
         dstAcctRoot->clearFlag(lsfPasswordSpent);
 
-    view().update(dstAcctRoot);
-    view().erase(srcAcctRoot);
+    view().update(*dstAcctRoot);
+    view().erase(*srcAcctRoot);
 
     return tesSUCCESS;
 }

--- a/src/ripple/app/tx/impl/DepositPreauth.cpp
+++ b/src/ripple/app/tx/impl/DepositPreauth.cpp
@@ -149,7 +149,7 @@ DepositPreauth::doApply()
         slePreauth->setFieldU64(sfOwnerNode, *page);
 
         // If we succeeded, the new entry counts against the creator's reserve.
-        adjustOwnerCount(view(), ownerAcctRoot, 1, viewJ);
+        adjustOwnerCount(view(), *ownerAcctRoot, 1, viewJ);
     }
     else
     {
@@ -192,7 +192,7 @@ DepositPreauth::removeFromLedger(
     if (!ownerAcctRoot)
         return tefINTERNAL;
 
-    adjustOwnerCount(view, ownerAcctRoot, -1, app.journal("View"));
+    adjustOwnerCount(view, *ownerAcctRoot, -1, app.journal("View"));
 
     // Remove DepositPreauth from ledger.
     view.erase(slePreauth);

--- a/src/ripple/app/tx/impl/DepositPreauth.cpp
+++ b/src/ripple/app/tx/impl/DepositPreauth.cpp
@@ -108,7 +108,7 @@ DepositPreauth::doApply()
 {
     if (ctx_.tx.isFieldPresent(sfAuthorize))
     {
-        auto const sleOwner = view().peek(keylet::account(account_));
+        auto const sleOwner = view().peekSLE(keylet::account(account_));
         if (!sleOwner)
             return {tefINTERNAL};
 
@@ -172,7 +172,7 @@ DepositPreauth::removeFromLedger(
     // Verify that the Preauth entry they asked to remove is
     // in the ledger.
     std::shared_ptr<SLE> const slePreauth{
-        view.peek(keylet::depositPreauth(preauthIndex))};
+        view.peekSLE(keylet::depositPreauth(preauthIndex))};
     if (!slePreauth)
     {
         JLOG(j.warn()) << "Selected DepositPreauth does not exist.";
@@ -188,7 +188,7 @@ DepositPreauth::removeFromLedger(
     }
 
     // If we succeeded, update the DepositPreauth owner's reserve.
-    auto const sleOwner = view.peek(keylet::account(account));
+    auto const sleOwner = view.peekSLE(keylet::account(account));
     if (!sleOwner)
         return tefINTERNAL;
 

--- a/src/ripple/app/tx/impl/Escrow.cpp
+++ b/src/ripple/app/tx/impl/Escrow.cpp
@@ -194,7 +194,7 @@ EscrowCreate::doApply()
     }
 
     auto const account = ctx_.tx[sfAccount];
-    auto const sle = ctx_.view().peek(keylet::account(account));
+    auto const sle = ctx_.view().peekSLE(keylet::account(account));
     if (!sle)
         return tefINTERNAL;
 
@@ -214,7 +214,7 @@ EscrowCreate::doApply()
     // Check destination account
     {
         auto const sled =
-            ctx_.view().read(keylet::account(ctx_.tx[sfDestination]));
+            ctx_.view().readSLE(keylet::account(ctx_.tx[sfDestination]));
         if (!sled)
             return tecNO_DST;
         if (((*sled)[sfFlags] & lsfRequireDestTag) &&
@@ -355,7 +355,7 @@ TER
 EscrowFinish::doApply()
 {
     auto const k = keylet::escrow(ctx_.tx[sfOwner], ctx_.tx[sfOfferSequence]);
-    auto const slep = ctx_.view().peek(k);
+    auto const slep = ctx_.view().peekSLE(k);
     if (!slep)
         return tecNO_TARGET;
 
@@ -438,7 +438,7 @@ EscrowFinish::doApply()
 
     // NOTE: Escrow payments cannot be used to fund accounts.
     AccountID const destID = (*slep)[sfDestination];
-    auto const sled = ctx_.view().peek(keylet::account(destID));
+    auto const sled = ctx_.view().peekSLE(keylet::account(destID));
     if (!sled)
         return tecNO_DST;
 
@@ -488,7 +488,7 @@ EscrowFinish::doApply()
     ctx_.view().update(sled);
 
     // Adjust source owner count
-    auto const sle = ctx_.view().peek(keylet::account(account));
+    auto const sle = ctx_.view().peekSLE(keylet::account(account));
     adjustOwnerCount(ctx_.view(), sle, -1, ctx_.journal);
     ctx_.view().update(sle);
 
@@ -516,7 +516,7 @@ TER
 EscrowCancel::doApply()
 {
     auto const k = keylet::escrow(ctx_.tx[sfOwner], ctx_.tx[sfOfferSequence]);
-    auto const slep = ctx_.view().peek(k);
+    auto const slep = ctx_.view().peekSLE(k);
     if (!slep)
         return tecNO_TARGET;
 
@@ -569,7 +569,7 @@ EscrowCancel::doApply()
     }
 
     // Transfer amount back to owner, decrement owner count
-    auto const sle = ctx_.view().peek(keylet::account(account));
+    auto const sle = ctx_.view().peekSLE(keylet::account(account));
     (*sle)[sfBalance] = (*sle)[sfBalance] + (*slep)[sfAmount];
     adjustOwnerCount(ctx_.view(), sle, -1, ctx_.journal);
     ctx_.view().update(sle);

--- a/src/ripple/app/tx/impl/Escrow.cpp
+++ b/src/ripple/app/tx/impl/Escrow.cpp
@@ -265,8 +265,8 @@ EscrowCreate::doApply()
 
     // Deduct owner's balance, increment owner count
     acctRoot->setBalance(acctRoot->balance() - ctx_.tx[sfAmount]);
-    adjustOwnerCount(ctx_.view(), acctRoot, 1, ctx_.journal);
-    ctx_.view().update(acctRoot);
+    adjustOwnerCount(ctx_.view(), *acctRoot, 1, ctx_.journal);
+    ctx_.view().update(*acctRoot);
 
     return tesSUCCESS;
 }
@@ -485,12 +485,12 @@ EscrowFinish::doApply()
 
     // Transfer amount to destination
     destAcctRoot->setBalance(destAcctRoot->balance() + (*slep)[sfAmount]);
-    ctx_.view().update(destAcctRoot);
+    ctx_.view().update(*destAcctRoot);
 
     // Adjust source owner count
     auto acctRoot = ctx_.view().peek(keylet::account(account));
-    adjustOwnerCount(ctx_.view(), acctRoot, -1, ctx_.journal);
-    ctx_.view().update(acctRoot);
+    adjustOwnerCount(ctx_.view(), *acctRoot, -1, ctx_.journal);
+    ctx_.view().update(*acctRoot);
 
     // Remove escrow from ledger
     ctx_.view().erase(slep);
@@ -571,8 +571,8 @@ EscrowCancel::doApply()
     // Transfer amount back to owner, decrement owner count
     auto acctRoot = ctx_.view().peek(keylet::account(account));
     acctRoot->setBalance(acctRoot->balance() + (*slep)[sfAmount]);
-    adjustOwnerCount(ctx_.view(), acctRoot, -1, ctx_.journal);
-    ctx_.view().update(acctRoot);
+    adjustOwnerCount(ctx_.view(), *acctRoot, -1, ctx_.journal);
+    ctx_.view().update(*acctRoot);
 
     // Remove escrow from ledger
     ctx_.view().erase(slep);

--- a/src/ripple/app/tx/impl/NFTokenAcceptOffer.cpp
+++ b/src/ripple/app/tx/impl/NFTokenAcceptOffer.cpp
@@ -70,7 +70,7 @@ NFTokenAcceptOffer::preclaim(PreclaimContext const& ctx)
             if (id->isZero())
                 return {nullptr, tecOBJECT_NOT_FOUND};
 
-            auto offerSLE = ctx.view.read(keylet::nftoffer(*id));
+            auto offerSLE = ctx.view.readSLE(keylet::nftoffer(*id));
 
             if (!offerSLE)
                 return {nullptr, tecOBJECT_NOT_FOUND};
@@ -352,7 +352,7 @@ NFTokenAcceptOffer::doApply()
     auto const loadToken = [this](std::optional<uint256> const& id) {
         std::shared_ptr<SLE> sle;
         if (id)
-            sle = view().peek(keylet::nftoffer(*id));
+            sle = view().peekSLE(keylet::nftoffer(*id));
         return sle;
     };
 

--- a/src/ripple/app/tx/impl/NFTokenBurn.cpp
+++ b/src/ripple/app/tx/impl/NFTokenBurn.cpp
@@ -106,7 +106,7 @@ NFTokenBurn::doApply()
     {
         issuerAcctRoot->setBurnedNFTokens(
             issuerAcctRoot->burnedNFTokens().value_or(0) + 1);
-        view().update(issuerAcctRoot);
+        view().update(*issuerAcctRoot);
     }
 
     if (ctx_.view().rules().enabled(fixNonFungibleTokensV1_2))

--- a/src/ripple/app/tx/impl/NFTokenBurn.cpp
+++ b/src/ripple/app/tx/impl/NFTokenBurn.cpp
@@ -68,7 +68,7 @@ NFTokenBurn::preclaim(PreclaimContext const& ctx)
         if (auto const issuer = nft::getIssuer(ctx.tx[sfNFTokenID]);
             issuer != account)
         {
-            if (auto const sle = ctx.view.read(keylet::account(issuer)); sle)
+            if (auto const sle = ctx.view.readSLE(keylet::account(issuer)); sle)
             {
                 if (auto const minter = (*sle)[~sfNFTokenMinter];
                     minter != account)
@@ -101,8 +101,8 @@ NFTokenBurn::doApply()
     if (!isTesSuccess(ret))
         return ret;
 
-    if (auto issuer =
-            view().peek(keylet::account(nft::getIssuer(ctx_.tx[sfNFTokenID]))))
+    if (auto issuer = view().peekSLE(
+            keylet::account(nft::getIssuer(ctx_.tx[sfNFTokenID]))))
     {
         (*issuer)[~sfBurnedNFTokens] =
             (*issuer)[~sfBurnedNFTokens].value_or(0) + 1;

--- a/src/ripple/app/tx/impl/NFTokenCancelOffer.cpp
+++ b/src/ripple/app/tx/impl/NFTokenCancelOffer.cpp
@@ -62,7 +62,7 @@ NFTokenCancelOffer::preclaim(PreclaimContext const& ctx)
 
     auto ret = std::find_if(
         ids.begin(), ids.end(), [&ctx, &account](uint256 const& id) {
-            auto const offer = ctx.view.read(keylet::child(id));
+            auto const offer = ctx.view.readSLE(keylet::child(id));
 
             // If id is not in the ledger we assume the offer was consumed
             // before we got here.
@@ -100,7 +100,7 @@ NFTokenCancelOffer::doApply()
 {
     for (auto const& id : ctx_.tx[sfNFTokenOffers])
     {
-        if (auto offer = view().peek(keylet::nftoffer(id));
+        if (auto offer = view().peekSLE(keylet::nftoffer(id));
             offer && !nft::deleteTokenOffer(view(), offer))
         {
             JLOG(j_.fatal()) << "Unable to delete token offer " << id

--- a/src/ripple/app/tx/impl/NFTokenCreateOffer.cpp
+++ b/src/ripple/app/tx/impl/NFTokenCreateOffer.cpp
@@ -182,9 +182,9 @@ NFTokenCreateOffer::preclaim(PreclaimContext const& ctx)
     {
         // If a destination is specified, the destination must already be in
         // the ledger.
-        auto const sleDst = ctx.view.readSLE(keylet::account(*destination));
+        auto const dstAcct = ctx.view.read(keylet::account(*destination));
 
-        if (!sleDst)
+        if (!dstAcct)
             return tecNO_DST;
 
         // check if the destination has disallowed incoming offers
@@ -193,7 +193,7 @@ NFTokenCreateOffer::preclaim(PreclaimContext const& ctx)
             // flag cannot be set unless amendment is enabled but
             // out of an abundance of caution check anyway
 
-            if (sleDst->getFlags() & lsfDisallowIncomingNFTokenOffer)
+            if (dstAcct->flags() & lsfDisallowIncomingNFTokenOffer)
                 return tecNO_PERMISSION;
         }
     }
@@ -203,14 +203,14 @@ NFTokenCreateOffer::preclaim(PreclaimContext const& ctx)
         // Check if the owner (buy offer) has disallowed incoming offers
         if (ctx.view.rules().enabled(featureDisallowIncoming))
         {
-            auto const sleOwner = ctx.view.readSLE(keylet::account(*owner));
+            auto const ownerAcct = ctx.view.read(keylet::account(*owner));
 
             // defensively check
             // it should not be possible to specify owner that doesn't exist
-            if (!sleOwner)
+            if (!ownerAcct)
                 return tecNO_TARGET;
 
-            if (sleOwner->getFlags() & lsfDisallowIncomingNFTokenOffer)
+            if (ownerAcct->flags() & lsfDisallowIncomingNFTokenOffer)
                 return tecNO_PERMISSION;
         }
     }

--- a/src/ripple/app/tx/impl/NFTokenCreateOffer.cpp
+++ b/src/ripple/app/tx/impl/NFTokenCreateOffer.cpp
@@ -280,7 +280,7 @@ NFTokenCreateOffer::doApply()
     }
 
     // Update owner count.
-    adjustOwnerCount(view(), acctRoot, 1, j_);
+    adjustOwnerCount(view(), *acctRoot, 1, j_);
 
     return tesSUCCESS;
 }

--- a/src/ripple/app/tx/impl/NFTokenCreateOffer.cpp
+++ b/src/ripple/app/tx/impl/NFTokenCreateOffer.cpp
@@ -133,7 +133,7 @@ NFTokenCreateOffer::preclaim(PreclaimContext const& ctx)
 
     if (issuer != ctx.tx[sfAccount] && !(nftFlags & nft::flagTransferable))
     {
-        auto const root = ctx.view.read(keylet::account(issuer));
+        auto const root = ctx.view.readSLE(keylet::account(issuer));
         assert(root);
 
         if (auto minter = (*root)[~sfNFTokenMinter];
@@ -182,7 +182,7 @@ NFTokenCreateOffer::preclaim(PreclaimContext const& ctx)
     {
         // If a destination is specified, the destination must already be in
         // the ledger.
-        auto const sleDst = ctx.view.read(keylet::account(*destination));
+        auto const sleDst = ctx.view.readSLE(keylet::account(*destination));
 
         if (!sleDst)
             return tecNO_DST;
@@ -203,7 +203,7 @@ NFTokenCreateOffer::preclaim(PreclaimContext const& ctx)
         // Check if the owner (buy offer) has disallowed incoming offers
         if (ctx.view.rules().enabled(featureDisallowIncoming))
         {
-            auto const sleOwner = ctx.view.read(keylet::account(*owner));
+            auto const sleOwner = ctx.view.readSLE(keylet::account(*owner));
 
             // defensively check
             // it should not be possible to specify owner that doesn't exist
@@ -221,7 +221,7 @@ NFTokenCreateOffer::preclaim(PreclaimContext const& ctx)
 TER
 NFTokenCreateOffer::doApply()
 {
-    if (auto const acct = view().read(keylet::account(ctx_.tx[sfAccount]));
+    if (auto const acct = view().readSLE(keylet::account(ctx_.tx[sfAccount]));
         mPriorBalance < view().fees().accountReserve((*acct)[sfOwnerCount] + 1))
         return tecINSUFFICIENT_RESERVE;
 
@@ -279,7 +279,7 @@ NFTokenCreateOffer::doApply()
     }
 
     // Update owner count.
-    adjustOwnerCount(view(), view().peek(keylet::account(account_)), 1, j_);
+    adjustOwnerCount(view(), view().peekSLE(keylet::account(account_)), 1, j_);
 
     return tesSUCCESS;
 }

--- a/src/ripple/app/tx/impl/NFTokenMint.cpp
+++ b/src/ripple/app/tx/impl/NFTokenMint.cpp
@@ -172,7 +172,7 @@ NFTokenMint::doApply()
 
                 issuerAcctRoot->setMintedNFTokens(nextTokenSeq);
             }
-            ctx_.view().update(issuerAcctRoot);
+            ctx_.view().update(*issuerAcctRoot);
             return tokenSeq;
         }
 
@@ -221,7 +221,7 @@ NFTokenMint::doApply()
         if (tokenSeq + 1u == 0u || tokenSeq < offset)
             return Unexpected(tecMAX_SEQUENCE_REACHED);
 
-        ctx_.view().update(issuerAcctRoot);
+        ctx_.view().update(*issuerAcctRoot);
         return tokenSeq;
     }();
 

--- a/src/ripple/app/tx/impl/OfferStream.cpp
+++ b/src/ripple/app/tx/impl/OfferStream.cpp
@@ -28,7 +28,7 @@ bool
 checkIssuers(ReadView const& view, Book const& book)
 {
     auto issuerExists = [](ReadView const& view, Issue const& iss) -> bool {
-        return isXRP(iss.account) || view.readSLE(keylet::account(iss.account));
+        return isXRP(iss.account) || view.read(keylet::account(iss.account));
     };
     return issuerExists(view, book.in) && issuerExists(view, book.out);
 }

--- a/src/ripple/app/tx/impl/OfferStream.cpp
+++ b/src/ripple/app/tx/impl/OfferStream.cpp
@@ -28,7 +28,7 @@ bool
 checkIssuers(ReadView const& view, Book const& book)
 {
     auto issuerExists = [](ReadView const& view, Issue const& iss) -> bool {
-        return isXRP(iss.account) || view.read(keylet::account(iss.account));
+        return isXRP(iss.account) || view.readSLE(keylet::account(iss.account));
     };
     return issuerExists(view, book.in) && issuerExists(view, book.out);
 }
@@ -64,7 +64,7 @@ TOfferStreamBase<TIn, TOut>::erase(ApplyView& view)
     //           correctly remove the directory if its the last entry.
     //           Unfortunately this is a protocol breaking change.
 
-    auto p = view.peek(keylet::page(tip_.dir()));
+    auto p = view.peekSLE(keylet::page(tip_.dir()));
 
     if (p == nullptr)
     {
@@ -364,7 +364,8 @@ TOfferStreamBase<TIn, TOut>::step()
 void
 OfferStream::permRmOffer(uint256 const& offerIndex)
 {
-    offerDelete(cancelView_, cancelView_.peek(keylet::offer(offerIndex)), j_);
+    offerDelete(
+        cancelView_, cancelView_.peekSLE(keylet::offer(offerIndex)), j_);
 }
 
 template <class TIn, class TOut>

--- a/src/ripple/app/tx/impl/PayChan.cpp
+++ b/src/ripple/app/tx/impl/PayChan.cpp
@@ -145,7 +145,7 @@ closeChannel(
     }
 
     // Transfer amount back to owner, decrement owner count
-    auto const sle = view.peek(keylet::account(src));
+    auto const sle = view.peekSLE(keylet::account(src));
     if (!sle)
         return tefINTERNAL;
 
@@ -193,7 +193,7 @@ TER
 PayChanCreate::preclaim(PreclaimContext const& ctx)
 {
     auto const account = ctx.tx[sfAccount];
-    auto const sle = ctx.view.read(keylet::account(account));
+    auto const sle = ctx.view.readSLE(keylet::account(account));
     if (!sle)
         return terNO_ACCOUNT;
 
@@ -214,7 +214,7 @@ PayChanCreate::preclaim(PreclaimContext const& ctx)
 
     {
         // Check destination account
-        auto const sled = ctx.view.read(keylet::account(dst));
+        auto const sled = ctx.view.readSLE(keylet::account(dst));
         if (!sled)
             return tecNO_DST;
 
@@ -242,7 +242,7 @@ TER
 PayChanCreate::doApply()
 {
     auto const account = ctx_.tx[sfAccount];
-    auto const sle = ctx_.view().peek(keylet::account(account));
+    auto const sle = ctx_.view().peekSLE(keylet::account(account));
     if (!sle)
         return tefINTERNAL;
 
@@ -326,7 +326,7 @@ TER
 PayChanFund::doApply()
 {
     Keylet const k(ltPAYCHAN, ctx_.tx[sfChannel]);
-    auto const slep = ctx_.view().peek(k);
+    auto const slep = ctx_.view().peekSLE(k);
     if (!slep)
         return tecNO_ENTRY;
 
@@ -362,7 +362,7 @@ PayChanFund::doApply()
         ctx_.view().update(slep);
     }
 
-    auto const sle = ctx_.view().peek(keylet::account(txAccount));
+    auto const sle = ctx_.view().peekSLE(keylet::account(txAccount));
     if (!sle)
         return tefINTERNAL;
 
@@ -381,7 +381,7 @@ PayChanFund::doApply()
 
     // do not allow adding funds if dst does not exist
     if (AccountID const dst = (*slep)[sfDestination];
-        !ctx_.view().read(keylet::account(dst)))
+        !ctx_.view().readSLE(keylet::account(dst)))
     {
         return tecNO_DST;
     }
@@ -457,7 +457,7 @@ TER
 PayChanClaim::doApply()
 {
     Keylet const k(ltPAYCHAN, ctx_.tx[sfChannel]);
-    auto const slep = ctx_.view().peek(k);
+    auto const slep = ctx_.view().peekSLE(k);
     if (!slep)
         return tecNO_TARGET;
 
@@ -502,7 +502,7 @@ PayChanClaim::doApply()
             // nothing requested
             return tecUNFUNDED_PAYMENT;
 
-        auto const sled = ctx_.view().peek(keylet::account(dst));
+        auto const sled = ctx_.view().peekSLE(keylet::account(dst));
         if (!sled)
             return tecNO_DST;
 

--- a/src/ripple/app/tx/impl/PayChan.cpp
+++ b/src/ripple/app/tx/impl/PayChan.cpp
@@ -152,8 +152,8 @@ closeChannel(
     assert((*slep)[sfAmount] >= (*slep)[sfBalance]);
     acctRoot->setBalance(
         acctRoot->balance() + (*slep)[sfAmount] - (*slep)[sfBalance]);
-    adjustOwnerCount(view, acctRoot, -1, j);
-    view.update(acctRoot);
+    adjustOwnerCount(view, *acctRoot, -1, j);
+    view.update(*acctRoot);
 
     // Remove PayChan from ledger
     view.erase(slep);
@@ -293,8 +293,8 @@ PayChanCreate::doApply()
 
     // Deduct owner's balance, increment owner count
     acctRoot->setBalance(acctRoot->balance() - ctx_.tx[sfAmount]);
-    adjustOwnerCount(ctx_.view(), acctRoot, 1, ctx_.journal);
-    ctx_.view().update(acctRoot);
+    adjustOwnerCount(ctx_.view(), *acctRoot, 1, ctx_.journal);
+    ctx_.view().update(*acctRoot);
 
     return tesSUCCESS;
 }
@@ -390,7 +390,7 @@ PayChanFund::doApply()
     ctx_.view().update(slep);
 
     acctRoot->setBalance(acctRoot->balance() - ctx_.tx[sfAmount]);
-    ctx_.view().update(acctRoot);
+    ctx_.view().update(*acctRoot);
 
     return tesSUCCESS;
 }
@@ -531,7 +531,7 @@ PayChanClaim::doApply()
         XRPAmount const reqDelta = reqBalance - chanBalance;
         assert(reqDelta >= beast::zero);
         destAcctRoot->setBalance(destAcctRoot->balance() + reqDelta);
-        ctx_.view().update(destAcctRoot);
+        ctx_.view().update(*destAcctRoot);
         ctx_.view().update(slep);
     }
 

--- a/src/ripple/app/tx/impl/Payment.cpp
+++ b/src/ripple/app/tx/impl/Payment.cpp
@@ -353,7 +353,7 @@ Payment::doApply()
         // Tell the engine that we are intending to change the destination
         // account.  The source account gets always charged a fee so it's always
         // marked as modified.
-        view().update(acctRootDst);
+        view().update(*acctRootDst);
     }
 
     // Determine whether the destination requires deposit authorization.

--- a/src/ripple/app/tx/impl/Payment.cpp
+++ b/src/ripple/app/tx/impl/Payment.cpp
@@ -216,7 +216,7 @@ Payment::preclaim(PreclaimContext const& ctx)
     STAmount const saDstAmount(ctx.tx[sfAmount]);
 
     auto const k = keylet::account(uDstAccountID);
-    auto const sleDst = ctx.view.read(k);
+    auto const sleDst = ctx.view.readSLE(k);
 
     if (!sleDst)
     {
@@ -329,7 +329,7 @@ Payment::doApply()
 
     // Open a ledger for editing.
     auto const k = keylet::account(uDstAccountID);
-    SLE::pointer sleDst = view().peek(k);
+    SLE::pointer sleDst = view().peekSLE(k);
 
     if (!sleDst)
     {
@@ -438,7 +438,7 @@ Payment::doApply()
 
     // Direct XRP payment.
 
-    auto const sleSrc = view().peek(keylet::account(account_));
+    auto const sleSrc = view().peekSLE(keylet::account(account_));
     if (!sleSrc)
         return tefINTERNAL;
 

--- a/src/ripple/app/tx/impl/SetAccount.cpp
+++ b/src/ripple/app/tx/impl/SetAccount.cpp
@@ -194,7 +194,7 @@ SetAccount::preclaim(PreclaimContext const& ctx)
 
     std::uint32_t const uTxFlags = ctx.tx.getFlags();
 
-    auto const sle = ctx.view.read(keylet::account(id));
+    auto const sle = ctx.view.readSLE(keylet::account(id));
     if (!sle)
         return terNO_ACCOUNT;
 
@@ -224,7 +224,7 @@ SetAccount::preclaim(PreclaimContext const& ctx)
 TER
 SetAccount::doApply()
 {
-    auto const sle = view().peek(keylet::account(account_));
+    auto const sle = view().peekSLE(keylet::account(account_));
     if (!sle)
         return tefINTERNAL;
 
@@ -320,7 +320,7 @@ SetAccount::doApply()
         }
 
         if ((!sle->isFieldPresent(sfRegularKey)) &&
-            (!view().peek(keylet::signers(account_))))
+            (!view().peekSLE(keylet::signers(account_))))
         {
             // Account has no regular key or multi-signer signer list.
             return tecNO_ALTERNATIVE_KEY;

--- a/src/ripple/app/tx/impl/SetRegularKey.cpp
+++ b/src/ripple/app/tx/impl/SetRegularKey.cpp
@@ -34,7 +34,7 @@ SetRegularKey::calculateBaseFee(ReadView const& view, STTx const& tx)
     {
         if (calcAccountID(PublicKey(makeSlice(spk))) == id)
         {
-            auto const sle = view.read(keylet::account(id));
+            auto const sle = view.readSLE(keylet::account(id));
 
             if (sle && (!(sle->getFlags() & lsfPasswordSpent)))
             {
@@ -75,7 +75,7 @@ SetRegularKey::preflight(PreflightContext const& ctx)
 TER
 SetRegularKey::doApply()
 {
-    auto const sle = view().peek(keylet::account(account_));
+    auto const sle = view().peekSLE(keylet::account(account_));
     if (!sle)
         return tefINTERNAL;
 
@@ -90,7 +90,7 @@ SetRegularKey::doApply()
     {
         // Account has disabled master key and no multi-signer signer list.
         if (sle->isFlag(lsfDisableMaster) &&
-            !view().peek(keylet::signers(account_)))
+            !view().peekSLE(keylet::signers(account_)))
             return tecNO_ALTERNATIVE_KEY;
 
         sle->makeFieldAbsent(sfRegularKey);

--- a/src/ripple/app/tx/impl/SetSignerList.cpp
+++ b/src/ripple/app/tx/impl/SetSignerList.cpp
@@ -187,7 +187,7 @@ removeSignersFromLedger(
 {
     // We have to examine the current SignerList so we know how much to
     // reduce the OwnerCount.
-    SLE::pointer signers = view.peek(signerListKeylet);
+    SLE::pointer signers = view.peekSLE(signerListKeylet);
 
     // If the signer list doesn't exist we've already succeeded in deleting it.
     if (!signers)
@@ -216,7 +216,7 @@ removeSignersFromLedger(
 
     adjustOwnerCount(
         view,
-        view.peek(accountKeylet),
+        view.peekSLE(accountKeylet),
         removeFromOwnerCount,
         app.journal("View"));
 
@@ -328,7 +328,7 @@ SetSignerList::replaceSignerList()
             j_))
         return ter;
 
-    auto const sle = view().peek(accountKeylet);
+    auto const sle = view().peekSLE(accountKeylet);
     if (!sle)
         return tefINTERNAL;
 
@@ -384,7 +384,7 @@ SetSignerList::destroySignerList()
     auto const accountKeylet = keylet::account(account_);
     // Destroying the signer list is only allowed if either the master key
     // is enabled or there is a regular key.
-    SLE::pointer ledgerEntry = view().peek(accountKeylet);
+    SLE::pointer ledgerEntry = view().peekSLE(accountKeylet);
     if (!ledgerEntry)
         return tefINTERNAL;
 

--- a/src/ripple/app/tx/impl/SetSignerList.cpp
+++ b/src/ripple/app/tx/impl/SetSignerList.cpp
@@ -215,7 +215,8 @@ removeSignersFromLedger(
     }
 
     auto acctRoot = view.peek(accountKeylet);
-    adjustOwnerCount(view, acctRoot, removeFromOwnerCount, app.journal("View"));
+    adjustOwnerCount(
+        view, *acctRoot, removeFromOwnerCount, app.journal("View"));
 
     view.erase(signers);
 
@@ -371,7 +372,7 @@ SetSignerList::replaceSignerList()
 
     // If we succeeded, the new entry counts against the
     // creator's reserve.
-    adjustOwnerCount(view(), acctRoot, addedOwnerCount, viewJ);
+    adjustOwnerCount(view(), *acctRoot, addedOwnerCount, viewJ);
     return tesSUCCESS;
 }
 

--- a/src/ripple/app/tx/impl/SetTrust.cpp
+++ b/src/ripple/app/tx/impl/SetTrust.cpp
@@ -85,7 +85,7 @@ SetTrust::preclaim(PreclaimContext const& ctx)
 {
     auto const id = ctx.tx[sfAccount];
 
-    auto const sle = ctx.view.read(keylet::account(id));
+    auto const sle = ctx.view.readSLE(keylet::account(id));
     if (!sle)
         return terNO_ACCOUNT;
 
@@ -117,7 +117,7 @@ SetTrust::preclaim(PreclaimContext const& ctx)
             // unless one has somehow already been created
             // (in which case doApply will clean it up).
             auto const sleDelete =
-                ctx.view.read(keylet::line(id, uDstAccountID, currency));
+                ctx.view.readSLE(keylet::line(id, uDstAccountID, currency));
 
             if (!sleDelete)
             {
@@ -132,7 +132,7 @@ SetTrust::preclaim(PreclaimContext const& ctx)
     // then honour that flag
     if (ctx.view.rules().enabled(featureDisallowIncoming))
     {
-        auto const sleDst = ctx.view.read(keylet::account(uDstAccountID));
+        auto const sleDst = ctx.view.readSLE(keylet::account(uDstAccountID));
 
         if (!sleDst)
             return tecNO_DST;
@@ -160,7 +160,7 @@ SetTrust::doApply()
     // true, iff current is high account.
     bool const bHigh = account_ > uDstAccountID;
 
-    auto const sle = view().peek(keylet::account(account_));
+    auto const sle = view().peekSLE(keylet::account(account_));
     if (!sle)
         return tefINTERNAL;
 
@@ -214,13 +214,13 @@ SetTrust::doApply()
     {
         return trustDelete(
             view(),
-            view().peek(keylet::line(account_, uDstAccountID, currency)),
+            view().peekSLE(keylet::line(account_, uDstAccountID, currency)),
             account_,
             uDstAccountID,
             viewJ);
     }
 
-    SLE::pointer sleDst = view().peek(keylet::account(uDstAccountID));
+    SLE::pointer sleDst = view().peekSLE(keylet::account(uDstAccountID));
 
     if (!sleDst)
     {
@@ -233,7 +233,7 @@ SetTrust::doApply()
     saLimitAllow.setIssuer(account_);
 
     SLE::pointer sleRippleState =
-        view().peek(keylet::line(account_, uDstAccountID, currency));
+        view().peekSLE(keylet::line(account_, uDstAccountID, currency));
 
     if (sleRippleState)
     {

--- a/src/ripple/app/tx/impl/SetTrust.cpp
+++ b/src/ripple/app/tx/impl/SetTrust.cpp
@@ -247,8 +247,8 @@ SetTrust::doApply()
         std::uint32_t uHighQualityOut;
         auto const& uLowAccountID = !bHigh ? account_ : uDstAccountID;
         auto const& uHighAccountID = bHigh ? account_ : uDstAccountID;
-        std::optional<AcctRoot>& lowAcctRoot = !bHigh ? acctRoot : destAcctRoot;
-        std::optional<AcctRoot>& highAcctRoot = bHigh ? acctRoot : destAcctRoot;
+        AcctRoot& lowAcctRoot = !bHigh ? *acctRoot : *destAcctRoot;
+        AcctRoot& highAcctRoot = bHigh ? *acctRoot : *destAcctRoot;
 
         //
         // Balances
@@ -383,8 +383,8 @@ SetTrust::doApply()
         if (QUALITY_ONE == uHighQualityOut)
             uHighQualityOut = 0;
 
-        bool const bLowDefRipple = lowAcctRoot->isFlag(lsfDefaultRipple);
-        bool const bHighDefRipple = highAcctRoot->isFlag(lsfDefaultRipple);
+        bool const bLowDefRipple = lowAcctRoot.isFlag(lsfDefaultRipple);
+        bool const bHighDefRipple = highAcctRoot.isFlag(lsfDefaultRipple);
 
         bool const bLowReserveSet = uLowQualityIn || uLowQualityOut ||
             ((uFlagsOut & lsfLowNoRipple) == 0) != bLowDefRipple ||
@@ -510,7 +510,7 @@ SetTrust::doApply()
             account_,
             uDstAccountID,
             k.key,
-            acctRoot,
+            *acctRoot,
             bSetAuth,
             bSetNoRipple && !bClearNoRipple,
             bSetFreeze && !bClearFreeze,

--- a/src/ripple/app/tx/impl/SetTrust.cpp
+++ b/src/ripple/app/tx/impl/SetTrust.cpp
@@ -132,13 +132,12 @@ SetTrust::preclaim(PreclaimContext const& ctx)
     // then honour that flag
     if (ctx.view.rules().enabled(featureDisallowIncoming))
     {
-        auto const sleDst = ctx.view.readSLE(keylet::account(uDstAccountID));
+        auto const dstAcct = ctx.view.read(keylet::account(uDstAccountID));
 
-        if (!sleDst)
+        if (!dstAcct)
             return tecNO_DST;
 
-        auto const dstFlags = sleDst->getFlags();
-        if (dstFlags & lsfDisallowIncomingTrustline)
+        if (dstAcct->isFlag(lsfDisallowIncomingTrustline))
             return tecNO_PERMISSION;
     }
 

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -423,7 +423,7 @@ Transactor::ticketDelete(
     }
 
     // Update the Ticket owner's reserve.
-    adjustOwnerCount(view, acctRoot, -1, j);
+    adjustOwnerCount(view, *acctRoot, -1, j);
 
     // Remove Ticket from ledger.
     view.erase(sleTicket);
@@ -466,7 +466,7 @@ Transactor::apply()
         if (acctRoot->accountTxnID())
             acctRoot->setAccountTxnID(ctx_.tx.getTransactionID());
 
-        view().update(acctRoot);
+        view().update(*acctRoot);
     }
 
     return doApply();
@@ -788,7 +788,7 @@ Transactor::reset(XRPAmount fee)
     assert(isTesSuccess(ter));
 
     if (isTesSuccess(ter))
-        view().update(txnAcctRoot);
+        view().update(*txnAcctRoot);
 
     return {ter, fee};
 }

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -191,7 +191,7 @@ private:
     reset(XRPAmount fee);
 
     TER
-    consumeSeqProxy(SLE::pointer const& sleAccount);
+    consumeSeqProxy(AcctRoot& acctRoot);
     TER
     payFee();
     static NotTEC

--- a/src/ripple/app/tx/impl/details/NFTokenUtils.cpp
+++ b/src/ripple/app/tx/impl/details/NFTokenUtils.cpp
@@ -255,7 +255,7 @@ insertToken(ApplyView& view, AccountID owner, STObject&& nft)
             auto ownerAcctRoot = view.peek(keylet::account(owner));
             adjustOwnerCount(
                 view,
-                ownerAcctRoot,
+                *ownerAcctRoot,
                 1,
                 beast::Journal{beast::Journal::getNullSink()});
         });
@@ -423,7 +423,7 @@ removeToken(
         if (cnt != 0)
             adjustOwnerCount(
                 view,
-                ownerAcctRoot,
+                *ownerAcctRoot,
                 cnt,
                 beast::Journal{beast::Journal::getNullSink()});
 
@@ -475,7 +475,7 @@ removeToken(
     auto ownerAcctRoot = view.peek(keylet::account(owner));
     adjustOwnerCount(
         view,
-        ownerAcctRoot,
+        *ownerAcctRoot,
         -1 * cnt,
         beast::Journal{beast::Journal::getNullSink()});
 
@@ -632,7 +632,10 @@ deleteTokenOffer(ApplyView& view, std::shared_ptr<SLE> const& offer)
 
     auto ownerAcctRoot = view.peek(keylet::account(owner));
     adjustOwnerCount(
-        view, ownerAcctRoot, -1, beast::Journal{beast::Journal::getNullSink()});
+        view,
+        *ownerAcctRoot,
+        -1,
+        beast::Journal{beast::Journal::getNullSink()});
 
     view.erase(offer);
     return true;

--- a/src/ripple/app/tx/impl/details/NFTokenUtils.cpp
+++ b/src/ripple/app/tx/impl/details/NFTokenUtils.cpp
@@ -42,7 +42,7 @@ locatePage(ReadView const& view, AccountID owner, uint256 const& id)
     // This NFT can only be found in the first page with a key that's strictly
     // greater than `first`, so look for that, up until the maximum possible
     // page.
-    return view.read(Keylet(
+    return view.readSLE(Keylet(
         ltNFTOKEN_PAGE,
         view.succ(first.key, last.key.next()).value_or(last.key)));
 }
@@ -56,7 +56,7 @@ locatePage(ApplyView& view, AccountID owner, uint256 const& id)
     // This NFT can only be found in the first page with a key that's strictly
     // greater than `first`, so look for that, up until the maximum possible
     // page.
-    return view.peek(Keylet(
+    return view.peekSLE(Keylet(
         ltNFTOKEN_PAGE,
         view.succ(first.key, last.key.next()).value_or(last.key)));
 }
@@ -75,7 +75,7 @@ getPageForToken(
     // This NFT can only be found in the first page with a key that's strictly
     // greater than `first`, so look for that, up until the maximum possible
     // page.
-    auto cp = view.peek(Keylet(
+    auto cp = view.peekSLE(Keylet(
         ltNFTOKEN_PAGE,
         view.succ(first.key, last.key.next()).value_or(last.key)));
 
@@ -198,7 +198,7 @@ getPageForToken(
     {
         np->setFieldH256(sfPreviousPageMin, *ppm);
 
-        if (auto p3 = view.peek(Keylet(ltNFTOKEN_PAGE, *ppm)))
+        if (auto p3 = view.peekSLE(Keylet(ltNFTOKEN_PAGE, *ppm)))
         {
             p3->setFieldH256(sfNextPageMin, np->key());
             view.update(p3);
@@ -254,7 +254,7 @@ insertToken(ApplyView& view, AccountID owner, STObject&& nft)
         [](ApplyView& view, AccountID const& owner) {
             adjustOwnerCount(
                 view,
-                view.peek(keylet::account(owner)),
+                view.peekSLE(keylet::account(owner)),
                 1,
                 beast::Journal{beast::Journal::getNullSink()});
         });
@@ -327,7 +327,7 @@ mergePages(
 
     if (auto const ppm = (*p1)[~sfPreviousPageMin])
     {
-        auto p0 = view.peek(Keylet(ltNFTOKEN_PAGE, *ppm));
+        auto p0 = view.peekSLE(Keylet(ltNFTOKEN_PAGE, *ppm));
 
         if (!p0)
             Throw<std::runtime_error>("mergePages: p0 can't be located!");
@@ -388,7 +388,7 @@ removeToken(
 
         if (auto const id = (*page1)[~field])
         {
-            page2 = view.peek(Keylet(ltNFTOKEN_PAGE, *id));
+            page2 = view.peekSLE(Keylet(ltNFTOKEN_PAGE, *id));
 
             if (!page2)
                 Throw<std::runtime_error>(
@@ -421,7 +421,7 @@ removeToken(
         if (cnt != 0)
             adjustOwnerCount(
                 view,
-                view.peek(keylet::account(owner)),
+                view.peekSLE(keylet::account(owner)),
                 cnt,
                 beast::Journal{beast::Journal::getNullSink()});
 
@@ -466,13 +466,13 @@ removeToken(
     if (prev && next &&
         mergePages(
             view,
-            view.peek(Keylet(ltNFTOKEN_PAGE, prev->key())),
-            view.peek(Keylet(ltNFTOKEN_PAGE, next->key()))))
+            view.peekSLE(Keylet(ltNFTOKEN_PAGE, prev->key())),
+            view.peekSLE(Keylet(ltNFTOKEN_PAGE, next->key()))))
         cnt++;
 
     adjustOwnerCount(
         view,
-        view.peek(keylet::account(owner)),
+        view.peekSLE(keylet::account(owner)),
         -1 * cnt,
         beast::Journal{beast::Journal::getNullSink()});
 
@@ -538,7 +538,7 @@ removeTokenOffersWithLimit(
 
     do
     {
-        auto const page = view.peek(keylet::page(directory, *pageIndex));
+        auto const page = view.peekSLE(keylet::page(directory, *pageIndex));
         if (!page)
             break;
 
@@ -556,7 +556,8 @@ removeTokenOffersWithLimit(
         // deleting during iteration.
         for (int i = offerIndexes.size() - 1; i >= 0; --i)
         {
-            if (auto const offer = view.peek(keylet::nftoffer(offerIndexes[i])))
+            if (auto const offer =
+                    view.peekSLE(keylet::nftoffer(offerIndexes[i])))
             {
                 if (deleteTokenOffer(view, offer))
                     ++deletedOffersCount;
@@ -628,7 +629,7 @@ deleteTokenOffer(ApplyView& view, std::shared_ptr<SLE> const& offer)
 
     adjustOwnerCount(
         view,
-        view.peek(keylet::account(owner)),
+        view.peekSLE(keylet::account(owner)),
         -1,
         beast::Journal{beast::Journal::getNullSink()});
 

--- a/src/ripple/app/tx/impl/details/NFTokenUtils.cpp
+++ b/src/ripple/app/tx/impl/details/NFTokenUtils.cpp
@@ -252,9 +252,10 @@ insertToken(ApplyView& view, AccountID owner, STObject&& nft)
         owner,
         nft[sfNFTokenID],
         [](ApplyView& view, AccountID const& owner) {
+            auto ownerAcctRoot = view.peek(keylet::account(owner));
             adjustOwnerCount(
                 view,
-                view.peekSLE(keylet::account(owner)),
+                ownerAcctRoot,
                 1,
                 beast::Journal{beast::Journal::getNullSink()});
         });
@@ -418,10 +419,11 @@ removeToken(
         if (next && mergePages(view, curr, next))
             cnt--;
 
+        auto ownerAcctRoot = view.peek(keylet::account(owner));
         if (cnt != 0)
             adjustOwnerCount(
                 view,
-                view.peekSLE(keylet::account(owner)),
+                ownerAcctRoot,
                 cnt,
                 beast::Journal{beast::Journal::getNullSink()});
 
@@ -470,9 +472,10 @@ removeToken(
             view.peekSLE(Keylet(ltNFTOKEN_PAGE, next->key()))))
         cnt++;
 
+    auto ownerAcctRoot = view.peek(keylet::account(owner));
     adjustOwnerCount(
         view,
-        view.peekSLE(keylet::account(owner)),
+        ownerAcctRoot,
         -1 * cnt,
         beast::Journal{beast::Journal::getNullSink()});
 
@@ -627,11 +630,9 @@ deleteTokenOffer(ApplyView& view, std::shared_ptr<SLE> const& offer)
             false))
         return false;
 
+    auto ownerAcctRoot = view.peek(keylet::account(owner));
     adjustOwnerCount(
-        view,
-        view.peekSLE(keylet::account(owner)),
-        -1,
-        beast::Journal{beast::Journal::getNullSink()});
+        view, ownerAcctRoot, -1, beast::Journal{beast::Journal::getNullSink()});
 
     view.erase(offer);
     return true;

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -343,7 +343,7 @@ public:
     std::optional<std::uint64_t>
     dirInsert(
         Keylet const& directory,
-        Keylet const& key,
+        KeyletBase const& key,
         std::function<void(std::shared_ptr<SLE> const&)> const& describe)
     {
         return dirAdd(false, directory, key.key, describe);

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -171,7 +171,7 @@ public:
         @return `nullptr` if the key is not present
     */
     virtual std::shared_ptr<SLE>
-    peek(Keylet const& k) = 0;
+    peek(KeyletBase const& k) = 0;
 
     /** Remove a peeked SLE.
 

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -201,16 +201,11 @@ public:
     erase(std::shared_ptr<SLE> const& sle) = 0;
 
     template <class T>
-    void
-    erase(std::optional<T>& wrapper)
+    requires(std::is_convertible_v<
+             decltype(std::declval<T>().slePtr()),
+             std::shared_ptr<SLE> const&>) void erase(T& wrapper)
     {
-        static_assert(
-            std::is_convertible_v<
-                decltype(std::declval<T>().slePtr()),
-                std::shared_ptr<SLE> const&>,
-            "Parameter must be std::optional with slePtr() method");
-        if (wrapper)
-            erase(wrapper->slePtr());
+        erase(wrapper.slePtr());
     }
 
     /** Insert a new state SLE
@@ -254,16 +249,11 @@ public:
     update(std::shared_ptr<SLE> const& sle) = 0;
 
     template <class T>
-    void
-    update(std::optional<T>& wrapper)
+    requires(std::is_convertible_v<
+             decltype(std::declval<T>().slePtr()),
+             std::shared_ptr<SLE> const&>) void update(T& wrapper)
     {
-        static_assert(
-            std::is_convertible_v<
-                decltype(std::declval<T>().slePtr()),
-                std::shared_ptr<SLE> const&>,
-            "Parameter must be std::optional with slePtr() method");
-        if (wrapper)
-            update(wrapper->slePtr());
+        update(wrapper.slePtr());
     }
 
     //--------------------------------------------------------------------------

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -120,7 +120,7 @@ operator&=(ApplyFlags& lhs, ApplyFlags const& rhs)
         v.insert(sle);
 
         // Check out a value for modification
-        sle = v.peek(k);
+        sle = v.peekSLE(k);
 
         // Indicate that changes were made
         v.update(sle)
@@ -171,13 +171,13 @@ public:
         @return `nullptr` if the key is not present
     */
     virtual std::shared_ptr<SLE>
-    peek(KeyletBase const& k) = 0;
+    peekSLE(KeyletBase const& k) = 0;
 
     /** Remove a peeked SLE.
 
         Requirements:
 
-            `sle` was obtained from prior call to peek()
+            `sle` was obtained from prior call to peekSLE()
             on this instance of the RawView.
 
         Effects:
@@ -192,7 +192,7 @@ public:
         Requirements:
 
             `sle` was not obtained from any calls to
-            peek() on any instances of RawView.
+            peekSLE() on any instances of RawView.
 
             The SLE's key must not already exist.
 
@@ -214,7 +214,7 @@ public:
 
             The SLE's key must exist.
 
-            `sle` was obtained from prior call to peek()
+            `sle` was obtained from prior call to peekSLE()
             on this instance of the RawView.
 
         Effects:

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -173,6 +173,19 @@ public:
     virtual std::shared_ptr<SLE>
     peekSLE(KeyletBase const& k) = 0;
 
+    template <
+        class TKeylet,
+        typename Wrapped = typename TKeylet::template TWrapped<true>>
+    auto
+    peek(TKeylet const& keylet) -> std::optional<Wrapped>
+    {
+        if (auto sle = peekSLE(keylet))
+        {
+            return Wrapped(std::move(sle));
+        }
+        return {};
+    }
+
     /** Remove a peeked SLE.
 
         Requirements:
@@ -186,6 +199,19 @@ public:
     */
     virtual void
     erase(std::shared_ptr<SLE> const& sle) = 0;
+
+    template <class T>
+    void
+    erase(std::optional<T>& wrapper)
+    {
+        static_assert(
+            std::is_convertible_v<
+                decltype(std::declval<T>().slePtr()),
+                std::shared_ptr<SLE> const&>,
+            "Parameter must be std::optional with slePtr() method");
+        if (wrapper)
+            erase(wrapper->slePtr());
+    }
 
     /** Insert a new state SLE
 
@@ -226,6 +252,19 @@ public:
     /** @{ */
     virtual void
     update(std::shared_ptr<SLE> const& sle) = 0;
+
+    template <class T>
+    void
+    update(std::optional<T>& wrapper)
+    {
+        static_assert(
+            std::is_convertible_v<
+                decltype(std::declval<T>().slePtr()),
+                std::shared_ptr<SLE> const&>,
+            "Parameter must be std::optional with slePtr() method");
+        if (wrapper)
+            update(wrapper->slePtr());
+    }
 
     //--------------------------------------------------------------------------
 

--- a/src/ripple/ledger/CachedView.h
+++ b/src/ripple/ledger/CachedView.h
@@ -62,7 +62,7 @@ public:
     exists(KeyletBase const& k) const override;
 
     std::shared_ptr<SLE const>
-    read(KeyletBase const& k) const override;
+    readSLE(KeyletBase const& k) const override;
 
     bool
     open() const override

--- a/src/ripple/ledger/CachedView.h
+++ b/src/ripple/ledger/CachedView.h
@@ -59,10 +59,10 @@ public:
     //
 
     bool
-    exists(Keylet const& k) const override;
+    exists(KeyletBase const& k) const override;
 
     std::shared_ptr<SLE const>
-    read(Keylet const& k) const override;
+    read(KeyletBase const& k) const override;
 
     bool
     open() const override

--- a/src/ripple/ledger/OpenView.h
+++ b/src/ripple/ledger/OpenView.h
@@ -201,7 +201,7 @@ public:
     rules() const override;
 
     bool
-    exists(Keylet const& k) const override;
+    exists(KeyletBase const& k) const override;
 
     std::optional<key_type>
     succ(
@@ -209,7 +209,7 @@ public:
         std::optional<key_type> const& last = std::nullopt) const override;
 
     std::shared_ptr<SLE const>
-    read(Keylet const& k) const override;
+    read(KeyletBase const& k) const override;
 
     std::unique_ptr<sles_type::iter_base>
     slesBegin() const override;

--- a/src/ripple/ledger/OpenView.h
+++ b/src/ripple/ledger/OpenView.h
@@ -209,7 +209,7 @@ public:
         std::optional<key_type> const& last = std::nullopt) const override;
 
     std::shared_ptr<SLE const>
-    read(KeyletBase const& k) const override;
+    readSLE(KeyletBase const& k) const override;
 
     std::unique_ptr<sles_type::iter_base>
     slesBegin() const override;

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -211,7 +211,7 @@ public:
                 specified key.
     */
     virtual bool
-    exists(Keylet const& k) const = 0;
+    exists(KeyletBase const& k) const = 0;
 
     /** Return the key of the next state item.
 
@@ -242,7 +242,7 @@ public:
                 if the type does not match.
     */
     virtual std::shared_ptr<SLE const>
-    read(Keylet const& k) const = 0;
+    read(KeyletBase const& k) const = 0;
 
     // Accounts in a payment are not allowed to use assets acquired during that
     // payment. The PaymentSandbox tracks the debits, credits, and owner count

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -242,7 +242,7 @@ public:
                 if the type does not match.
     */
     virtual std::shared_ptr<SLE const>
-    read(KeyletBase const& k) const = 0;
+    readSLE(KeyletBase const& k) const = 0;
 
     // Accounts in a payment are not allowed to use assets acquired during that
     // payment. The PaymentSandbox tracks the debits, credits, and owner count

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -244,6 +244,19 @@ public:
     virtual std::shared_ptr<SLE const>
     readSLE(KeyletBase const& k) const = 0;
 
+    template <
+        class TKeylet,
+        typename Wrapped = typename TKeylet::template TWrapped<false>>
+    auto
+    read(TKeylet const& keylet) const -> std::optional<Wrapped>
+    {
+        if (auto sle = readSLE(keylet))
+        {
+            return Wrapped(std::move(sle));
+        }
+        return {};
+    }
+
     // Accounts in a payment are not allowed to use assets acquired during that
     // payment. The PaymentSandbox tracks the debits, credits, and owner count
     // changes that accounts make during a payment. `balanceHook` adjusts

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -251,7 +251,7 @@ areCompatible(
 void
 adjustOwnerCount(
     ApplyView& view,
-    std::shared_ptr<SLE> const& sle,
+    std::optional<AcctRoot>& acctRoot,
     std::int32_t amount,
     beast::Journal j);
 
@@ -335,15 +335,15 @@ trustCreate(
     const bool bSrcHigh,
     AccountID const& uSrcAccountID,
     AccountID const& uDstAccountID,
-    uint256 const& uIndex,      // --> ripple state entry
-    SLE::ref sleAccount,        // --> the account being set.
-    const bool bAuth,           // --> authorize account.
-    const bool bNoRipple,       // --> others cannot ripple through
-    const bool bFreeze,         // --> funds cannot leave
-    STAmount const& saBalance,  // --> balance of account being set.
-                                // Issuer should be noAccount()
-    STAmount const& saLimit,    // --> limit for account being set.
-                                // Issuer should be the account being set.
+    uint256 const& uIndex,              // --> ripple state entry
+    std::optional<AcctRoot>& acctRoot,  // --> the account being set.
+    const bool bAuth,                   // --> authorize account.
+    const bool bNoRipple,               // --> others cannot ripple through
+    const bool bFreeze,                 // --> funds cannot leave
+    STAmount const& saBalance,          // --> balance of account being set.
+                                        // Issuer should be noAccount()
+    STAmount const& saLimit,            // --> limit for account being set.
+                                        // Issuer should be account being set.
     std::uint32_t uSrcQualityIn,
     std::uint32_t uSrcQualityOut,
     beast::Journal j);

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -251,7 +251,7 @@ areCompatible(
 void
 adjustOwnerCount(
     ApplyView& view,
-    std::optional<AcctRoot>& acctRoot,
+    AcctRoot& acctRoot,
     std::int32_t amount,
     beast::Journal j);
 
@@ -335,15 +335,15 @@ trustCreate(
     const bool bSrcHigh,
     AccountID const& uSrcAccountID,
     AccountID const& uDstAccountID,
-    uint256 const& uIndex,              // --> ripple state entry
-    std::optional<AcctRoot>& acctRoot,  // --> the account being set.
-    const bool bAuth,                   // --> authorize account.
-    const bool bNoRipple,               // --> others cannot ripple through
-    const bool bFreeze,                 // --> funds cannot leave
-    STAmount const& saBalance,          // --> balance of account being set.
-                                        // Issuer should be noAccount()
-    STAmount const& saLimit,            // --> limit for account being set.
-                                        // Issuer should be account being set.
+    uint256 const& uIndex,      // --> ripple state entry
+    AcctRoot& acctRoot,         // --> the account being set.
+    const bool bAuth,           // --> authorize account.
+    const bool bNoRipple,       // --> others cannot ripple through
+    const bool bFreeze,         // --> funds cannot leave
+    STAmount const& saBalance,  // --> balance of account being set.
+                                // Issuer should be noAccount()
+    STAmount const& saLimit,    // --> limit for account being set.
+                                // Issuer should be account being set.
     std::uint32_t uSrcQualityIn,
     std::uint32_t uSrcQualityOut,
     beast::Journal j);

--- a/src/ripple/ledger/detail/ApplyStateTable.h
+++ b/src/ripple/ledger/detail/ApplyStateTable.h
@@ -82,10 +82,10 @@ public:
         std::optional<key_type> const& last) const;
 
     std::shared_ptr<SLE const>
-    read(ReadView const& base, KeyletBase const& k) const;
+    readSLE(ReadView const& base, KeyletBase const& k) const;
 
     std::shared_ptr<SLE>
-    peek(ReadView const& base, KeyletBase const& k);
+    peekSLE(ReadView const& base, KeyletBase const& k);
 
     std::size_t
     size() const;

--- a/src/ripple/ledger/detail/ApplyStateTable.h
+++ b/src/ripple/ledger/detail/ApplyStateTable.h
@@ -73,7 +73,7 @@ public:
         beast::Journal j);
 
     bool
-    exists(ReadView const& base, Keylet const& k) const;
+    exists(ReadView const& base, KeyletBase const& k) const;
 
     std::optional<key_type>
     succ(
@@ -82,10 +82,10 @@ public:
         std::optional<key_type> const& last) const;
 
     std::shared_ptr<SLE const>
-    read(ReadView const& base, Keylet const& k) const;
+    read(ReadView const& base, KeyletBase const& k) const;
 
     std::shared_ptr<SLE>
-    peek(ReadView const& base, Keylet const& k);
+    peek(ReadView const& base, KeyletBase const& k);
 
     std::size_t
     size() const;

--- a/src/ripple/ledger/detail/ApplyViewBase.h
+++ b/src/ripple/ledger/detail/ApplyViewBase.h
@@ -57,7 +57,7 @@ public:
     rules() const override;
 
     bool
-    exists(Keylet const& k) const override;
+    exists(KeyletBase const& k) const override;
 
     std::optional<key_type>
     succ(
@@ -65,7 +65,7 @@ public:
         std::optional<key_type> const& last = std::nullopt) const override;
 
     std::shared_ptr<SLE const>
-    read(Keylet const& k) const override;
+    read(KeyletBase const& k) const override;
 
     std::unique_ptr<sles_type::iter_base>
     slesBegin() const override;
@@ -94,7 +94,7 @@ public:
     flags() const override;
 
     std::shared_ptr<SLE>
-    peek(Keylet const& k) override;
+    peek(KeyletBase const& k) override;
 
     void
     erase(std::shared_ptr<SLE> const& sle) override;

--- a/src/ripple/ledger/detail/ApplyViewBase.h
+++ b/src/ripple/ledger/detail/ApplyViewBase.h
@@ -99,11 +99,17 @@ public:
     void
     erase(std::shared_ptr<SLE> const& sle) override;
 
+    // Avoid name hiding of non-virtual erase functions.
+    using ApplyView::erase;
+
     void
     insert(std::shared_ptr<SLE> const& sle) override;
 
     void
     update(std::shared_ptr<SLE> const& sle) override;
+
+    // Avoid name hiding of non-virtual update functions.
+    using ApplyView::update;
 
     // RawView
 

--- a/src/ripple/ledger/detail/ApplyViewBase.h
+++ b/src/ripple/ledger/detail/ApplyViewBase.h
@@ -65,7 +65,7 @@ public:
         std::optional<key_type> const& last = std::nullopt) const override;
 
     std::shared_ptr<SLE const>
-    read(KeyletBase const& k) const override;
+    readSLE(KeyletBase const& k) const override;
 
     std::unique_ptr<sles_type::iter_base>
     slesBegin() const override;
@@ -94,7 +94,7 @@ public:
     flags() const override;
 
     std::shared_ptr<SLE>
-    peek(KeyletBase const& k) override;
+    peekSLE(KeyletBase const& k) override;
 
     void
     erase(std::shared_ptr<SLE> const& sle) override;

--- a/src/ripple/ledger/detail/RawStateTable.h
+++ b/src/ripple/ledger/detail/RawStateTable.h
@@ -66,7 +66,7 @@ public:
     apply(RawView& to) const;
 
     bool
-    exists(ReadView const& base, Keylet const& k) const;
+    exists(ReadView const& base, KeyletBase const& k) const;
 
     std::optional<key_type>
     succ(
@@ -84,7 +84,7 @@ public:
     replace(std::shared_ptr<SLE> const& sle);
 
     std::shared_ptr<SLE const>
-    read(ReadView const& base, Keylet const& k) const;
+    read(ReadView const& base, KeyletBase const& k) const;
 
     void
     destroyXRP(XRPAmount const& fee);

--- a/src/ripple/ledger/detail/RawStateTable.h
+++ b/src/ripple/ledger/detail/RawStateTable.h
@@ -84,7 +84,7 @@ public:
     replace(std::shared_ptr<SLE> const& sle);
 
     std::shared_ptr<SLE const>
-    read(ReadView const& base, KeyletBase const& k) const;
+    readSLE(ReadView const& base, KeyletBase const& k) const;
 
     void
     destroyXRP(XRPAmount const& fee);

--- a/src/ripple/ledger/impl/ApplyStateTable.cpp
+++ b/src/ripple/ledger/impl/ApplyStateTable.cpp
@@ -265,7 +265,7 @@ ApplyStateTable::apply(
 //---
 
 bool
-ApplyStateTable::exists(ReadView const& base, Keylet const& k) const
+ApplyStateTable::exists(ReadView const& base, KeyletBase const& k) const
 {
     auto const iter = items_.find(k.key);
     if (iter == items_.end())
@@ -322,7 +322,7 @@ ApplyStateTable::succ(
 }
 
 std::shared_ptr<SLE const>
-ApplyStateTable::read(ReadView const& base, Keylet const& k) const
+ApplyStateTable::read(ReadView const& base, KeyletBase const& k) const
 {
     auto const iter = items_.find(k.key);
     if (iter == items_.end())
@@ -344,7 +344,7 @@ ApplyStateTable::read(ReadView const& base, Keylet const& k) const
 }
 
 std::shared_ptr<SLE>
-ApplyStateTable::peek(ReadView const& base, Keylet const& k)
+ApplyStateTable::peek(ReadView const& base, KeyletBase const& k)
 {
     auto iter = items_.lower_bound(k.key);
     if (iter == items_.end() || iter->first != k.key)

--- a/src/ripple/ledger/impl/ApplyStateTable.cpp
+++ b/src/ripple/ledger/impl/ApplyStateTable.cpp
@@ -87,7 +87,7 @@ ApplyStateTable::visit(
                 func(
                     item.first,
                     true,
-                    to.read(keylet::unchecked(item.first)),
+                    to.readSLE(keylet::unchecked(item.first)),
                     item.second.second);
                 break;
 
@@ -99,7 +99,7 @@ ApplyStateTable::visit(
                 func(
                     item.first,
                     false,
-                    to.read(keylet::unchecked(item.first)),
+                    to.readSLE(keylet::unchecked(item.first)),
                     item.second.second);
                 break;
 
@@ -145,7 +145,7 @@ ApplyStateTable::apply(
                     type = &sfModifiedNode;
                     break;
             }
-            auto const origNode = to.read(keylet::unchecked(item.first));
+            auto const origNode = to.readSLE(keylet::unchecked(item.first));
             auto curNode = item.second.second;
             if ((type == &sfModifiedNode) && (*curNode == *origNode))
                 continue;
@@ -322,11 +322,11 @@ ApplyStateTable::succ(
 }
 
 std::shared_ptr<SLE const>
-ApplyStateTable::read(ReadView const& base, KeyletBase const& k) const
+ApplyStateTable::readSLE(ReadView const& base, KeyletBase const& k) const
 {
     auto const iter = items_.find(k.key);
     if (iter == items_.end())
-        return base.read(k);
+        return base.readSLE(k);
     auto const& item = iter->second;
     auto const& sle = item.second;
     switch (item.first)
@@ -344,12 +344,12 @@ ApplyStateTable::read(ReadView const& base, KeyletBase const& k) const
 }
 
 std::shared_ptr<SLE>
-ApplyStateTable::peek(ReadView const& base, KeyletBase const& k)
+ApplyStateTable::peekSLE(ReadView const& base, KeyletBase const& k)
 {
     auto iter = items_.lower_bound(k.key);
     if (iter == items_.end() || iter->first != k.key)
     {
-        auto const sle = base.read(k);
+        auto const sle = base.readSLE(k);
         if (!sle)
             return nullptr;
         // Make our own copy
@@ -579,7 +579,7 @@ ApplyStateTable::getForMod(
             // metadata; fall through and track it in the mods table.
         }
     }
-    auto c = base.read(keylet::unchecked(key));
+    auto c = base.readSLE(keylet::unchecked(key));
     if (!c)
     {
         // The Destination of an Escrow or a PayChannel may have been

--- a/src/ripple/ledger/impl/ApplyView.cpp
+++ b/src/ripple/ledger/impl/ApplyView.cpp
@@ -31,7 +31,7 @@ ApplyView::dirAdd(
     uint256 const& key,
     std::function<void(std::shared_ptr<SLE> const&)> const& describe)
 {
-    auto root = peek(directory);
+    auto root = peekSLE(directory);
 
     if (!root)
     {
@@ -54,7 +54,7 @@ ApplyView::dirAdd(
 
     if (page)
     {
-        node = peek(keylet::page(directory, page));
+        node = peekSLE(keylet::page(directory, page));
         if (!node)
             LogicError("Directory chain: root back-pointer broken.");
     }
@@ -124,7 +124,7 @@ ApplyView::dirAdd(
 bool
 ApplyView::emptyDirDelete(Keylet const& directory)
 {
-    auto node = peek(directory);
+    auto node = peekSLE(directory);
 
     if (!node)
         return false;
@@ -155,7 +155,7 @@ ApplyView::emptyDirDelete(Keylet const& directory)
     // page to be empty. Remove such pages:
     if (nextPage == prevPage && nextPage != rootPage)
     {
-        auto last = peek(keylet::page(directory, nextPage));
+        auto last = peekSLE(keylet::page(directory, nextPage));
 
         if (!last)
             LogicError("Directory chain: fwd link broken.");
@@ -192,7 +192,7 @@ ApplyView::dirRemove(
     uint256 const& key,
     bool keepRoot)
 {
-    auto node = peek(keylet::page(directory, page));
+    auto node = peekSLE(keylet::page(directory, page));
 
     if (!node)
         return false;
@@ -240,7 +240,7 @@ ApplyView::dirRemove(
         // pages if we stumble on them:
         if (nextPage == prevPage && nextPage != page)
         {
-            auto last = peek(keylet::page(directory, nextPage));
+            auto last = peekSLE(keylet::page(directory, nextPage));
             if (!last)
                 LogicError("Directory chain: fwd link broken.");
 
@@ -283,14 +283,14 @@ ApplyView::dirRemove(
     // middle of the list, or at the end. Unlink it first
     // and then check if that leaves the list with only a
     // root:
-    auto prev = peek(keylet::page(directory, prevPage));
+    auto prev = peekSLE(keylet::page(directory, prevPage));
     if (!prev)
         LogicError("Directory chain: fwd link broken.");
     // Fix previous to point to its new next.
     prev->setFieldU64(sfIndexNext, nextPage);
     update(prev);
 
-    auto next = peek(keylet::page(directory, nextPage));
+    auto next = peekSLE(keylet::page(directory, nextPage));
     if (!next)
         LogicError("Directory chain: rev link broken.");
     // Fix next to point to its new previous.
@@ -314,7 +314,7 @@ ApplyView::dirRemove(
         update(prev);
 
         // And the root points to the the last page:
-        auto root = peek(keylet::page(directory, rootPage));
+        auto root = peekSLE(keylet::page(directory, rootPage));
         if (!root)
             LogicError("Directory chain: root link broken.");
         root->setFieldU64(sfIndexPrevious, prevPage);
@@ -343,7 +343,7 @@ ApplyView::dirDelete(
 
     do
     {
-        auto const page = peek(keylet::page(directory, pi.value_or(0)));
+        auto const page = peekSLE(keylet::page(directory, pi.value_or(0)));
 
         if (!page)
             return false;

--- a/src/ripple/ledger/impl/ApplyViewBase.cpp
+++ b/src/ripple/ledger/impl/ApplyViewBase.cpp
@@ -68,9 +68,9 @@ ApplyViewBase::succ(key_type const& key, std::optional<key_type> const& last)
 }
 
 std::shared_ptr<SLE const>
-ApplyViewBase::read(KeyletBase const& k) const
+ApplyViewBase::readSLE(KeyletBase const& k) const
 {
-    return items_.read(*base_, k);
+    return items_.readSLE(*base_, k);
 }
 
 auto
@@ -125,9 +125,9 @@ ApplyViewBase::flags() const
 }
 
 std::shared_ptr<SLE>
-ApplyViewBase::peek(KeyletBase const& k)
+ApplyViewBase::peekSLE(KeyletBase const& k)
 {
-    return items_.peek(*base_, k);
+    return items_.peekSLE(*base_, k);
 }
 
 void

--- a/src/ripple/ledger/impl/ApplyViewBase.cpp
+++ b/src/ripple/ledger/impl/ApplyViewBase.cpp
@@ -55,7 +55,7 @@ ApplyViewBase::rules() const
 }
 
 bool
-ApplyViewBase::exists(Keylet const& k) const
+ApplyViewBase::exists(KeyletBase const& k) const
 {
     return items_.exists(*base_, k);
 }
@@ -68,7 +68,7 @@ ApplyViewBase::succ(key_type const& key, std::optional<key_type> const& last)
 }
 
 std::shared_ptr<SLE const>
-ApplyViewBase::read(Keylet const& k) const
+ApplyViewBase::read(KeyletBase const& k) const
 {
     return items_.read(*base_, k);
 }
@@ -125,7 +125,7 @@ ApplyViewBase::flags() const
 }
 
 std::shared_ptr<SLE>
-ApplyViewBase::peek(Keylet const& k)
+ApplyViewBase::peek(KeyletBase const& k)
 {
     return items_.peek(*base_, k);
 }

--- a/src/ripple/ledger/impl/BookDirs.cpp
+++ b/src/ripple/ledger/impl/BookDirs.cpp
@@ -80,7 +80,7 @@ BookDirs::const_iterator::operator*() const
 {
     assert(index_ != beast::zero);
     if (!cache_)
-        cache_ = view_->read(keylet::offer(index_));
+        cache_ = view_->readSLE(keylet::offer(index_));
     return *cache_;
 }
 

--- a/src/ripple/ledger/impl/CachedView.cpp
+++ b/src/ripple/ledger/impl/CachedView.cpp
@@ -25,13 +25,13 @@ namespace ripple {
 namespace detail {
 
 bool
-CachedViewImpl::exists(Keylet const& k) const
+CachedViewImpl::exists(KeyletBase const& k) const
 {
     return read(k) != nullptr;
 }
 
 std::shared_ptr<SLE const>
-CachedViewImpl::read(Keylet const& k) const
+CachedViewImpl::read(KeyletBase const& k) const
 {
     {
         std::lock_guard lock(mutex_);

--- a/src/ripple/ledger/impl/CachedView.cpp
+++ b/src/ripple/ledger/impl/CachedView.cpp
@@ -27,11 +27,11 @@ namespace detail {
 bool
 CachedViewImpl::exists(KeyletBase const& k) const
 {
-    return read(k) != nullptr;
+    return readSLE(k) != nullptr;
 }
 
 std::shared_ptr<SLE const>
-CachedViewImpl::read(KeyletBase const& k) const
+CachedViewImpl::readSLE(KeyletBase const& k) const
 {
     {
         std::lock_guard lock(mutex_);
@@ -46,7 +46,7 @@ CachedViewImpl::read(KeyletBase const& k) const
     auto const digest = base_.digest(k.key);
     if (!digest)
         return nullptr;
-    auto sle = cache_.fetch(*digest, [&]() { return base_.read(k); });
+    auto sle = cache_.fetch(*digest, [&]() { return base_.readSLE(k); });
     std::lock_guard lock(mutex_);
     auto const er = map_.emplace(k.key, sle);
     auto const& iter = er.first;

--- a/src/ripple/ledger/impl/Directory.cpp
+++ b/src/ripple/ledger/impl/Directory.cpp
@@ -24,7 +24,7 @@ namespace ripple {
 using const_iterator = Dir::const_iterator;
 
 Dir::Dir(ReadView const& view, Keylet const& key)
-    : view_(&view), root_(key), sle_(view_->read(root_))
+    : view_(&view), root_(key), sle_(view_->readSLE(root_))
 {
     if (sle_ != nullptr)
         indexes_ = &sle_->getFieldV256(sfIndexes);
@@ -69,7 +69,7 @@ const_iterator::operator*() const
 {
     assert(index_ != beast::zero);
     if (!cache_)
-        cache_ = view_->read(keylet::child(index_));
+        cache_ = view_->readSLE(keylet::child(index_));
     return *cache_;
 }
 
@@ -108,7 +108,7 @@ const_iterator::next_page()
     else
     {
         page_ = keylet::page(root_, next);
-        sle_ = view_->read(page_);
+        sle_ = view_->readSLE(page_);
         assert(sle_);
         indexes_ = &sle_->getFieldV256(sfIndexes);
         if (indexes_->empty())

--- a/src/ripple/ledger/impl/OpenView.cpp
+++ b/src/ripple/ledger/impl/OpenView.cpp
@@ -168,9 +168,9 @@ OpenView::succ(key_type const& key, std::optional<key_type> const& last) const
 }
 
 std::shared_ptr<SLE const>
-OpenView::read(KeyletBase const& k) const
+OpenView::readSLE(KeyletBase const& k) const
 {
-    return items_.read(*base_, k);
+    return items_.readSLE(*base_, k);
 }
 
 auto

--- a/src/ripple/ledger/impl/OpenView.cpp
+++ b/src/ripple/ledger/impl/OpenView.cpp
@@ -155,7 +155,7 @@ OpenView::rules() const
 }
 
 bool
-OpenView::exists(Keylet const& k) const
+OpenView::exists(KeyletBase const& k) const
 {
     return items_.exists(*base_, k);
 }
@@ -168,7 +168,7 @@ OpenView::succ(key_type const& key, std::optional<key_type> const& last) const
 }
 
 std::shared_ptr<SLE const>
-OpenView::read(Keylet const& k) const
+OpenView::read(KeyletBase const& k) const
 {
     return items_.read(*base_, k);
 }

--- a/src/ripple/ledger/impl/RawStateTable.cpp
+++ b/src/ripple/ledger/impl/RawStateTable.cpp
@@ -177,7 +177,7 @@ RawStateTable::apply(RawView& to) const
 }
 
 bool
-RawStateTable::exists(ReadView const& base, Keylet const& k) const
+RawStateTable::exists(ReadView const& base, KeyletBase const& k) const
 {
     assert(k.key.isNonZero());
     auto const iter = items_.find(k.key);
@@ -304,7 +304,7 @@ RawStateTable::replace(std::shared_ptr<SLE> const& sle)
 }
 
 std::shared_ptr<SLE const>
-RawStateTable::read(ReadView const& base, Keylet const& k) const
+RawStateTable::read(ReadView const& base, KeyletBase const& k) const
 {
     auto const iter = items_.find(k.key);
     if (iter == items_.end())

--- a/src/ripple/ledger/impl/RawStateTable.cpp
+++ b/src/ripple/ledger/impl/RawStateTable.cpp
@@ -304,11 +304,11 @@ RawStateTable::replace(std::shared_ptr<SLE> const& sle)
 }
 
 std::shared_ptr<SLE const>
-RawStateTable::read(ReadView const& base, KeyletBase const& k) const
+RawStateTable::readSLE(ReadView const& base, KeyletBase const& k) const
 {
     auto const iter = items_.find(k.key);
     if (iter == items_.end())
-        return base.read(k);
+        return base.readSLE(k);
     auto const& item = iter->second;
     if (item.action == Action::erase)
         return nullptr;

--- a/src/ripple/ledger/impl/ReadView.cpp
+++ b/src/ripple/ledger/impl/ReadView.cpp
@@ -80,7 +80,7 @@ makeRulesGivenLedger(
     std::optional digest = ledger.digest(k.key);
     if (digest)
     {
-        auto const sle = ledger.read(k);
+        auto const sle = ledger.readSLE(k);
         if (sle)
             return Rules(presets, digest, sle->getFieldV256(sfAmendments));
     }

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -211,8 +211,9 @@ isFrozen(
     if (issuer != account)
     {
         // Check if the issuer froze the line
-        auto const sle = view.readSLE(keylet::line(account, issuer, currency));
-        if (sle &&
+        if (auto const sle =
+                view.readSLE(keylet::line(account, issuer, currency));
+            sle &&
             sle->isFlag((issuer > account) ? lsfHighFreeze : lsfLowFreeze))
             return true;
     }

--- a/src/ripple/nodestore/impl/Shard.cpp
+++ b/src/ripple/nodestore/impl/Shard.cpp
@@ -690,7 +690,7 @@ Shard::finalize(bool writeSQLite, std::optional<uint256> const& referenceHash)
         ledger->txMap().setLedgerSeq(ledgerSeq);
         assert(
             ledger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
-            ledger->read(keylet::fees()));
+            ledger->readSLE(keylet::fees()));
         ledger->setImmutable();
         if (!ledger->stateMap().fetchRoot(
                 SHAMapHash{ledger->info().accountHash}, nullptr))

--- a/src/ripple/protocol/AcctRoot.h
+++ b/src/ripple/protocol/AcctRoot.h
@@ -48,25 +48,6 @@ private:
     friend class ApplyView;
 
 public:
-    AcctRootImpl(AcctRootImpl const&) = default;
-    AcctRootImpl(AcctRootImpl&&) = default;
-
-    AcctRootImpl&
-    operator=(AcctRootImpl const& rhs)
-    {
-        Base::operator=(rhs);
-        return *this;
-    }
-
-    AcctRootImpl&
-    operator=(AcctRootImpl&& rhs)
-    {
-        Base::operator=(std::move(rhs));
-        return *this;
-    }
-
-    ~AcctRootImpl() = default;
-
     // Conversion operator from AcctRootImpl<true> to AcctRootImpl<false>.
     operator AcctRootImpl<true>() const
     {

--- a/src/ripple/protocol/AcctRoot.h
+++ b/src/ripple/protocol/AcctRoot.h
@@ -1,0 +1,390 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2021 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_PROTOCOL_ACCT_ROOT_H_INCLUDED
+#define RIPPLE_PROTOCOL_ACCT_ROOT_H_INCLUDED
+
+#include <ripple/protocol/LedgerEntryWrapper.h>
+#include <ripple/protocol/STAccount.h>
+#include <ripple/protocol/STAmount.h>
+
+namespace ripple {
+
+template <bool Writable>
+class AcctRootImpl final : public LedgerEntryWrapper<Writable>
+{
+private:
+    using Base = LedgerEntryWrapper<Writable>;
+    using SleT = typename Base::SleT;
+    using Base::wrapped_;
+
+    // This constructor is private so only the factory functions can
+    // construct an AcctRootImpl.
+    AcctRootImpl(std::shared_ptr<SleT>&& w) : Base(std::move(w))
+    {
+    }
+
+    // Friend declarations of factory functions.
+    //
+    // For classes that contain factories we must declare the entire class
+    // as a friend unless the class declaration is visible at this point.
+    friend class ReadView;
+    friend class ApplyView;
+
+public:
+    AcctRootImpl(AcctRootImpl const&) = default;
+    AcctRootImpl(AcctRootImpl&&) = default;
+
+    AcctRootImpl&
+    operator=(AcctRootImpl const& rhs)
+    {
+        Base::operator=(rhs);
+        return *this;
+    }
+
+    AcctRootImpl&
+    operator=(AcctRootImpl&& rhs)
+    {
+        Base::operator=(std::move(rhs));
+        return *this;
+    }
+
+    ~AcctRootImpl() = default;
+
+    // Conversion operator from AcctRootImpl<true> to AcctRootImpl<false>.
+    operator AcctRootImpl<true>() const
+    {
+        return AcctRootImpl<false>(
+            std::const_pointer_cast<std::shared_ptr<STLedgerEntry const>>(
+                wrapped_));
+    }
+
+    [[nodiscard]] AccountID
+    accountID() const
+    {
+        return wrapped_->at(sfAccount);
+    }
+
+    [[nodiscard]] std::uint32_t
+    sequence() const
+    {
+        return wrapped_->at(sfSequence);
+    }
+
+    void
+    setSequence(std::uint32_t seq)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        wrapped_->at(sfSequence) = seq;
+    }
+
+    [[nodiscard]] STAmount
+    balance() const
+    {
+        return wrapped_->at(sfBalance);
+    }
+
+    void
+    setBalance(STAmount const& amount)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        wrapped_->at(sfBalance) = amount;
+    }
+
+    [[nodiscard]] std::uint32_t
+    ownerCount() const
+    {
+        return wrapped_->at(sfOwnerCount);
+    }
+
+    void
+    setOwnerCount(std::uint32_t newCount)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        wrapped_->at(sfOwnerCount) = newCount;
+    }
+
+    [[nodiscard]] std::uint32_t
+    previousTxnID() const
+    {
+        return wrapped_->at(sfOwnerCount);
+    }
+
+    void
+    setPreviousTxnID(uint256 prevTxID)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        wrapped_->at(sfPreviousTxnID) = prevTxID;
+    }
+
+    [[nodiscard]] std::uint32_t
+    previousTxnLgrSeq() const
+    {
+        return wrapped_->at(sfPreviousTxnLgrSeq);
+    }
+
+    void
+    setPreviousTxnLgrSeq(std::uint32_t prevTxLgrSeq)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        wrapped_->at(sfPreviousTxnLgrSeq) = prevTxLgrSeq;
+    }
+
+    [[nodiscard]] std::optional<uint256>
+    accountTxnID() const
+    {
+        return wrapped_->at(~sfAccountTxnID);
+    }
+
+    void
+    setAccountTxnID(uint256 const& newAcctTxnID)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->setOptional(sfAccountTxnID, newAcctTxnID);
+    }
+
+    void
+    clearAccountTxnID()
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->clearOptional(sfAccountTxnID);
+    }
+
+    [[nodiscard]] std::optional<AccountID>
+    regularKey() const
+    {
+        return wrapped_->at(~sfRegularKey);
+    }
+
+    void
+    setRegularKey(AccountID const& newRegKey)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->setOptional(sfRegularKey, newRegKey);
+    }
+
+    void
+    clearRegularKey()
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->clearOptional(sfRegularKey);
+    }
+
+    [[nodiscard]] std::optional<uint128>
+    emailHash() const
+    {
+        return wrapped_->at(~sfEmailHash);
+    }
+
+    void
+    setEmailHash(uint128 const& newEmailHash)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->setOrClearBaseUintIfZero(sfEmailHash, newEmailHash);
+    }
+
+    [[nodiscard]] std::optional<uint256>
+    walletLocator() const
+    {
+        return wrapped_->at(~sfWalletLocator);
+    }
+
+    void
+    setWalletLocator(uint256 const& newWalletLocator)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->setOrClearBaseUintIfZero(sfWalletLocator, newWalletLocator);
+    }
+
+    [[nodiscard]] std::optional<std::uint32_t>
+    walletSize() const
+    {
+        return wrapped_->at(~sfWalletSize);
+    }
+
+    [[nodiscard]] Blob
+    messageKey() const
+    {
+        return this->getOptionalVL(sfMessageKey);
+    }
+
+    void
+    setMessageKey(Blob const& newMessageKey)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->setOrClearVLIfEmpty(sfMessageKey, newMessageKey);
+    }
+
+    [[nodiscard]] std::optional<std::uint32_t>
+    transferRate() const
+    {
+        return wrapped_->at(~sfTransferRate);
+    }
+
+    void
+    setTransferRate(std::uint32_t newTransferRate)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->setOptional(sfTransferRate, newTransferRate);
+    }
+
+    void
+    clearTransferRate()
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->clearOptional(sfTransferRate);
+    }
+
+    [[nodiscard]] Blob
+    domain() const
+    {
+        return this->getOptionalVL(sfDomain);
+    }
+
+    void
+    setDomain(Blob const& newDomain)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->setOrClearVLIfEmpty(sfDomain, newDomain);
+    }
+
+    [[nodiscard]] std::optional<std::uint8_t>
+    tickSize() const
+    {
+        return wrapped_->at(~sfTickSize);
+    }
+
+    void
+    setTickSize(std::uint8_t newTickSize)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->setOptional(sfTickSize, newTickSize);
+    }
+
+    void
+    clearTickSize()
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->clearOptional(sfTickSize);
+    }
+
+    [[nodiscard]] std::optional<std::uint32_t>
+    ticketCount() const
+    {
+        return wrapped_->at(~sfTicketCount);
+    }
+
+    void
+    setTicketCount(std::uint32_t newTicketCount)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->setOptional(sfTicketCount, newTicketCount);
+    }
+
+    void
+    clearTicketCount()
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->clearOptional(sfTicketCount);
+    }
+
+    [[nodiscard]] std::optional<AccountID>
+    NFTokenMinter() const
+    {
+        return wrapped_->at(~sfNFTokenMinter);
+    }
+
+    void
+    setNFTokenMinter(AccountID const& newMinter)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->setOptional(sfNFTokenMinter, newMinter);
+    }
+
+    void
+    clearNFTokenMinter()
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->clearOptional(sfNFTokenMinter);
+    }
+
+    [[nodiscard]] std::optional<std::uint32_t>
+    mintedNFTokens() const
+    {
+        return wrapped_->at(~sfMintedNFTokens);
+    }
+
+    void
+    setMintedNFTokens(std::uint32_t newMintedCount)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->setOptional(sfMintedNFTokens, newMintedCount);
+    }
+
+    [[nodiscard]] std::optional<std::uint32_t>
+    burnedNFTokens() const
+    {
+        return wrapped_->at(~sfBurnedNFTokens);
+    }
+
+    void
+    setBurnedNFTokens(std::uint32_t newBurnedCount)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->setOptional(sfBurnedNFTokens, newBurnedCount);
+    }
+
+    [[nodiscard]] std::optional<std::uint32_t>
+    firstNFTokenSequence() const
+    {
+        return wrapped_->at(~sfFirstNFTokenSequence);
+    }
+
+    void
+    setFirstNFTokenSequence(std::uint32_t newFirstNFTokenSeq)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        this->setOptional(sfFirstNFTokenSequence, newFirstNFTokenSeq);
+    }
+};
+
+using AcctRootRd = AcctRootImpl<false>;
+using AcctRoot = AcctRootImpl<true>;
+
+// clang-format off
+#ifndef __INTELLISENSE__
+static_assert(not std::is_default_constructible_v<AcctRootRd>);
+static_assert(    std::is_copy_constructible_v<AcctRootRd>);
+static_assert(    std::is_move_constructible_v<AcctRootRd>);
+static_assert(    std::is_copy_assignable_v<AcctRootRd>);
+static_assert(    std::is_move_assignable_v<AcctRootRd>);
+static_assert(    std::is_nothrow_destructible_v<AcctRootRd>);
+
+static_assert(not std::is_default_constructible_v<AcctRoot>);
+static_assert(    std::is_copy_constructible_v<AcctRoot>);
+static_assert(    std::is_move_constructible_v<AcctRoot>);
+static_assert(    std::is_copy_assignable_v<AcctRoot>);
+static_assert(    std::is_move_assignable_v<AcctRoot>);
+static_assert(    std::is_nothrow_destructible_v<AcctRoot>);
+#endif  // __INTELLISENSE__
+// clang-format on
+
+}  // namespace ripple
+
+#endif  // RIPPLE_PROTOCOL_ACCT_ROOT_H_INCLUDED

--- a/src/ripple/protocol/AcctRoot.h
+++ b/src/ripple/protocol/AcctRoot.h
@@ -88,9 +88,8 @@ public:
     }
 
     void
-    setSequence(std::uint32_t seq)
+    setSequence(std::uint32_t seq) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         wrapped_->at(sfSequence) = seq;
     }
 
@@ -101,9 +100,8 @@ public:
     }
 
     void
-    setBalance(STAmount const& amount)
+    setBalance(STAmount const& amount) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         wrapped_->at(sfBalance) = amount;
     }
 
@@ -114,9 +112,8 @@ public:
     }
 
     void
-    setOwnerCount(std::uint32_t newCount)
+    setOwnerCount(std::uint32_t newCount) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         wrapped_->at(sfOwnerCount) = newCount;
     }
 
@@ -127,9 +124,8 @@ public:
     }
 
     void
-    setPreviousTxnID(uint256 prevTxID)
+    setPreviousTxnID(uint256 prevTxID) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         wrapped_->at(sfPreviousTxnID) = prevTxID;
     }
 
@@ -140,9 +136,8 @@ public:
     }
 
     void
-    setPreviousTxnLgrSeq(std::uint32_t prevTxLgrSeq)
+    setPreviousTxnLgrSeq(std::uint32_t prevTxLgrSeq) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         wrapped_->at(sfPreviousTxnLgrSeq) = prevTxLgrSeq;
     }
 
@@ -153,16 +148,14 @@ public:
     }
 
     void
-    setAccountTxnID(uint256 const& newAcctTxnID)
+    setAccountTxnID(uint256 const& newAcctTxnID) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->setOptional(sfAccountTxnID, newAcctTxnID);
     }
 
     void
-    clearAccountTxnID()
+    clearAccountTxnID() requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->clearOptional(sfAccountTxnID);
     }
 
@@ -173,16 +166,14 @@ public:
     }
 
     void
-    setRegularKey(AccountID const& newRegKey)
+    setRegularKey(AccountID const& newRegKey) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->setOptional(sfRegularKey, newRegKey);
     }
 
     void
-    clearRegularKey()
+    clearRegularKey() requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->clearOptional(sfRegularKey);
     }
 
@@ -193,9 +184,8 @@ public:
     }
 
     void
-    setEmailHash(uint128 const& newEmailHash)
+    setEmailHash(uint128 const& newEmailHash) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->setOrClearBaseUintIfZero(sfEmailHash, newEmailHash);
     }
 
@@ -206,9 +196,8 @@ public:
     }
 
     void
-    setWalletLocator(uint256 const& newWalletLocator)
+    setWalletLocator(uint256 const& newWalletLocator) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->setOrClearBaseUintIfZero(sfWalletLocator, newWalletLocator);
     }
 
@@ -225,9 +214,8 @@ public:
     }
 
     void
-    setMessageKey(Blob const& newMessageKey)
+    setMessageKey(Blob const& newMessageKey) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->setOrClearVLIfEmpty(sfMessageKey, newMessageKey);
     }
 
@@ -238,16 +226,14 @@ public:
     }
 
     void
-    setTransferRate(std::uint32_t newTransferRate)
+    setTransferRate(std::uint32_t newTransferRate) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->setOptional(sfTransferRate, newTransferRate);
     }
 
     void
-    clearTransferRate()
+    clearTransferRate() requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->clearOptional(sfTransferRate);
     }
 
@@ -258,9 +244,8 @@ public:
     }
 
     void
-    setDomain(Blob const& newDomain)
+    setDomain(Blob const& newDomain) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->setOrClearVLIfEmpty(sfDomain, newDomain);
     }
 
@@ -271,16 +256,14 @@ public:
     }
 
     void
-    setTickSize(std::uint8_t newTickSize)
+    setTickSize(std::uint8_t newTickSize) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->setOptional(sfTickSize, newTickSize);
     }
 
     void
-    clearTickSize()
+    clearTickSize() requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->clearOptional(sfTickSize);
     }
 
@@ -291,16 +274,14 @@ public:
     }
 
     void
-    setTicketCount(std::uint32_t newTicketCount)
+    setTicketCount(std::uint32_t newTicketCount) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->setOptional(sfTicketCount, newTicketCount);
     }
 
     void
-    clearTicketCount()
+    clearTicketCount() requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->clearOptional(sfTicketCount);
     }
 
@@ -311,16 +292,14 @@ public:
     }
 
     void
-    setNFTokenMinter(AccountID const& newMinter)
+    setNFTokenMinter(AccountID const& newMinter) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->setOptional(sfNFTokenMinter, newMinter);
     }
 
     void
-    clearNFTokenMinter()
+    clearNFTokenMinter() requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->clearOptional(sfNFTokenMinter);
     }
 
@@ -331,9 +310,8 @@ public:
     }
 
     void
-    setMintedNFTokens(std::uint32_t newMintedCount)
+    setMintedNFTokens(std::uint32_t newMintedCount) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->setOptional(sfMintedNFTokens, newMintedCount);
     }
 
@@ -344,9 +322,8 @@ public:
     }
 
     void
-    setBurnedNFTokens(std::uint32_t newBurnedCount)
+    setBurnedNFTokens(std::uint32_t newBurnedCount) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         this->setOptional(sfBurnedNFTokens, newBurnedCount);
     }
 
@@ -369,19 +346,19 @@ using AcctRoot = AcctRootImpl<true>;
 
 // clang-format off
 #ifndef __INTELLISENSE__
-static_assert(not std::is_default_constructible_v<AcctRootRd>);
-static_assert(    std::is_copy_constructible_v<AcctRootRd>);
-static_assert(    std::is_move_constructible_v<AcctRootRd>);
-static_assert(    std::is_copy_assignable_v<AcctRootRd>);
-static_assert(    std::is_move_assignable_v<AcctRootRd>);
-static_assert(    std::is_nothrow_destructible_v<AcctRootRd>);
+static_assert(! std::is_default_constructible_v<AcctRootRd>);
+static_assert(  std::is_copy_constructible_v<AcctRootRd>);
+static_assert(  std::is_move_constructible_v<AcctRootRd>);
+static_assert(  std::is_copy_assignable_v<AcctRootRd>);
+static_assert(  std::is_move_assignable_v<AcctRootRd>);
+static_assert(  std::is_nothrow_destructible_v<AcctRootRd>);
 
-static_assert(not std::is_default_constructible_v<AcctRoot>);
-static_assert(    std::is_copy_constructible_v<AcctRoot>);
-static_assert(    std::is_move_constructible_v<AcctRoot>);
-static_assert(    std::is_copy_assignable_v<AcctRoot>);
-static_assert(    std::is_move_assignable_v<AcctRoot>);
-static_assert(    std::is_nothrow_destructible_v<AcctRoot>);
+static_assert(! std::is_default_constructible_v<AcctRoot>);
+static_assert(  std::is_copy_constructible_v<AcctRoot>);
+static_assert(  std::is_move_constructible_v<AcctRoot>);
+static_assert(  std::is_copy_assignable_v<AcctRoot>);
+static_assert(  std::is_move_assignable_v<AcctRoot>);
+static_assert(  std::is_nothrow_destructible_v<AcctRoot>);
 #endif  // __INTELLISENSE__
 // clang-format on
 

--- a/src/ripple/protocol/Indexes.h
+++ b/src/ripple/protocol/Indexes.h
@@ -50,7 +50,7 @@ class SeqProxy;
 namespace keylet {
 
 /** AccountID root */
-Keylet
+AccountRootKeylet
 account(AccountID const& id) noexcept;
 
 /** The index of the amendment table */

--- a/src/ripple/protocol/Keylet.h
+++ b/src/ripple/protocol/Keylet.h
@@ -69,12 +69,12 @@ public:
 };
 
 #ifndef __INTELLISENSE__
-static_assert(not std::is_default_constructible_v<KeyletBase>);
-static_assert(not std::is_copy_constructible_v<KeyletBase>);
-static_assert(not std::is_move_constructible_v<KeyletBase>);
-static_assert(not std::is_copy_assignable_v<KeyletBase>);
-static_assert(not std::is_move_assignable_v<KeyletBase>);
-static_assert(not std::is_nothrow_destructible_v<KeyletBase>);
+static_assert(!std::is_default_constructible_v<KeyletBase>);
+static_assert(!std::is_copy_constructible_v<KeyletBase>);
+static_assert(!std::is_move_constructible_v<KeyletBase>);
+static_assert(!std::is_copy_assignable_v<KeyletBase>);
+static_assert(!std::is_move_assignable_v<KeyletBase>);
+static_assert(!std::is_nothrow_destructible_v<KeyletBase>);
 #endif
 
 struct Keylet final : public KeyletBase
@@ -87,7 +87,7 @@ struct Keylet final : public KeyletBase
 };
 
 #ifndef __INTELLISENSE__
-static_assert(not std::is_default_constructible_v<Keylet>);
+static_assert(!std::is_default_constructible_v<Keylet>);
 static_assert(std::is_copy_constructible_v<Keylet>);
 static_assert(std::is_move_constructible_v<Keylet>);
 static_assert(std::is_copy_assignable_v<Keylet>);
@@ -111,7 +111,7 @@ struct AccountRootKeylet final : public KeyletBase
 };
 
 #ifndef __INTELLISENSE__
-static_assert(not std::is_default_constructible_v<AccountRootKeylet>);
+static_assert(!std::is_default_constructible_v<AccountRootKeylet>);
 static_assert(std::is_copy_constructible_v<AccountRootKeylet>);
 static_assert(std::is_move_constructible_v<AccountRootKeylet>);
 static_assert(std::is_copy_assignable_v<AccountRootKeylet>);

--- a/src/ripple/protocol/Keylet.h
+++ b/src/ripple/protocol/Keylet.h
@@ -29,25 +29,70 @@ class STLedgerEntry;
 
 /** A pair of SHAMap key and LedgerEntryType.
 
-    A Keylet identifies both a key in the state map
-    and its ledger entry type.
+    A Keylet identifies both a key in the state map and its ledger entry type.
 
-    @note Keylet is a portmanteau of the words key
-          and LET, an acronym for LedgerEntryType.
+    @note Keylet is a portmanteau of the words key and LET, an acronym for
+          LedgerEntryType.
 */
-struct Keylet
+struct KeyletBase
 {
-    uint256 key;
     LedgerEntryType type;
+    uint256 key;
 
-    Keylet(LedgerEntryType type_, uint256 const& key_) : key(key_), type(type_)
+protected:
+    // Only derived classes should be able to construct a KeyletBase.
+    KeyletBase(LedgerEntryType type_, uint256 const& key_)
+        : type(type_), key(key_)
     {
     }
 
+    // You should be able to copy construct derived classes.
+    KeyletBase(KeyletBase const&) = default;
+    KeyletBase(KeyletBase&&) = default;
+
+    // You should be able to assign derived classes.
+    KeyletBase&
+    operator=(KeyletBase const&) = default;
+    KeyletBase&
+    operator=(KeyletBase&&) = default;
+
+    // The destructor is protected so derived classes cannot be destroyed
+    // through a pointer to the base.  It also allows us to do derivation
+    // without needing a virtual table.
+    ~KeyletBase() = default;
+
+public:
     /** Returns true if the SLE matches the type */
     bool
     check(STLedgerEntry const&) const;
 };
+
+#ifndef __INTELLISENSE__
+static_assert(not std::is_default_constructible_v<KeyletBase>);
+static_assert(not std::is_copy_constructible_v<KeyletBase>);
+static_assert(not std::is_move_constructible_v<KeyletBase>);
+static_assert(not std::is_copy_assignable_v<KeyletBase>);
+static_assert(not std::is_move_assignable_v<KeyletBase>);
+static_assert(not std::is_nothrow_destructible_v<KeyletBase>);
+#endif
+
+struct Keylet final : public KeyletBase
+{
+    Keylet(LedgerEntryType type, uint256 const& key) : KeyletBase(type, key)
+    {
+    }
+
+    using KeyletBase::check;
+};
+
+#ifndef __INTELLISENSE__
+static_assert(not std::is_default_constructible_v<Keylet>);
+static_assert(std::is_copy_constructible_v<Keylet>);
+static_assert(std::is_move_constructible_v<Keylet>);
+static_assert(std::is_copy_assignable_v<Keylet>);
+static_assert(std::is_move_assignable_v<Keylet>);
+static_assert(std::is_nothrow_destructible_v<Keylet>);
+#endif
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/Keylet.h
+++ b/src/ripple/protocol/Keylet.h
@@ -21,6 +21,7 @@
 #define RIPPLE_PROTOCOL_KEYLET_H_INCLUDED
 
 #include <ripple/basics/base_uint.h>
+#include <ripple/protocol/AcctRoot.h>
 #include <ripple/protocol/LedgerFormats.h>
 
 namespace ripple {
@@ -92,6 +93,30 @@ static_assert(std::is_move_constructible_v<Keylet>);
 static_assert(std::is_copy_assignable_v<Keylet>);
 static_assert(std::is_move_assignable_v<Keylet>);
 static_assert(std::is_nothrow_destructible_v<Keylet>);
+#endif
+
+template <bool>
+class AcctRootImpl;
+
+struct AccountRootKeylet final : public KeyletBase
+{
+    template <bool Writable>
+    using TWrapped = AcctRootImpl<Writable>;
+
+    using KeyletBase::check;
+
+    AccountRootKeylet(uint256 const& key) : KeyletBase(ltACCOUNT_ROOT, key)
+    {
+    }
+};
+
+#ifndef __INTELLISENSE__
+static_assert(not std::is_default_constructible_v<AccountRootKeylet>);
+static_assert(std::is_copy_constructible_v<AccountRootKeylet>);
+static_assert(std::is_move_constructible_v<AccountRootKeylet>);
+static_assert(std::is_copy_assignable_v<AccountRootKeylet>);
+static_assert(std::is_move_assignable_v<AccountRootKeylet>);
+static_assert(std::is_nothrow_destructible_v<AccountRootKeylet>);
 #endif
 
 }  // namespace ripple

--- a/src/ripple/protocol/Keylet.h
+++ b/src/ripple/protocol/Keylet.h
@@ -105,7 +105,8 @@ struct AccountRootKeylet final : public KeyletBase
 
     using KeyletBase::check;
 
-    AccountRootKeylet(uint256 const& key) : KeyletBase(ltACCOUNT_ROOT, key)
+    explicit AccountRootKeylet(uint256 const& key)
+        : KeyletBase(ltACCOUNT_ROOT, key)
     {
     }
 };

--- a/src/ripple/protocol/LedgerEntryWrapper.h
+++ b/src/ripple/protocol/LedgerEntryWrapper.h
@@ -1,0 +1,194 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2021 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_PROTOCOL_LEDGER_ENTRY_WRAPPER_H_INCLUDED
+#define RIPPLE_PROTOCOL_LEDGER_ENTRY_WRAPPER_H_INCLUDED
+
+#include <ripple/basics/Blob.h>
+#include <ripple/protocol/SField.h>
+#include <type_traits>
+#include <utility>
+
+namespace ripple {
+
+class STLedgerEntry;
+
+// A base class for ledger entry wrappers.
+//
+// Provides basic management for:
+//  o Handling of const/non-const representation
+//  o The wrapped serialized ledger entry
+//  o The flags
+//  o Utility methods shared by derived classes
+template <bool Writable>
+class LedgerEntryWrapper
+{
+protected:
+    using SleT = typename std::
+        conditional_t<Writable, STLedgerEntry, STLedgerEntry const>;
+
+    std::shared_ptr<SleT> wrapped_;
+
+    //--------------------------------------------------------------------------
+    // Constructors are protected so only derived classes can construct.
+    LedgerEntryWrapper(std::shared_ptr<SleT>&& w) : wrapped_(std::move(w))
+    {
+    }
+
+    LedgerEntryWrapper(LedgerEntryWrapper const&) = default;
+    LedgerEntryWrapper(LedgerEntryWrapper&&) = default;
+    LedgerEntryWrapper&
+    operator=(LedgerEntryWrapper const&) = default;
+    LedgerEntryWrapper&
+    operator=(LedgerEntryWrapper&&) = default;
+
+    // Destructor is protected so the base class cannot be directly destroyed.
+    // There is no virtual table, so the most derived class must be destroyed.
+    ~LedgerEntryWrapper() = default;
+
+    //--------------------------------------------------------------------------
+    // Helper functions that are useful to some derived classes.
+    template <typename SF, typename T>
+    void
+    setOptional(SF const& field, T const& value)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        static_assert(
+            std::is_base_of_v<SField, SF>,
+            "setOptional()requires an SField as its first argument.");
+
+        if (!wrapped_->isFieldPresent(field))
+            wrapped_->makeFieldPresent(field);
+
+        wrapped_->at(field) = value;
+    }
+
+    template <typename SF>
+    void
+    clearOptional(SF const& field)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        static_assert(
+            std::is_base_of_v<SField, SF>,
+            "clearOptional()requires an SField as its argument.");
+
+        if (wrapped_->isFieldPresent(field))
+            wrapped_->makeFieldAbsent(field);
+    }
+
+    [[nodiscard]] Blob
+    getOptionalVL(SF_VL const& field) const
+    {
+        Blob ret;
+        if (wrapped_->isFieldPresent(field))
+            ret = wrapped_->getFieldVL(field);
+        return ret;
+    }
+
+    template <typename SF, std::size_t Bits, class Tag>
+    void
+    setOrClearBaseUintIfZero(SF const& field, base_uint<Bits, Tag> const& value)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        static_assert(
+            std::is_base_of_v<SField, SF>,
+            "setOrClearBaseUintIfZero()requires an SField as its argument.");
+
+        if (value.signum() == 0)
+            return clearOptional(field);
+
+        if (!wrapped_->isFieldPresent(field))
+            wrapped_->makeFieldPresent(field);
+
+        wrapped_->at(field) = value;
+    }
+
+    void
+    setOrClearVLIfEmpty(SF_VL const& field, Blob const& value)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+
+        if (value.empty())
+            return clearOptional(field);
+
+        if (!wrapped_->isFieldPresent(field))
+            wrapped_->makeFieldPresent(field);
+
+        wrapped_->setFieldVL(field, value);
+    }
+
+public:
+    //--------------------------------------------------------------------------
+    // Methods applicable to all ledger entries.
+
+    [[nodiscard]] std::shared_ptr<STLedgerEntry const>
+    slePtr() const
+    {
+        if constexpr (Writable)
+            return std::const_pointer_cast<
+                std::shared_ptr<STLedgerEntry const>>(wrapped_);
+        else
+            return wrapped_;
+    }
+
+    [[nodiscard]] std::shared_ptr<STLedgerEntry> const&
+    slePtr()
+    {
+        static_assert(
+            Writable, "Cannot access non-const SLE of const ledger entry.");
+        return wrapped_;
+    }
+
+    [[nodiscard]] std::uint32_t
+    flags() const
+    {
+        return wrapped_->at(sfFlags);
+    }
+
+    [[nodiscard]] bool
+    isFlag(std::uint32_t flagsToCheck) const
+    {
+        return (flags() & flagsToCheck) == flagsToCheck;
+    }
+
+    void
+    replaceAllFlags(std::uint32_t newFlags)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        wrapped_->at(sfFlags) = newFlags;
+    }
+
+    void
+    setFlag(std::uint32_t flagsToSet)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        replaceAllFlags(flags() | flagsToSet);
+    }
+
+    void
+    clearFlag(std::uint32_t flagsToClear)
+    {
+        static_assert(Writable, "Cannot set member of const ledger entry.");
+        replaceAllFlags(flags() & ~flagsToClear);
+    }
+};
+
+}  // namespace ripple
+
+#endif  // RIPPLE_PROTOCOL_LEDGER_ENTRY_WRAPPER_H_INCLUDED

--- a/src/ripple/protocol/LedgerEntryWrapper.h
+++ b/src/ripple/protocol/LedgerEntryWrapper.h
@@ -66,13 +66,10 @@ protected:
     // Helper functions that are useful to some derived classes.
     template <typename SF, typename T>
     void
-    setOptional(SF const& field, T const& value)
+    setOptional(
+        SF const& field,
+        T const& value) requires Writable&& std::is_base_of_v<SField, SF>
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
-        static_assert(
-            std::is_base_of_v<SField, SF>,
-            "setOptional()requires an SField as its first argument.");
-
         if (!wrapped_->isFieldPresent(field))
             wrapped_->makeFieldPresent(field);
 
@@ -81,13 +78,9 @@ protected:
 
     template <typename SF>
     void
-    clearOptional(SF const& field)
+    clearOptional(
+        SF const& field) requires Writable&& std::is_base_of_v<SField, SF>
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
-        static_assert(
-            std::is_base_of_v<SField, SF>,
-            "clearOptional()requires an SField as its argument.");
-
         if (wrapped_->isFieldPresent(field))
             wrapped_->makeFieldAbsent(field);
     }
@@ -103,13 +96,11 @@ protected:
 
     template <typename SF, std::size_t Bits, class Tag>
     void
-    setOrClearBaseUintIfZero(SF const& field, base_uint<Bits, Tag> const& value)
+    setOrClearBaseUintIfZero(
+        SF const& field,
+        base_uint<Bits, Tag> const&
+            value) requires Writable&& std::is_base_of_v<SField, SF>
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
-        static_assert(
-            std::is_base_of_v<SField, SF>,
-            "setOrClearBaseUintIfZero()requires an SField as its argument.");
-
         if (value.signum() == 0)
             return clearOptional(field);
 
@@ -120,10 +111,8 @@ protected:
     }
 
     void
-    setOrClearVLIfEmpty(SF_VL const& field, Blob const& value)
+    setOrClearVLIfEmpty(SF_VL const& field, Blob const& value) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
-
         if (value.empty())
             return clearOptional(field);
 
@@ -148,10 +137,8 @@ public:
     }
 
     [[nodiscard]] std::shared_ptr<STLedgerEntry> const&
-    slePtr()
+    slePtr() requires Writable
     {
-        static_assert(
-            Writable, "Cannot access non-const SLE of const ledger entry.");
         return wrapped_;
     }
 
@@ -168,23 +155,20 @@ public:
     }
 
     void
-    replaceAllFlags(std::uint32_t newFlags)
+    replaceAllFlags(std::uint32_t newFlags) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         wrapped_->at(sfFlags) = newFlags;
     }
 
     void
-    setFlag(std::uint32_t flagsToSet)
+    setFlag(std::uint32_t flagsToSet) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         replaceAllFlags(flags() | flagsToSet);
     }
 
     void
-    clearFlag(std::uint32_t flagsToClear)
+    clearFlag(std::uint32_t flagsToClear) requires Writable
     {
-        static_assert(Writable, "Cannot set member of const ledger entry.");
         replaceAllFlags(flags() & ~flagsToClear);
     }
 };

--- a/src/ripple/protocol/STLedgerEntry.h
+++ b/src/ripple/protocol/STLedgerEntry.h
@@ -37,7 +37,7 @@ public:
     using ref = const std::shared_ptr<STLedgerEntry>&;
 
     /** Create an empty object with the given key and type. */
-    explicit STLedgerEntry(Keylet const& k);
+    explicit STLedgerEntry(KeyletBase const& k);
     STLedgerEntry(LedgerEntryType type, uint256 const& key);
     STLedgerEntry(SerialIter& sit, uint256 const& index);
     STLedgerEntry(SerialIter&& sit, uint256 const& index);

--- a/src/ripple/protocol/impl/Indexes.cpp
+++ b/src/ripple/protocol/impl/Indexes.cpp
@@ -129,10 +129,10 @@ getTicketIndex(AccountID const& account, SeqProxy ticketSeq)
 
 namespace keylet {
 
-Keylet
+AccountRootKeylet
 account(AccountID const& id) noexcept
 {
-    return Keylet{ltACCOUNT_ROOT, indexHash(LedgerNameSpace::ACCOUNT, id)};
+    return {indexHash(LedgerNameSpace::ACCOUNT, id)};
 }
 
 Keylet

--- a/src/ripple/protocol/impl/Indexes.cpp
+++ b/src/ripple/protocol/impl/Indexes.cpp
@@ -132,7 +132,7 @@ namespace keylet {
 AccountRootKeylet
 account(AccountID const& id) noexcept
 {
-    return {indexHash(LedgerNameSpace::ACCOUNT, id)};
+    return AccountRootKeylet(indexHash(LedgerNameSpace::ACCOUNT, id));
 }
 
 Keylet

--- a/src/ripple/protocol/impl/Keylet.cpp
+++ b/src/ripple/protocol/impl/Keylet.cpp
@@ -23,7 +23,7 @@
 namespace ripple {
 
 bool
-Keylet::check(STLedgerEntry const& sle) const
+KeyletBase::check(STLedgerEntry const& sle) const
 {
     assert(sle.getType() != ltANY || sle.getType() != ltCHILD);
 

--- a/src/ripple/protocol/impl/STLedgerEntry.cpp
+++ b/src/ripple/protocol/impl/STLedgerEntry.cpp
@@ -29,7 +29,7 @@
 
 namespace ripple {
 
-STLedgerEntry::STLedgerEntry(Keylet const& k)
+STLedgerEntry::STLedgerEntry(KeyletBase const& k)
     : STObject(sfLedgerEntry), key_(k.key), type_(k.type)
 {
     auto const format = LedgerFormats::getInstance().findByType(type_);

--- a/src/ripple/rpc/handlers/AccountChannels.cpp
+++ b/src/ripple/rpc/handlers/AccountChannels.cpp
@@ -146,7 +146,7 @@ doAccountChannels(RPC::JsonContext& context)
 
         // We then must check if the object pointed to by the marker is actually
         // owned by the account in the request.
-        auto const sle = ledger->read(Keylet(ltANY, startAfter));
+        auto const sle = ledger->readSLE(Keylet(ltANY, startAfter));
 
         if (!sle)
             return rpcError(rpcINVALID_PARAMS);

--- a/src/ripple/rpc/handlers/AccountChannels.cpp
+++ b/src/ripple/rpc/handlers/AccountChannels.cpp
@@ -146,7 +146,7 @@ doAccountChannels(RPC::JsonContext& context)
 
         // We then must check if the object pointed to by the marker is actually
         // owned by the account in the request.
-        auto const sle = ledger->read({ltANY, startAfter});
+        auto const sle = ledger->read(Keylet(ltANY, startAfter));
 
         if (!sle)
             return rpcError(rpcINVALID_PARAMS);

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -99,7 +99,7 @@ doAccountInfo(RPC::JsonContext& context)
                  {"disallowIncomingPayChan", lsfDisallowIncomingPayChan},
                  {"disallowIncomingTrustline", lsfDisallowIncomingTrustline}}};
 
-    auto const sleAccepted = ledger->read(keylet::account(accountID));
+    auto const sleAccepted = ledger->readSLE(keylet::account(accountID));
     if (sleAccepted)
     {
         auto const queue =
@@ -137,7 +137,7 @@ doAccountInfo(RPC::JsonContext& context)
 
             // This code will need to be revisited if in the future we support
             // multiple SignerLists on one account.
-            auto const sleSigners = ledger->read(keylet::signers(accountID));
+            auto const sleSigners = ledger->readSLE(keylet::signers(accountID));
             if (sleSigners)
                 jvSignerList.append(sleSigners->getJson(JsonOptions::none));
 

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -99,8 +99,8 @@ doAccountInfo(RPC::JsonContext& context)
                  {"disallowIncomingPayChan", lsfDisallowIncomingPayChan},
                  {"disallowIncomingTrustline", lsfDisallowIncomingTrustline}}};
 
-    auto const sleAccepted = ledger->readSLE(keylet::account(accountID));
-    if (sleAccepted)
+    auto const acctRootAccepted = ledger->read(keylet::account(accountID));
+    if (acctRootAccepted)
     {
         auto const queue =
             params.isMember(jss::queue) && params[jss::queue].asBool();
@@ -113,17 +113,18 @@ doAccountInfo(RPC::JsonContext& context)
             return result;
         }
 
-        RPC::injectSLE(jvAccepted, *sleAccepted);
+        RPC::injectSLE(jvAccepted, *acctRootAccepted->slePtr());
         result[jss::account_data] = jvAccepted;
 
         Json::Value acctFlags{Json::objectValue};
         for (auto const& lsf : lsFlags)
-            acctFlags[lsf.first.data()] = sleAccepted->isFlag(lsf.second);
+            acctFlags[lsf.first.data()] = acctRootAccepted->isFlag(lsf.second);
 
         if (ledger->rules().enabled(featureDisallowIncoming))
         {
             for (auto const& lsf : disallowIncomingFlags)
-                acctFlags[lsf.first.data()] = sleAccepted->isFlag(lsf.second);
+                acctFlags[lsf.first.data()] =
+                    acctRootAccepted->isFlag(lsf.second);
         }
         result[jss::account_flags] = std::move(acctFlags);
 

--- a/src/ripple/rpc/handlers/AccountLines.cpp
+++ b/src/ripple/rpc/handlers/AccountLines.cpp
@@ -172,7 +172,7 @@ doAccountLines(RPC::JsonContext& context)
 
         // We then must check if the object pointed to by the marker is actually
         // owned by the account in the request.
-        auto const sle = ledger->read({ltANY, startAfter});
+        auto const sle = ledger->read(Keylet(ltANY, startAfter));
 
         if (!sle)
             return rpcError(rpcINVALID_PARAMS);

--- a/src/ripple/rpc/handlers/AccountLines.cpp
+++ b/src/ripple/rpc/handlers/AccountLines.cpp
@@ -172,7 +172,7 @@ doAccountLines(RPC::JsonContext& context)
 
         // We then must check if the object pointed to by the marker is actually
         // owned by the account in the request.
-        auto const sle = ledger->read(Keylet(ltANY, startAfter));
+        auto const sle = ledger->readSLE(Keylet(ltANY, startAfter));
 
         if (!sle)
             return rpcError(rpcINVALID_PARAMS);

--- a/src/ripple/rpc/handlers/AccountObjects.cpp
+++ b/src/ripple/rpc/handlers/AccountObjects.cpp
@@ -94,7 +94,7 @@ doAccountNFTs(RPC::JsonContext& context)
     auto const first = keylet::nftpage(keylet::nftpage_min(accountID), marker);
     auto const last = keylet::nftpage_max(accountID);
 
-    auto cp = ledger->read(Keylet(
+    auto cp = ledger->readSLE(Keylet(
         ltNFTOKEN_PAGE,
         ledger->succ(first.key, last.key.next()).value_or(last.key)));
 
@@ -155,7 +155,7 @@ doAccountNFTs(RPC::JsonContext& context)
         }
 
         if (auto npm = (*cp)[~sfNextPageMin])
-            cp = ledger->read(Keylet(ltNFTOKEN_PAGE, *npm));
+            cp = ledger->readSLE(Keylet(ltNFTOKEN_PAGE, *npm));
         else
             cp = nullptr;
     }

--- a/src/ripple/rpc/handlers/AccountOffers.cpp
+++ b/src/ripple/rpc/handlers/AccountOffers.cpp
@@ -123,7 +123,7 @@ doAccountOffers(RPC::JsonContext& context)
 
         // We then must check if the object pointed to by the marker is actually
         // owned by the account in the request.
-        auto const sle = ledger->read(Keylet(ltANY, startAfter));
+        auto const sle = ledger->readSLE(Keylet(ltANY, startAfter));
 
         if (!sle)
             return rpcError(rpcINVALID_PARAMS);

--- a/src/ripple/rpc/handlers/AccountOffers.cpp
+++ b/src/ripple/rpc/handlers/AccountOffers.cpp
@@ -123,7 +123,7 @@ doAccountOffers(RPC::JsonContext& context)
 
         // We then must check if the object pointed to by the marker is actually
         // owned by the account in the request.
-        auto const sle = ledger->read({ltANY, startAfter});
+        auto const sle = ledger->read(Keylet(ltANY, startAfter));
 
         if (!sle)
             return rpcError(rpcINVALID_PARAMS);

--- a/src/ripple/rpc/handlers/DepositAuthorized.cpp
+++ b/src/ripple/rpc/handlers/DepositAuthorized.cpp
@@ -85,7 +85,7 @@ doDepositAuthorized(RPC::JsonContext& context)
     }
 
     // If destination account is not in the ledger you can't deposit to it, eh?
-    auto const sleDest = ledger->read(keylet::account(dstAcct));
+    auto const sleDest = ledger->readSLE(keylet::account(dstAcct));
     if (!sleDest)
     {
         RPC::inject_error(rpcDST_ACT_NOT_FOUND, result);
@@ -102,7 +102,7 @@ doDepositAuthorized(RPC::JsonContext& context)
         {
             // See if a preauthorization entry is in the ledger.
             auto const sleDepositAuth =
-                ledger->read(keylet::depositPreauth(dstAcct, srcAcct));
+                ledger->readSLE(keylet::depositPreauth(dstAcct, srcAcct));
             depositAuthorized = static_cast<bool>(sleDepositAuth);
         }
     }

--- a/src/ripple/rpc/handlers/DepositAuthorized.cpp
+++ b/src/ripple/rpc/handlers/DepositAuthorized.cpp
@@ -85,8 +85,8 @@ doDepositAuthorized(RPC::JsonContext& context)
     }
 
     // If destination account is not in the ledger you can't deposit to it, eh?
-    auto const sleDest = ledger->readSLE(keylet::account(dstAcct));
-    if (!sleDest)
+    auto const destAcctRoot = ledger->read(keylet::account(dstAcct));
+    if (!destAcctRoot)
     {
         RPC::inject_error(rpcDST_ACT_NOT_FOUND, result);
         return result;
@@ -98,7 +98,7 @@ doDepositAuthorized(RPC::JsonContext& context)
     {
         // Check destination for the DepositAuth flag.  If that flag is
         // not set then a deposit should be just fine.
-        if (sleDest->getFlags() & lsfDepositAuth)
+        if (destAcctRoot->isFlag(lsfDepositAuth))
         {
             // See if a preauthorization entry is in the ledger.
             auto const sleDepositAuth =

--- a/src/ripple/rpc/handlers/LedgerData.cpp
+++ b/src/ripple/rpc/handlers/LedgerData.cpp
@@ -102,7 +102,7 @@ doLedgerData(RPC::JsonContext& context)
     auto e = lpLedger->sles.end();
     for (auto i = lpLedger->sles.upper_bound(key); i != e; ++i)
     {
-        auto sle = lpLedger->read(keylet::unchecked((*i)->key()));
+        auto sle = lpLedger->readSLE(keylet::unchecked((*i)->key()));
         if (limit-- <= 0)
         {
             // Stop processing before the current key.
@@ -184,7 +184,7 @@ doLedgerDataGrpc(
 
     for (auto i = ledger->sles.upper_bound(startKey); i != e; ++i)
     {
-        auto sle = ledger->read(keylet::unchecked((*i)->key()));
+        auto sle = ledger->readSLE(keylet::unchecked((*i)->key()));
         if (maxLimit-- <= 0)
         {
             // Stop processing before the current key.

--- a/src/ripple/rpc/handlers/LedgerEntry.cpp
+++ b/src/ripple/rpc/handlers/LedgerEntry.cpp
@@ -363,7 +363,7 @@ doLedgerEntry(RPC::JsonContext& context)
 
     if (uNodeIndex.isNonZero())
     {
-        auto const sleNode = lpLedger->read(keylet::unchecked(uNodeIndex));
+        auto const sleNode = lpLedger->readSLE(keylet::unchecked(uNodeIndex));
         if (context.params.isMember(jss::binary))
             bNodeBinary = context.params[jss::binary].asBool();
 
@@ -429,7 +429,7 @@ doLedgerEntryGrpc(
         return {response, errorStatus};
     }
 
-    auto const sleNode = ledger->read(keylet::unchecked(*key));
+    auto const sleNode = ledger->readSLE(keylet::unchecked(*key));
     if (!sleNode)
     {
         grpc::Status errorStatus{

--- a/src/ripple/rpc/handlers/NFTOffers.cpp
+++ b/src/ripple/rpc/handlers/NFTOffers.cpp
@@ -99,7 +99,7 @@ enumerateNFTOffers(
         if (!startAfter.parseHex(marker.asString()))
             return rpcError(rpcINVALID_PARAMS);
 
-        auto const sle = ledger->read(keylet::nftoffer(startAfter));
+        auto const sle = ledger->readSLE(keylet::nftoffer(startAfter));
 
         if (!sle || nftId != sle->getFieldH256(sfNFTokenID))
             return rpcError(rpcINVALID_PARAMS);

--- a/src/ripple/rpc/handlers/NoRippleCheck.cpp
+++ b/src/ripple/rpc/handlers/NoRippleCheck.cpp
@@ -103,15 +103,15 @@ doNoRippleCheck(RPC::JsonContext& context)
         return result;
     }
 
-    auto const sle = ledger->readSLE(keylet::account(accountID));
-    if (!sle)
+    auto const acctRoot = ledger->read(keylet::account(accountID));
+    if (!acctRoot)
         return rpcError(rpcACT_NOT_FOUND);
 
-    std::uint32_t seq = sle->getFieldU32(sfSequence);
+    std::uint32_t seq = acctRoot->sequence();
 
     Json::Value& problems = (result["problems"] = Json::arrayValue);
 
-    bool bDefaultRipple = sle->getFieldU32(sfFlags) & lsfDefaultRipple;
+    bool bDefaultRipple = acctRoot->isFlag(lsfDefaultRipple);
 
     if (bDefaultRipple & !roleGateway)
     {

--- a/src/ripple/rpc/handlers/NoRippleCheck.cpp
+++ b/src/ripple/rpc/handlers/NoRippleCheck.cpp
@@ -103,7 +103,7 @@ doNoRippleCheck(RPC::JsonContext& context)
         return result;
     }
 
-    auto const sle = ledger->read(keylet::account(accountID));
+    auto const sle = ledger->readSLE(keylet::account(accountID));
     if (!sle)
         return rpcError(rpcACT_NOT_FOUND);
 

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -201,14 +201,14 @@ getAccountObjects(
         uint256 ck = ledger.succ(first.key, last.key.next()).value_or(last.key);
 
         // current page
-        auto cp = ledger.read(Keylet{ltNFTOKEN_PAGE, ck});
+        auto cp = ledger.readSLE(Keylet{ltNFTOKEN_PAGE, ck});
 
         while (cp)
         {
             jvObjects.append(cp->getJson(JsonOptions::none));
             auto const npm = (*cp)[~sfNextPageMin];
             if (npm)
-                cp = ledger.read(Keylet(ltNFTOKEN_PAGE, *npm));
+                cp = ledger.readSLE(Keylet(ltNFTOKEN_PAGE, *npm));
             else
                 cp = nullptr;
 
@@ -244,7 +244,7 @@ getAccountObjects(
         found = true;
     }
 
-    auto dir = ledger.read(Keylet(ltDIR_NODE, dirIndex));
+    auto dir = ledger.readSLE(Keylet(ltDIR_NODE, dirIndex));
     if (!dir)
     {
         // it's possible the user had nftoken pages but no
@@ -279,7 +279,7 @@ getAccountObjects(
 
         for (; iter != entries.end(); ++iter)
         {
-            auto const sleNode = ledger.read(keylet::child(*iter));
+            auto const sleNode = ledger.readSLE(keylet::child(*iter));
 
             if (!typeFilter.has_value() ||
                 typeMatchesFilter(typeFilter.value(), sleNode->getType()))
@@ -306,7 +306,7 @@ getAccountObjects(
             return true;
 
         dirIndex = keylet::page(root, nodeIndex).key;
-        dir = ledger.read(Keylet(ltDIR_NODE, dirIndex));
+        dir = ledger.readSLE(Keylet(ltDIR_NODE, dirIndex));
         if (!dir)
             return true;
 

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -244,7 +244,7 @@ getAccountObjects(
         found = true;
     }
 
-    auto dir = ledger.read({ltDIR_NODE, dirIndex});
+    auto dir = ledger.read(Keylet(ltDIR_NODE, dirIndex));
     if (!dir)
     {
         // it's possible the user had nftoken pages but no
@@ -306,7 +306,7 @@ getAccountObjects(
             return true;
 
         dirIndex = keylet::page(root, nodeIndex).key;
-        dir = ledger.read({ltDIR_NODE, dirIndex});
+        dir = ledger.read(Keylet(ltDIR_NODE, dirIndex));
         if (!dir)
             return true;
 

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -402,7 +402,8 @@ transactionPreProcessImpl(
 
     std::shared_ptr<SLE const> sle;
     if (verify)
-        sle = app.openLedger().current()->read(keylet::account(srcAddressID));
+        sle =
+            app.openLedger().current()->readSLE(keylet::account(srcAddressID));
 
     if (verify && !sle)
     {
@@ -989,7 +990,7 @@ transactionSignFor(
 
     {
         std::shared_ptr<SLE const> account_state =
-            ledger->read(keylet::account(*signerAccountID));
+            ledger->readSLE(keylet::account(*signerAccountID));
         // Make sure the account and secret belong together.
         auto const err =
             acctMatchesPubKey(account_state, *signerAccountID, multiSignPubKey);
@@ -1068,7 +1069,7 @@ transactionSubmitMultiSigned(
         return std::move(txJsonResult);
 
     std::shared_ptr<SLE const> sle =
-        ledger->read(keylet::account(srcAddressID));
+        ledger->readSLE(keylet::account(srcAddressID));
 
     if (!sle)
     {

--- a/src/test/app/AccountDelete_test.cpp
+++ b/src/test/app/AccountDelete_test.cpp
@@ -488,7 +488,7 @@ public:
         env.close();
 
         // Verify that becky's account root is present.
-        Keylet const beckyAcctKey{keylet::account(becky.id())};
+        AccountRootKeylet const beckyAcctKey{keylet::account(becky.id())};
         BEAST_EXPECT(env.closed()->exists(beckyAcctKey));
 
         using namespace std::chrono_literals;
@@ -567,7 +567,7 @@ public:
         incLgrSeqForAccDel(env, alice);
 
         // Verify that alice's account root is present.
-        Keylet const aliceAcctKey{keylet::account(alice.id())};
+        AccountRootKeylet const aliceAcctKey{keylet::account(alice.id())};
         BEAST_EXPECT(env.closed()->exists(aliceAcctKey));
 
         auto const alicePreDelBal{env.balance(alice)};

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -494,7 +494,7 @@ struct Flow_test : public beast::unit_test::suite
                         return false;
                     Sandbox sb(&view, tapNONE);
                     for (auto const& o : flowResult.removableOffers)
-                        if (auto ok = sb.peek(keylet::offer(o)))
+                        if (auto ok = sb.peekSLE(keylet::offer(o)))
                             offerDelete(sb, ok, flowJournal);
                     sb.apply(view);
                     return true;

--- a/src/test/app/NFToken_test.cpp
+++ b/src/test/app/NFToken_test.cpp
@@ -485,7 +485,7 @@ class NFToken_test : public beast::unit_test::suite
         env.app().openLedger().modify(
             [&alice, &env](OpenView& view, beast::Journal j) {
                 // Get the account root we want to hijack.
-                auto const sle = view.read(keylet::account(alice.id()));
+                auto const sle = view.readSLE(keylet::account(alice.id()));
                 if (!sle)
                     return false;  // This would be really surprising!
 

--- a/src/test/app/NFToken_test.cpp
+++ b/src/test/app/NFToken_test.cpp
@@ -6133,7 +6133,7 @@ class NFToken_test : public beast::unit_test::suite
             incLgrSeqForAcctDel(env, alice);
 
             // alice's account is deleted
-            Keylet const aliceAcctKey{keylet::account(alice.id())};
+            auto const aliceAcctKey{keylet::account(alice.id())};
             auto const acctDelFee{drops(env.current()->fees().increment)};
             env(acctdelete(alice, becky), fee(acctDelFee));
             env.close();
@@ -6207,7 +6207,7 @@ class NFToken_test : public beast::unit_test::suite
             incLgrSeqForAcctDel(env, alice);
 
             // Verify that alice's account root is present.
-            Keylet const aliceAcctKey{keylet::account(alice.id())};
+            auto const aliceAcctKey{keylet::account(alice.id())};
             BEAST_EXPECT(env.closed()->exists(aliceAcctKey));
             BEAST_EXPECT(env.current()->exists(aliceAcctKey));
 
@@ -6350,7 +6350,7 @@ class NFToken_test : public beast::unit_test::suite
             incLgrSeqForAcctDel(env, alice);
 
             // Verify that alice's account root is present.
-            Keylet const aliceAcctKey{keylet::account(alice.id())};
+            auto const aliceAcctKey{keylet::account(alice.id())};
             BEAST_EXPECT(env.closed()->exists(aliceAcctKey));
             BEAST_EXPECT(env.current()->exists(aliceAcctKey));
 
@@ -6507,7 +6507,7 @@ class NFToken_test : public beast::unit_test::suite
             incLgrSeqForAcctDel(env, alice);
 
             // Verify that alice's account root is present.
-            Keylet const aliceAcctKey{keylet::account(alice.id())};
+            auto const aliceAcctKey{keylet::account(alice.id())};
             BEAST_EXPECT(env.closed()->exists(aliceAcctKey));
             BEAST_EXPECT(env.current()->exists(aliceAcctKey));
 

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -2270,9 +2270,7 @@ public:
         payment[jss::build_path] = true;
         payment[jss::tx_json] = pay(bob, bob, bob["XXX"](1));
         payment[jss::tx_json][jss::Sequence] =
-            env.current()
-                ->readSLE(keylet::account(bob.id()))
-                ->getFieldU32(sfSequence);
+            env.current()->read(keylet::account(bob.id()))->sequence();
         payment[jss::tx_json][jss::Fee] = to_string(env.current()->fees().base);
         payment[jss::tx_json][jss::SendMax] =
             bob["XTS"](1.5).value().getJson(JsonOptions::none);

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -2271,7 +2271,7 @@ public:
         payment[jss::tx_json] = pay(bob, bob, bob["XXX"](1));
         payment[jss::tx_json][jss::Sequence] =
             env.current()
-                ->read(keylet::account(bob.id()))
+                ->readSLE(keylet::account(bob.id()))
                 ->getFieldU32(sfSequence);
         payment[jss::tx_json][jss::Fee] = to_string(env.current()->fees().base);
         payment[jss::tx_json][jss::SendMax] =

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -72,7 +72,7 @@ struct PayChan_test : public beast::unit_test::suite
     static STAmount
     channelBalance(ReadView const& view, uint256 const& chan)
     {
-        auto const slep = view.read({ltPAYCHAN, chan});
+        auto const slep = view.read(Keylet(ltPAYCHAN, chan));
         if (!slep)
             return XRPAmount{-1};
         return (*slep)[sfBalance];
@@ -81,14 +81,14 @@ struct PayChan_test : public beast::unit_test::suite
     static bool
     channelExists(ReadView const& view, uint256 const& chan)
     {
-        auto const slep = view.read({ltPAYCHAN, chan});
+        auto const slep = view.read(Keylet(ltPAYCHAN, chan));
         return bool(slep);
     }
 
     static STAmount
     channelAmount(ReadView const& view, uint256 const& chan)
     {
-        auto const slep = view.read({ltPAYCHAN, chan});
+        auto const slep = view.read(Keylet(ltPAYCHAN, chan));
         if (!slep)
             return XRPAmount{-1};
         return (*slep)[sfAmount];
@@ -97,7 +97,7 @@ struct PayChan_test : public beast::unit_test::suite
     static std::optional<std::int64_t>
     channelExpiration(ReadView const& view, uint256 const& chan)
     {
-        auto const slep = view.read({ltPAYCHAN, chan});
+        auto const slep = view.read(Keylet(ltPAYCHAN, chan));
         if (!slep)
             return std::nullopt;
         if (auto const r = (*slep)[~sfExpiration])

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -50,10 +50,10 @@ struct PayChan_test : public beast::unit_test::suite
         jtx::Account const& account,
         jtx::Account const& dst)
     {
-        auto const sle = view.readSLE(keylet::account(account));
-        if (!sle)
+        auto const acctRoot = view.read(keylet::account(account));
+        if (!acctRoot)
             return {};
-        auto const k = keylet::payChan(account, dst, (*sle)[sfSequence] - 1);
+        auto const k = keylet::payChan(account, dst, acctRoot->sequence() - 1);
         return {k.key, view.readSLE(k)};
     }
 

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -50,11 +50,11 @@ struct PayChan_test : public beast::unit_test::suite
         jtx::Account const& account,
         jtx::Account const& dst)
     {
-        auto const sle = view.read(keylet::account(account));
+        auto const sle = view.readSLE(keylet::account(account));
         if (!sle)
             return {};
         auto const k = keylet::payChan(account, dst, (*sle)[sfSequence] - 1);
-        return {k.key, view.read(k)};
+        return {k.key, view.readSLE(k)};
     }
 
     static Buffer
@@ -72,7 +72,7 @@ struct PayChan_test : public beast::unit_test::suite
     static STAmount
     channelBalance(ReadView const& view, uint256 const& chan)
     {
-        auto const slep = view.read(Keylet(ltPAYCHAN, chan));
+        auto const slep = view.readSLE(Keylet(ltPAYCHAN, chan));
         if (!slep)
             return XRPAmount{-1};
         return (*slep)[sfBalance];
@@ -81,14 +81,14 @@ struct PayChan_test : public beast::unit_test::suite
     static bool
     channelExists(ReadView const& view, uint256 const& chan)
     {
-        auto const slep = view.read(Keylet(ltPAYCHAN, chan));
+        auto const slep = view.readSLE(Keylet(ltPAYCHAN, chan));
         return bool(slep);
     }
 
     static STAmount
     channelAmount(ReadView const& view, uint256 const& chan)
     {
-        auto const slep = view.read(Keylet(ltPAYCHAN, chan));
+        auto const slep = view.readSLE(Keylet(ltPAYCHAN, chan));
         if (!slep)
             return XRPAmount{-1};
         return (*slep)[sfAmount];
@@ -97,7 +97,7 @@ struct PayChan_test : public beast::unit_test::suite
     static std::optional<std::int64_t>
     channelExpiration(ReadView const& view, uint256 const& chan)
     {
-        auto const slep = view.read(Keylet(ltPAYCHAN, chan));
+        auto const slep = view.readSLE(Keylet(ltPAYCHAN, chan));
         if (!slep)
             return std::nullopt;
         if (auto const r = (*slep)[~sfExpiration])

--- a/src/test/app/PayStrand_test.cpp
+++ b/src/test/app/PayStrand_test.cpp
@@ -519,11 +519,12 @@ struct ExistingElementPool
     {
         std::vector<std::tuple<STAmount, STAmount, AccountID, AccountID>> diffs;
 
-        auto xrpBalance = [](ReadView const& v, ripple::Keylet const& k) {
-            auto const sle = v.readSLE(k);
-            if (!sle)
+        auto xrpBalance = [](ReadView const& v,
+                             ripple::AccountRootKeylet const& k) {
+            auto const acctRoot = v.read(k);
+            if (!acctRoot)
                 return STAmount{};
-            return (*sle)[sfBalance];
+            return acctRoot->balance();
         };
         auto lineBalance = [](ReadView const& v, ripple::Keylet const& k) {
             auto const sle = v.readSLE(k);

--- a/src/test/app/PayStrand_test.cpp
+++ b/src/test/app/PayStrand_test.cpp
@@ -499,10 +499,10 @@ struct ExistingElementPool
         std::uint64_t totalXRP = 0;
         auto add = [&](auto const& a) {
             // XRP balance
-            auto const sle = v.readSLE(keylet::account(a));
-            if (!sle)
+            auto const acctRoot = v.read(keylet::account(a));
+            if (!acctRoot)
                 return;
-            auto const b = (*sle)[sfBalance];
+            auto const b = acctRoot->balance();
             totalXRP += b.mantissa();
         };
         for (auto const& a : accounts)

--- a/src/test/app/PayStrand_test.cpp
+++ b/src/test/app/PayStrand_test.cpp
@@ -499,7 +499,7 @@ struct ExistingElementPool
         std::uint64_t totalXRP = 0;
         auto add = [&](auto const& a) {
             // XRP balance
-            auto const sle = v.read(keylet::account(a));
+            auto const sle = v.readSLE(keylet::account(a));
             if (!sle)
                 return;
             auto const b = (*sle)[sfBalance];
@@ -520,13 +520,13 @@ struct ExistingElementPool
         std::vector<std::tuple<STAmount, STAmount, AccountID, AccountID>> diffs;
 
         auto xrpBalance = [](ReadView const& v, ripple::Keylet const& k) {
-            auto const sle = v.read(k);
+            auto const sle = v.readSLE(k);
             if (!sle)
                 return STAmount{};
             return (*sle)[sfBalance];
         };
         auto lineBalance = [](ReadView const& v, ripple::Keylet const& k) {
-            auto const sle = v.read(k);
+            auto const sle = v.readSLE(k);
             if (!sle)
                 return STAmount{};
             return (*sle)[sfBalance];

--- a/src/test/app/RCLValidations_test.cpp
+++ b/src/test/app/RCLValidations_test.cpp
@@ -106,7 +106,7 @@ class RCLValidations_test : public beast::unit_test::suite
                 *prev, env.app().timeKeeper().closeTime());
             // Force a different hash on the first iteration
             next->updateSkipList();
-            BEAST_EXPECT(next->read(keylet::fees()));
+            BEAST_EXPECT(next->readSLE(keylet::fees()));
             if (forceHash)
             {
                 next->setImmutable();

--- a/src/test/app/Regression_test.cpp
+++ b/src/test/app/Regression_test.cpp
@@ -84,7 +84,8 @@ struct Regression_test : public beast::unit_test::suite
         expectedDrops -= next->fees().base;
         BEAST_EXPECT(next->info().drops == expectedDrops);
         {
-            auto const sle = next->read(keylet::account(Account("alice").id()));
+            auto const sle =
+                next->readSLE(keylet::account(Account("alice").id()));
             BEAST_EXPECT(sle);
             auto balance = sle->getFieldAmount(sfBalance);
 
@@ -106,7 +107,8 @@ struct Regression_test : public beast::unit_test::suite
             accum.apply(*next);
         }
         {
-            auto const sle = next->read(keylet::account(Account("alice").id()));
+            auto const sle =
+                next->readSLE(keylet::account(Account("alice").id()));
             BEAST_EXPECT(sle);
             auto balance = sle->getFieldAmount(sfBalance);
 

--- a/src/test/app/Regression_test.cpp
+++ b/src/test/app/Regression_test.cpp
@@ -84,10 +84,10 @@ struct Regression_test : public beast::unit_test::suite
         expectedDrops -= next->fees().base;
         BEAST_EXPECT(next->info().drops == expectedDrops);
         {
-            auto const sle =
-                next->readSLE(keylet::account(Account("alice").id()));
-            BEAST_EXPECT(sle);
-            auto balance = sle->getFieldAmount(sfBalance);
+            auto const acctRoot =
+                next->read(keylet::account(Account("alice").id()));
+            BEAST_EXPECT(acctRoot);
+            auto balance = acctRoot->balance();
 
             BEAST_EXPECT(balance == aliceAmount);
         }
@@ -107,10 +107,10 @@ struct Regression_test : public beast::unit_test::suite
             accum.apply(*next);
         }
         {
-            auto const sle =
-                next->readSLE(keylet::account(Account("alice").id()));
-            BEAST_EXPECT(sle);
-            auto balance = sle->getFieldAmount(sfBalance);
+            auto const acctRoot =
+                next->read(keylet::account(Account("alice").id()));
+            BEAST_EXPECT(acctRoot);
+            auto balance = acctRoot->balance();
 
             BEAST_EXPECT(balance == XRP(0));
         }

--- a/src/test/consensus/NegativeUNL_test.cpp
+++ b/src/test/consensus/NegativeUNL_test.cpp
@@ -1932,7 +1932,7 @@ VerifyPubKeyAndSeq(
     std::shared_ptr<Ledger const> const& l,
     hash_map<PublicKey, std::uint32_t> nUnlLedgerSeq)
 {
-    auto sle = l->read(keylet::negativeUNL());
+    auto sle = l->readSLE(keylet::negativeUNL());
     if (!sle)
         return false;
     if (!sle->isFieldPresent(sfDisabledValidators))

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -431,7 +431,7 @@ public:
         @return empty if the ledger entry does not exist
     */
     std::shared_ptr<SLE const>
-    le(Keylet const& k) const;
+    le(KeyletBase const& k) const;
 
     /** Create a JTx from parameters. */
     template <class JsonValue, class... FN>

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -219,7 +219,7 @@ Env::le(Account const& account) const
 }
 
 std::shared_ptr<SLE const>
-Env::le(Keylet const& k) const
+Env::le(KeyletBase const& k) const
 {
     return current()->readSLE(k);
 }

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -221,7 +221,7 @@ Env::le(Account const& account) const
 std::shared_ptr<SLE const>
 Env::le(Keylet const& k) const
 {
-    return current()->read(k);
+    return current()->readSLE(k);
 }
 
 void

--- a/src/test/jtx/impl/utility.cpp
+++ b/src/test/jtx/impl/utility.cpp
@@ -67,10 +67,10 @@ fill_seq(Json::Value& jv, ReadView const& view)
     auto const account = parseBase58<AccountID>(jv[jss::Account].asString());
     if (!account)
         Throw<parse_error>("unexpected invalid Account");
-    auto const ar = view.readSLE(keylet::account(*account));
-    if (!ar)
+    auto const acctRoot = view.read(keylet::account(*account));
+    if (!acctRoot)
         Throw<parse_error>("unexpected missing account root");
-    jv[jss::Sequence] = ar->getFieldU32(sfSequence);
+    jv[jss::Sequence] = acctRoot->sequence();
 }
 
 }  // namespace jtx

--- a/src/test/jtx/impl/utility.cpp
+++ b/src/test/jtx/impl/utility.cpp
@@ -67,7 +67,7 @@ fill_seq(Json::Value& jv, ReadView const& view)
     auto const account = parseBase58<AccountID>(jv[jss::Account].asString());
     if (!account)
         Throw<parse_error>("unexpected invalid Account");
-    auto const ar = view.read(keylet::account(*account));
+    auto const ar = view.readSLE(keylet::account(*account));
     if (!ar)
         Throw<parse_error>("unexpected missing account root");
     jv[jss::Sequence] = ar->getFieldU32(sfSequence);

--- a/src/test/ledger/Directory_test.cpp
+++ b/src/test/ledger/Directory_test.cpp
@@ -104,7 +104,7 @@ struct Directory_test : public beast::unit_test::suite
             do
             {
                 auto p =
-                    view->read(keylet::page(keylet::ownerDir(alice), page));
+                    view->readSLE(keylet::page(keylet::ownerDir(alice), page));
 
                 // Ensure that the entries in the page are sorted
                 auto const& v = p->getFieldV256(sfIndexes);
@@ -118,7 +118,7 @@ struct Directory_test : public beast::unit_test::suite
 
                 for (auto const& e : v)
                 {
-                    auto c = view->read(keylet::child(e));
+                    auto c = view->readSLE(keylet::child(e));
                     BEAST_EXPECT(c);
                     BEAST_EXPECT(c->getFieldU32(sfSequence) >= minSeq);
                     BEAST_EXPECT(c->getFieldU32(sfSequence) < maxSeq);
@@ -334,7 +334,7 @@ struct Directory_test : public beast::unit_test::suite
 
             // Insert an item in the middle page:
             {
-                auto p = sb.peek(keylet::page(base, 1));
+                auto p = sb.peekSLE(keylet::page(base, 1));
                 BEAST_EXPECT(p);
 
                 STVector256 v;
@@ -347,9 +347,9 @@ struct Directory_test : public beast::unit_test::suite
             // page. This should cause all pages to be deleted:
             BEAST_EXPECT(sb.dirRemove(
                 keylet::page(base, 0), 1, keylet::unchecked(item), false));
-            BEAST_EXPECT(!sb.peek(keylet::page(base, 2)));
-            BEAST_EXPECT(!sb.peek(keylet::page(base, 1)));
-            BEAST_EXPECT(!sb.peek(keylet::page(base, 0)));
+            BEAST_EXPECT(!sb.peekSLE(keylet::page(base, 2)));
+            BEAST_EXPECT(!sb.peekSLE(keylet::page(base, 1)));
+            BEAST_EXPECT(!sb.peekSLE(keylet::page(base, 0)));
         }
 
         {
@@ -359,7 +359,7 @@ struct Directory_test : public beast::unit_test::suite
 
             // Now add items on pages 1 and 2:
             {
-                auto p1 = sb.peek(keylet::page(base, 1));
+                auto p1 = sb.peekSLE(keylet::page(base, 1));
                 BEAST_EXPECT(p1);
 
                 STVector256 v1;
@@ -367,7 +367,7 @@ struct Directory_test : public beast::unit_test::suite
                 p1->setFieldV256(sfIndexes, v1);
                 sb.update(p1);
 
-                auto p2 = sb.peek(keylet::page(base, 2));
+                auto p2 = sb.peekSLE(keylet::page(base, 2));
                 BEAST_EXPECT(p2);
 
                 STVector256 v2;
@@ -381,15 +381,15 @@ struct Directory_test : public beast::unit_test::suite
             // deleted:
             BEAST_EXPECT(sb.dirRemove(
                 keylet::page(base, 0), 2, keylet::unchecked(item), false));
-            BEAST_EXPECT(!sb.peek(keylet::page(base, 3)));
-            BEAST_EXPECT(!sb.peek(keylet::page(base, 2)));
+            BEAST_EXPECT(!sb.peekSLE(keylet::page(base, 3)));
+            BEAST_EXPECT(!sb.peekSLE(keylet::page(base, 2)));
 
-            auto p1 = sb.peek(keylet::page(base, 1));
+            auto p1 = sb.peekSLE(keylet::page(base, 1));
             BEAST_EXPECT(p1);
             BEAST_EXPECT(p1->getFieldU64(sfIndexNext) == 0);
             BEAST_EXPECT(p1->getFieldU64(sfIndexPrevious) == 0);
 
-            auto p0 = sb.peek(keylet::page(base, 0));
+            auto p0 = sb.peekSLE(keylet::page(base, 0));
             BEAST_EXPECT(p0);
             BEAST_EXPECT(p0->getFieldU64(sfIndexNext) == 1);
             BEAST_EXPECT(p0->getFieldU64(sfIndexPrevious) == 1);

--- a/src/test/ledger/Invariants_test.cpp
+++ b/src/test/ledger/Invariants_test.cpp
@@ -421,7 +421,7 @@ class Invariants_test : public beast::unit_test::suite
                 // Insert a new account root created by a non-payment into
                 // the view.
                 const Account A3{"A3"};
-                Keylet const acctKeylet = keylet::account(A3);
+                AccountRootKeylet const acctKeylet = keylet::account(A3);
                 auto const sleNew = std::make_shared<SLE>(acctKeylet);
                 ac.view().insert(sleNew);
                 return true;
@@ -433,13 +433,13 @@ class Invariants_test : public beast::unit_test::suite
                 // Insert two new account roots into the view.
                 {
                     const Account A3{"A3"};
-                    Keylet const acctKeylet = keylet::account(A3);
+                    AccountRootKeylet const acctKeylet = keylet::account(A3);
                     auto const sleA3 = std::make_shared<SLE>(acctKeylet);
                     ac.view().insert(sleA3);
                 }
                 {
                     const Account A4{"A4"};
-                    Keylet const acctKeylet = keylet::account(A4);
+                    AccountRootKeylet const acctKeylet = keylet::account(A4);
                     auto const sleA4 = std::make_shared<SLE>(acctKeylet);
                     ac.view().insert(sleA4);
                 }
@@ -451,7 +451,7 @@ class Invariants_test : public beast::unit_test::suite
             [](Account const&, Account const&, ApplyContext& ac) {
                 // Insert a new account root with the wrong starting sequence.
                 const Account A3{"A3"};
-                Keylet const acctKeylet = keylet::account(A3);
+                AccountRootKeylet const acctKeylet = keylet::account(A3);
                 auto const sleNew = std::make_shared<SLE>(acctKeylet);
                 sleNew->setFieldU32(sfSequence, ac.view().seq() + 1);
                 ac.view().insert(sleNew);

--- a/src/test/ledger/Invariants_test.cpp
+++ b/src/test/ledger/Invariants_test.cpp
@@ -103,7 +103,7 @@ class Invariants_test : public beast::unit_test::suite
             {{"XRP net change was positive: 500"}},
             [](Account const& A1, Account const&, ApplyContext& ac) {
                 // put a single account in the view and "manufacture" some XRP
-                auto const sle = ac.view().peek(keylet::account(A1.id()));
+                auto const sle = ac.view().peekSLE(keylet::account(A1.id()));
                 if (!sle)
                     return false;
                 auto amt = sle->getFieldAmount(sfBalance);
@@ -124,7 +124,7 @@ class Invariants_test : public beast::unit_test::suite
             {{"an account root was deleted"}},
             [](Account const& A1, Account const&, ApplyContext& ac) {
                 // remove an account from the view
-                auto const sle = ac.view().peek(keylet::account(A1.id()));
+                auto const sle = ac.view().peekSLE(keylet::account(A1.id()));
                 if (!sle)
                     return false;
                 ac.view().erase(sle);
@@ -150,8 +150,8 @@ class Invariants_test : public beast::unit_test::suite
             {{"account deletion succeeded but deleted multiple accounts"}},
             [](Account const& A1, Account const& A2, ApplyContext& ac) {
                 // remove two accounts from the view
-                auto const sleA1 = ac.view().peek(keylet::account(A1.id()));
-                auto const sleA2 = ac.view().peek(keylet::account(A2.id()));
+                auto const sleA1 = ac.view().peekSLE(keylet::account(A1.id()));
+                auto const sleA2 = ac.view().peekSLE(keylet::account(A2.id()));
                 if (!sleA1 || !sleA2)
                     return false;
                 ac.view().erase(sleA1);
@@ -172,7 +172,7 @@ class Invariants_test : public beast::unit_test::suite
              {"XRP net change of -1000000000 doesn't match fee 0"}},
             [](Account const& A1, Account const&, ApplyContext& ac) {
                 // replace an entry in the table with an SLE of a different type
-                auto const sle = ac.view().peek(keylet::account(A1.id()));
+                auto const sle = ac.view().peekSLE(keylet::account(A1.id()));
                 if (!sle)
                     return false;
                 auto sleNew = std::make_shared<SLE>(ltTICKET, sle->key());
@@ -184,7 +184,7 @@ class Invariants_test : public beast::unit_test::suite
             {{"invalid ledger entry type added"}},
             [](Account const& A1, Account const&, ApplyContext& ac) {
                 // add an entry in the table with an SLE of an invalid type
-                auto const sle = ac.view().peek(keylet::account(A1.id()));
+                auto const sle = ac.view().peekSLE(keylet::account(A1.id()));
                 if (!sle)
                     return false;
 
@@ -228,7 +228,7 @@ class Invariants_test : public beast::unit_test::suite
             {{"Cannot return non-native STAmount as XRPAmount"}},
             [](Account const& A1, Account const& A2, ApplyContext& ac) {
                 // non-native balance
-                auto const sle = ac.view().peek(keylet::account(A1.id()));
+                auto const sle = ac.view().peekSLE(keylet::account(A1.id()));
                 if (!sle)
                     return false;
                 STAmount nonNative(A2["USD"](51));
@@ -242,7 +242,7 @@ class Invariants_test : public beast::unit_test::suite
              {"XRP net change was positive: 99999999000000001"}},
             [this](Account const& A1, Account const&, ApplyContext& ac) {
                 // balance exceeds genesis amount
-                auto const sle = ac.view().peek(keylet::account(A1.id()));
+                auto const sle = ac.view().peekSLE(keylet::account(A1.id()));
                 if (!sle)
                     return false;
                 // Use `drops(1)` to bypass a call to STAmount::canonicalize
@@ -258,7 +258,7 @@ class Invariants_test : public beast::unit_test::suite
              {"XRP net change of -1000000001 doesn't match fee 0"}},
             [this](Account const& A1, Account const&, ApplyContext& ac) {
                 // balance is negative
-                auto const sle = ac.view().peek(keylet::account(A1.id()));
+                auto const sle = ac.view().peekSLE(keylet::account(A1.id()));
                 if (!sle)
                     return false;
                 sle->setFieldAmount(sfBalance, STAmount{1, true});
@@ -308,7 +308,7 @@ class Invariants_test : public beast::unit_test::suite
             {{"offer with a bad amount"}},
             [](Account const& A1, Account const&, ApplyContext& ac) {
                 // offer with negative takerpays
-                auto const sle = ac.view().peek(keylet::account(A1.id()));
+                auto const sle = ac.view().peekSLE(keylet::account(A1.id()));
                 if (!sle)
                     return false;
                 auto sleNew = std::make_shared<SLE>(
@@ -324,7 +324,7 @@ class Invariants_test : public beast::unit_test::suite
             {{"offer with a bad amount"}},
             [](Account const& A1, Account const&, ApplyContext& ac) {
                 // offer with negative takergets
-                auto const sle = ac.view().peek(keylet::account(A1.id()));
+                auto const sle = ac.view().peekSLE(keylet::account(A1.id()));
                 if (!sle)
                     return false;
                 auto sleNew = std::make_shared<SLE>(
@@ -341,7 +341,7 @@ class Invariants_test : public beast::unit_test::suite
             {{"offer with a bad amount"}},
             [](Account const& A1, Account const&, ApplyContext& ac) {
                 // offer XRP to XRP
-                auto const sle = ac.view().peek(keylet::account(A1.id()));
+                auto const sle = ac.view().peekSLE(keylet::account(A1.id()));
                 if (!sle)
                     return false;
                 auto sleNew = std::make_shared<SLE>(
@@ -365,7 +365,7 @@ class Invariants_test : public beast::unit_test::suite
             {{"Cannot return non-native STAmount as XRPAmount"}},
             [](Account const& A1, Account const& A2, ApplyContext& ac) {
                 // escrow with nonnative amount
-                auto const sle = ac.view().peek(keylet::account(A1.id()));
+                auto const sle = ac.view().peekSLE(keylet::account(A1.id()));
                 if (!sle)
                     return false;
                 auto sleNew = std::make_shared<SLE>(
@@ -381,7 +381,7 @@ class Invariants_test : public beast::unit_test::suite
              {"escrow specifies invalid amount"}},
             [](Account const& A1, Account const&, ApplyContext& ac) {
                 // escrow with negative amount
-                auto const sle = ac.view().peek(keylet::account(A1.id()));
+                auto const sle = ac.view().peekSLE(keylet::account(A1.id()));
                 if (!sle)
                     return false;
                 auto sleNew = std::make_shared<SLE>(
@@ -396,7 +396,7 @@ class Invariants_test : public beast::unit_test::suite
              {"escrow specifies invalid amount"}},
             [](Account const& A1, Account const&, ApplyContext& ac) {
                 // escrow with too-large amount
-                auto const sle = ac.view().peek(keylet::account(A1.id()));
+                auto const sle = ac.view().peekSLE(keylet::account(A1.id()));
                 if (!sle)
                     return false;
                 auto sleNew = std::make_shared<SLE>(

--- a/src/test/rpc/AccountSet_test.cpp
+++ b/src/test/rpc/AccountSet_test.cpp
@@ -434,7 +434,7 @@ public:
             env.app().openLedger().modify(
                 [&gw, transferRate](OpenView& view, beast::Journal j) {
                     // Get the account root we want to hijack.
-                    auto const sle = view.read(keylet::account(gw.id()));
+                    auto const sle = view.readSLE(keylet::account(gw.id()));
                     if (!sle)
                         return false;  // This would be really surprising!
 

--- a/src/test/rpc/AccountTx_test.cpp
+++ b/src/test/rpc/AccountTx_test.cpp
@@ -473,7 +473,7 @@ class AccountTx_test : public beast::unit_test::suite
         env.close();
 
         // Verify that becky's account root is present.
-        Keylet const beckyAcctKey{keylet::account(becky.id())};
+        AccountRootKeylet const beckyAcctKey{keylet::account(becky.id())};
         BEAST_EXPECT(env.closed()->exists(beckyAcctKey));
 
         // becky does an AccountSet .

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -37,12 +37,12 @@ class Book_test : public beast::unit_test::suite
         auto key = view->succ(uBookBase, uBookEnd);
         if (key)
         {
-            auto sleOfferDir = view->read(keylet::page(key.value()));
+            auto sleOfferDir = view->readSLE(keylet::page(key.value()));
             uint256 offerIndex;
             unsigned int bookEntry;
             cdirFirst(
                 *view, sleOfferDir->key(), sleOfferDir, bookEntry, offerIndex);
-            auto sleOffer = view->read(keylet::offer(offerIndex));
+            auto sleOffer = view->readSLE(keylet::offer(offerIndex));
             dir = to_string(sleOffer->getFieldH256(sfBookDirectory));
         }
         return dir;


### PR DESCRIPTION
## High Level Overview of Change

Up to this point the server's internal code has presented every ledger object type to programmers as a

- `std::shared_ptr<STLedgerEntry>` or as a
- `std::shared_ptr<STLedgerEntry const>`.

The choice of representation was based on whether or not the returned object was mutable.

That's fine, and it has gotten us a long way.  But it has some limitations.

The different types of objects in the ledger are in fact, different.  We use the same type, a `std::shared_ptr<STLedgerEntry>`, to represent an account root, a directory node, and a trust line (RippleState).  These things are very different, and programmers think about them them differently.  But we're treating all three of these types (and many more) as identical with the C++ type system.

It doesn't have to be like that, and this pull request is a step along that journey.

### Context of Change

We've been considering ways to have ledger objects take up less space in the ledger.  But many the changes that these space reductions would entail are hard to manage given the ad hoc way that we handle ledger entry objects.  It would be nice to put a uniform face on, say, a `TrustLine`.  Then any funny stuff we do to save space can be hidden behind that uniform face.  We don't have to pollute every individual piece of code that operates on `TrustLine` with the funny stuff.  We can hide any funny stuff behind the uniform face.

So that's the motivation for the change.  But it's not the only benefit.  If an account root has the type `AcctRoot`, and we pass a reference to it, then the receiving end knows at _compile time_ that they got an `AcctRoot`.  As it stands today the receiving end gets a `std::shared_ptr<STLedgerEntry>` which _could_ be an account root or a signer list or a ticket or an escrow or something else altogether.

#### Techniques

To achieve this end we'll use the following techniques:

1. We'll make our `Keylet`s strongly typed.  So each kind of `Keylet` is a distinct type that knows exactly which type it is supposed to retrieve from the ledger at compile time.
2. These strongly typed `Keylet`s will allow the `AppyView` or `ReadView` to know which ledger object type needs to be returned.
3. We'll use templates to reduce the boiler plate involved in making strongly typed `Keylet`s and ledger object types.

#### Steps

This pull request contains early stages toward making all ledger objects strongly typed.  But it does not finish the job.  This pull request has three separate commits, each of which takes us one step along the way:

1. The first commit introduces a base class to `Keylet`.  This gives us a place to put common behavior that is shared between all of the strongly typed `Keylet`s.

2. The second commit renames the `ReadView::read()` method to `ReadView::readSLE()` and `ApplyView::peek()` method to `ApplyView::peekSLE()`.  This rename is propagated to the derived classes as well.  The renamed methods will continue to return serialized ledger entries.  This is in anticipation of having future `read()` and `peek()` methods that return strongly typed objects.

3. The third commit introduces the first strongly typed `Keylet` and its corresponding strongly typed ledger object `AcctRoot`.  The account root was chosen as the first type because it is used a lot and should provide a good test ground for the methodology.

The first two commits allow the transition to using strongly-typed ledger objects to be incremental.  The third commit is just the first of many.  Future commits will convert more ledger objects to be strongly typed.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

Before:
```
std::shared_ptr<SLE const> sleAcct = view.read(keylet::account(acctID));
if (!sleAcct)
    return terNO_ACCOUNT;

SeqProxy const acctSeqProx = SeqProxy::sequence((*sleAccount)[sfSequence]);
```

After:
```
std::optional<AcctRoot> acctRoot = view.read(keylet::account(acctID));
if (!acctRoot)
    return terNO_ACCOUNT;

SeqProxy const acctSeqProx = SeqProxy::sequence(acctRoot->sequence());
```

## Test Plan

I looked at the code coverage of these changes based on existing unit tests.  I was surprised and pleased at how thoroughly these refactoring changes were exercised by pre-existing unit tests.  As a result I felt no inclination to introduce additional tests.  Reviewers may feel differently.

## Future Tasks

These are only the first few steps of this project.  In order to have a coherent code base it will be important to complete the conversion of all other ledger types to strongly typed.  I anticipate that each newly introduced strongly typed ledger object will arrive in a separate pull request.
