### PR TITLE
Fix clang 15 warnings

### DIFF
--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -78,8 +78,6 @@ increase(FeeLevel64 level, std::uint32_t increasePercent)
 
 //////////////////////////////////////////////////////////////////////////
 
-constexpr FeeLevel64 TxQ::baseLevel;
-
 std::size_t
 TxQ::FeeMetrics::update(
     Application& app,

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -263,8 +263,6 @@ getEnvVar(char const* name)
     return value;
 }
 
-constexpr FeeUnit32 Config::TRANSACTION_FEE_BASE;
-
 Config::Config()
     : j_(beast::Journal::getNullSink()), ramSize_(detail::getMemorySize())
 {

--- a/src/ripple/rpc/impl/Status.cpp
+++ b/src/ripple/rpc/impl/Status.cpp
@@ -23,8 +23,6 @@
 namespace ripple {
 namespace RPC {
 
-constexpr Status::Code Status::OK;
-
 std::string
 Status::codeString() const
 {

--- a/src/test/unit_test/multi_runner.cpp
+++ b/src/test/unit_test/multi_runner.cpp
@@ -389,11 +389,6 @@ multi_runner_base<IsParent>::add_failures(std::size_t failures)
     any_failed(failures != 0);
 }
 
-template <bool IsParent>
-constexpr const char* multi_runner_base<IsParent>::shared_mem_name_;
-template <bool IsParent>
-constexpr const char* multi_runner_base<IsParent>::message_queue_name_;
-
 }  // namespace detail
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Clang warns about the code removed in this patch with the following warning:
```
warning: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated [-Wdeprecated]
```