### PR TITLE
Catch transaction deserialization error in doLedgerGrpc

### DIFF
--- a/src/ripple/rpc/handlers/LedgerHandler.cpp
+++ b/src/ripple/rpc/handlers/LedgerHandler.cpp
@@ -164,7 +164,8 @@ doLedgerGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetLedgerRequest>& context)
             JLOG(context.j.error())
                 << __func__ << " - Error deserializing transaction in ledger "
                 << ledger->info().seq
-                << " . skipping transaction. you should look into this further";
+                << " . skipping transaction and following transactions. You "
+                   "should look into this further";
         }
     }
 

--- a/src/ripple/rpc/handlers/LedgerHandler.cpp
+++ b/src/ripple/rpc/handlers/LedgerHandler.cpp
@@ -134,27 +134,37 @@ doLedgerGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetLedgerRequest>& context)
 
     if (request.transactions())
     {
-        for (auto& i : ledger->txs)
+        try
         {
-            assert(i.first);
-            if (request.expand())
+            for (auto& i : ledger->txs)
             {
-                auto txn =
-                    response.mutable_transactions_list()->add_transactions();
-                Serializer sTxn = i.first->getSerializer();
-                txn->set_transaction_blob(sTxn.data(), sTxn.getLength());
-                if (i.second)
+                assert(i.first);
+                if (request.expand())
                 {
-                    Serializer sMeta = i.second->getSerializer();
-                    txn->set_metadata_blob(sMeta.data(), sMeta.getLength());
+                    auto txn = response.mutable_transactions_list()
+                                   ->add_transactions();
+                    Serializer sTxn = i.first->getSerializer();
+                    txn->set_transaction_blob(sTxn.data(), sTxn.getLength());
+                    if (i.second)
+                    {
+                        Serializer sMeta = i.second->getSerializer();
+                        txn->set_metadata_blob(sMeta.data(), sMeta.getLength());
+                    }
+                }
+                else
+                {
+                    auto const& hash = i.first->getTransactionID();
+                    response.mutable_hashes_list()->add_hashes(
+                        hash.data(), hash.size());
                 }
             }
-            else
-            {
-                auto const& hash = i.first->getTransactionID();
-                response.mutable_hashes_list()->add_hashes(
-                    hash.data(), hash.size());
-            }
+        }
+        catch (std::exception const& e)
+        {
+            JLOG(context.j.error())
+                << __func__ << " - Error deserializing transaction in ledger "
+                << ledger->info().seq
+                << " . skipping transaction. you should look into this further";
         }
     }
 


### PR DESCRIPTION
* Allow clio to extract ledgers with transactions that can no longer be deserialized. The problem transactions will be skipped.

Some old transactions cannot be deserialized by current rippled code. Clio can still extract the ledger headers and state objects, just not the transactions.
