### PR TITLE
Fix errors for Clang 16

### DIFF
--- a/src/ripple/beast/container/detail/aged_ordered_container.h
+++ b/src/ripple/beast/container/detail/aged_ordered_container.h
@@ -146,7 +146,7 @@ private:
 
     // VFALCO TODO This should only be enabled for maps.
     class pair_value_compare
-        : public beast::detail::empty_base_optimization<Compare>
+        : public Compare
     {
     public:
         using first_argument = value_type;
@@ -156,7 +156,7 @@ private:
         bool
         operator()(value_type const& lhs, value_type const& rhs) const
         {
-            return this->member()(lhs.first, rhs.first);
+            return Compare::operator()(lhs.first, rhs.first);
         }
 
         pair_value_compare()
@@ -164,7 +164,7 @@ private:
         }
 
         pair_value_compare(pair_value_compare const& other)
-            : beast::detail::empty_base_optimization<Compare>(other)
+            : Compare(other)
         {
         }
 
@@ -172,7 +172,7 @@ private:
         friend aged_ordered_container;
 
         pair_value_compare(Compare const& compare)
-            : beast::detail::empty_base_optimization<Compare>(compare)
+            : Compare(compare)
         {
         }
     };
@@ -180,7 +180,7 @@ private:
     // Compares value_type against element, used in insert_check
     // VFALCO TODO hoist to remove template argument dependencies
     class KeyValueCompare
-        : public beast::detail::empty_base_optimization<Compare>
+        : public Compare
     {
     public:
         using first_argument = Key;
@@ -190,54 +190,38 @@ private:
         KeyValueCompare() = default;
 
         KeyValueCompare(Compare const& compare)
-            : beast::detail::empty_base_optimization<Compare>(compare)
+            : Compare(compare)
         {
         }
-
-        // VFALCO NOTE WE might want only to enable these overloads
-        //                if Compare has is_transparent
-#if 0
-        template <class K>
-        bool operator() (K const& k, element const& e) const
-        {
-            return this->member() (k, extract (e.value));
-        }
-
-        template <class K>
-        bool operator() (element const& e, K const& k) const
-        {
-            return this->member() (extract (e.value), k);
-        }
-#endif
 
         bool
         operator()(Key const& k, element const& e) const
         {
-            return this->member()(k, extract(e.value));
+            return Compare::operator()(k, extract(e.value));
         }
 
         bool
         operator()(element const& e, Key const& k) const
         {
-            return this->member()(extract(e.value), k);
+            return Compare::operator()(extract(e.value), k);
         }
 
         bool
         operator()(element const& x, element const& y) const
         {
-            return this->member()(extract(x.value), extract(y.value));
+            return Compare::operator()(extract(x.value), extract(y.value));
         }
 
         Compare&
         compare()
         {
-            return beast::detail::empty_base_optimization<Compare>::member();
+            return *this;
         }
 
         Compare const&
         compare() const
         {
-            return beast::detail::empty_base_optimization<Compare>::member();
+            return *this;
         }
     };
 

--- a/src/ripple/beast/container/detail/aged_ordered_container.h
+++ b/src/ripple/beast/container/detail/aged_ordered_container.h
@@ -147,17 +147,11 @@ private:
     // VFALCO TODO This should only be enabled for maps.
     class pair_value_compare
         : public beast::detail::empty_base_optimization<Compare>
-#ifdef _LIBCPP_VERSION
-        ,
-          public std::binary_function<value_type, value_type, bool>
-#endif
     {
     public:
-#ifndef _LIBCPP_VERSION
         using first_argument = value_type;
         using second_argument = value_type;
         using result_type = bool;
-#endif
 
         bool
         operator()(value_type const& lhs, value_type const& rhs) const
@@ -187,17 +181,11 @@ private:
     // VFALCO TODO hoist to remove template argument dependencies
     class KeyValueCompare
         : public beast::detail::empty_base_optimization<Compare>
-#ifdef _LIBCPP_VERSION
-        ,
-          public std::binary_function<Key, element, bool>
-#endif
     {
     public:
-#ifndef _LIBCPP_VERSION
         using first_argument = Key;
         using second_argument = element;
         using result_type = bool;
-#endif
 
         KeyValueCompare() = default;
 

--- a/src/ripple/beast/container/detail/aged_ordered_container.h
+++ b/src/ripple/beast/container/detail/aged_ordered_container.h
@@ -145,8 +145,7 @@ private:
     };
 
     // VFALCO TODO This should only be enabled for maps.
-    class pair_value_compare
-        : public Compare
+    class pair_value_compare : public Compare
     {
     public:
         using first_argument = value_type;
@@ -163,24 +162,21 @@ private:
         {
         }
 
-        pair_value_compare(pair_value_compare const& other)
-            : Compare(other)
+        pair_value_compare(pair_value_compare const& other) : Compare(other)
         {
         }
 
     private:
         friend aged_ordered_container;
 
-        pair_value_compare(Compare const& compare)
-            : Compare(compare)
+        pair_value_compare(Compare const& compare) : Compare(compare)
         {
         }
     };
 
     // Compares value_type against element, used in insert_check
     // VFALCO TODO hoist to remove template argument dependencies
-    class KeyValueCompare
-        : public Compare
+    class KeyValueCompare : public Compare
     {
     public:
         using first_argument = Key;
@@ -189,8 +185,7 @@ private:
 
         KeyValueCompare() = default;
 
-        KeyValueCompare(Compare const& compare)
-            : Compare(compare)
+        KeyValueCompare(Compare const& compare) : Compare(compare)
         {
         }
 

--- a/src/ripple/beast/container/detail/aged_unordered_container.h
+++ b/src/ripple/beast/container/detail/aged_unordered_container.h
@@ -149,16 +149,10 @@ private:
 
     // VFALCO TODO hoist to remove template argument dependencies
     class ValueHash : private beast::detail::empty_base_optimization<Hash>
-#ifdef _LIBCPP_VERSION
-        ,
-                      public std::unary_function<element, std::size_t>
-#endif
     {
     public:
-#ifndef _LIBCPP_VERSION
         using argument_type = element;
         using result_type = size_t;
-#endif
 
         ValueHash()
         {
@@ -192,17 +186,11 @@ private:
     // VFALCO TODO hoist to remove template argument dependencies
     class KeyValueEqual
         : private beast::detail::empty_base_optimization<KeyEqual>
-#ifdef _LIBCPP_VERSION
-        ,
-          public std::binary_function<Key, element, bool>
-#endif
     {
     public:
-#ifndef _LIBCPP_VERSION
         using first_argument_type = Key;
         using second_argument_type = element;
         using result_type = bool;
-#endif
 
         KeyValueEqual()
         {

--- a/src/ripple/beast/container/detail/aged_unordered_container.h
+++ b/src/ripple/beast/container/detail/aged_unordered_container.h
@@ -148,7 +148,7 @@ private:
     };
 
     // VFALCO TODO hoist to remove template argument dependencies
-    class ValueHash : private beast::detail::empty_base_optimization<Hash>
+    class ValueHash : public Hash
     {
     public:
         using argument_type = element;
@@ -159,33 +159,33 @@ private:
         }
 
         ValueHash(Hash const& h)
-            : beast::detail::empty_base_optimization<Hash>(h)
+            : Hash(h)
         {
         }
 
         std::size_t
         operator()(element const& e) const
         {
-            return this->member()(extract(e.value));
+            return Hash::operator()(extract(e.value));
         }
 
         Hash&
         hash_function()
         {
-            return this->member();
+            return *this;
         }
 
         Hash const&
         hash_function() const
         {
-            return this->member();
+            return *this;
         }
     };
 
     // Compares value_type against element, used in find/insert_check
     // VFALCO TODO hoist to remove template argument dependencies
     class KeyValueEqual
-        : private beast::detail::empty_base_optimization<KeyEqual>
+        : public KeyEqual
     {
     public:
         using first_argument_type = Key;
@@ -197,54 +197,38 @@ private:
         }
 
         KeyValueEqual(KeyEqual const& keyEqual)
-            : beast::detail::empty_base_optimization<KeyEqual>(keyEqual)
+            : KeyEqual(keyEqual)
         {
         }
-
-        // VFALCO NOTE WE might want only to enable these overloads
-        //                if KeyEqual has is_transparent
-#if 0
-        template <class K>
-        bool operator() (K const& k, element const& e) const
-        {
-            return this->member() (k, extract (e.value));
-        }
-
-        template <class K>
-        bool operator() (element const& e, K const& k) const
-        {
-            return this->member() (extract (e.value), k);
-        }
-#endif
 
         bool
         operator()(Key const& k, element const& e) const
         {
-            return this->member()(k, extract(e.value));
+            return KeyEqual::operator()(k, extract(e.value));
         }
 
         bool
         operator()(element const& e, Key const& k) const
         {
-            return this->member()(extract(e.value), k);
+            return KeyEqual::operator()(extract(e.value), k);
         }
 
         bool
         operator()(element const& lhs, element const& rhs) const
         {
-            return this->member()(extract(lhs.value), extract(rhs.value));
+            return KeyEqual::operator()(extract(lhs.value), extract(rhs.value));
         }
 
         KeyEqual&
         key_eq()
         {
-            return this->member();
+            return *this;
         }
 
         KeyEqual const&
         key_eq() const
         {
-            return this->member();
+            return *this;
         }
     };
 

--- a/src/ripple/beast/container/detail/aged_unordered_container.h
+++ b/src/ripple/beast/container/detail/aged_unordered_container.h
@@ -158,8 +158,7 @@ private:
         {
         }
 
-        ValueHash(Hash const& h)
-            : Hash(h)
+        ValueHash(Hash const& h) : Hash(h)
         {
         }
 
@@ -184,8 +183,7 @@ private:
 
     // Compares value_type against element, used in find/insert_check
     // VFALCO TODO hoist to remove template argument dependencies
-    class KeyValueEqual
-        : public KeyEqual
+    class KeyValueEqual : public KeyEqual
     {
     public:
         using first_argument_type = Key;
@@ -196,8 +194,7 @@ private:
         {
         }
 
-        KeyValueEqual(KeyEqual const& keyEqual)
-            : KeyEqual(keyEqual)
+        KeyValueEqual(KeyEqual const& keyEqual) : KeyEqual(keyEqual)
         {
         }
 

--- a/src/ripple/peerfinder/impl/Bootcache.h
+++ b/src/ripple/peerfinder/impl/Bootcache.h
@@ -91,17 +91,10 @@ private:
     using value_type = map_type::value_type;
 
     struct Transform
-#ifdef _LIBCPP_VERSION
-        : std::unary_function<
-              map_type::right_map::const_iterator::value_type const&,
-              beast::IP::Endpoint const&>
-#endif
     {
-#ifndef _LIBCPP_VERSION
         using first_argument_type =
             map_type::right_map::const_iterator::value_type const&;
         using result_type = beast::IP::Endpoint const&;
-#endif
 
         explicit Transform() = default;
 

--- a/src/ripple/peerfinder/impl/Livecache.h
+++ b/src/ripple/peerfinder/impl/Livecache.h
@@ -69,14 +69,9 @@ public:
     public:
         // Iterator transformation to extract the endpoint from Element
         struct Transform
-#ifdef _LIBCPP_VERSION
-            : public std::unary_function<Element, Endpoint>
-#endif
         {
-#ifndef _LIBCPP_VERSION
             using first_argument = Element;
             using result_type = Endpoint;
-#endif
 
             explicit Transform() = default;
 
@@ -239,15 +234,9 @@ public:
 
         template <bool IsConst>
         struct Transform
-#ifdef _LIBCPP_VERSION
-            : public std::
-                  unary_function<typename lists_type::value_type, Hop<IsConst>>
-#endif
         {
-#ifndef _LIBCPP_VERSION
             using first_argument = typename lists_type::value_type;
             using result_type = Hop<IsConst>;
-#endif
 
             explicit Transform() = default;
 

--- a/src/ripple/shamap/impl/SHAMapInnerNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapInnerNode.cpp
@@ -398,7 +398,7 @@ SHAMapInnerNode::canonicalizeChild(
 void
 SHAMapInnerNode::invariants(bool is_root) const
 {
-    unsigned count = 0;
+    [[maybe_unused]] unsigned count = 0;
     auto [numAllocated, hashes, children] =
         hashesAndChildren_.getHashesAndChildren();
 


### PR DESCRIPTION
- `std::{u,bi}nary_function` were removed in C++17. They were empty classes with a few associated types. We already have conditional code to define the types. Just make it unconditional.
- libc++ checks a cast in an unevaluated context to see if a type inherits from a binary function class in the standard library, e.g. `std::equal_to`, and this causes an error when the type privately inherits from such a class. Change these instances to public inheritance.
- We don't need a middle-man for the empty base optimization. Prefer to inherit directly from an empty class than from `beast::detail::empty_base_optimization`.
- Clang warns when all the uses of a variable are removed by conditional compilation of assertions. Add a `[[maybe_unused]]` annotation to suppress it.
- As a drive-by clean-up, remove commented code.

See related work in #4486.