### PR TITLE
[TRIVIAL] Allow gcc 12 compilation

### DIFF
--- a/src/ripple/basics/impl/Archive.cpp
+++ b/src/ripple/basics/impl/Archive.cpp
@@ -23,6 +23,8 @@
 #include <archive.h>
 #include <archive_entry.h>
 
+#include <memory>
+
 namespace ripple {
 
 void


### PR DESCRIPTION
Compiling with gcc 12 on manjaro (arch variant) had compilation errors without adding an additional include file.

