### PR TITLE
add `.build` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ bin/project-cache.jam
 # Ignore object files.
 *.o
 build
+.build
 .nih_c
 tags
 TAGS


### PR DESCRIPTION
## High Level Overview of Change

Updated the .gitignore file to include the `.build` directory that is referenced in the BUILD.md instructions for conan.

Without this github will attempt to commit the entire build folder which is not ideal.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release
