### PR TITLE
fixes issue where brokers cannot perform NFTokenAcceptOffer in certain scenarios

### DIFF
--- a/src/ripple/app/tx/impl/NFTokenAcceptOffer.cpp
+++ b/src/ripple/app/tx/impl/NFTokenAcceptOffer.cpp
@@ -199,19 +199,18 @@ NFTokenAcceptOffer::preclaim(PreclaimContext const& ctx)
             if (auto const dest = so->at(~sfDestination);
                 dest.has_value() && *dest != ctx.tx[sfAccount])
                 return tecNO_PERMISSION;
+
+            // The account offering to buy must have funds:
+            auto const needed = so->at(sfAmount);
+            if (accountHolds(
+                    ctx.view,
+                    ctx.tx[sfAccount],
+                    needed.getCurrency(),
+                    needed.getIssuer(),
+                    fhZERO_IF_FROZEN,
+                    ctx.j) < needed)
+                return tecINSUFFICIENT_FUNDS;
         }
-
-        // The account offering to buy must have funds:
-        auto const needed = so->at(sfAmount);
-
-        if (accountHolds(
-                ctx.view,
-                ctx.tx[sfAccount],
-                needed.getCurrency(),
-                needed.getIssuer(),
-                fhZERO_IF_FROZEN,
-                ctx.j) < needed)
-            return tecINSUFFICIENT_FUNDS;
     }
 
     return tesSUCCESS;

--- a/src/test/app/NFToken_test.cpp
+++ b/src/test/app/NFToken_test.cpp
@@ -3933,8 +3933,8 @@ class NFToken_test : public beast::unit_test::suite
             [this, &gw, &gwXAU, &env](
                 std::initializer_list<std::reference_wrapper<Account const>>
                     accounts,
-                int line,
-                int amount = 1000) {
+                int amount,
+                int line) {
                 for (Account const& acct : accounts)
                 {
                     auto const xauAmt = gwXAU(amount);
@@ -3963,7 +3963,7 @@ class NFToken_test : public beast::unit_test::suite
         // transfer fee.
         {
             checkOwnerCountIsOne({issuer, minter, buyer, broker}, __LINE__);
-            setXAUBalance({issuer, minter, buyer, broker}, __LINE__);
+            setXAUBalance({issuer, minter, buyer, broker}, 1000, __LINE__);
 
             uint256 const nftID = mintNFT();
 
@@ -4048,7 +4048,7 @@ class NFToken_test : public beast::unit_test::suite
         // There are both transfer and broker fees.
         {
             checkOwnerCountIsOne({issuer, minter, buyer, broker}, __LINE__);
-            setXAUBalance({issuer, minter, buyer, broker}, __LINE__);
+            setXAUBalance({issuer, minter, buyer, broker}, 1000, __LINE__);
 
             uint256 const nftID = mintNFT(maxTransferFee);
 
@@ -4134,7 +4134,7 @@ class NFToken_test : public beast::unit_test::suite
         // the maximum.
         {
             checkOwnerCountIsOne({issuer, minter, buyer, broker}, __LINE__);
-            setXAUBalance({issuer, minter, buyer, broker}, __LINE__);
+            setXAUBalance({issuer, minter, buyer, broker}, 1000, __LINE__);
 
             uint256 const nftID = mintNFT(maxTransferFee / 2);  // 25%
 
@@ -4175,8 +4175,8 @@ class NFToken_test : public beast::unit_test::suite
         // broker has a balance less than the seller offer
         {
             checkOwnerCountIsOne({issuer, minter, buyer, broker}, __LINE__);
-            setXAUBalance({issuer, minter, buyer}, __LINE__);
-            setXAUBalance({broker}, __LINE__, 500);
+            setXAUBalance({issuer, minter, buyer}, 1000, __LINE__);
+            setXAUBalance({broker}, 500, __LINE__);
 
             uint256 const nftID = mintNFT(maxTransferFee / 2);  // 25%
 


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

In the follow scenario, an account cannot perform NFTokenAcceptOffer even though it should be allowed to:

0) BROKER has < `S`
1) ALICE offers to sell token for `S`
2) BOB offers to buy token for > `S`
3) BROKER tries to bridge the two offers

This will result in a tecINSUFFICIENT_FUNDS, but should not because BROKER is not spending any funds in this transaction, beyond the transaction fee.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

The fix here is to only validate that the tx submitter has enough funds to cover the sell offer when NOT bridging two offers. This fixes the issue because in the case of bridging two offers, the submitter is the broker, not the buyer.

This fix is OK and doesn't need to happen at all in bridged mode, because there is already a check in preclaim to ensure that the buyer has sufficient funds if there is a BuyOffer in play. Here, we appropriately are checking the funds of the owner of the NFTokenOffer object, not the tx submitter.

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

Tested manually with some scripting and a standalone node. Also added integration test scenario for this and verified that it fails with change backed out, but passes with change included.

<!--
## Future Tasks
For future tasks related to PR.
-->
