### PR TITLE
Fix build by removing the #include in rippled/src/ripple/rpc/DeliveredAmount.h

### DIFF
--- a/src/ripple/rpc/DeliveredAmount.h
+++ b/src/ripple/rpc/DeliveredAmount.h
@@ -22,7 +22,6 @@
 
 #include <ripple/protocol/Protocol.h>
 #include <ripple/protocol/STAmount.h>
-#include <org/xrpl/rpc/v1/amount.pb.h>
 
 #include <functional>
 #include <memory>


### PR DESCRIPTION
Fix build by removing `#include <org/xrpl/rpc/v1/amount.pb.h>` in `DeliveredAmount.h`
That file was removed in #4272 so it wouldn't build.
- [x] Bug fix (non-breaking change which fixes an issue) 