### PR TITLE
fixNFTokenBrokerAccept

### DIFF
--- a/src/ripple/app/tx/impl/NFTokenAcceptOffer.cpp
+++ b/src/ripple/app/tx/impl/NFTokenAcceptOffer.cpp
@@ -112,19 +112,19 @@ NFTokenAcceptOffer::preclaim(PreclaimContext const& ctx)
         if ((*so)[sfAmount] > (*bo)[sfAmount])
             return tecINSUFFICIENT_PAYMENT;
 
-        // If the buyer specified a destination, that destination must be
-        // the seller or the broker.
+        // If the buyer specified a destination
         if (auto const dest = bo->at(~sfDestination))
         {
-            if (*dest != so->at(sfOwner) && *dest != ctx.tx[sfAccount])
+            // that destination must be the tx account
+            if (*dest != ctx.tx[sfAccount])
                 return tecNFTOKEN_BUY_SELL_MISMATCH;
         }
 
-        // If the seller specified a destination, that destination must be
-        // the buyer or the broker.
+        // If the seller specified a destination
         if (auto const dest = so->at(~sfDestination))
         {
-            if (*dest != bo->at(sfOwner) && *dest != ctx.tx[sfAccount])
+            // that destination must be the tx account
+            if (*dest != ctx.tx[sfAccount])
                 return tecNFTOKEN_BUY_SELL_MISMATCH;
         }
 

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -74,7 +74,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 54;
+static constexpr std::size_t numFeatures = 55;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -341,6 +341,7 @@ extern uint256 const fixTrustLinesToSelf;
 extern uint256 const fixRemoveNFTokenAutoTrustLine;
 extern uint256 const featureImmediateOfferKilled;
 extern uint256 const featureDisallowIncoming;
+extern uint256 const fixNFTokenBrokerAccept;
 
 }  // namespace ripple
 


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

Currently with NFTs using broker mode if the sell offer contains a destination and that destination is the buyer account, anyone can broker the transaction.

It is also true that if a buy offer contains a destination and that destination is the seller account, anyone can broker the transaction.

Imo this is not ideal and is misleading to everyone.

The comments in the code are;

```
// If the buyer specified a destination, that destination must be
// the seller or the broker.
```

This is misleading because the broker is the account submitting the transaction. Its anyone. Again, if the buyer specified a destination and that destination is the seller, anyone can settle the tx. I don't think that makes sense. Why even have that? If anyone can settle the tx then there is no point in having this arithmetic I think.

I believe the point was; If you set a destination, that destination needs to be the person settling the transaction.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

The changes made now force the broker to be the destination if they want to settle. If the buyer is the destination, then the buyer must accept the sell offer, as you cannot broker your own offers.

If users want their offers open to the public then not setting a destination would be the recommended way. Inversely, if users want to limit who can settle the offers, then they would set a destination.

There is also a discussion issue [here](https://github.com/XRPLF/rippled/issues/4373):

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

## Test Plan

I also added a test function to show one of the more recent issues. There are 2 things tested. 

1. The broker cannot broker a destination offer to the buyer/seller and the buyer must accept the sell offer. (0 transfer)
2. If the broker is the destination, the broker will take the difference. (broker mode)

<!--
## Future Tasks
For future tasks related to PR.
-->
