### PR TITLE
Eliminate the use of the empty struct Coro_create_t

### DIFF
--- a/src/ripple/core/Coro.ipp
+++ b/src/ripple/core/Coro.ipp
@@ -25,12 +25,7 @@
 namespace ripple {
 
 template <class F>
-JobQueue::Coro::Coro(
-    Coro_create_t,
-    JobQueue& jq,
-    JobType type,
-    std::string const& name,
-    F&& f)
+JobQueue::Coro::Coro(JobQueue& jq, JobType type, std::string const& name, F&& f)
     : jq_(jq)
     , type_(type)
     , name_(name)

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -37,10 +37,6 @@ class PerfLog;
 }
 
 class Logs;
-struct Coro_create_t
-{
-    explicit Coro_create_t() = default;
-};
 
 /** A pool of threads to perform work.
 
@@ -76,7 +72,7 @@ public:
     public:
         // Private: Used in the implementation
         template <class F>
-        Coro(Coro_create_t, JobQueue&, JobType, std::string const&, F&&);
+        Coro(JobQueue&, JobType, std::string const&, F&&);
 
         // Not copy-constructible or assignable
         Coro(Coro const&) = delete;
@@ -414,8 +410,7 @@ JobQueue::postCoro(JobType t, std::string const& name, F&& f)
         Last param is the function the coroutine runs. Signature of
         void(std::shared_ptr<Coro>).
     */
-    auto coro = std::make_shared<Coro>(
-        Coro_create_t{}, *this, t, name, std::forward<F>(f));
+    auto coro = std::make_shared<Coro>(*this, t, name, std::forward<F>(f));
     if (!coro->post())
     {
         // The Coro was not successfully posted.  Disable it so it's destructor


### PR DESCRIPTION
This commit seeks to eliminate the use of the empty struct Coro_create_t.

To my knowledge, empty structs are used for tag dispatch or method coloring. Both of these use cases are irrelevant here because there is only one constructor in the Coro class. Furthermore, no access-restriction (private or protected) was placed on Coro_create_t and hence it was publicly usable.

- [ x ] Refactor (non-breaking change that only restructures code)
