### PR TITLE
Fix Conan version constraint in workflows

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -44,7 +44,7 @@ jobs:
             path: ${{ steps.pip-cache.outputs.dir }}
             key: ${{ runner.os }}-${{ hashFiles('.github/workflows/nix.yml') }}
       - name: install Conan
-        run: pip install wheel 'conan>=1.52.0'
+        run: pip install wheel 'conan~=1.52'
       - name: check environment
         run: |
           echo ${PATH} | tr ':' '\n'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,7 @@ jobs:
             path: ${{ steps.pip-cache.outputs.dir }}
             key: ${{ runner.os }}-${{ hashFiles('.github/workflows/windows.yml') }}
       - name: install Conan
-        run: pip install wheel 'conan>=1.52.0'
+        run: pip install wheel 'conan~=1.52'
       - name: check environment
         run: |
           $env:PATH -split ';'


### PR DESCRIPTION
Conan 2.0 was released today and is not compatible with our workflows. 