### PR TITLE
Improve move semantics in Expected

### DIFF
--- a/src/ripple/basics/Expected.h
+++ b/src/ripple/basics/Expected.h
@@ -135,14 +135,15 @@ public:
     template <
         typename U,
         typename = std::enable_if_t<std::is_convertible_v<U, T>>>
-    constexpr Expected(U r) : Base(T{std::forward<U>(r)})
+    constexpr Expected(U && r) : Base(T{std::forward<U>(r)})
     {
     }
 
     template <
         typename U,
-        typename = std::enable_if_t<std::is_convertible_v<U, E>>>
-    constexpr Expected(Unexpected<U> e) : Base(E{std::forward<U>(e.value())})
+        typename = std::enable_if_t<
+            std::is_convertible_v<U, E> && !std::is_reference_v<U>>>
+    constexpr Expected(Unexpected<U> e) : Base(E{std::move(e.value())})
     {
     }
 
@@ -217,8 +218,9 @@ public:
 
     template <
         typename U,
-        typename = std::enable_if_t<std::is_convertible_v<U, E>>>
-    constexpr Expected(Unexpected<U> e) : Base(E{std::forward<U>(e.value())})
+        typename = std::enable_if_t<
+            std::is_convertible_v<U, E> && !std::is_reference_v<U>>>
+    constexpr Expected(Unexpected<U> e) : Base(E{std::move(e.value())})
     {
     }
 


### PR DESCRIPTION
This patch unconditionally moves an `Unexpected<U>` value parameter as long as `U` is not a reference. If `U` is a reference the code should not compile. An error type that holds a reference is a strange use-case, and an overload is not provided. If it is required in the future it can be added.

The `Expected(U r)` overload should take a forwarding ref.