### PR TITLE
Remove const_cast usage in BookChanges

### DIFF
--- a/src/ripple/rpc/BookChanges.h
+++ b/src/ripple/rpc/BookChanges.h
@@ -88,13 +88,10 @@ computeBookChanges(std::shared_ptr<L const> const& lpAccepted)
                 !node.isFieldPresent(sfPreviousFields))
                 continue;
 
-            STObject& finalFields = (const_cast<STObject&>(node))
-                                        .getField(sfFinalFields)
-                                        .downcast<STObject>();
-
-            STObject& previousFields = (const_cast<STObject&>(node))
-                                           .getField(sfPreviousFields)
-                                           .downcast<STObject>();
+            auto const& ffBase = node.peekAtField(sfFinalFields);
+            auto const& finalFields = ffBase.template downcast<STObject>();
+            auto const& pfBase = node.peekAtField(sfPreviousFields);
+            auto const& previousFields = pfBase.template downcast<STObject>();
 
             // defensive case that should never be hit
             if (!finalFields.isFieldPresent(sfTakerGets) ||


### PR DESCRIPTION
## High Level Overview of Change

Removing an unnecessary `const_cast`.

### Context of Change

While porting `book_changes` to `clio` a couple of `const_cast`s were discovered. 
It's entirely possible to do the same `downcast` without `const_cast` so here we are.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
