### PR TITLE
Don't try to read SLE with key 0 from the ledger:

### DIFF
--- a/src/ripple/app/tx/impl/NFTokenAcceptOffer.cpp
+++ b/src/ripple/app/tx/impl/NFTokenAcceptOffer.cpp
@@ -67,6 +67,9 @@ NFTokenAcceptOffer::preclaim(PreclaimContext const& ctx)
         -> std::pair<std::shared_ptr<const SLE>, TER> {
         if (id)
         {
+            if (id->isZero())
+                return {nullptr, tecOBJECT_NOT_FOUND};
+
             auto offerSLE = ctx.view.read(keylet::nftoffer(*id));
 
             if (!offerSLE)

--- a/src/test/app/NFToken_test.cpp
+++ b/src/test/app/NFToken_test.cpp
@@ -1130,6 +1130,12 @@ class NFToken_test : public beast::unit_test::suite
         //----------------------------------------------------------------------
         // preclaim
 
+        // The buy offer must be non-zero.
+        env(token::acceptBuyOffer(buyer, beast::zero),
+            ter(tecOBJECT_NOT_FOUND));
+        env.close();
+        BEAST_EXPECT(ownerCount(env, buyer) == 0);
+
         // The buy offer must be present in the ledger.
         uint256 const missingOfferIndex = keylet::nftoffer(alice, 1).key;
         env(token::acceptBuyOffer(buyer, missingOfferIndex),
@@ -1139,6 +1145,12 @@ class NFToken_test : public beast::unit_test::suite
 
         // The buy offer must not have expired.
         env(token::acceptBuyOffer(buyer, aliceExpOfferIndex), ter(tecEXPIRED));
+        env.close();
+        BEAST_EXPECT(ownerCount(env, buyer) == 0);
+
+        // The sell offer must be non-zero.
+        env(token::acceptSellOffer(buyer, beast::zero),
+            ter(tecOBJECT_NOT_FOUND));
         env.close();
         BEAST_EXPECT(ownerCount(env, buyer) == 0);
 


### PR DESCRIPTION
## High Level Overview of Change

Debug builds are occasionally hitting an `assert` at Ledger.cpp line 436 (see #4341). The `assert` is at least 8 years old and appears to still be relevant. `Ledger::read` should not be called with an ID of 0.

`NFTokenAcceptOffer` transactions can be written (presumably incorrectly) in such a way that the `NFTokenSellOffer` and `NFTokenBuyOffer` fields can contain a 0 value. The `preclaim` function for this transaction did not validate the value before calling `Ledger::read`.

Note that this issue is **not** harmful in release builds. If an `assert` fails in a debug build, as it did in this case, it will stop the program. However, `assert`s are not included in release builds, so they are skipped. In this case, `Ledger::read` properly handles that case, and returns a `nullptr` if the ID is 0. `NFTokenSellOffer::preclaim` checks that `nullptr` and correctly returns `tecOBJECT_NOT_FOUND`, as it would if the transaction provided a valid ID which was not in the ledger.

This fix preserves that functionality, but checks for 0 in `NFTokenSellOffer::preclaim` before calling `Ledger::read`, and returns the same `tecOBJECT_NOT_FOUND` result. Thus, an amendment is **not** required.

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)
- [X ] Refactor (non-breaking change that only restructures code)

