### PR TITLE
Build packages for branches `stable`, `unstable`

### DIFF
--- a/Builds/containers/gitlab-ci/get_component.sh
+++ b/Builds/containers/gitlab-ci/get_component.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env sh
 case ${CI_COMMIT_REF_NAME} in
-    develop)
+    unstable)
         export COMPONENT="nightly"
         ;;
     release)
         export COMPONENT="unstable"
         ;;
-    master)
+    stable)
         export COMPONENT="stable"
         ;;
     *)

--- a/Builds/containers/gitlab-ci/pkgbuild.yml
+++ b/Builds/containers/gitlab-ci/pkgbuild.yml
@@ -1,6 +1,6 @@
 #########################################################################
 ##                                                                     ##
-##  gitlab CI defintition for rippled build containers and distro      ##
+##  gitlab CI definition for rippled build containers and distro       ##
 ##  packages (rpm and dpkg).                                           ##
 ##                                                                     ##
 #########################################################################
@@ -58,7 +58,7 @@ stages:
 .only_primary_template: &only_primary
   only:
     refs:
-      - /^(master|release|develop)$/
+      - /^(stable|release|unstable)$/
     variables:
       - $IS_PRIMARY_REPO == "true"
 


### PR DESCRIPTION
## High Level Overview of Change

Update the CI pipeline so that packages are built for the branches `stable` and `unstable` instead of `master` and `develop`.

### Context of Change

Previously, the `develop` branch was reserved for beta releases, and PRs would need to wait for a beta release before they could be merged. Now, the `unstable` branch will serve that purpose; going forward, PRs will be able to be merged into `develop` as soon as they are ready. Ready means:
- Approved by 2 reviewers (typically, and usually maintainers)
- All unit tests pass
- Successfully builds on the 3 supported platforms (Mac, Linux, Windows)
- Syncs with Mainnet

### Type of Change

- [x] Release Process / Build System