### PR TITLE
Fix a case where ripple::Expected returned a json array, not a value

### DIFF
--- a/src/ripple/basics/Expected.h
+++ b/src/ripple/basics/Expected.h
@@ -137,14 +137,14 @@ class [[nodiscard]] Expected
 public:
     template <typename U>
     requires std::convertible_to<U, T> constexpr Expected(U && r)
-        : Base(T{std::forward<U>(r)})
+        : Base(T(std::forward<U>(r)))
     {
     }
 
     template <typename U>
         requires std::convertible_to<U, E> &&
         (!std::is_reference_v<U>)constexpr Expected(Unexpected<U> e)
-        : Base(E{std::move(e.value())})
+        : Base(E(std::move(e.value())))
     {
     }
 
@@ -220,7 +220,7 @@ public:
     template <typename U>
         requires std::convertible_to<U, E> &&
         (!std::is_reference_v<U>)constexpr Expected(Unexpected<U> e)
-        : Base(E{std::move(e.value())})
+        : Base(E(std::move(e.value())))
     {
     }
 

--- a/src/test/basics/Expected_test.cpp
+++ b/src/test/basics/Expected_test.cpp
@@ -20,6 +20,9 @@
 #include <ripple/basics/Expected.h>
 #include <ripple/beast/unit_test.h>
 #include <ripple/protocol/TER.h>
+#if BOOST_VERSION >= 107500
+#include <boost/json.hpp>  // Not part of boost before version 1.75
+#endif                     // BOOST_VERSION
 #include <array>
 #include <cstdint>
 
@@ -203,6 +206,16 @@ struct Expected_test : beast::unit_test::suite
             std::string const s(std::move(expected.error()));
             BEAST_EXPECT(s == "Not what is expected!");
         }
+        // Test a case that previously unintentionally returned an array.
+#if BOOST_VERSION >= 107500
+        {
+            auto expected = []() -> Expected<boost::json::value, std::string> {
+                return boost::json::object{{"oops", "me array now"}};
+            }();
+            BEAST_EXPECT(expected);
+            BEAST_EXPECT(!expected.value().is_array());
+        }
+#endif  // BOOST_VERSION
     }
 };
 


### PR DESCRIPTION
## High Level Overview of Change

@godexsoft reported a problem with the `ripple::Expected` implementation and provided a proposed fix.  The problem is that there are conditions where `Expected` invokes the wrong constructor for the expected type.  A constructor that takes multiple arguments might be interpreted as an array.

The proposed fix was a minor adjustment to three constructors that replaces the use of curly braces with parens.

A unit test also came along for the ride.

This pull request incorporates the suggested fix and the unit test into the rippled code base.

### Context of Change

Clio is using `ripple::Expected` and had a problem.  This change makes `Expected` useable for Clio.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
