### PR TITLE
Link to BUILD.md from Builds/README.md

### DIFF
--- a/Builds/README.md
+++ b/Builds/README.md
@@ -1,0 +1,1 @@
+[Please see the BUILD instructions here](../BUILD.md)


### PR DESCRIPTION
## High Level Overview of Change

In the release notes (current and historical), there is a link to the Builds directory. By adding a link to BUILD.md, it is easier for people to find those build instructions.

### Context of Change

The most up-to-date build instructions are in BUILD.md.

### Type of Change

- [x] Documentation Updates
