### PR TITLE
Update Github Actions to ubuntu-latest:

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CLANG_VERSION: 10
     steps:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install clang-format
       run: |
-        codename=$( lsb_release -cs )
+        codename=$( lsb_release --codename --short )
         sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null <<EOF
         deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${CLANG_VERSION} main
         deb-src http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${CLANG_VERSION} main

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -4,16 +4,17 @@ on: [push, pull_request]
 
 jobs:
   check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       CLANG_VERSION: 10
     steps:
     - uses: actions/checkout@v2
     - name: Install clang-format
       run: |
+        codename=$( lsb_release -cs )
         sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null <<EOF
-        deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${CLANG_VERSION} main
-        deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${CLANG_VERSION} main
+        deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${CLANG_VERSION} main
+        deb-src http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${CLANG_VERSION} main
         EOF
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add
         sudo apt-get update

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container:
       image: docker://rippleci/rippled-ci-builder:2944b78d22db
     steps:

--- a/.github/workflows/levelization.yml
+++ b/.github/workflows/levelization.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       CLANG_VERSION: 10
     steps:


### PR DESCRIPTION
## High Level Overview of Change

Per actions/runner-images#6002, the ubuntu-18.04 image is being deprecated in Github Actions. They are having scheduled "brownouts" to drive the point home. That could get pretty annoying if the timing is bad.

Instead of picking a version, I changed the jobs to use `ubuntu-latest`. This will reduce maintenance as new versions are introduced, if the jobs keep working. And if they stop working, we'll need to fix them anyway, so this will let us catch it early.

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)

## Test Plan

No specific testing is needed. If the Github Actions jobs work, that's it.

## Future Tasks

Jobs in pending PRs that affect Github Actions may need to be updated. E.g. #4223 #3851 