### PR TITLE
Reduce reserves to 10/2

### DIFF
--- a/src/ripple/app/misc/FeeVote.h
+++ b/src/ripple/app/misc/FeeVote.h
@@ -46,10 +46,10 @@ public:
         static constexpr FeeUnit32 reference_fee_units{10};
 
         /** The account reserve requirement in drops. */
-        XRPAmount account_reserve{20 * DROPS_PER_XRP};
+        XRPAmount account_reserve{10 * DROPS_PER_XRP};
 
         /** The per-owned item reserve requirement in drops. */
-        XRPAmount owner_reserve{5 * DROPS_PER_XRP};
+        XRPAmount owner_reserve{2 * DROPS_PER_XRP};
     };
 
     virtual ~FeeVote() = default;

--- a/src/test/app/AccountDelete_test.cpp
+++ b/src/test/app/AccountDelete_test.cpp
@@ -515,16 +515,16 @@ public:
 
         // All it takes is a large enough XRP payment to resurrect
         // becky's account.  Try too small a payment.
-        env(pay(alice, becky, XRP(19)), ter(tecNO_DST_INSUF_XRP));
+        env(pay(alice, becky, XRP(9)), ter(tecNO_DST_INSUF_XRP));
         env.close();
 
         // Actually resurrect becky's account.
-        env(pay(alice, becky, XRP(20)));
+        env(pay(alice, becky, XRP(10)));
         env.close();
 
         // becky's account root should be back.
         BEAST_EXPECT(env.closed()->exists(beckyAcctKey));
-        BEAST_EXPECT(env.balance(becky) == XRP(20));
+        BEAST_EXPECT(env.balance(becky) == XRP(10));
 
         // becky's resurrected account can be the destination of alice's
         // PayChannel.
@@ -541,7 +541,7 @@ public:
         env(payChanClaim());
         env.close();
 
-        BEAST_EXPECT(env.balance(becky) == XRP(20) + payChanXRP);
+        BEAST_EXPECT(env.balance(becky) == XRP(10) + payChanXRP);
     }
 
     void

--- a/src/test/app/FeeVote_test.cpp
+++ b/src/test/app/FeeVote_test.cpp
@@ -34,8 +34,8 @@ class FeeVote_test : public beast::unit_test::suite
             Section config;
             auto setup = setup_FeeVote(config);
             BEAST_EXPECT(setup.reference_fee == 10);
-            BEAST_EXPECT(setup.account_reserve == 20 * DROPS_PER_XRP);
-            BEAST_EXPECT(setup.owner_reserve == 5 * DROPS_PER_XRP);
+            BEAST_EXPECT(setup.account_reserve == 10 * DROPS_PER_XRP);
+            BEAST_EXPECT(setup.owner_reserve == 2 * DROPS_PER_XRP);
         }
         {
             Section config;
@@ -57,8 +57,8 @@ class FeeVote_test : public beast::unit_test::suite
             // Illegal values are ignored, and the defaults left unchanged
             auto setup = setup_FeeVote(config);
             BEAST_EXPECT(setup.reference_fee == 10);
-            BEAST_EXPECT(setup.account_reserve == 20 * DROPS_PER_XRP);
-            BEAST_EXPECT(setup.owner_reserve == 5 * DROPS_PER_XRP);
+            BEAST_EXPECT(setup.account_reserve == 10 * DROPS_PER_XRP);
+            BEAST_EXPECT(setup.owner_reserve == 2 * DROPS_PER_XRP);
         }
         {
             Section config;
@@ -87,8 +87,8 @@ class FeeVote_test : public beast::unit_test::suite
             // Illegal values are ignored, and the defaults left unchanged
             auto setup = setup_FeeVote(config);
             BEAST_EXPECT(setup.reference_fee == 10);
-            BEAST_EXPECT(setup.account_reserve == 20 * DROPS_PER_XRP);
-            BEAST_EXPECT(setup.owner_reserve == 5 * DROPS_PER_XRP);
+            BEAST_EXPECT(setup.account_reserve == 10 * DROPS_PER_XRP);
+            BEAST_EXPECT(setup.owner_reserve == 2 * DROPS_PER_XRP);
         }
     }
 

--- a/src/test/rpc/AccountTx_test.cpp
+++ b/src/test/rpc/AccountTx_test.cpp
@@ -547,7 +547,7 @@ class AccountTx_test : public beast::unit_test::suite
 
         // All it takes is a large enough XRP payment to resurrect
         // becky's account.  Try too small a payment.
-        env(pay(alice, becky, XRP(19)), ter(tecNO_DST_INSUF_XRP));
+        env(pay(alice, becky, XRP(9)), ter(tecNO_DST_INSUF_XRP));
         env.close();
 
         // Actually resurrect becky's account.


### PR DESCRIPTION
The current network reserves are 10/2 as against the older 20/5. These reserves have been in force for long enough that new validators should not have to vote explicitly for this.
