### PR TITLE
Change the contributor suggested (default) voting for three amendments

### DIFF
--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -436,12 +436,12 @@ REGISTER_FEATURE(TicketBatch,                   Supported::yes, DefaultVote::yes
 REGISTER_FEATURE(FlowSortStrands,               Supported::yes, DefaultVote::yes);
 REGISTER_FIX    (fixSTAmountCanonicalize,       Supported::yes, DefaultVote::yes);
 REGISTER_FIX    (fixRmSmallIncreasedQOffers,    Supported::yes, DefaultVote::yes);
-REGISTER_FEATURE(CheckCashMakesTrustLine,       Supported::yes, DefaultVote::no);
+REGISTER_FEATURE(CheckCashMakesTrustLine,       Supported::yes, DefaultVote::yes);
 REGISTER_FEATURE(NonFungibleTokensV1,           Supported::yes, DefaultVote::no);
-REGISTER_FEATURE(ExpandedSignerList,            Supported::yes, DefaultVote::no);
+REGISTER_FEATURE(ExpandedSignerList,            Supported::yes, DefaultVote::yes);
 REGISTER_FIX    (fixNFTokenDirV1,               Supported::yes, DefaultVote::no);
 REGISTER_FIX    (fixNFTokenNegOffer,            Supported::yes, DefaultVote::no);
-REGISTER_FEATURE(NonFungibleTokensV1_1,         Supported::yes, DefaultVote::no);
+REGISTER_FEATURE(NonFungibleTokensV1_1,         Supported::yes, DefaultVote::yes);
 
 // The following amendments have been active for at least two years. Their
 // pre-amendment code has been removed and the identifiers are deprecated.


### PR DESCRIPTION
Change the contributor suggested (default) voting to `yes` for three amendments: 
- NonFungibleTokensV1_1 (XLS20)
- ExpandedSignerList
- CheckCashMakesTrustLine

Following discussions with other contributors about how _default voting_ should work, I am submitting my suggestion, as a contributor, that validators who have opted not to cast a vote should now vote `yes` by default on these amendments.