### PR TITLE
fix: Ledger data returns an empty list (instead of null) when all entries are filtered out

### DIFF
--- a/src/ripple/rpc/handlers/LedgerData.cpp
+++ b/src/ripple/rpc/handlers/LedgerData.cpp
@@ -94,6 +94,10 @@ doLedgerData(RPC::JsonContext& context)
         return jvResult;
     }
     Json::Value& nodes = jvResult[jss::state];
+    if (nodes.type() == Json::nullValue)
+    {
+        nodes = Json::Value(Json::arrayValue);
+    }
 
     auto e = lpLedger->sles.end();
     for (auto i = lpLedger->sles.upper_bound(key); i != e; ++i)

--- a/src/test/rpc/LedgerData_test.cpp
+++ b/src/test/rpc/LedgerData_test.cpp
@@ -314,6 +314,34 @@ public:
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);
 
+        auto makeRequest = [&env](Json::StaticString const& type) {
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = "current";
+            jvParams[jss::type] = type;
+            return env.rpc(
+                "json",
+                "ledger_data",
+                boost::lexical_cast<std::string>(jvParams))[jss::result];
+        };
+
+        // Assert that state is an empty array.
+        for (auto const& type :
+             {jss::amendments,
+              jss::check,
+              jss::directory,
+              jss::fee,
+              jss::offer,
+              jss::signer_list,
+              jss::state,
+              jss::ticket,
+              jss::escrow,
+              jss::payment_channel,
+              jss::deposit_preauth})
+        {
+            auto const jrr = makeRequest(type);
+            BEAST_EXPECT(checkArraySize(jrr[jss::state], 0));
+        }
+
         int const num_accounts = 10;
 
         for (auto i = 0; i < num_accounts; i++)
@@ -372,15 +400,6 @@ public:
         env.close();
 
         // Now fetch each type
-        auto makeRequest = [&env](Json::StaticString t) {
-            Json::Value jvParams;
-            jvParams[jss::ledger_index] = "current";
-            jvParams[jss::type] = t;
-            return env.rpc(
-                "json",
-                "ledger_data",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
-        };
 
         {  // jvParams[jss::type] = "account";
             auto const jrr = makeRequest(jss::account);


### PR DESCRIPTION
## High Level Overview of Change

This PR resolves [issue 4392](https://github.com/XRPLF/rippled/issues/4392). When the ```type``` field to the ```ledger_data``` method is specified, it is possible that no objects of the specified type are found. When this happens, the ```state``` field of the response has the value ```null``` instead of an empty array ([]).

### Context of Change

The PR initializes the ```state``` field of the response to an empty list so that the field is not a ```null```. This can break client code that explicitly checks for ```null```. However, this behavior is consistent with the documentation.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
