### PR TITLE
Introduce fixRemoveNFTokenAutoTrustLine amendment

### DIFF
--- a/src/ripple/app/tx/impl/NFTokenMint.cpp
+++ b/src/ripple/app/tx/impl/NFTokenMint.cpp
@@ -53,10 +53,10 @@ NFTokenMint::preflight(PreflightContext const& ctx)
     // The fixRemoveNFTokenAutoTrustLine amendment disables minting with the
     // tfTrustLine flag as a way to prevent the attack.  But until the
     // amendment passes we still need to keep the old behavior available.
-    std::uint32_t const NFTokeMintMask =
+    std::uint32_t const NFTokenMintMask =
         ctx.rules.enabled(fixRemoveNFTokenAutoTrustLine) ? tfNFTokenMintMask
                                                          : tfNFTokenMintOldMask;
-    if (ctx.tx.getFlags() & NFTokeMintMask)
+    if (ctx.tx.getFlags() & NFTokenMintMask)
         return temINVALID_FLAG;
 
     if (auto const f = ctx.tx[~sfTransferFee])

--- a/src/ripple/app/tx/impl/NFTokenMint.cpp
+++ b/src/ripple/app/tx/impl/NFTokenMint.cpp
@@ -40,7 +40,23 @@ NFTokenMint::preflight(PreflightContext const& ctx)
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
 
-    if (ctx.tx.getFlags() & tfNFTokenMintMask)
+    // Prior to fixRemoveNFTokenAutoTrustLine, transfer of an NFToken between
+    // accounts allowed a TrustLine to be added to the issuer of that token
+    // without explicit permission from that issuer.  This was enabled by
+    // minting the NFToken with the tfTrustLine flag set.
+    //
+    // That capability could be used to attack the NFToken issuer.  It
+    // would be possible for two accounts to trade the NFToken back and forth
+    // building up any number of TrustLines on the issuer, increasing the
+    // issuer's reserve without bound.
+    //
+    // The fixRemoveNFTokenAutoTrustLine amendment disables minting with the
+    // tfTrustLine flag as a way to prevent the attack.  But until the
+    // amendment passes we still need to keep the old behavior available.
+    std::uint32_t const NFTokeMintMask =
+        ctx.rules.enabled(fixRemoveNFTokenAutoTrustLine) ? tfNFTokenMintMask
+                                                         : tfNFTokenMintOldMask;
+    if (ctx.tx.getFlags() & NFTokeMintMask)
         return temINVALID_FLAG;
 
     if (auto const f = ctx.tx[~sfTransferFee])

--- a/src/ripple/beast/container/detail/aged_ordered_container.h
+++ b/src/ripple/beast/container/detail/aged_ordered_container.h
@@ -989,22 +989,20 @@ public:
     template <
         bool is_const,
         class Iterator,
-        class Base,
         class = std::enable_if_t<!is_boost_reverse_iterator<Iterator>::value>>
-    beast::detail::aged_container_iterator<false, Iterator, Base>
-    erase(beast::detail::aged_container_iterator<is_const, Iterator, Base> pos);
+    beast::detail::aged_container_iterator<false, Iterator>
+    erase(beast::detail::aged_container_iterator<is_const, Iterator> pos);
 
     // enable_if prevents erase (reverse_iterator first, reverse_iterator last)
     // from compiling
     template <
         bool is_const,
         class Iterator,
-        class Base,
         class = std::enable_if_t<!is_boost_reverse_iterator<Iterator>::value>>
-    beast::detail::aged_container_iterator<false, Iterator, Base>
+    beast::detail::aged_container_iterator<false, Iterator>
     erase(
-        beast::detail::aged_container_iterator<is_const, Iterator, Base> first,
-        beast::detail::aged_container_iterator<is_const, Iterator, Base> last);
+        beast::detail::aged_container_iterator<is_const, Iterator> first,
+        beast::detail::aged_container_iterator<is_const, Iterator> last);
 
     template <class K>
     auto
@@ -1019,10 +1017,9 @@ public:
     template <
         bool is_const,
         class Iterator,
-        class Base,
         class = std::enable_if_t<!is_boost_reverse_iterator<Iterator>::value>>
     void
-    touch(beast::detail::aged_container_iterator<is_const, Iterator, Base> pos)
+    touch(beast::detail::aged_container_iterator<is_const, Iterator> pos)
     {
         touch(pos, clock().now());
     }
@@ -1264,11 +1261,10 @@ private:
     template <
         bool is_const,
         class Iterator,
-        class Base,
         class = std::enable_if_t<!is_boost_reverse_iterator<Iterator>::value>>
     void
     touch(
-        beast::detail::aged_container_iterator<is_const, Iterator, Base> pos,
+        beast::detail::aged_container_iterator<is_const, Iterator> pos,
         typename clock_type::time_point const& now);
 
     template <
@@ -2010,13 +2006,13 @@ template <
     class Clock,
     class Compare,
     class Allocator>
-template <bool is_const, class Iterator, class Base, class>
-beast::detail::aged_container_iterator<false, Iterator, Base>
+template <bool is_const, class Iterator, class>
+beast::detail::aged_container_iterator<false, Iterator>
 aged_ordered_container<IsMulti, IsMap, Key, T, Clock, Compare, Allocator>::
-    erase(beast::detail::aged_container_iterator<is_const, Iterator, Base> pos)
+    erase(beast::detail::aged_container_iterator<is_const, Iterator> pos)
 {
     unlink_and_delete_element(&*((pos++).iterator()));
-    return beast::detail::aged_container_iterator<false, Iterator, Base>(
+    return beast::detail::aged_container_iterator<false, Iterator>(
         pos.iterator());
 }
 
@@ -2028,17 +2024,17 @@ template <
     class Clock,
     class Compare,
     class Allocator>
-template <bool is_const, class Iterator, class Base, class>
-beast::detail::aged_container_iterator<false, Iterator, Base>
+template <bool is_const, class Iterator, class>
+beast::detail::aged_container_iterator<false, Iterator>
 aged_ordered_container<IsMulti, IsMap, Key, T, Clock, Compare, Allocator>::
     erase(
-        beast::detail::aged_container_iterator<is_const, Iterator, Base> first,
-        beast::detail::aged_container_iterator<is_const, Iterator, Base> last)
+        beast::detail::aged_container_iterator<is_const, Iterator> first,
+        beast::detail::aged_container_iterator<is_const, Iterator> last)
 {
     for (; first != last;)
         unlink_and_delete_element(&*((first++).iterator()));
 
-    return beast::detail::aged_container_iterator<false, Iterator, Base>(
+    return beast::detail::aged_container_iterator<false, Iterator>(
         first.iterator());
 }
 
@@ -2173,11 +2169,11 @@ template <
     class Clock,
     class Compare,
     class Allocator>
-template <bool is_const, class Iterator, class Base, class>
+template <bool is_const, class Iterator, class>
 void
 aged_ordered_container<IsMulti, IsMap, Key, T, Clock, Compare, Allocator>::
     touch(
-        beast::detail::aged_container_iterator<is_const, Iterator, Base> pos,
+        beast::detail::aged_container_iterator<is_const, Iterator> pos,
         typename clock_type::time_point const& now)
 {
     auto& e(*pos.iterator());

--- a/src/ripple/beast/container/detail/aged_unordered_container.h
+++ b/src/ripple/beast/container/detail/aged_unordered_container.h
@@ -1205,15 +1205,15 @@ public:
         return emplace<maybe_multi>(std::forward<Args>(args)...);
     }
 
-    template <bool is_const, class Iterator, class Base>
-    beast::detail::aged_container_iterator<false, Iterator, Base>
-    erase(beast::detail::aged_container_iterator<is_const, Iterator, Base> pos);
+    template <bool is_const, class Iterator>
+    beast::detail::aged_container_iterator<false, Iterator>
+    erase(beast::detail::aged_container_iterator<is_const, Iterator> pos);
 
-    template <bool is_const, class Iterator, class Base>
-    beast::detail::aged_container_iterator<false, Iterator, Base>
+    template <bool is_const, class Iterator>
+    beast::detail::aged_container_iterator<false, Iterator>
     erase(
-        beast::detail::aged_container_iterator<is_const, Iterator, Base> first,
-        beast::detail::aged_container_iterator<is_const, Iterator, Base> last);
+        beast::detail::aged_container_iterator<is_const, Iterator> first,
+        beast::detail::aged_container_iterator<is_const, Iterator> last);
 
     template <class K>
     auto
@@ -1222,9 +1222,9 @@ public:
     void
     swap(aged_unordered_container& other) noexcept;
 
-    template <bool is_const, class Iterator, class Base>
+    template <bool is_const, class Iterator>
     void
-    touch(beast::detail::aged_container_iterator<is_const, Iterator, Base> pos)
+    touch(beast::detail::aged_container_iterator<is_const, Iterator> pos)
     {
         touch(pos, clock().now());
     }
@@ -1541,10 +1541,10 @@ private:
         insert_unchecked(first, last);
     }
 
-    template <bool is_const, class Iterator, class Base>
+    template <bool is_const, class Iterator>
     void
     touch(
-        beast::detail::aged_container_iterator<is_const, Iterator, Base> pos,
+        beast::detail::aged_container_iterator<is_const, Iterator> pos,
         typename clock_type::time_point const& now)
     {
         auto& e(*pos.iterator());
@@ -3044,8 +3044,8 @@ template <
     class Hash,
     class KeyEqual,
     class Allocator>
-template <bool is_const, class Iterator, class Base>
-beast::detail::aged_container_iterator<false, Iterator, Base>
+template <bool is_const, class Iterator>
+beast::detail::aged_container_iterator<false, Iterator>
 aged_unordered_container<
     IsMulti,
     IsMap,
@@ -3054,11 +3054,11 @@ aged_unordered_container<
     Clock,
     Hash,
     KeyEqual,
-    Allocator>::
-    erase(beast::detail::aged_container_iterator<is_const, Iterator, Base> pos)
+    Allocator>::erase(beast::detail::aged_container_iterator<is_const, Iterator>
+                          pos)
 {
     unlink_and_delete_element(&*((pos++).iterator()));
-    return beast::detail::aged_container_iterator<false, Iterator, Base>(
+    return beast::detail::aged_container_iterator<false, Iterator>(
         pos.iterator());
 }
 
@@ -3071,8 +3071,8 @@ template <
     class Hash,
     class KeyEqual,
     class Allocator>
-template <bool is_const, class Iterator, class Base>
-beast::detail::aged_container_iterator<false, Iterator, Base>
+template <bool is_const, class Iterator>
+beast::detail::aged_container_iterator<false, Iterator>
 aged_unordered_container<
     IsMulti,
     IsMap,
@@ -3083,13 +3083,13 @@ aged_unordered_container<
     KeyEqual,
     Allocator>::
     erase(
-        beast::detail::aged_container_iterator<is_const, Iterator, Base> first,
-        beast::detail::aged_container_iterator<is_const, Iterator, Base> last)
+        beast::detail::aged_container_iterator<is_const, Iterator> first,
+        beast::detail::aged_container_iterator<is_const, Iterator> last)
 {
     for (; first != last;)
         unlink_and_delete_element(&*((first++).iterator()));
 
-    return beast::detail::aged_container_iterator<false, Iterator, Base>(
+    return beast::detail::aged_container_iterator<false, Iterator>(
         first.iterator());
 }
 

--- a/src/ripple/beast/core/List.h
+++ b/src/ripple/beast/core/List.h
@@ -72,11 +72,12 @@ private:
 
 template <typename N>
 class ListIterator
-    : public std::iterator<std::bidirectional_iterator_tag, std::size_t>
 {
 public:
+    using iterator_category = std::bidirectional_iterator_tag;
     using value_type =
         typename beast::detail::CopyConst<N, typename N::value_type>::type;
+    using difference_type = std::ptrdiff_t;
     using pointer = value_type*;
     using reference = value_type&;
     using size_type = std::size_t;

--- a/src/ripple/beast/core/LockFreeStack.h
+++ b/src/ripple/beast/core/LockFreeStack.h
@@ -29,18 +29,7 @@ namespace beast {
 //------------------------------------------------------------------------------
 
 template <class Container, bool IsConst>
-class LockFreeStackIterator : public std::iterator<
-                                  std::forward_iterator_tag,
-                                  typename Container::value_type,
-                                  typename Container::difference_type,
-                                  typename std::conditional<
-                                      IsConst,
-                                      typename Container::const_pointer,
-                                      typename Container::pointer>::type,
-                                  typename std::conditional<
-                                      IsConst,
-                                      typename Container::const_reference,
-                                      typename Container::reference>::type>
+class LockFreeStackIterator
 {
 protected:
     using Node = typename Container::Node;
@@ -48,7 +37,9 @@ protected:
         typename std::conditional<IsConst, Node const*, Node*>::type;
 
 public:
+    using iterator_category = std::forward_iterator_tag;
     using value_type = typename Container::value_type;
+    using difference_type = typename Container::difference_type;
     using pointer = typename std::conditional<
         IsConst,
         typename Container::const_pointer,

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -74,7 +74,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 50;
+static constexpr std::size_t numFeatures = 51;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -338,6 +338,7 @@ extern uint256 const featureExpandedSignerList;
 extern uint256 const fixNFTokenDirV1;
 extern uint256 const fixNFTokenNegOffer;
 extern uint256 const featureNonFungibleTokensV1_1;
+extern uint256 const fixRemoveNFTokenAutoTrustLine;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/TxFlags.h
+++ b/src/ripple/protocol/TxFlags.h
@@ -120,8 +120,24 @@ constexpr std::uint32_t const tfOnlyXRP                = 0x00000002;
 constexpr std::uint32_t const tfTrustLine              = 0x00000004;
 constexpr std::uint32_t const tfTransferable           = 0x00000008;
 
-constexpr std::uint32_t const tfNFTokenMintMask =
+// Prior to fixRemoveNFTokenAutoTrustLine, transfer of an NFToken between
+// accounts allowed a TrustLine to be added to the issuer of that token
+// without explicit permission from that issuer.  This was enabled by
+// minting the NFToken with the tfTrustLine flag set.
+//
+// That capability could be used to attack the NFToken issuer.  It
+// would be possible for two accounts to trade the NFToken back and forth
+// building up any number of TrustLines on the issuer, increasing the
+// issuer's reserve without bound.
+//
+// The fixRemoveNFTokenAutoTrustLine amendment disables minting with the
+// tfTrustLine flag as a way to prevent the attack.  But until the
+// amendment passes we still need to keep the old behavior available.
+constexpr std::uint32_t const tfNFTokenMintOldMask =
     ~(tfUniversal | tfBurnable | tfOnlyXRP | tfTrustLine | tfTransferable);
+
+constexpr std::uint32_t const tfNFTokenMintMask =
+    ~(tfUniversal | tfBurnable | tfOnlyXRP | tfTransferable);
 
 // NFTokenCreateOffer flags:
 constexpr std::uint32_t const tfSellNFToken            = 0x00000001;

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -447,6 +447,7 @@ REGISTER_FEATURE(ExpandedSignerList,            Supported::yes, DefaultVote::no)
 REGISTER_FIX    (fixNFTokenDirV1,               Supported::yes, DefaultVote::no);
 REGISTER_FIX    (fixNFTokenNegOffer,            Supported::yes, DefaultVote::no);
 REGISTER_FEATURE(NonFungibleTokensV1_1,         Supported::yes, DefaultVote::no);
+REGISTER_FIX    (fixRemoveNFTokenAutoTrustLine, Supported::yes, DefaultVote::yes);
 
 // The following amendments have been active for at least two years. Their
 // pre-amendment code has been removed and the identifiers are deprecated.

--- a/src/test/app/NFToken_test.cpp
+++ b/src/test/app/NFToken_test.cpp
@@ -1574,7 +1574,6 @@ class NFToken_test : public beast::unit_test::suite
 
         using namespace test::jtx;
 
-        Env env{*this, features};
         Account const alice{"alice"};
         Account const becky{"becky"};
         Account const cheri{"cheri"};
@@ -1583,155 +1582,179 @@ class NFToken_test : public beast::unit_test::suite
         IOU const gwCAD(gw["CAD"]);
         IOU const gwEUR(gw["EUR"]);
 
-        env.fund(XRP(1000), alice, becky, cheri, gw);
-        env.close();
-
-        // Set trust lines so becky and cheri can use gw's currency.
-        env(trust(becky, gwAUD(1000)));
-        env(trust(cheri, gwAUD(1000)));
-        env(trust(becky, gwCAD(1000)));
-        env(trust(cheri, gwCAD(1000)));
-        env(trust(becky, gwEUR(1000)));
-        env(trust(cheri, gwEUR(1000)));
-        env.close();
-        env(pay(gw, becky, gwAUD(500)));
-        env(pay(gw, becky, gwCAD(500)));
-        env(pay(gw, becky, gwEUR(500)));
-        env(pay(gw, cheri, gwAUD(500)));
-        env(pay(gw, cheri, gwCAD(500)));
-        env.close();
-
-        // An nft without flagCreateTrustLines but with a non-zero transfer
-        // fee will not allow creating offers that use IOUs for payment.
-        for (std::uint32_t xferFee : {0, 1})
+        // The behavior of this test changes dramatically based on the
+        // presence (or absence) of the fixRemoveNFTokenAutoTrustLine
+        // amendment.  So we test both cases here.
+        for (auto const& tweakedFeatures :
+             {features - fixRemoveNFTokenAutoTrustLine,
+              features | fixRemoveNFTokenAutoTrustLine})
         {
-            uint256 const nftNoAutoTrustID{
-                token::getNextID(env, alice, 0u, tfTransferable, xferFee)};
-            env(token::mint(alice, 0u),
-                token::xferFee(xferFee),
-                txflags(tfTransferable));
+            Env env{*this, tweakedFeatures};
+            env.fund(XRP(1000), alice, becky, cheri, gw);
             env.close();
 
-            // becky buys the nft for 1 drop.
-            uint256 const beckyBuyOfferIndex =
-                keylet::nftoffer(becky, env.seq(becky)).key;
-            env(token::createOffer(becky, nftNoAutoTrustID, drops(1)),
-                token::owner(alice));
+            // Set trust lines so becky and cheri can use gw's currency.
+            env(trust(becky, gwAUD(1000)));
+            env(trust(cheri, gwAUD(1000)));
+            env(trust(becky, gwCAD(1000)));
+            env(trust(cheri, gwCAD(1000)));
+            env(trust(becky, gwEUR(1000)));
+            env(trust(cheri, gwEUR(1000)));
             env.close();
-            env(token::acceptBuyOffer(alice, beckyBuyOfferIndex));
-            env.close();
-
-            // becky attempts to sell the nft for AUD.
-            TER const createOfferTER =
-                xferFee ? TER(tecNO_LINE) : TER(tesSUCCESS);
-            uint256 const beckyOfferIndex =
-                keylet::nftoffer(becky, env.seq(becky)).key;
-            env(token::createOffer(becky, nftNoAutoTrustID, gwAUD(100)),
-                txflags(tfSellNFToken),
-                ter(createOfferTER));
+            env(pay(gw, becky, gwAUD(500)));
+            env(pay(gw, becky, gwCAD(500)));
+            env(pay(gw, becky, gwEUR(500)));
+            env(pay(gw, cheri, gwAUD(500)));
+            env(pay(gw, cheri, gwCAD(500)));
             env.close();
 
-            // cheri offers to buy the nft for CAD.
-            uint256 const cheriOfferIndex =
-                keylet::nftoffer(cheri, env.seq(cheri)).key;
-            env(token::createOffer(cheri, nftNoAutoTrustID, gwCAD(100)),
-                token::owner(becky),
-                ter(createOfferTER));
-            env.close();
+            // An nft without flagCreateTrustLines but with a non-zero transfer
+            // fee will not allow creating offers that use IOUs for payment.
+            for (std::uint32_t xferFee : {0, 1})
+            {
+                uint256 const nftNoAutoTrustID{
+                    token::getNextID(env, alice, 0u, tfTransferable, xferFee)};
+                env(token::mint(alice, 0u),
+                    token::xferFee(xferFee),
+                    txflags(tfTransferable));
+                env.close();
 
-            // To keep things tidy, cancel the offers.
-            env(token::cancelOffer(becky, {beckyOfferIndex}));
-            env(token::cancelOffer(cheri, {cheriOfferIndex}));
-            env.close();
-        }
-        // An nft with flagCreateTrustLines but with a non-zero transfer
-        // fee allows transfers using IOUs for payment.
-        {
-            std::uint16_t transferFee = 10000;  // 10%
+                // becky buys the nft for 1 drop.
+                uint256 const beckyBuyOfferIndex =
+                    keylet::nftoffer(becky, env.seq(becky)).key;
+                env(token::createOffer(becky, nftNoAutoTrustID, drops(1)),
+                    token::owner(alice));
+                env.close();
+                env(token::acceptBuyOffer(alice, beckyBuyOfferIndex));
+                env.close();
 
-            uint256 const nftAutoTrustID{token::getNextID(
-                env, alice, 0u, tfTransferable | tfTrustLine, transferFee)};
-            env(token::mint(alice, 0u),
-                token::xferFee(transferFee),
-                txflags(tfTransferable | tfTrustLine));
-            env.close();
+                // becky attempts to sell the nft for AUD.
+                TER const createOfferTER =
+                    xferFee ? TER(tecNO_LINE) : TER(tesSUCCESS);
+                uint256 const beckyOfferIndex =
+                    keylet::nftoffer(becky, env.seq(becky)).key;
+                env(token::createOffer(becky, nftNoAutoTrustID, gwAUD(100)),
+                    txflags(tfSellNFToken),
+                    ter(createOfferTER));
+                env.close();
 
-            // becky buys the nft for 1 drop.
-            uint256 const beckyBuyOfferIndex =
-                keylet::nftoffer(becky, env.seq(becky)).key;
-            env(token::createOffer(becky, nftAutoTrustID, drops(1)),
-                token::owner(alice));
-            env.close();
-            env(token::acceptBuyOffer(alice, beckyBuyOfferIndex));
-            env.close();
+                // cheri offers to buy the nft for CAD.
+                uint256 const cheriOfferIndex =
+                    keylet::nftoffer(cheri, env.seq(cheri)).key;
+                env(token::createOffer(cheri, nftNoAutoTrustID, gwCAD(100)),
+                    token::owner(becky),
+                    ter(createOfferTER));
+                env.close();
 
-            // becky sells the nft for AUD.
-            uint256 const beckySellOfferIndex =
-                keylet::nftoffer(becky, env.seq(becky)).key;
-            env(token::createOffer(becky, nftAutoTrustID, gwAUD(100)),
-                txflags(tfSellNFToken));
-            env.close();
-            env(token::acceptSellOffer(cheri, beckySellOfferIndex));
-            env.close();
+                // To keep things tidy, cancel the offers.
+                env(token::cancelOffer(becky, {beckyOfferIndex}));
+                env(token::cancelOffer(cheri, {cheriOfferIndex}));
+                env.close();
+            }
+            // An nft with flagCreateTrustLines but with a non-zero transfer
+            // fee allows transfers using IOUs for payment.
+            {
+                std::uint16_t transferFee = 10000;  // 10%
 
-            // alice should now have a trust line for gwAUD.
-            BEAST_EXPECT(env.balance(alice, gwAUD) == gwAUD(10));
+                uint256 const nftAutoTrustID{token::getNextID(
+                    env, alice, 0u, tfTransferable | tfTrustLine, transferFee)};
 
-            // becky buys the nft back for CAD.
-            uint256 const beckyBuyBackOfferIndex =
-                keylet::nftoffer(becky, env.seq(becky)).key;
-            env(token::createOffer(becky, nftAutoTrustID, gwCAD(50)),
-                token::owner(cheri));
-            env.close();
-            env(token::acceptBuyOffer(cheri, beckyBuyBackOfferIndex));
-            env.close();
+                // If the fixRemoveNFTokenAutoTrustLine amendment is active
+                // then this transaction fails.
+                {
+                    TER const mintTER =
+                        tweakedFeatures[fixRemoveNFTokenAutoTrustLine]
+                        ? static_cast<TER>(temINVALID_FLAG)
+                        : static_cast<TER>(tesSUCCESS);
 
-            // alice should now have a trust line for gwAUD and gwCAD.
-            BEAST_EXPECT(env.balance(alice, gwAUD) == gwAUD(10));
-            BEAST_EXPECT(env.balance(alice, gwCAD) == gwCAD(5));
-        }
-        // Now that alice has trust lines already established, an nft without
-        // flagCreateTrustLines will work for preestablished trust lines.
-        {
-            std::uint16_t transferFee = 5000;  // 5%
-            uint256 const nftNoAutoTrustID{
-                token::getNextID(env, alice, 0u, tfTransferable, transferFee)};
-            env(token::mint(alice, 0u),
-                token::xferFee(transferFee),
-                txflags(tfTransferable));
-            env.close();
+                    env(token::mint(alice, 0u),
+                        token::xferFee(transferFee),
+                        txflags(tfTransferable | tfTrustLine),
+                        ter(mintTER));
+                    env.close();
 
-            // alice sells the nft using AUD.
-            uint256 const aliceSellOfferIndex =
-                keylet::nftoffer(alice, env.seq(alice)).key;
-            env(token::createOffer(alice, nftNoAutoTrustID, gwAUD(200)),
-                txflags(tfSellNFToken));
-            env.close();
-            env(token::acceptSellOffer(cheri, aliceSellOfferIndex));
-            env.close();
+                    // If fixRemoveNFTokenAutoTrustLine is active the rest
+                    // of this test falls on its face.
+                    if (tweakedFeatures[fixRemoveNFTokenAutoTrustLine])
+                        break;
+                }
+                // becky buys the nft for 1 drop.
+                uint256 const beckyBuyOfferIndex =
+                    keylet::nftoffer(becky, env.seq(becky)).key;
+                env(token::createOffer(becky, nftAutoTrustID, drops(1)),
+                    token::owner(alice));
+                env.close();
+                env(token::acceptBuyOffer(alice, beckyBuyOfferIndex));
+                env.close();
 
-            // alice should now have AUD(210):
-            //  o 200 for this sale and
-            //  o 10 for the previous sale's fee.
-            BEAST_EXPECT(env.balance(alice, gwAUD) == gwAUD(210));
+                // becky sells the nft for AUD.
+                uint256 const beckySellOfferIndex =
+                    keylet::nftoffer(becky, env.seq(becky)).key;
+                env(token::createOffer(becky, nftAutoTrustID, gwAUD(100)),
+                    txflags(tfSellNFToken));
+                env.close();
+                env(token::acceptSellOffer(cheri, beckySellOfferIndex));
+                env.close();
 
-            // cheri can't sell the NFT for EUR, but can for CAD.
-            env(token::createOffer(cheri, nftNoAutoTrustID, gwEUR(50)),
-                txflags(tfSellNFToken),
-                ter(tecNO_LINE));
-            env.close();
-            uint256 const cheriSellOfferIndex =
-                keylet::nftoffer(cheri, env.seq(cheri)).key;
-            env(token::createOffer(cheri, nftNoAutoTrustID, gwCAD(100)),
-                txflags(tfSellNFToken));
-            env.close();
-            env(token::acceptSellOffer(becky, cheriSellOfferIndex));
-            env.close();
+                // alice should now have a trust line for gwAUD.
+                BEAST_EXPECT(env.balance(alice, gwAUD) == gwAUD(10));
 
-            // alice should now have CAD(10):
-            //  o 5 from this sale's fee and
-            //  o 5 for the previous sale's fee.
-            BEAST_EXPECT(env.balance(alice, gwCAD) == gwCAD(10));
+                // becky buys the nft back for CAD.
+                uint256 const beckyBuyBackOfferIndex =
+                    keylet::nftoffer(becky, env.seq(becky)).key;
+                env(token::createOffer(becky, nftAutoTrustID, gwCAD(50)),
+                    token::owner(cheri));
+                env.close();
+                env(token::acceptBuyOffer(cheri, beckyBuyBackOfferIndex));
+                env.close();
+
+                // alice should now have a trust line for gwAUD and gwCAD.
+                BEAST_EXPECT(env.balance(alice, gwAUD) == gwAUD(10));
+                BEAST_EXPECT(env.balance(alice, gwCAD) == gwCAD(5));
+            }
+            // Now that alice has trust lines preestablished, an nft without
+            // flagCreateTrustLines will work for preestablished trust lines.
+            {
+                std::uint16_t transferFee = 5000;  // 5%
+                uint256 const nftNoAutoTrustID{token::getNextID(
+                    env, alice, 0u, tfTransferable, transferFee)};
+                env(token::mint(alice, 0u),
+                    token::xferFee(transferFee),
+                    txflags(tfTransferable));
+                env.close();
+
+                // alice sells the nft using AUD.
+                uint256 const aliceSellOfferIndex =
+                    keylet::nftoffer(alice, env.seq(alice)).key;
+                env(token::createOffer(alice, nftNoAutoTrustID, gwAUD(200)),
+                    txflags(tfSellNFToken));
+                env.close();
+                env(token::acceptSellOffer(cheri, aliceSellOfferIndex));
+                env.close();
+
+                // alice should now have AUD(210):
+                //  o 200 for this sale and
+                //  o 10 for the previous sale's fee.
+                BEAST_EXPECT(env.balance(alice, gwAUD) == gwAUD(210));
+
+                // cheri can't sell the NFT for EUR, but can for CAD.
+                env(token::createOffer(cheri, nftNoAutoTrustID, gwEUR(50)),
+                    txflags(tfSellNFToken),
+                    ter(tecNO_LINE));
+                env.close();
+                uint256 const cheriSellOfferIndex =
+                    keylet::nftoffer(cheri, env.seq(cheri)).key;
+                env(token::createOffer(cheri, nftNoAutoTrustID, gwCAD(100)),
+                    txflags(tfSellNFToken));
+                env.close();
+                env(token::acceptSellOffer(becky, cheriSellOfferIndex));
+                env.close();
+
+                // alice should now have CAD(10):
+                //  o 5 from this sale's fee and
+                //  o 5 for the previous sale's fee.
+                BEAST_EXPECT(env.balance(alice, gwCAD) == gwCAD(10));
+            }
         }
     }
 


### PR DESCRIPTION
## High Level Overview of Change

It turns out that the feature enabled by the `tfTrustLine` flag on an `NFTokenMint` transaction could be used as a means to attack the NFToken issuer.  Details are in https://github.com/XRPLF/rippled/issues/4300

The `fixRemoveNFTokenAutoTrustLine` amendment in this pull request removes the ability to set the `tfTrustLine` flag on an `NFTokenMint` transaction.

Closes https://github.com/XRPLF/rippled/issues/4300

### Context of Change

There are two commits in this pull request.  They are both needed, but they should be kept separate (not squashed).

- The first commit, by @HowardHinnant, is required to allow the code to be compiled without warnings by the latest version of Xcode (Version 13.4.1.  This commit has already been accepted into the 1.10.0-b1 develop branch.  This first commit does not require review.

- The second commit disables the `tfTrustLine` flag on an NFTokenMint transaction.  This commit needs review.

### Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Amendment (amendment going live will cause amendment blocking of out-of-date servers)
- [x] Tests (tests were added for the new amendment)
- [x] Requires documentation updates
