### PR TITLE
Allow redirect for browser connections

### DIFF
--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -295,6 +295,9 @@ public:
     // First, attempt to load the latest ledger directly from disk.
     bool FAST_LOAD = false;
 
+    // Redirect location for HTTPS requests
+    std::string BROWSER_REDIRECT;
+
 public:
     Config();
 

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -100,6 +100,7 @@ struct ConfigSection
 #define SECTION_BETA_RPC_API "beta_rpc_api"
 #define SECTION_SWEEP_INTERVAL "sweep_interval"
 #define SECTION_NETWORK_ID "network_id"
+#define SECTION_BROWSER_REDIRECT "browser_redirect"
 
 }  // namespace ripple
 

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -754,6 +754,33 @@ Config::loadFromString(std::string const& fileContents)
         SERVER_DOMAIN = strTemp;
     }
 
+    if (getSingleSection(secConfig, SECTION_BROWSER_REDIRECT, strTemp, j_))
+    {
+        parsedURL url;
+
+        if (!parseUrl(url, strTemp))
+            Throw<std::runtime_error>(
+                "Invalid " SECTION_BROWSER_REDIRECT
+                ": Must specify valid http or https URL.");
+
+        if (auto const scheme = boost::algorithm::to_lower_copy(url.scheme);
+            scheme != "http" && scheme != "https")
+            Throw<std::runtime_error>(
+                "Invalid " SECTION_BROWSER_REDIRECT
+                ": Must specify valid http or https URL.");
+
+        if (!url.username.empty() || !url.password.empty())
+            Throw<std::runtime_error>(
+                "Invalid " SECTION_BROWSER_REDIRECT
+                ": URL must not have the username or the password.");
+
+        if (url.domain.empty())
+            Throw<std::runtime_error>("Invalid " SECTION_BROWSER_REDIRECT
+                                      ": URL must have domain.");
+
+        BROWSER_REDIRECT = strTemp;
+    }
+
     if (exists(SECTION_OVERLAY))
     {
         auto const sec = section(SECTION_OVERLAY);


### PR DESCRIPTION
The peer port accepts HTTP connections but if someone connects with browser they seen only "Forbiden" message. A config option allows administrator to redirect to a webpage.

For example the servers of an exchange could load the exchange page or some other status page.

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation Updates

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
