### PR TITLE
Make it easy for projects to depend on libxrpl

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -13,6 +13,10 @@ if (unity)
   set_target_properties(xrpl_core PROPERTIES UNITY_BUILD ON)
 endif ()
 
+add_library(libxrpl INTERFACE)
+target_link_libraries(libxrpl INTERFACE xrpl_core)
+add_library(xrpl::libxrpl ALIAS libxrpl)
+
 
 #[===============================[
     beast/legacy FILES:

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile
+from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 import re
 
@@ -108,7 +108,9 @@ class Xrpl(ConanFile):
         if self.options.rocksdb:
             self.requires('rocksdb/6.27.3')
 
-    exports_sources = 'CMakeLists.txt', 'Builds/CMake/*', 'src/*', 'cfg/*'
+    exports_sources = (
+        'CMakeLists.txt', 'Builds/*', 'bin/getRippledInfo', 'src/*', 'cfg/*'
+    )
 
     def layout(self):
         cmake_layout(self)
@@ -142,8 +144,11 @@ class Xrpl(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = [
+        libxrpl = self.cpp_info.components['libxrpl']
+        libxrpl.libs = [
             'libxrpl_core.a',
-            'libed25519-donna.a',
+            'libed25519.a',
             'libsecp256k1.a',
         ]
+        libxrpl.includedirs = ['include']
+        libxrpl.requires = ['boost::boost']

--- a/docs/build/depend.md
+++ b/docs/build/depend.md
@@ -1,0 +1,98 @@
+We recommend two different methods to depend on libxrpl in your own [CMake][]
+project.
+Both methods add a CMake library target named `xrpl::libxrpl`.
+
+
+## Conan requirement 
+
+The first method adds libxrpl as a [Conan][] requirement.
+With this method, there is no need for a Git [submodule][].
+It is good for when you just need a dependency on libxrpl as-is.
+
+```
+# This conanfile.txt is just an example.
+[requires]
+xrpl/1.10.0
+
+[generators]
+CMakeDeps
+CMakeToolchain
+```
+
+```
+# If you want to depend on a version of libxrpl that is not in ConanCenter,
+# then you can export the recipe from the rippled project.
+conan export <path>
+```
+
+```cmake
+# Find and link the library in your CMake project.
+find_package(xrpl)
+target_link_libraries(<target> PUBLIC xrpl::libxrpl)
+```
+
+```
+# Download, build, and connect dependencies with Conan.
+mkdir .build
+cd .build
+mkdir -p build/generators
+conan install \
+  --install-folder build/generators \
+  --build missing \
+  --settings build_type=Release \
+  ..
+cmake \
+  -DCMAKE_TOOLCHAIN_FILE=build/generators/conan_toolchain.cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  ..
+cmake --build . --parallel
+```
+
+
+## CMake subdirectory
+
+The second method adds the [rippled][] project as a CMake
+[subdirectory][add_subdirectory].
+This method works well when you keep the rippled project as a Git
+[submodule][].
+It's good for when you want to make changes to libxrpl as part of your own
+project.
+Be careful, though.
+Your project will inherit all of the same CMake options,
+so watch out for name collisions.
+We still recommend using [Conan][] to download, build, and connect dependencies.
+
+```
+# Add the project as a Git submodule.
+mkdir submodules
+git submodule add https://github.com/XRPLF/rippled.git submodules/rippled
+```
+
+```cmake
+# Add and link the library in your CMake project.
+add_subdirectory(submodules/rippled)
+target_link_libraries(<target> PUBLIC xrpl::libxrpl)
+```
+
+```
+# Download, build, and connect dependencies with Conan.
+mkdir .build
+cd .build
+conan install \
+  --output-folder . \
+  --build missing \
+  --settings build_type=Release \
+  ../submodules/rippled
+cmake \
+  -DCMAKE_TOOLCHAIN_FILE=build/generators/conan_toolchain.cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  ..
+cmake --build . --parallel
+```
+
+
+[add_subdirectory]: https://cmake.org/cmake/help/latest/command/add_subdirectory.html
+[submodule]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
+[rippled]: https://github.com/ripple/rippled
+[Conan]: https://docs.conan.io/
+[CMake]: https://cmake.org/cmake/help/latest/


### PR DESCRIPTION
This changeset does a few things:

- Adds an `ALIAS` target named `xrpl::libxrpl` for projects to link.
  - I chose this name for a few reasons. The current library target is named `xrpl_core`. There is no other "non-core" library target against which we need to distinguish the "core" library. We only export one library target, and it should just be named after the project to keep things simple and predictable. (I think underscores in target or library names are generally discouraged anyway.) Every target exported in CMake should be prefixed with the project name. The project should not be named after the company Ripple. I think most of us prefer to just name it after the ledger.
  - By _adding_ an `ALIAS` target, existing consumers who use the `xrpl_core` target will not be affected. In the future, we can start a migration plan to make `xrpl_core` the `ALIAS` target (and `libxrpl` the "real" target, which will affect the filename of the compiled binary), and eventually remove it entirely.
- Fixes the Conan recipe so that consumers using Conan import a target named `xrpl::libxrpl`. This way, every consumer can use the same instructions.
- Documents the two easiest methods to depend on libxrpl. I have tested both. I'll work on adding CI tests for both methods.

See #4443.