### PR TITLE
Allow port numbers be be specified using a either a colon or a space

### DIFF
--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -482,17 +482,31 @@ private:
         return jvRequest;
     }
 
-    // connect <ip> [port]
+    // connect <ip[:port]> [port]
     Json::Value
     parseConnect(Json::Value const& jvParams)
     {
         Json::Value jvRequest(Json::objectValue);
-
-        jvRequest[jss::ip] = jvParams[0u].asString();
-
+        std::string ip = jvParams[0u].asString();
         if (jvParams.size() == 2)
+        {
+            jvRequest[jss::ip] = ip;
             jvRequest[jss::port] = jvParams[1u].asUInt();
+            return jvRequest;
+        }
 
+        // handle case where there is one argument of the form ip:port
+        if (std::count(ip.begin(), ip.end(), ':') == 1)
+        {
+            std::size_t colon = ip.find_last_of(":");
+            jvRequest[jss::ip] = std::string{ip, 0, colon};
+            jvRequest[jss::port] =
+                Json::Value{std::string{ip, colon + 1}}.asUInt();
+            return jvRequest;
+        }
+
+        // default case, no port
+        jvRequest[jss::ip] = ip;
         return jvRequest;
     }
 

--- a/src/ripple/rpc/handlers/Connect.cpp
+++ b/src/ripple/rpc/handlers/Connect.cpp
@@ -59,13 +59,15 @@ doConnect(RPC::JsonContext& context)
     else
         iPort = DEFAULT_PEER_PORT;
 
-    auto ip =
-        beast::IP::Endpoint::from_string(context.params[jss::ip].asString());
+    auto const ip_str = context.params[jss::ip].asString();
+    auto ip = beast::IP::Endpoint::from_string(ip_str);
 
     if (!is_unspecified(ip))
         context.app.overlay().connect(ip.at_port(iPort));
 
-    return RPC::makeObjectValue("connecting");
+    return RPC::makeObjectValue(
+        "attempting connection to IP:" + ip_str +
+        " port: " + std::to_string(iPort));
 }
 
 }  // namespace ripple

--- a/src/test/core/Config_test.cpp
+++ b/src/test/core/Config_test.cpp
@@ -857,6 +857,84 @@ r.ripple.com 51235
     }
 
     void
+    testColons()
+    {
+        Config cfg;
+        /* NOTE: this string includes some explicit
+         * space chars in order to verify proper trimming */
+        std::string toLoad(R"(
+[port_rpc])"
+                           "\x20"
+                           R"(
+# comment
+    # indented comment
+)"
+                           "\x20\x20"
+                           R"(
+[ips])"
+                           "\x20"
+                           R"(
+r.ripple.com:51235
+
+  [ips_fixed])"
+                           "\x20\x20"
+                           R"(
+    # COMMENT
+    s1.ripple.com:51235
+    s2.ripple.com 51235
+    anotherserversansport
+    anotherserverwithport:12
+    1.1.1.1:1
+    1.1.1.1 1
+    12.34.12.123:12345
+    12.34.12.123 12345
+    ::
+    2001:db8::
+    ::1
+    ::1:12345
+    [::1]:12345
+    2001:db8:3333:4444:5555:6666:7777:8888:12345
+    [2001:db8:3333:4444:5555:6666:7777:8888]:1
+
+
+)");
+        cfg.loadFromString(toLoad);
+        BEAST_EXPECT(
+            cfg.exists("port_rpc") && cfg.section("port_rpc").lines().empty() &&
+            cfg.section("port_rpc").values().empty());
+        BEAST_EXPECT(
+            cfg.exists(SECTION_IPS) &&
+            cfg.section(SECTION_IPS).lines().size() == 1 &&
+            cfg.section(SECTION_IPS).values().size() == 1);
+        BEAST_EXPECT(
+            cfg.exists(SECTION_IPS_FIXED) &&
+            cfg.section(SECTION_IPS_FIXED).lines().size() == 15 &&
+            cfg.section(SECTION_IPS_FIXED).values().size() == 15);
+        BEAST_EXPECT(cfg.IPS[0] == "r.ripple.com 51235");
+
+        BEAST_EXPECT(cfg.IPS_FIXED[0] == "s1.ripple.com 51235");
+        BEAST_EXPECT(cfg.IPS_FIXED[1] == "s2.ripple.com 51235");
+        BEAST_EXPECT(cfg.IPS_FIXED[2] == "anotherserversansport");
+        BEAST_EXPECT(cfg.IPS_FIXED[3] == "anotherserverwithport 12");
+        BEAST_EXPECT(cfg.IPS_FIXED[4] == "1.1.1.1 1");
+        BEAST_EXPECT(cfg.IPS_FIXED[5] == "1.1.1.1 1");
+        BEAST_EXPECT(cfg.IPS_FIXED[6] == "12.34.12.123 12345");
+        BEAST_EXPECT(cfg.IPS_FIXED[7] == "12.34.12.123 12345");
+
+        // all ipv6 should be ignored by colon replacer, howsoever formated
+        BEAST_EXPECT(cfg.IPS_FIXED[8] == "::");
+        BEAST_EXPECT(cfg.IPS_FIXED[9] == "2001:db8::");
+        BEAST_EXPECT(cfg.IPS_FIXED[10] == "::1");
+        BEAST_EXPECT(cfg.IPS_FIXED[11] == "::1:12345");
+        BEAST_EXPECT(cfg.IPS_FIXED[12] == "[::1]:12345");
+        BEAST_EXPECT(
+            cfg.IPS_FIXED[13] ==
+            "2001:db8:3333:4444:5555:6666:7777:8888:12345");
+        BEAST_EXPECT(
+            cfg.IPS_FIXED[14] == "[2001:db8:3333:4444:5555:6666:7777:8888]:1");
+    }
+
+    void
     testComments()
     {
         struct TestCommentData
@@ -1147,6 +1225,7 @@ r.ripple.com 51235
         testSetup(true);
         testPort();
         testWhitespace();
+        testColons();
         testComments();
         testGetters();
         testAmendment();


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change
An annoying *gotcha* for node operators is accidentally specifying IP:PORT combinations using a colon. Rippled expects a space, not a colon, and for whatever reason does not provide good feedback when this operator error is made.

This small PR simply allows this mistake (colon) to be replaced inline with a space, preserving the intention of the operator.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

## Test Plan
* `testColons()` has been added to the config unit tests. This tests the functionality when specifying IP:PORT in rippled.cfg.
* The RPCCall test regime is not specific enough to test this functionality, but I have tested it by hand (and you should too).

<!--
## Future Tasks
For future tasks related to PR.
-->
