### PR TITLE
Undo API changes introduced in XRPFees:

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2184,16 +2184,15 @@ NetworkOPsImp::pubValidation(std::shared_ptr<STValidation> const& val)
         //  simplifies later operations)
         if (auto const baseFeeXRP = ~val->at(~sfBaseFeeDrops);
             baseFeeXRP && baseFeeXRP->native())
-            jvObj[jss::base_fee_drops] = baseFeeXRP->xrp().jsonClipped();
+            jvObj[jss::base_fee] = baseFeeXRP->xrp().jsonClipped();
 
         if (auto const reserveBaseXRP = ~val->at(~sfReserveBaseDrops);
             reserveBaseXRP && reserveBaseXRP->native())
-            jvObj[jss::reserve_base_drops] =
-                reserveBaseXRP->xrp().jsonClipped();
+            jvObj[jss::reserve_base] = reserveBaseXRP->xrp().jsonClipped();
 
         if (auto const reserveIncXRP = ~val->at(~sfReserveIncrementDrops);
             reserveIncXRP && reserveIncXRP->native())
-            jvObj[jss::reserve_inc_drops] = reserveIncXRP->xrp().jsonClipped();
+            jvObj[jss::reserve_inc] = reserveIncXRP->xrp().jsonClipped();
 
         for (auto i = mStreamMaps[sValidations].begin();
              i != mStreamMaps[sValidations].end();)

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -151,7 +151,6 @@ JSS(balance);                // out: AccountLines
 JSS(balances);               // out: GatewayBalances
 JSS(base);                   // out: LogLevel
 JSS(base_fee);               // out: NetworkOPs
-JSS(base_fee_drops);         // out: NetworkOPs
 JSS(base_fee_xrp);           // out: NetworkOPs
 JSS(bids);                   // out: Subscribe
 JSS(binary);                 // in: AccountTX, LedgerEntry,
@@ -496,10 +495,8 @@ JSS(request);               // RPC
 JSS(requested);             // out: Manifest
 JSS(reservations);          // out: Reservations
 JSS(reserve_base);          // out: NetworkOPs
-JSS(reserve_base_drops);    // out: NetworkOPs
 JSS(reserve_base_xrp);      // out: NetworkOPs
 JSS(reserve_inc);           // out: NetworkOPs
-JSS(reserve_inc_drops);     // out: NetworkOPs
 JSS(reserve_inc_xrp);       // out: NetworkOPs
 JSS(response);              // websocket
 JSS(result);                // RPC

--- a/src/test/rpc/Subscribe_test.cpp
+++ b/src/test/rpc/Subscribe_test.cpp
@@ -412,24 +412,10 @@ public:
                     return false;
 
                 bool xrpFees = env.closed()->rules().enabled(featureXRPFees);
-                if ((!xrpFees &&
-                     jv.isMember(jss::reserve_base) != isFlagLedger) ||
-                    (xrpFees && jv.isMember(jss::reserve_base)))
+                if (jv.isMember(jss::reserve_base) != isFlagLedger)
                     return false;
 
-                if ((!xrpFees &&
-                     jv.isMember(jss::reserve_inc) != isFlagLedger) ||
-                    (xrpFees && jv.isMember(jss::reserve_inc)))
-                    return false;
-
-                if ((xrpFees &&
-                     jv.isMember(jss::reserve_base_drops) != isFlagLedger) ||
-                    (!xrpFees && jv.isMember(jss::reserve_base_drops)))
-                    return false;
-
-                if ((xrpFees &&
-                     jv.isMember(jss::reserve_inc_drops) != isFlagLedger) ||
-                    (!xrpFees && jv.isMember(jss::reserve_inc_drops)))
+                if (jv.isMember(jss::reserve_inc) != isFlagLedger)
                     return false;
 
                 return true;


### PR DESCRIPTION
## High Level Overview of Change

#4247 made some unnecessary breaking changes to the API for the validation subscription stream. This PR reverts those changes.

* Original changes: https://github.com/XRPLF/rippled/commit/e4b17d1cf2c43e33128dd70b6036fe10f38b0c0d
* Resolves #4425

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)