### PR TITLE
Revert "Improve detection & handling of duplicate Node ID:"

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -86,11 +86,9 @@ RCLConsensus::Adaptor::Adaptor(
     , inboundTransactions_{inboundTransactions}
     , j_(journal)
     , validatorKeys_(validatorKeys)
-    , valCookie_(
-          1 +
-          rand_int(
-              crypto_prng(),
-              std::numeric_limits<std::uint64_t>::max() - 1))
+    , valCookie_{rand_int<std::uint64_t>(
+          1,
+          std::numeric_limits<std::uint64_t>::max())}
     , nUnlVote_(validatorKeys_.nodeID, j_)
 {
     assert(valCookie_ != 0);

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -28,7 +28,6 @@
 #include <ripple/shamap/FullBelowCache.h>
 #include <ripple/shamap/TreeNodeCache.h>
 #include <boost/asio.hpp>
-#include <boost/program_options.hpp>
 #include <memory>
 #include <mutex>
 
@@ -136,14 +135,13 @@ public:
     virtual ~Application() = default;
 
     virtual bool
-    setup(boost::program_options::variables_map const& options) = 0;
-
+    setup() = 0;
     virtual void
     start(bool withTimers) = 0;
     virtual void
     run() = 0;
     virtual void
-    signalStop(std::string msg = "") = 0;
+    signalStop() = 0;
     virtual bool
     checkSigs() const = 0;
     virtual void
@@ -154,10 +152,6 @@ public:
     //
     // ---
     //
-
-    /** Returns a 64-bit instance identifier, generated at startup */
-    virtual std::uint64_t
-    instanceID() const = 0;
 
     virtual Logs&
     logs() = 0;

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -372,10 +372,6 @@ run(int argc, char** argv)
         "conf", po::value<std::string>(), "Specify the configuration file.")(
         "debug", "Enable normally suppressed debug logging")(
         "help,h", "Display this message.")(
-        "newnodeid", "Generate a new node identity for this server.")(
-        "nodeid",
-        po::value<std::string>(),
-        "Specify the node identity for this server.")(
         "quorum",
         po::value<std::size_t>(),
         "Override the minimum validation quorum.")(
@@ -760,7 +756,7 @@ run(int argc, char** argv)
         auto app = make_Application(
             std::move(config), std::move(logs), std::move(timeKeeper));
 
-        if (!app->setup(vm))
+        if (!app->setup())
             return -1;
 
         // With our configuration parsed, ensure we have

--- a/src/ripple/app/main/NodeIdentity.cpp
+++ b/src/ripple/app/main/NodeIdentity.cpp
@@ -20,38 +20,27 @@
 #include <ripple/app/main/Application.h>
 #include <ripple/app/main/NodeIdentity.h>
 #include <ripple/app/rdb/Wallet.h>
+#include <ripple/basics/Log.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>
+#include <boost/format.hpp>
 #include <boost/optional.hpp>
 
 namespace ripple {
 
 std::pair<PublicKey, SecretKey>
-getNodeIdentity(
-    Application& app,
-    boost::program_options::variables_map const& cmdline)
+getNodeIdentity(Application& app)
 {
-    std::optional<Seed> seed;
-
-    if (cmdline.count("nodeid"))
+    // If a seed is specified in the configuration file use that directly.
+    if (app.config().exists(SECTION_NODE_SEED))
     {
-        seed = parseGenericSeed(cmdline["nodeid"].as<std::string>(), false);
-
-        if (!seed)
-            Throw<std::runtime_error>("Invalid 'nodeid' in command line");
-    }
-    else if (app.config().exists(SECTION_NODE_SEED))
-    {
-        seed = parseBase58<Seed>(
+        auto const seed = parseBase58<Seed>(
             app.config().section(SECTION_NODE_SEED).lines().front());
 
         if (!seed)
-            Throw<std::runtime_error>("Invalid [" SECTION_NODE_SEED
-                                      "] in configuration file");
-    }
+            Throw<std::runtime_error>("NodeIdentity: Bad [" SECTION_NODE_SEED
+                                      "] specified");
 
-    if (seed)
-    {
         auto secretKey = generateSecretKey(KeyType::secp256k1, *seed);
         auto publicKey = derivePublicKey(KeyType::secp256k1, secretKey);
 
@@ -59,10 +48,6 @@ getNodeIdentity(
     }
 
     auto db = app.getWalletDB().checkoutDb();
-
-    if (cmdline.count("newnodeid") != 0)
-        clearNodeIdentity(*db);
-
     return getNodeIdentity(*db);
 }
 

--- a/src/ripple/app/main/NodeIdentity.h
+++ b/src/ripple/app/main/NodeIdentity.h
@@ -23,20 +23,13 @@
 #include <ripple/app/main/Application.h>
 #include <ripple/protocol/PublicKey.h>
 #include <ripple/protocol/SecretKey.h>
-#include <boost/program_options.hpp>
 #include <utility>
 
 namespace ripple {
 
-/** The cryptographic credentials identifying this server instance.
-
-    @param app The application object
-    @param cmdline The command line parameters passed into the application.
- */
+/** The cryptographic credentials identifying this server instance. */
 std::pair<PublicKey, SecretKey>
-getNodeIdentity(
-    Application& app,
-    boost::program_options::variables_map const& cmdline);
+getNodeIdentity(Application& app);
 
 }  // namespace ripple
 

--- a/src/ripple/app/rdb/Wallet.h
+++ b/src/ripple/app/rdb/Wallet.h
@@ -87,19 +87,10 @@ saveManifests(
 void
 addValidatorManifest(soci::session& session, std::string const& serialized);
 
-/** Delete any saved public/private key associated with this node. */
-void
-clearNodeIdentity(soci::session& session);
-
-/** Returns a stable public and private key for this node.
-
-    The node's public identity is defined by a secp256k1 keypair
-    that is (normally) randomly generated. This function will
-    return such a keypair, securely generating one if needed.
-
-    @param session Session with the database.
-
-    @return Pair of public and private secp256k1 keys.
+/**
+ * @brief getNodeIdentity Returns the public and private keys of this node.
+ * @param session Session with the database.
+ * @return Pair of public and private keys.
  */
 std::pair<PublicKey, SecretKey>
 getNodeIdentity(soci::session& session);

--- a/src/ripple/app/rdb/impl/Wallet.cpp
+++ b/src/ripple/app/rdb/impl/Wallet.cpp
@@ -119,12 +119,6 @@ addValidatorManifest(soci::session& session, std::string const& serialized)
     tr.commit();
 }
 
-void
-clearNodeIdentity(soci::session& session)
-{
-    session << "DELETE FROM NodeIdentity;";
-}
-
 std::pair<PublicKey, SecretKey>
 getNodeIdentity(soci::session& session)
 {

--- a/src/ripple/overlay/README.md
+++ b/src/ripple/overlay/README.md
@@ -296,8 +296,8 @@ For more on the Peer Crawler, please visit https://xrpl.org/peer-crawler.html.
 If present, identifies the hash of the last ledger that the sending server
 considers to be closed.
 
-The value is encoded as **HEX**, but implementations should support both
-**Base64** and **HEX** encoding for this value for legacy purposes.
+The value is presently encoded using **Base64** encoding, but implementations
+should support both **Base64** and **HEX** encoding for this value.
     
 | Field Name          	|  Request          	| Response          	|
 |---------------------	|:-----------------:	|:-----------------:	|

--- a/src/ripple/overlay/impl/ProtocolVersion.cpp
+++ b/src/ripple/overlay/impl/ProtocolVersion.cpp
@@ -36,6 +36,7 @@ namespace ripple {
 // clang-format off
 constexpr ProtocolVersion const supportedProtocolList[]
 {
+    {2, 0},
     {2, 1},
     {2, 2}
 };

--- a/src/ripple/protocol/Seed.h
+++ b/src/ripple/protocol/Seed.h
@@ -116,13 +116,9 @@ template <>
 std::optional<Seed>
 parseBase58(std::string const& s);
 
-/** Attempt to parse a string as a seed.
-
-    @param str the string to parse
-    @param rfc1751 true if we should attempt RFC1751 style parsing (deprecated)
- * */
+/** Attempt to parse a string as a seed */
 std::optional<Seed>
-parseGenericSeed(std::string const& str, bool rfc1751 = true);
+parseGenericSeed(std::string const& str);
 
 /** Encode a Seed in RFC1751 format */
 std::string

--- a/src/ripple/protocol/impl/Seed.cpp
+++ b/src/ripple/protocol/impl/Seed.cpp
@@ -87,7 +87,7 @@ parseBase58(std::string const& s)
 }
 
 std::optional<Seed>
-parseGenericSeed(std::string const& str, bool rfc1751)
+parseGenericSeed(std::string const& str)
 {
     if (str.empty())
         return std::nullopt;
@@ -111,7 +111,6 @@ parseGenericSeed(std::string const& str, bool rfc1751)
     if (auto seed = parseBase58<Seed>(str))
         return seed;
 
-    if (rfc1751)
     {
         std::string key;
         if (RFC1751::getKeyFromEnglish(key, str) == 1)

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -83,7 +83,7 @@ Env::AppBundle::AppBundle(
         std::move(config), std::move(logs), std::move(timeKeeper_));
     app = owned.get();
     app->logs().threshold(thresh);
-    if (!app->setup({}))
+    if (!app->setup())
         Throw<std::runtime_error>("Env::AppBundle: setup failed");
     timeKeeper->set(app->getLedgerMaster().getClosedLedger()->info().closeTime);
     app->start(false /*don't start timers*/);

--- a/src/test/overlay/ProtocolVersion_test.cpp
+++ b/src/test/overlay/ProtocolVersion_test.cpp
@@ -25,21 +25,22 @@ namespace ripple {
 class ProtocolVersion_test : public beast::unit_test::suite
 {
 private:
+    template <class FwdIt>
+    static std::string
+    join(FwdIt first, FwdIt last, char const* sep = ",")
+    {
+        std::string result;
+        if (first == last)
+            return result;
+        result = to_string(*first++);
+        while (first != last)
+            result += sep + to_string(*first++);
+        return result;
+    }
+
     void
     check(std::string const& s, std::string const& answer)
     {
-        auto join = [](auto first, auto last) {
-            std::string result;
-            if (first != last)
-            {
-                result = to_string(*first++);
-
-                while (first != last)
-                    result += "," + to_string(*first++);
-            }
-            return result;
-        };
-
         auto const result = parseProtocolVersions(s);
         BEAST_EXPECT(join(result.begin(), result.end()) == answer);
     }
@@ -59,21 +60,20 @@ public:
 
             // Empty string
             check("", "");
-
-            // clang-format off
             check(
-                "RTXP/1.1,RTXP/1.2,RTXP/1.3,XRPL/2.1,XRPL/2.0,/XRPL/3.0",
+                "RTXP/1.1,RTXP/1.2,RTXP/1.3,XRPL/2.1,XRPL/2.0",
                 "XRPL/2.0,XRPL/2.1");
             check(
-                "RTXP/0.9,RTXP/1.01,XRPL/0.3,XRPL/2.01,websocket",
+                "RTXP/0.9,RTXP/1.01,XRPL/0.3,XRPL/2.01,XRPL/19.04,Oscar/"
+                "123,NIKB",
                 "");
             check(
-                "XRPL/2.0,XRPL/2.0,XRPL/19.4,XRPL/7.89,XRPL/XRPL/3.0,XRPL/2.01",
+                "XRPL/2.0,RTXP/1.2,XRPL/2.0,XRPL/19.4,XRPL/7.89,XRPL/"
+                "A.1,XRPL/2.01",
                 "XRPL/2.0,XRPL/7.89,XRPL/19.4");
             check(
                 "XRPL/2.0,XRPL/3.0,XRPL/4,XRPL/,XRPL,OPT XRPL/2.2,XRPL/5.67",
                 "XRPL/2.0,XRPL/3.0,XRPL/5.67");
-            // clang-format on
         }
 
         {
@@ -81,14 +81,13 @@ public:
 
             BEAST_EXPECT(negotiateProtocolVersion("RTXP/1.2") == std::nullopt);
             BEAST_EXPECT(
-                negotiateProtocolVersion("RTXP/1.2, XRPL/2.0, XRPL/2.1") ==
-                make_protocol(2, 1));
+                negotiateProtocolVersion("RTXP/1.2, XRPL/2.0") ==
+                make_protocol(2, 0));
             BEAST_EXPECT(
-                negotiateProtocolVersion("XRPL/2.2") == make_protocol(2, 2));
+                negotiateProtocolVersion("XRPL/2.0") == make_protocol(2, 0));
             BEAST_EXPECT(
-                negotiateProtocolVersion(
-                    "RTXP/1.2, XRPL/2.2, XRPL/2.3, XRPL/999.999") ==
-                make_protocol(2, 2));
+                negotiateProtocolVersion("RTXP/1.2, XRPL/2.0, XRPL/999.999") ==
+                make_protocol(2, 0));
             BEAST_EXPECT(
                 negotiateProtocolVersion("XRPL/999.999, WebSocket/1.0") ==
                 std::nullopt);


### PR DESCRIPTION
## High Level Overview of Change

This reverts commit 5a15229eeb13b69c8adf1f653b88a8f8b9480546, which was introduced in 1.10.0-b1 and is not present in the code that is currently running in production (version 1.9.4).

Notice that this PR, #4439, is a "smaller" change than #4438 from the perspective of what node operators will be getting when they upgrade from 1.9.4.


### Context of Change

Alternative to #4438.

Given that 1.9.4 is stable and not vulnerable, the safest and most conservative change would be no change at all.

Therefore, we should consider the option of simply reverting the problematic commit, which is what this does. While `git` did not report any conflicts, the revert should still be code reviewed to ensure no unintended consequences.

Only one of {self, #4438} should be merged, a decision ideally based on a consensus of the maintainers.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

## Test Plan

@manojsdoshi @sgramkumar to prepare a test plan.

<!--
## Future Tasks
For future tasks related to PR.
-->


<hr>

```
Acknowledgements:
Aaron Hook for responsibly disclosing this issue.

Bug Bounties and Responsible Disclosures:
We welcome reviews of the rippled code and urge researchers to
responsibly disclose any issues they may find.

To report a bug, please send a detailed report to:

    bugs@xrpl.org
```