### PR TITLE
Improve MITM detection during session establishment:

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -186,6 +186,8 @@ public:
     NodeCache m_tempNodeCache;
     CachedSLEs cachedSLEs_;
     std::pair<PublicKey, SecretKey> nodeIdentity_;
+    std::string nodePublicIdentity_;
+
     ValidatorKeys const validatorKeys_;
 
     std::unique_ptr<Resource::Manager> m_resourceManager;
@@ -588,6 +590,12 @@ public:
     nodeIdentity() override
     {
         return nodeIdentity_;
+    }
+
+    std::string const&
+    getNodePublicIdentity() const override
+    {
+        return nodePublicIdentity_;
     }
 
     PublicKey const&
@@ -1276,6 +1284,7 @@ ApplicationImp::setup(boost::program_options::variables_map const& cmdline)
         m_orderBookDB.setup(getLedgerMaster().getCurrentLedger());
 
     nodeIdentity_ = getNodeIdentity(*this, cmdline);
+    nodePublicIdentity_ = toBase58(TokenType::NodePublic, nodeIdentity().first);
 
     if (!cluster_->load(config().section(SECTION_CLUSTER_NODES)))
     {

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -239,6 +239,9 @@ public:
     virtual std::pair<PublicKey, SecretKey> const&
     nodeIdentity() = 0;
 
+    virtual std::string const&
+    getNodePublicIdentity() const = 0;
+
     virtual PublicKey const&
     getValidationPublicKey() const = 0;
 

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -547,6 +547,7 @@ public:
 using uint128 = base_uint<128>;
 using uint160 = base_uint<160>;
 using uint256 = base_uint<256>;
+using uint512 = base_uint<512>;
 
 template <std::size_t Bits, class Tag>
 inline int

--- a/src/ripple/overlay/README.md
+++ b/src/ripple/overlay/README.md
@@ -65,9 +65,10 @@ Network-ID: 1
 Network-Time: 619234489
 Public-Key: n94MvLTiHQJjByfGZzvQewTxQP2qjF6shQcuHwCjh5WoiozBrdpX
 Session-Signature: MEUCIQCOO8tHOh/tgCSRNe6WwOwmIF6urZ5uSB8l9aAf5q7iRAIgA4aONKBZhpP5RuOuhJP2dP+2UIRioEJcfU4/m4gZdYo=
+Session-EKM-Signature: 4F73F4DF23453250BDDF81AFBB5CBF0FD32B92AAF548331DB0ECF1DB988BE2F3D7264621FC1E93404B77612F235AC6FFD4F1B7B4D420E8071384273D9A60201D
 Remote-IP: 192.0.2.79
-Closed-Ledger: llRZSKqvNieGpPqbFGnm358pmF1aW96SDIUQcnMh6HI=
-Previous-Ledger: q4aKbP7sd5wv+EXArwCmQiWZhq9AwBl2p/hCtpGJNsc=
+Closed-Ledger: 4F73F45E95343F7446F91B5F70E3AE4E155CCAA2B1CF2F267C99FD39C1C24178
+Previous-Ledger: F9D75AAB7D975BADC6D008C4AE94D9B7B6AA323EEE4B133F5B75CE92445C88ED
 ```
 
 ##### Example HTTP Upgrade Response (Success)
@@ -260,17 +261,31 @@ under the specified domain and locating the public key of this server under the
 Sending a malformed domain will prevent a connection from being established.
 
 
+| Field Name              |  Request          	| Response          	|
+|-------------------------|:-----------------:	|:-----------------:	|
+| `Session-EKM-Signature` | :heavy_check_mark: 	| :heavy_check_mark: 	|
+
+The `Session-EKM-Signature` field supersedes the `Session-Signature` field and is
+mandatory if `Session-Signature` is not present. It is used to secure the peer
+link against certain types of attack. For more details see the section titled
+"Session Security" below.
+
+The value is specified in **HEX** encoding.
+
+
 | Field Name          	|  Request          	| Response          	|
 |---------------------	|:-----------------:	|:-----------------:	|
 | `Session-Signature` 	| :heavy_check_mark: 	| :heavy_check_mark: 	|
 
-The `Session-Signature` field is mandatory and is used to secure the peer link
-against certain types of attack. For more details see "Session Signature" below.
+The `Session-Signature` field is a legacy field that has been superseded by the
+`Session-EKM-Signature` field. It will be removed in a future release of the
+software.
+
+It is used to secure the peer link against certain types of attack. For more
+details see the section titled "Session Signature" below.
 
 The value is presently encoded using **Base64** encoding, but implementations
 should support both **Base64** and **HEX** encoding for this value.
-
-For more details on this field, please see **Session Signature** below.
 
 
 | Field Name          	|  Request          	| Response          	|
@@ -298,7 +313,7 @@ considers to be closed.
 
 The value is encoded as **HEX**, but implementations should support both
 **Base64** and **HEX** encoding for this value for legacy purposes.
-    
+
 | Field Name          	|  Request          	| Response          	|
 |---------------------	|:-----------------:	|:-----------------:	|
 | `Previous-Ledger`   	| :white_check_mark: 	| :white_check_mark: 	|
@@ -306,8 +321,8 @@ The value is encoded as **HEX**, but implementations should support both
 If present, identifies the hash of the parent ledger that the sending server
 considers to be closed.
 
-The value is presently encoded using **Base64** encoding, but implementations
-should support both **Base64** and **HEX** encoding for this value.
+The field data should be encoded using **HEX**, but implementations should
+correctly interpret both **Base64** and **HEX** encodings.
 
 #### Additional Headers
 
@@ -318,16 +333,16 @@ Implementations should not reject requests because of the presence of fields
 that they do not understand.
 
 
-### Session Signature
+### Session Security
 
 Even for SSL/TLS encrypted connections, it is possible for an attacker to mount
 relatively inexpensive MITM attacks that can be extremely hard to detect and
 may afford the attacker the ability to intelligently tamper with messages
 exchanged between the two endpoints.
 
-This risk can be mitigated if at least one side has a certificate from a certificate
-authority trusted by the other endpoint, but having a certificate is not always
-possible (or even desirable) in a decentralized and permissionless network.
+This risk can be mitigated if at least one side has a certificate from a CA that
+is trusted by the other endpoint, but having a certificate is not always
+possible (or, indeed, desirable) in a decentralized and permissionless network.
 
 Ultimately, the goal is to ensure that two endpoints A and B know that they are
 talking directly to each other over a single end-to-end SSL/TLS session instead
@@ -335,18 +350,14 @@ of two separate SSL/TLS sessions, with an attacker acting as a proxy.
 
 The XRP Ledger protocol prevents this attack by leveraging the fact that the two
 servers each have a node identity, in the form of **`secp256k1`** keypairs, and
-use that to strongly bind the SSL/TLS session to the node identities of each of
-the two servers at the end of the SSL/TLS session.
+use that, along with a secure fingerprint associated with the SSL/TLS session to
+strongly bind the SSL/TLS session to the node identities of each of the servers
+at the end of the SSL/TLS session.
 
-To do this we "reach into" the SSL/TLS session, and extract the **`finished`**
-messages for the local and remote endpoints, and combine them to generate a unique
-"fingerprint". By design, this fingerprint should be the same for both SSL/TLS
-endpoints.
-
-That fingerprint, which is never shared over the wire (since each endpoint will
-calculate it independently), is then signed by each server using its public
-**`secp256k1`** node identity and the signature is transferred over the SSL/TLS
-encrypted link during the protocol handshake phase.
+The fingerprint is never shared over the wire (the two endpoints calculate it
+independently) and is signed by each server using its public **`secp256k1`**
+node identity. The resulting signature is transferred over the SSL/TLS session
+during the protocol handshake phase.
 
 Each side of the link will verify that the provided signature is from the claimed
 public key against the session's unique fingerprint. If this signature check fails
@@ -365,17 +376,12 @@ message stream between Alice and Bob, although she may be still be able to injec
 delays or terminate the link.
 
 
-# Ripple Clustering #
+# Clustering #
 
-A cluster consists of more than one Ripple server under common
-administration that share load information, distribute cryptography
-operations, and provide greater response consistency.
-
-Cluster nodes are identified by their public node keys. Cluster nodes
-exchange information about endpoints that are imposing load upon them.
-Cluster nodes share information about their internal load status.  Cluster
-nodes do not have to verify the cryptographic signatures on messages
-received from other cluster nodes.
+A cluster consists of several servers, typically under common administration,
+that are configured to work cooperatively by sharing server load information,
+details about shards, optimizing processing to avoid duplicating work that other
+cluster members have done, and more.
 
 ## Configuration ##
 
@@ -385,9 +391,9 @@ beginning with the letter `n`.  The key is maintained across runs in a
 database.
 
 Cluster members are configured in the `rippled.cfg` file under
-`[cluster_nodes]`.  Each member should be configured on a line beginning
-with the node public key, followed optionally by a space and a friendly
-name.
+`[cluster_nodes]`.  Each member should be configured on a separate line,
+beginning with its node public key, followed optionally by a space and a
+friendly name.
 
 Because cluster members can introduce other cluster members, it is not
 necessary to configure every cluster member on every other cluster member.
@@ -413,11 +419,11 @@ not relay a transaction with an incorrect signature.  Validators may wish to
 disable this feature, preferring the additional load to get the additional
 security of having validators check each transaction.
 
-Local checks for transaction checking are also bypassed. For example, a
-server will not reject a transaction from a cluster peer because the fee
-does not meet its current relay fee.  It is preferable to keep the cluster
-in agreement and permit confirmation from one cluster member to more
-reliably indicate the transaction's acceptance by the cluster.
+Several "local" checks are also bypassed. For example, a server will not reject
+a transaction from a cluster peer because the fee does not meet its current
+relay fee. It is preferable to keep the cluster in agreement and permit
+confirmation from one cluster member to more reliably indicate the transaction's
+acceptance by the cluster.
 
 ## Server Load Information ##
 

--- a/src/ripple/overlay/impl/Handshake.h
+++ b/src/ripple/overlay/impl/Handshake.h
@@ -48,6 +48,23 @@ using http_request_type =
 using http_response_type =
     boost::beast::http::response<boost::beast::http::dynamic_body>;
 
+/** Returns a value shared by the two endpoints of a TLS-secured connection.
+
+    This value is generated in a secure fashion and is never communicated over
+    the wire, even over an encrypted connection. Used properly, it can help to
+    detect and prevent preventing active MITM attacks.
+
+    @param ssl the SSL/TLS connection state.
+    @param instance a 64-bit cookie, used in computing the shared value.
+    @param outgoing true to return the "outgoing" value is needed; false for
+                    the "incoming" value.
+
+    @return On success, the 256-bit value this side believes both endpoints
+            share; an unseated optional otherwise.
+ */
+[[nodiscard]] std::optional<uint256>
+getSessionEKM(stream_type& ssl, std::uint64_t instance, bool outgoing);
+
 /** Computes a shared value based on the SSL connection state.
 
     When there is no man in the middle, both sides will compute the same
@@ -60,32 +77,60 @@ using http_response_type =
 std::optional<uint256>
 makeSharedValue(stream_type& ssl, beast::Journal journal);
 
-/** Insert fields headers necessary for upgrading the link to the peer protocol.
+/** Populate header fields needed when upgrading the link to the peer protocol.
+
+    Some of the fields are used in critical security checks that can prevent
+    active MITM attacks and ensure that the remote peer has the private keys
+    that correspond to the public identity it claims.
+
+    @param h the list of HTTP headers fields to send.
+    @param sharedValue a 256-bit value derived from the SSL session (legacy).
+    @param ekm a 256-bit value derived from the SSL session.
+    @param networkID the identifier of the network the server is configured for.
+    @param public_ip The server's public IP.
+    @param remote_ip The IP to which the server attempted to connect.
+    @param app The main application object.
+
+    @note The `sharedValue` parameter is deprecated and will be removed in a
+          future version of the code. It is replaced by `ekm` which is derived
+          in a more standardized function.
+
+          \sa makeSharedValue, getSessionEKM
  */
 void
 buildHandshake(
     boost::beast::http::fields& h,
     uint256 const& sharedValue,
+    uint256 const& ekm,
     std::optional<std::uint32_t> networkID,
     beast::IP::Address public_ip,
     beast::IP::Address remote_ip,
     Application& app);
 
-/** Validate header fields necessary for upgrading the link to the peer
-   protocol.
+/** Validate header fields needed when upgrading the link to the peer protocol.
 
-    This performs critical security checks that ensure that prevent
-    MITM attacks on our peer-to-peer links and that the remote peer
-    has the private keys that correspond to the public identity it
-    claims.
+    Some of the fields are used in critical security checks that can prevent
+    active MITM attacks and ensure that the remote peer has the private keys
+    that correspond to the public identity it claims.
 
-    @return The public key of the remote peer.
-    @throw A class derived from std::exception.
+    @param h the list of HTTP headers fields we received.
+    @param sharedValue a 256-bit value derived from the SSL session (legacy).
+    @param ekm a 256-bit value derived from the SSL session.
+    @param networkID the identifier of the network the server is configured for.
+    @param public_ip The server's public IP.
+    @param remote_ip The IP to which the server attempted to connect.
+    @param app The main application object.
+
+    @return The public key of the remote peer on success. An exception
+            otherwise.
+
+    @throw A class derived from std::exception, with an appropriate error message.
 */
-PublicKey
+[[nodiscard]] PublicKey
 verifyHandshake(
     boost::beast::http::fields const& headers,
     uint256 const& sharedValue,
+    uint256 const& ekm,
     std::optional<std::uint32_t> networkID,
     beast::IP::Address public_ip,
     beast::IP::Address remote,
@@ -117,6 +162,7 @@ makeRequest(
    @param public_ip server's public IP
    @param remote_ip peer's IP
    @param sharedValue shared value based on the SSL connection state
+   @param ekm shared value based on the SSL connection state
    @param networkID specifies what network we intend to connect to
    @param version supported protocol version
    @param app Application's reference to access some common properties
@@ -129,6 +175,7 @@ makeResponse(
     beast::IP::Address public_ip,
     beast::IP::Address remote_ip,
     uint256 const& sharedValue,
+    uint256 const& ekm,
     std::optional<std::uint32_t> networkID,
     ProtocolVersion version,
     Application& app);

--- a/src/ripple/overlay/impl/Handshake.h
+++ b/src/ripple/overlay/impl/Handshake.h
@@ -124,7 +124,8 @@ buildHandshake(
     @return The public key of the remote peer on success. An exception
             otherwise.
 
-    @throw A class derived from std::exception, with an appropriate error message.
+    @throw A class derived from std::exception, with an appropriate error
+           message.
 */
 [[nodiscard]] PublicKey
 verifyHandshake(

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -600,12 +600,10 @@ void
 PeerImp::fail(std::string const& reason)
 {
     if (!strand_.running_in_this_thread())
-        return post(
-            strand_,
-            std::bind(
-                (void(Peer::*)(std::string const&)) & PeerImp::fail,
-                shared_from_this(),
-                reason));
+        return post(strand_, [reason, self = shared_from_this()]() {
+            self->fail(reason);
+        });
+
     if (journal_.active(beast::severities::kWarning) && socket_.is_open())
     {
         std::string const n = name();

--- a/src/ripple/protocol/impl/SecretKey.cpp
+++ b/src/ripple/protocol/impl/SecretKey.cpp
@@ -251,26 +251,7 @@ sign(PublicKey const& pk, SecretKey const& sk, Slice const& m)
         case KeyType::secp256k1: {
             sha512_half_hasher h;
             h(m.data(), m.size());
-            auto const digest = sha512_half_hasher::result_type(h);
-
-            secp256k1_ecdsa_signature sig_imp;
-            if (secp256k1_ecdsa_sign(
-                    secp256k1Context(),
-                    &sig_imp,
-                    reinterpret_cast<unsigned char const*>(digest.data()),
-                    reinterpret_cast<unsigned char const*>(sk.data()),
-                    secp256k1_nonce_function_rfc6979,
-                    nullptr) != 1)
-                LogicError("sign: secp256k1_ecdsa_sign failed");
-
-            unsigned char sig[72];
-            size_t len = sizeof(sig);
-            if (secp256k1_ecdsa_signature_serialize_der(
-                    secp256k1Context(), sig, &len, &sig_imp) != 1)
-                LogicError(
-                    "sign: secp256k1_ecdsa_signature_serialize_der failed");
-
-            return Buffer{sig, len};
+            return signDigest(pk, sk, sha512_half_hasher::result_type(h));
         }
         default:
             LogicError("sign: invalid type");

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -1100,6 +1100,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
                 addr,
                 addr,
                 uint256{1},
+                uint256{1},
                 1,
                 {1, 0},
                 serverEnv.app());

--- a/src/test/overlay/compression_test.cpp
+++ b/src/test/overlay/compression_test.cpp
@@ -511,6 +511,7 @@ public:
                 addr,
                 addr,
                 uint256{1},
+                uint256{1},
                 1,
                 {1, 0},
                 env->app());

--- a/src/test/overlay/reduce_relay_test.cpp
+++ b/src/test/overlay/reduce_relay_test.cpp
@@ -1534,6 +1534,7 @@ vp_squelched=1
                     addr,
                     addr,
                     uint256{1},
+                    uint256{1},
                     1,
                     {1, 0},
                     env_.app());


### PR DESCRIPTION
Even with TLS encrypted connections, it is possible for a determined attacker to mount certain types of relatively easy man-in-the-middle attacks which, if successful, could allow an attacker to tamper with messages exchanged between endpoints.

The risk can be mitigated if each side has a certificate issued by a CA that the other side trusts. In the context of a decentralized and permissionless network, this is neither reasonable nor desirable.

To prevent this problem all we need is to allow the two endpoints, A and B, to be able to independently verify that they are connected to each other over a single end-to-end TLS session, instead of separate TLS sessions with the attacker bridges.

The protocol level handshake implements this security check by using digital signatures: each endpoint derives a fingerprint from the TLS session, which it signs with the private key associated with its own node identity. This strongly binds the TLS session to the identities of the two endpoints of the session.

This commit introduces a new fingerprint derivation that uses modern and standardized TLS exporter functionality, instead of the existing derivation whch uses OpenSSL APIs that are non-standard.

The change is backwards compatible and servers with this commit will still generate and verify old-style fingerprints, in addition to the new style fingerprints.

For a fuller discussion on this topic, please see:
    https://github.com/openssl/openssl/issues/5509
    https://github.com/ripple/rippled/issues/2413

This commit was previously introduced as #3929, which was closed. If merged, it also fixes #2413 (which had been closed as a 'WONTFIX').

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

## Test Plan

Running this against servers with and without this change and verifying that peer connections are established (e.g. by using the `peers` command) should be sufficient. Ideally, in addition to Linux, this should also be tested against servers running on the "compiles-on-but-it's-not supported" platforms: MacOS and Windows.

<!--
## Future Tasks
For future tasks related to PR.
-->