### PR TITLE
Add RPC/WS ports to server_info

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -602,6 +602,13 @@ public:
         return *m_networkOPs;
     }
 
+    virtual ServerHandlerImp&
+    getServerHandler() override
+    {
+        assert(serverHandler_);
+        return *serverHandler_;
+    }
+
     boost::asio::io_service&
     getIOService() override
     {

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -89,6 +89,7 @@ class Overlay;
 class PathRequests;
 class PendingSaves;
 class PublicKey;
+class ServerHandlerImp;
 class SecretKey;
 class STLedgerEntry;
 class TimeKeeper;
@@ -231,6 +232,8 @@ public:
     getOPs() = 0;
     virtual OrderBookDB&
     getOrderBookDB() = 0;
+    virtual ServerHandlerImp&
+    getServerHandler() = 0;
     virtual TransactionMaster&
     getMasterTransaction() = 0;
     virtual perf::PerfLog&

--- a/src/ripple/app/main/GRPCServer.cpp
+++ b/src/ripple/app/main/GRPCServer.cpp
@@ -429,7 +429,7 @@ GRPCServerImpl::GRPCServerImpl(Application& app)
     // if present, get endpoint from config
     if (app_.config().exists("port_grpc"))
     {
-        Section section = app_.config().section("port_grpc");
+        const auto& section = app_.config().section("port_grpc");
 
         auto const optIp = section.get("ip");
         if (!optIp)

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -65,6 +65,7 @@
 #include <ripple/rpc/BookChanges.h>
 #include <ripple/rpc/DeliveredAmount.h>
 #include <ripple/rpc/impl/RPCHelpers.h>
+#include <ripple/rpc/impl/ServerHandlerImp.h>
 #include <boost/asio/ip/host_name.hpp>
 #include <boost/asio/steady_timer.hpp>
 
@@ -2659,6 +2660,38 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
     else
     {
         info["reporting"] = app_.getReportingETL().getInfo();
+    }
+
+    // This array must be sorted in increasing order.
+    static constexpr std::array<std::string_view, 6> protocols{
+        "http", "https", "ws", "ws2", "wss", "wss2"};
+    {
+        Json::Value ports{Json::arrayValue};
+        std::vector<std::string> proto;
+        for (auto const& port : app_.getServerHandler().setup().ports)
+        {
+            // Don't publish admin ports for non-admin users
+            if (!admin &&
+                !(port.admin_nets_v4.empty() && port.admin_nets_v6.empty() &&
+                  port.admin_user.empty() && port.admin_password.empty()))
+                continue;
+            proto.clear();
+            std::set_intersection(
+                std::begin(port.protocol),
+                std::end(port.protocol),
+                std::begin(protocols),
+                std::end(protocols),
+                std::back_inserter(proto));
+            if (!proto.empty())
+            {
+                auto& jv = ports.append(Json::Value(Json::objectValue));
+                jv[jss::port] = std::to_string(port.port);
+                jv[jss::protocol] = Json::Value{Json::arrayValue};
+                for (auto const& p : proto)
+                    jv[jss::protocol].append(p);
+            }
+        }
+        info[jss::ports] = std::move(ports);
     }
 
     return info;

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2669,7 +2669,6 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
     static_assert(std::is_sorted(std::begin(protocols), std::end(protocols)));
     {
         Json::Value ports{Json::arrayValue};
-        std::vector<std::string> proto;
         for (auto const& port : app_.getServerHandler().setup().ports)
         {
             // Don't publish admin ports for non-admin users
@@ -2677,7 +2676,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
                 !(port.admin_nets_v4.empty() && port.admin_nets_v6.empty() &&
                   port.admin_user.empty() && port.admin_password.empty()))
                 continue;
-            proto.clear();
+            std::vector<std::string> proto;
             std::set_intersection(
                 std::begin(port.protocol),
                 std::end(port.protocol),
@@ -2703,7 +2702,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
                 auto& jv = ports.append(Json::Value(Json::objectValue));
                 jv[jss::port] = *optPort;
                 jv[jss::protocol] = Json::Value{Json::arrayValue};
-                jv[jss::protocol].append("port_grpc");
+                jv[jss::protocol].append("grpc");
             }
         }
         info[jss::ports] = std::move(ports);

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -459,13 +459,14 @@ JSS(peers);                       // out: InboundLedger, handlers/Peers, Overlay
 JSS(peer_disconnects);            // Severed peer connection counter.
 JSS(peer_disconnects_resources);  // Severed peer connections because of
                                   // excess resource consumption.
-JSS(port);                        // in: Connect
+JSS(port);                        // in: Connect, out: NetworkOPs
+JSS(ports);                       // out: NetworkOPs
 JSS(previous);                    // out: Reservations
 JSS(previous_ledger);             // out: LedgerPropose
 JSS(proof);                       // in: BookOffers
 JSS(propose_seq);                 // out: LedgerPropose
 JSS(proposers);                   // out: NetworkOPs, LedgerConsensus
-JSS(protocol);                    // out: PeerImp
+JSS(protocol);                    // out: NetworkOPs, PeerImp
 JSS(proxied);                     // out: RPC ping
 JSS(pubkey_node);                 // out: NetworkOPs
 JSS(pubkey_publisher);            // out: ValidatorList


### PR DESCRIPTION
## High Level Overview of Change

This PR resolves #2837. It adds info about WebSocket/RPC port(s) of the local `rippled`server to the response of `server_info`. The function processing requests to the /crawl endpoint actually calls `server_info` internally. Hence, this PR enables a `rippled` server to advertise info about its WebSocket/RPC port(s) to its peers via the endpoint /crawl. This allows the peers to build a richer topology instead of port-scanning all reachable nodes. For non-admin users (which is true for peers), the extended `server_info` method does not advertise info about admin RPC/WS poirts.

### Context of Change

The response of `server_info` includes a new array `ports`. Each array element contains a value `port` for the listening port and an array `protocols` for the supported protocol(s). The array `protocol` is sorted in increasing order.

```
./rippled server_info

2023-Feb-20 17:20:22.585574554 UTC HTTPClient:NFO Connecting to 127.0.0.1:5005
{
   "result" : {
      "info" : {
         "build_version" : "1.10.0-rc1"
         ...
         "ports" : [
            {
               "port" : "5005",
               "protocol" : [ "http", "ws2" ]
            },
            {
               "port" : "51235",
               "protocol" : [ "peer" ]
            },
            {
               "port" : "6006",
               "protocol" : [ "ws" ]
            },
            {
               "port" : "50051",
               "protocol" : [ "port_grpc" ]
            }
         ],
         ...
      },
      "status" : "success"
   }
}
```

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Needs Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
