### PR TITLE
Fix the fix for std::result_of

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -258,10 +258,11 @@ part of C++20, e.g. Apple Clang 15.0,
 then you might need to add a preprocessor definition to your bulid:
 
 ```
+conan profile update 'options.boost:extra_b2_flags="define=BOOST_ASIO_HAS_STD_INVOKE_RESULT"' default
 conan profile update 'env.CFLAGS="-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"' default
 conan profile update 'env.CXXFLAGS="-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"' default
-conan profile update 'tools.build:cflags+=["-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"]' default
-conan profile update 'tools.build:cxxflags+=["-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"]' default
+conan profile update 'conf.tools.build:cflags+=["-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"]' default
+conan profile update 'conf.tools.build:cxxflags+=["-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"]' default
 ```
 
 


### PR DESCRIPTION
Remade from #4495 under a different branch name, so that I can re-open #4472 after mistakenly closing it.