### PR TITLE
`fixReducedOffersV1`: curtail the occurrence of order books that are blocked by reduced offers

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -718,6 +718,7 @@ if (tests)
     src/test/app/PseudoTx_test.cpp
     src/test/app/RCLCensorshipDetector_test.cpp
     src/test/app/RCLValidations_test.cpp
+    src/test/app/ReducedOffer_test.cpp
     src/test/app/Regression_test.cpp
     src/test/app/SHAMapStore_test.cpp
     src/test/app/SetAuth_test.cpp

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -507,7 +507,8 @@ limitStepIn(
     TOut& ownerGives,
     std::uint32_t transferRateIn,
     std::uint32_t transferRateOut,
-    TIn const& limit)
+    TIn const& limit,
+    Rules const& rules)
 {
     if (limit < stpAmt.in)
     {
@@ -531,14 +532,22 @@ limitStepOut(
     TOut& ownerGives,
     std::uint32_t transferRateIn,
     std::uint32_t transferRateOut,
-    TOut const& limit)
+    TOut const& limit,
+    Rules const& rules)
 {
     if (limit < stpAmt.out)
     {
         stpAmt.out = limit;
         ownerGives = mulRatio(
             stpAmt.out, transferRateOut, QUALITY_ONE, /*roundUp*/ false);
-        ofrAmt = ofrQ.ceil_out(ofrAmt, stpAmt.out);
+        if (rules.enabled(fixReducedOffersV1))
+            // It turns out that the ceil_out implementation has some slop in
+            // it.  ceil_out_strict removes that slop.  But removing that slop
+            // affects transaction outcomes, so the change must be made using
+            // an amendment.
+            ofrAmt = ofrQ.ceil_out_strict(ofrAmt, stpAmt.out, /*roundUp*/ true);
+        else
+            ofrAmt = ofrQ.ceil_out(ofrAmt, stpAmt.out);
         stpAmt.in =
             mulRatio(ofrAmt.in, transferRateIn, QUALITY_ONE, /*roundUp*/ true);
     }
@@ -577,6 +586,7 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
         sb, afView, book_, sb.parentCloseTime(), counter, j_);
 
     bool const flowCross = afView.rules().enabled(featureFlowCross);
+    bool const fixReduced = afView.rules().enabled(fixReducedOffersV1);
     bool offerAttempted = false;
     std::optional<Quality> ofrQ;
     while (offers.step())
@@ -654,7 +664,16 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
             ownerGives = funds;
             stpAmt.out = mulRatio(
                 ownerGives, QUALITY_ONE, ofrOutRate, /*roundUp*/ false);
-            ofrAmt = ofrQ->ceil_out(ofrAmt, stpAmt.out);
+
+            // It turns out we can prevent order book blocking by rounding down
+            // the ceil_out() result.  This adjustment changes transaction
+            // outcomes, so it must be made under an amendment.
+            if (fixReduced)
+                ofrAmt = ofrQ->ceil_out_strict(
+                    ofrAmt, stpAmt.out, /* roundUp */ false);
+            else
+                ofrAmt = ofrQ->ceil_out(ofrAmt, stpAmt.out);
+
             stpAmt.in =
                 mulRatio(ofrAmt.in, ofrInRate, QUALITY_ONE, /*roundUp*/ true);
         }
@@ -770,7 +789,8 @@ BookStep<TIn, TOut, TDerived>::revImp(
                 ownerGivesAdj,
                 transferRateIn,
                 transferRateOut,
-                remainingOut);
+                remainingOut,
+                afView.rules());
             remainingOut = beast::zero;
             savedIns.insert(stpAdjAmt.in);
             savedOuts.insert(remainingOut);
@@ -891,7 +911,8 @@ BookStep<TIn, TOut, TDerived>::fwdImp(
                 ownerGivesAdj,
                 transferRateIn,
                 transferRateOut,
-                remainingIn);
+                remainingIn,
+                afView.rules());
             savedIns.insert(remainingIn);
             lastOut = savedOuts.insert(stpAdjAmt.out);
             result.out = sum(savedOuts);
@@ -922,7 +943,8 @@ BookStep<TIn, TOut, TDerived>::fwdImp(
                 ownerGivesAdjRev,
                 transferRateIn,
                 transferRateOut,
-                remainingOut);
+                remainingOut,
+                afView.rules());
 
             if (stpAdjAmtRev.in == remainingIn)
             {

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -507,8 +507,7 @@ limitStepIn(
     TOut& ownerGives,
     std::uint32_t transferRateIn,
     std::uint32_t transferRateOut,
-    TIn const& limit,
-    Rules const& rules)
+    TIn const& limit)
 {
     if (limit < stpAmt.in)
     {
@@ -911,8 +910,7 @@ BookStep<TIn, TOut, TDerived>::fwdImp(
                 ownerGivesAdj,
                 transferRateIn,
                 transferRateOut,
-                remainingIn,
-                afView.rules());
+                remainingIn);
             savedIns.insert(remainingIn);
             lastOut = savedOuts.insert(stpAdjAmt.out);
             result.out = sum(savedOuts);

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -665,9 +665,9 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
             stpAmt.out = mulRatio(
                 ownerGives, QUALITY_ONE, ofrOutRate, /*roundUp*/ false);
 
-            // It turns out we can prevent order book blocking by rounding down
-            // the ceil_out() result.  This adjustment changes transaction
-            // outcomes, so it must be made under an amendment.
+            // It turns out we can prevent order book blocking by (strictly)
+            // rounding down the ceil_out() result.  This adjustment changes
+            // transaction outcomes, so it must be made under an amendment.
             if (fixReduced)
                 ofrAmt = ofrQ->ceil_out_strict(
                     ofrAmt, stpAmt.out, /* roundUp */ false);

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -824,8 +824,15 @@ CreateOffer::flowCross(
                         // what is a good threshold to check?
                         afterCross.in.clear();
 
+                    // Careful analysis showed that rounding up this divRound
+                    // result could lead to placing a reduced offer in the
+                    // ledger that blocks order books.  So the
+                    // fixReducedOffersV1 amendment changes the behavior to
+                    // round down instead.
+                    bool const roundUp =
+                        !psb.rules().enabled(fixReducedOffersV1);
                     afterCross.out = divRound(
-                        afterCross.in, rate, takerAmount.out.issue(), true);
+                        afterCross.in, rate, takerAmount.out.issue(), roundUp);
                 }
                 else
                 {

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -824,15 +824,22 @@ CreateOffer::flowCross(
                         // what is a good threshold to check?
                         afterCross.in.clear();
 
-                    // Careful analysis showed that rounding up this divRound
-                    // result could lead to placing a reduced offer in the
-                    // ledger that blocks order books.  So the
-                    // fixReducedOffersV1 amendment changes the behavior to
-                    // round down instead.
-                    bool const roundUp =
-                        !psb.rules().enabled(fixReducedOffersV1);
-                    afterCross.out = divRound(
-                        afterCross.in, rate, takerAmount.out.issue(), roundUp);
+                    afterCross.out = [&]() {
+                        // Careful analysis showed that rounding up this
+                        // divRound result could lead to placing a reduced
+                        // offer in the ledger that blocks order books.  So
+                        // the fixReducedOffersV1 amendment changes the
+                        // behavior to round down instead.
+                        if (psb.rules().enabled(fixReducedOffersV1))
+                            return divRoundStrict(
+                                afterCross.in,
+                                rate,
+                                takerAmount.out.issue(),
+                                false);
+
+                        return divRound(
+                            afterCross.in, rate, takerAmount.out.issue(), true);
+                    }();
                 }
                 else
                 {

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -74,7 +74,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 58;
+static constexpr std::size_t numFeatures = 59;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -345,6 +345,7 @@ extern uint256 const featureXRPFees;
 extern uint256 const fixUniversalNumber;
 extern uint256 const fixNonFungibleTokensV1_2;
 extern uint256 const fixNFTokenRemint;
+extern uint256 const fixReducedOffersV1;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/Quality.h
+++ b/src/ripple/protocol/Quality.h
@@ -223,6 +223,29 @@ public:
             toAmount<In>(stRes.in), toAmount<Out>(stRes.out));
     }
 
+    Amounts
+    ceil_out_strict(Amounts const& amount, STAmount const& limit, bool roundUp)
+        const;
+
+    template <class In, class Out>
+    TAmounts<In, Out>
+    ceil_out_strict(
+        TAmounts<In, Out> const& amount,
+        Out const& limit,
+        bool roundUp) const
+    {
+        if (amount.out <= limit)
+            return amount;
+
+        // Use the existing STAmount implementation for now, but consider
+        // replacing with code specific to IOUAMount and XRPAmount
+        Amounts stAmt(toSTAmount(amount.in), toSTAmount(amount.out));
+        STAmount stLim(toSTAmount(limit));
+        auto const stRes = ceil_out_strict(stAmt, stLim, roundUp);
+        return TAmounts<In, Out>(
+            toAmount<In>(stRes.in), toAmount<Out>(stRes.out));
+    }
+
     /** Returns `true` if lhs is lower quality than `rhs`.
         Lower quality means the taker receives a worse deal.
         Higher quality is better for the taker.

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -527,6 +527,14 @@ divRound(
     Issue const& issue,
     bool roundUp);
 
+// divide following the rounding directions more precisely.
+STAmount
+divRoundStrict(
+    STAmount const& v1,
+    STAmount const& v2,
+    Issue const& issue,
+    bool roundUp);
+
 // Someone is offering X for Y, what is the rate?
 // Rate: smaller is better, the taker wants the most out: in/out
 // VFALCO TODO Return a Quality object

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -503,7 +503,7 @@ divide(STAmount const& v1, STAmount const& v2, Issue const& issue);
 STAmount
 multiply(STAmount const& v1, STAmount const& v2, Issue const& issue);
 
-// multiply, or divide rounding result in specified direction
+// multiply rounding result in specified direction
 STAmount
 mulRound(
     STAmount const& v1,
@@ -511,6 +511,15 @@ mulRound(
     Issue const& issue,
     bool roundUp);
 
+// multiply following the rounding directions more precisely.
+STAmount
+mulRoundStrict(
+    STAmount const& v1,
+    STAmount const& v2,
+    Issue const& issue,
+    bool roundUp);
+
+// divide rounding result in specified direction
 STAmount
 divRound(
     STAmount const& v1,

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -452,6 +452,7 @@ REGISTER_FEATURE(XRPFees,                       Supported::yes, VoteBehavior::De
 REGISTER_FIX    (fixUniversalNumber,            Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixNonFungibleTokensV1_2,      Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixNFTokenRemint,              Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FIX    (fixReducedOffersV1,            Supported::yes, VoteBehavior::DefaultNo);
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.

--- a/src/ripple/protocol/impl/Quality.cpp
+++ b/src/ripple/protocol/impl/Quality.cpp
@@ -81,10 +81,10 @@ Quality::ceil_in(Amounts const& amount, STAmount const& limit) const
     return amount;
 }
 
-template <
-    STAmount (*MUL_ROUND)(STAmount const&, STAmount const&, Issue const&, bool)>
+template <STAmount (
+    *MulRoundFunc)(STAmount const&, STAmount const&, Issue const&, bool)>
 static Amounts
-do_ceil_out(
+ceil_out_impl(
     Amounts const& amount,
     STAmount const& limit,
     bool roundUp,
@@ -93,7 +93,7 @@ do_ceil_out(
     if (amount.out > limit)
     {
         Amounts result(
-            MUL_ROUND(limit, quality.rate(), amount.in.issue(), roundUp),
+            MulRoundFunc(limit, quality.rate(), amount.in.issue(), roundUp),
             limit);
         // Clamp in
         if (result.in > amount.in)
@@ -108,7 +108,7 @@ do_ceil_out(
 Amounts
 Quality::ceil_out(Amounts const& amount, STAmount const& limit) const
 {
-    return do_ceil_out<mulRound>(amount, limit, /* roundUp */ true, *this);
+    return ceil_out_impl<mulRound>(amount, limit, /* roundUp */ true, *this);
 }
 
 Amounts
@@ -117,7 +117,7 @@ Quality::ceil_out_strict(
     STAmount const& limit,
     bool roundUp) const
 {
-    return do_ceil_out<mulRoundStrict>(amount, limit, roundUp, *this);
+    return ceil_out_impl<mulRoundStrict>(amount, limit, roundUp, *this);
 }
 
 Quality

--- a/src/ripple/protocol/impl/Quality.cpp
+++ b/src/ripple/protocol/impl/Quality.cpp
@@ -81,12 +81,20 @@ Quality::ceil_in(Amounts const& amount, STAmount const& limit) const
     return amount;
 }
 
-Amounts
-Quality::ceil_out(Amounts const& amount, STAmount const& limit) const
+template <
+    STAmount (*MUL_ROUND)(STAmount const&, STAmount const&, Issue const&, bool)>
+static Amounts
+do_ceil_out(
+    Amounts const& amount,
+    STAmount const& limit,
+    bool roundUp,
+    Quality const& quality)
 {
     if (amount.out > limit)
     {
-        Amounts result(mulRound(limit, rate(), amount.in.issue(), true), limit);
+        Amounts result(
+            MUL_ROUND(limit, quality.rate(), amount.in.issue(), roundUp),
+            limit);
         // Clamp in
         if (result.in > amount.in)
             result.in = amount.in;
@@ -95,6 +103,21 @@ Quality::ceil_out(Amounts const& amount, STAmount const& limit) const
     }
     assert(amount.out <= limit);
     return amount;
+}
+
+Amounts
+Quality::ceil_out(Amounts const& amount, STAmount const& limit) const
+{
+    return do_ceil_out<mulRound>(amount, limit, /* roundUp */ true, *this);
+}
+
+Amounts
+Quality::ceil_out_strict(
+    Amounts const& amount,
+    STAmount const& limit,
+    bool roundUp) const
+{
+    return do_ceil_out<mulRoundStrict>(amount, limit, roundUp, *this);
 }
 
 Quality

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -1347,7 +1347,7 @@ canonicalizeRoundStrict(
 }
 
 // Pass the canonicalizeRound function as a template parameter.
-template <void (*CANONICALIZE)(bool, std::uint64_t&, int&, bool)>
+template <void (*Canonicalize)(bool, std::uint64_t&, int&, bool)>
 static STAmount
 mulRoundImpl(
     STAmount const& v1,
@@ -1413,7 +1413,7 @@ mulRoundImpl(
     int offset = offset1 + offset2 + 14;
     if (resultNegative != roundUp)
     {
-        CANONICALIZE(xrp, amount, offset, roundUp);
+        Canonicalize(xrp, amount, offset, roundUp);
     }
     STAmount result(issue, amount, offset, resultNegative);
 

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -1564,8 +1564,11 @@ divRoundImpl(
 
     STAmount result = [&]() {
         // If appropriate, tell Number the rounding mode we are using.
+        // Note that "roundUp == true" actually means "round away from zero".
+        // Otherwise round toward zero.
+        using enum Number::rounding_mode;
         MightSaveRound const savedRound(
-            roundUp ? Number::upward : Number::towards_zero);
+            roundUp ^ resultNegative ? upward : downward);
         return STAmount(issue, amount, offset, resultNegative);
     }();
 

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -1361,6 +1361,11 @@ public:
         : saved_{Number::setround(mode)}
     {
     }
+
+    NumberRoundModeGuard(NumberRoundModeGuard const&) = delete;
+
+    NumberRoundModeGuard&
+    operator=(NumberRoundModeGuard const&) = delete;
 };
 
 // We need a class that has an interface similar to NumberRoundModeGuard
@@ -1371,6 +1376,11 @@ public:
     explicit DontAffectNumberRoundMode(Number::rounding_mode mode) noexcept
     {
     }
+
+    DontAffectNumberRoundMode(DontAffectNumberRoundMode const&) = delete;
+
+    DontAffectNumberRoundMode&
+    operator=(DontAffectNumberRoundMode const&) = delete;
 };
 
 }  // anonymous namespace

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -2126,18 +2126,17 @@ public:
             BEAST_EXPECT(
                 jrr[jss::node][sfBalance.fieldName][jss::value] ==
                 "49.96666666666667");
+
             jrr = ledgerEntryState(env, bob, gw, "USD");
-            if (NumberSwitchOver)
+            Json::Value const bobsUSD =
+                jrr[jss::node][sfBalance.fieldName][jss::value];
+            if (!NumberSwitchOver)
             {
-                BEAST_EXPECT(
-                    jrr[jss::node][sfBalance.fieldName][jss::value] ==
-                    "-0.9665000000333333");
+                BEAST_EXPECT(bobsUSD == "-0.966500000033334");
             }
             else
             {
-                BEAST_EXPECT(
-                    jrr[jss::node][sfBalance.fieldName][jss::value] ==
-                    "-0.966500000033334");
+                BEAST_EXPECT(bobsUSD == "-0.9665000000333333");
             }
         }
     }

--- a/src/test/app/ReducedOffer_test.cpp
+++ b/src/test/app/ReducedOffer_test.cpp
@@ -1,0 +1,626 @@
+//------------------------------------------------------------------------------
+/*
+  This file is part of rippled: https://github.com/ripple/rippled
+  Copyright (c) 2022 Ripple Labs Inc.
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose  with  or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+  MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/protocol/Feature.h>
+#include <ripple/protocol/Quality.h>
+#include <ripple/protocol/jss.h>
+#include <test/jtx.h>
+
+namespace ripple {
+namespace test {
+
+class ReducedOffer_test : public beast::unit_test::suite
+{
+    static auto
+    ledgerEntryOffer(
+        jtx::Env& env,
+        jtx::Account const& acct,
+        std::uint32_t offer_seq)
+    {
+        Json::Value jvParams;
+        jvParams[jss::offer][jss::account] = acct.human();
+        jvParams[jss::offer][jss::seq] = offer_seq;
+        return env.rpc(
+            "json", "ledger_entry", to_string(jvParams))[jss::result];
+    }
+
+public:
+    void
+    testPartialCrossNewXrpIouQChange()
+    {
+        testcase("exercise partial cross new XRP/IOU offer Q change");
+
+        using namespace jtx;
+
+        auto const gw = Account{"gateway"};
+        auto const alice = Account{"alice"};
+        auto const bob = Account{"bob"};
+        auto const USD = gw["USD"];
+
+        // Make one test run without fixReducedOffersV1 and one with.
+        for (FeatureBitset features :
+             {supported_amendments() - fixReducedOffersV1,
+              supported_amendments() | fixReducedOffersV1})
+        {
+            Env env{*this, features};
+
+            // Make sure none of the offers we generate are under funded.
+            env.fund(XRP(10'000'000), gw, alice, bob);
+            env.close();
+
+            env(trust(alice, USD(10'000'000)));
+            env(trust(bob, USD(10'000'000)));
+            env.close();
+
+            env(pay(gw, bob, USD(10'000'000)));
+            env.close();
+
+            // Lambda that:
+            //  1. Exercises one offer pair,
+            //  2. Collects the results, and
+            //  3. Cleans up for the next offer pair.
+            // Returns 1 if the crossed offer has a bad rate for the book.
+            auto exerciseOfferPair =
+                [this, &env, &alice, &bob](
+                    Amounts const& inLedger,
+                    Amounts const& newOffer) -> unsigned int {
+                // Put inLedger offer in the ledger so newOffer can cross it.
+                std::uint32_t const aliceOfferSeq = env.seq(alice);
+                env(offer(alice, inLedger.in, inLedger.out));
+                env.close();
+
+                // Now alice's offer will partially cross bob's offer.
+                STAmount const initialRate = Quality(newOffer).rate();
+                std::uint32_t const bobOfferSeq = env.seq(bob);
+                STAmount const bobInitialBalance = env.balance(bob);
+                STAmount const bobsFee = drops(10);
+                env(offer(bob, newOffer.in, newOffer.out, tfSell),
+                    fee(bobsFee));
+                env.close();
+                STAmount const bobFinalBalance = env.balance(bob);
+
+                // alice's offer should be fully crossed and so gone from
+                // the ledger.
+                {
+                    Json::Value aliceOffer =
+                        ledgerEntryOffer(env, alice, aliceOfferSeq);
+                    if (!BEAST_EXPECT(
+                            aliceOffer.isMember(jss::error) &&
+                            aliceOffer[jss::error].asString() ==
+                                "entryNotFound"))
+                        // If the in-ledger offer was not consumed then further
+                        // results are meaningless.
+                        return 1;
+                }
+                // bob's offer should be in the ledger, but reduced in size.
+                unsigned int badRate = 1;
+                {
+                    Json::Value bobOffer =
+                        ledgerEntryOffer(env, bob, bobOfferSeq);
+
+                    STAmount const reducedTakerGets = amountFromJson(
+                        sfTakerGets, bobOffer[jss::node][sfTakerGets.jsonName]);
+                    STAmount const reducedTakerPays = amountFromJson(
+                        sfTakerPays, bobOffer[jss::node][sfTakerPays.jsonName]);
+                    STAmount const bobGot =
+                        env.balance(bob) + bobsFee - bobInitialBalance;
+                    BEAST_EXPECT(reducedTakerPays < newOffer.in);
+                    BEAST_EXPECT(reducedTakerGets < newOffer.out);
+                    STAmount const inLedgerRate =
+                        Quality(Amounts{reducedTakerPays, reducedTakerGets})
+                            .rate();
+
+                    badRate = inLedgerRate > initialRate ? 1 : 0;
+
+                    // If the inLedgerRate is less than initial rate, then
+                    // incrementing the mantissa of the reduced taker pays
+                    // should result in a rate higher than initial.  Check
+                    // this to verify that the largest allowable TakerPays
+                    // was computed.
+                    if (badRate == 0)
+                    {
+                        STAmount const tweakedTakerPays =
+                            reducedTakerPays + drops(1);
+                        STAmount const tweakedRate =
+                            Quality(Amounts{tweakedTakerPays, reducedTakerGets})
+                                .rate();
+                        BEAST_EXPECT(tweakedRate > initialRate);
+                    }
+#if 0
+                    std::cout << "Placed rate: " << initialRate
+                              << "; in-ledger rate: " << inLedgerRate
+                              << "; TakerPays: " << reducedTakerPays
+                              << "; TakerGets: " << reducedTakerGets
+                              << "; bob already got: " << bobGot << std::endl;
+// #else
+                    std::string_view filler =
+                        inLedgerRate > initialRate ? "**" : "  ";
+                    std::cout << "| `" << reducedTakerGets << "` | `"
+                              << reducedTakerPays << "` | `" << initialRate
+                              << "` | " << filler << "`" << inLedgerRate << "`"
+                              << filler << " |`" << std::endl;
+#endif
+                }
+
+                // In preparation for the next iteration make sure the two
+                // offers are gone from the ledger.
+                env(offer_cancel(alice, aliceOfferSeq));
+                env(offer_cancel(bob, bobOfferSeq));
+                env.close();
+
+                return badRate;
+            };
+
+            // bob's offer (the new offer) is the same every time:
+            Amounts const bobsOffer{
+                STAmount(XRP(1)), STAmount(USD.issue(), 1, 0)};
+
+            // alice's offer has a slightly smaller TakerPays with each
+            // iteration.  This should mean that the size of the offer bob
+            // places in the ledger should increase with each iteration.
+            unsigned int blockedCount = 0;
+            for (std::uint64_t mantissaReduce = 1'000'000'000ull;
+                 mantissaReduce <= 5'000'000'000ull;
+                 mantissaReduce += 20'000'000ull)
+            {
+                STAmount aliceUSD{
+                    bobsOffer.out.issue(),
+                    bobsOffer.out.mantissa() - mantissaReduce,
+                    bobsOffer.out.exponent()};
+                STAmount aliceXRP{
+                    bobsOffer.in.issue(), bobsOffer.in.mantissa() - 1};
+                Amounts alicesOffer{aliceUSD, aliceXRP};
+                blockedCount += exerciseOfferPair(alicesOffer, bobsOffer);
+            }
+
+            // If fixReducedOffersV1 is enabled, then none of the test cases
+            // should produce a potentially blocking rate.
+            //
+            // Also verify that if fixReducedOffersV1 is not enabled then
+            // some of the test cases produced a potentially blocking rate.
+            if (features[fixReducedOffersV1])
+            {
+                BEAST_EXPECT(blockedCount == 0);
+            }
+            else
+            {
+                BEAST_EXPECT(blockedCount >= 180);
+            }
+        }
+    }
+
+    void
+    testPartialCrossOldXrpIouQChange()
+    {
+        testcase("exercise partial cross old XRP/IOU offer Q change");
+
+        using namespace jtx;
+
+        auto const gw = Account{"gateway"};
+        auto const alice = Account{"alice"};
+        auto const bob = Account{"bob"};
+        auto const USD = gw["USD"];
+
+        // Make one test run without fixReducedOffersV1 and one with.
+        for (FeatureBitset features :
+             {supported_amendments() - fixReducedOffersV1,
+              supported_amendments() | fixReducedOffersV1})
+        {
+            // Make sure none of the offers we generate are under funded.
+            Env env{*this, features};
+            env.fund(XRP(10'000'000), gw, alice, bob);
+            env.close();
+
+            env(trust(alice, USD(10'000'000)));
+            env(trust(bob, USD(10'000'000)));
+            env.close();
+
+            env(pay(gw, alice, USD(10'000'000)));
+            env.close();
+
+            // Lambda that:
+            //  1. Exercises one offer pair,
+            //  2. Collects the results, and
+            //  3. Cleans up for the next offer pair.
+            auto exerciseOfferPair =
+                [this, &env, &alice, &bob](
+                    Amounts const& inLedger,
+                    Amounts const& newOffer) -> unsigned int {
+                // Get the inLedger offer into the ledger so newOffer can cross
+                // it.
+                STAmount const initialRate = Quality(inLedger).rate();
+                std::uint32_t const aliceOfferSeq = env.seq(alice);
+                env(offer(alice, inLedger.in, inLedger.out));
+                env.close();
+
+                // Now bob's offer will partially cross alice's offer.
+                std::uint32_t const bobOfferSeq = env.seq(bob);
+                STAmount const aliceInitialBalance = env.balance(alice);
+                env(offer(bob, newOffer.in, newOffer.out));
+                env.close();
+                STAmount const aliceFinalBalance = env.balance(alice);
+
+                auto doCleanup =
+                    [&env, &alice, &bob, aliceOfferSeq, bobOfferSeq](
+                        unsigned int ret) -> unsigned int {
+                    env(offer_cancel(alice, aliceOfferSeq));
+                    env(offer_cancel(bob, bobOfferSeq));
+                    env.close();
+                    return ret;
+                };
+
+                // bob's offer should not have made it into the ledger.
+                {
+                    Json::Value bobOffer =
+                        ledgerEntryOffer(env, bob, bobOfferSeq);
+                    if (!BEAST_EXPECT(
+                            bobOffer.isMember(jss::error) &&
+                            bobOffer[jss::error].asString() == "entryNotFound"))
+                        // If the in-ledger offer was not consumed then further
+                        // results are meaningless.
+                        return doCleanup(1);
+                }
+                // alice's offer should still be in the ledger, but reduced in
+                // size.
+                unsigned int badRate = 1;
+                {
+                    Json::Value aliceOffer =
+                        ledgerEntryOffer(env, alice, aliceOfferSeq);
+
+                    STAmount const reducedTakerGets = amountFromJson(
+                        sfTakerGets,
+                        aliceOffer[jss::node][sfTakerGets.jsonName]);
+                    STAmount const reducedTakerPays = amountFromJson(
+                        sfTakerPays,
+                        aliceOffer[jss::node][sfTakerPays.jsonName]);
+                    STAmount const aliceGot =
+                        env.balance(alice) - aliceInitialBalance;
+                    BEAST_EXPECT(reducedTakerPays < inLedger.in);
+                    BEAST_EXPECT(reducedTakerGets < inLedger.out);
+                    STAmount const inLedgerRate =
+                        Quality(Amounts{reducedTakerPays, reducedTakerGets})
+                            .rate();
+                    badRate = inLedgerRate > initialRate ? 1 : 0;
+
+                    // If the inLedgerRate is less than initial rate, then
+                    // incrementing the mantissa of the reduced taker pays
+                    // should result in a rate higher than initial.  Check
+                    // this to verify that the largest allowable TakerPays
+                    // was computed.
+                    if (badRate == 0)
+                    {
+                        STAmount const tweakedTakerPays =
+                            reducedTakerPays + drops(1);
+                        STAmount const tweakedRate =
+                            Quality(Amounts{tweakedTakerPays, reducedTakerGets})
+                                .rate();
+                        BEAST_EXPECT(tweakedRate > initialRate);
+                    }
+#if 0
+                    std::cout << "Placed rate: " << initialRate
+                              << "; in-ledger rate: " << inLedgerRate
+                              << "; TakerPays: " << reducedTakerPays
+                              << "; TakerGets: " << reducedTakerGets
+                              << "; alice already got: " << aliceGot
+                              << std::endl;
+// #else
+                    std::string_view filler = badRate ? "**" : "  ";
+                    std::cout << "| `" << reducedTakerGets << "` | `"
+                              << reducedTakerPays << "` | `" << initialRate
+                              << "` | " << filler << "`" << inLedgerRate << "`"
+                              << filler << " | `" << aliceGot << "` |"
+                              << std::endl;
+#endif
+                }
+
+                // In preparation for the next iteration make sure the two
+                // offers are gone from the ledger.
+                return doCleanup(badRate);
+            };
+
+            // alice's offer (the old offer) is the same every time:
+            Amounts const aliceOffer{
+                STAmount(XRP(1)), STAmount(USD.issue(), 1, 0)};
+
+            // bob's offer has a slightly smaller TakerPays with each iteration.
+            // This should mean that the size of the offer alice leaves in the
+            // ledger should increase with each iteration.
+            unsigned int blockedCount = 0;
+            for (std::uint64_t mantissaReduce = 1'000'000'000ull;
+                 mantissaReduce < 4'000'000'000ull;
+                 mantissaReduce += 20'000'000ull)
+            {
+                STAmount bobUSD{
+                    aliceOffer.out.issue(),
+                    aliceOffer.out.mantissa() - mantissaReduce,
+                    aliceOffer.out.exponent()};
+                STAmount bobXRP{
+                    aliceOffer.in.issue(), aliceOffer.in.mantissa() - 1};
+                Amounts bobsOffer{bobUSD, bobXRP};
+
+                blockedCount += exerciseOfferPair(aliceOffer, bobsOffer);
+            }
+
+            // If fixReducedOffersV1 is enabled, then none of the test cases
+            // should produce a potentially blocking rate.
+            //
+            // Also verify that if fixReducedOffersV1 is not enabled then
+            // some of the test cases produced a potentially blocking rate.
+            if (features[fixReducedOffersV1])
+            {
+                BEAST_EXPECT(blockedCount == 0);
+            }
+            else
+            {
+                BEAST_EXPECT(blockedCount > 10);
+            }
+        }
+    }
+
+    void
+    testUnderFundedXrpIouQChange()
+    {
+        testcase("exercise underfunded XRP/IOU offer Q change");
+
+        // Bob places an offer that is not fully funded.
+        //
+        // This unit test compares the behavior of this situation before and
+        // after applying the fixReducedOffersV1 amendment.
+
+        using namespace jtx;
+        auto const alice = Account{"alice"};
+        auto const bob = Account{"bob"};
+        auto const gw = Account{"gw"};
+        auto const USD = gw["USD"];
+
+        // Make one test run without fixReducedOffersV1 and one with.
+        for (FeatureBitset features :
+             {supported_amendments() - fixReducedOffersV1,
+              supported_amendments() | fixReducedOffersV1})
+        {
+            Env env{*this, features};
+
+            env.fund(XRP(10000), alice, bob, gw);
+            env.close();
+            env.trust(USD(1000), alice, bob);
+
+            int blockedOrderBookCount = 0;
+            for (STAmount initialBobUSD = USD(0.45); initialBobUSD <= USD(1);
+                 initialBobUSD += USD(0.025))
+            {
+                // underfund bob's offer
+                env(pay(gw, bob, initialBobUSD));
+                env.close();
+
+                std::uint32_t const bobsOfferSeq = env.seq(bob);
+                env(offer(bob, drops(2), USD(1)));
+                env.close();
+
+                // alice places an offer would cross bob's if bob's were
+                // well funded.
+                std::uint32_t const aliceOfferSeq = env.seq(alice);
+                env(offer(alice, USD(1), drops(2)));
+                env.close();
+
+                // We want to detect order book blocking.  If:
+                //  1. bob's offer is still in the ledger and
+                //  2. alice received no USD
+                // then we use that as evidence that bob's offer blocked the
+                // order book.
+                {
+                    Json::Value bobsOfferJson =
+                        ledgerEntryOffer(env, bob, bobsOfferSeq);
+                    bool const bobsOfferGone =
+                        bobsOfferJson.isMember(jss::error) &&
+                        bobsOfferJson[jss::error] == "entryNotFound";
+
+                    STAmount aliceBalanceUSD = env.balance(alice, USD);
+
+                    // Sanity check the ledger if alice got USD.
+                    if (aliceBalanceUSD.signum() > 0)
+                    {
+                        BEAST_EXPECT(aliceBalanceUSD == initialBobUSD);
+                        BEAST_EXPECT(env.balance(bob, USD) == USD(0));
+                        BEAST_EXPECT(bobsOfferGone);
+                    }
+
+                    // Track occurrences of order book blocking.
+                    if (!bobsOfferGone && aliceBalanceUSD.signum() == 0)
+                    {
+                        ++blockedOrderBookCount;
+                    }
+
+                    // In preparation for the next iteration clean up any
+                    // leftover offers.
+                    env(offer_cancel(alice, aliceOfferSeq));
+                    env(offer_cancel(bob, bobsOfferSeq));
+                    env.close();
+
+                    // Zero out alice's and bob's USD balances.
+                    if (STAmount const aliceBalance = env.balance(alice, USD);
+                        aliceBalance.signum() > 0)
+                        env(pay(alice, gw, aliceBalance));
+
+                    if (STAmount const bobBalance = env.balance(bob, USD);
+                        bobBalance.signum() > 0)
+                        env(pay(bob, gw, bobBalance));
+
+                    env.close();
+                }
+            }
+
+            // If fixReducedOffersV1 is enabled, then none of the test cases
+            // should produce a potentially blocking rate.
+            //
+            // Also verify that if fixReducedOffersV1 is not enabled then
+            // some of the test cases produced a potentially blocking rate.
+            if (features[fixReducedOffersV1])
+            {
+                BEAST_EXPECT(blockedOrderBookCount == 0);
+            }
+            else
+            {
+                BEAST_EXPECT(blockedOrderBookCount > 15);
+            }
+        }
+    }
+
+    void
+    testUnderFundedIouIouQChange()
+    {
+        testcase("exercise underfunded IOU/IOU offer Q change");
+
+        // Bob places an IOU/IOU offer that is not fully funded.
+        //
+        // This unit test compares the behavior of this situation before and
+        // after applying the fixReducedOffersV1 amendment.
+
+        using namespace jtx;
+        using namespace std::chrono_literals;
+        auto const alice = Account{"alice"};
+        auto const bob = Account{"bob"};
+        auto const gw = Account{"gw"};
+
+        auto const USD = gw["USD"];
+        auto const EUR = gw["EUR"];
+
+        STAmount const tinyUSD(USD.issue(), /*mantissa*/ 1, /*exponent*/ -81);
+
+        // Make one test run without fixReducedOffersV1 and one with.
+        for (FeatureBitset features :
+             {supported_amendments() - fixReducedOffersV1,
+              supported_amendments() | fixReducedOffersV1})
+        {
+            Env env{*this, features};
+
+            env.fund(XRP(10000), alice, bob, gw);
+            env.close();
+            env.trust(USD(1000), alice, bob);
+            env.trust(EUR(1000), alice, bob);
+
+            STAmount const eurOffer(
+                EUR.issue(), /*mantissa*/ 2957, /*exponent*/ -76);
+            STAmount const usdOffer(
+                USD.issue(), /*mantissa*/ 7109, /*exponent*/ -76);
+
+            STAmount const endLoop(
+                USD.issue(), /*mantissa*/ 50, /*exponent*/ -81);
+
+            int blockedOrderBookCount = 0;
+            for (STAmount initialBobUSD = tinyUSD; initialBobUSD <= endLoop;
+                 initialBobUSD += tinyUSD)
+            {
+                // underfund bob's offer
+                env(pay(gw, bob, initialBobUSD));
+                env(pay(gw, alice, EUR(100)));
+                env.close();
+
+                // This offer is underfunded
+                std::uint32_t bobsOfferSeq = env.seq(bob);
+                env(offer(bob, eurOffer, usdOffer));
+                env.close();
+                env.require(offers(bob, 1));
+
+                // alice places an offer that crosses bob's.
+                std::uint32_t aliceOfferSeq = env.seq(alice);
+                env(offer(alice, usdOffer, eurOffer));
+                env.close();
+
+                // Examine the aftermath of alice's offer.
+                {
+                    Json::Value bobsOfferJson =
+                        ledgerEntryOffer(env, bob, bobsOfferSeq);
+                    bool const bobsOfferGone =
+                        bobsOfferJson.isMember(jss::error) &&
+                        bobsOfferJson[jss::error] == "entryNotFound";
+
+                    STAmount aliceBalanceUSD = env.balance(alice, USD);
+#if 0
+                    std::cout
+                        << "bobs initial: " << initialBobUSD
+                        << "; alice final: " << aliceBalanceUSD
+                        << "; bobs offer: " << bobsOfferJson.toStyledString()
+                        << std::endl;
+#endif
+                    // Sanity check the ledger if alice got USD.
+                    if (aliceBalanceUSD.signum() > 0)
+                    {
+                        BEAST_EXPECT(aliceBalanceUSD == initialBobUSD);
+                        BEAST_EXPECT(env.balance(bob, USD) == USD(0));
+                        BEAST_EXPECT(bobsOfferGone);
+                    }
+
+                    // Track occurrences of order book blocking.
+                    if (!bobsOfferGone && aliceBalanceUSD.signum() == 0)
+                    {
+                        ++blockedOrderBookCount;
+                    }
+                }
+
+                // In preparation for the next iteration clean up any
+                // leftover offers.
+                env(offer_cancel(alice, aliceOfferSeq));
+                env(offer_cancel(bob, bobsOfferSeq));
+                env.close();
+
+                // Zero out alice's and bob's IOU balances.
+                auto zeroBalance = [&env, &gw](
+                                       Account const& acct, IOU const& iou) {
+                    if (STAmount const balance = env.balance(acct, iou);
+                        balance.signum() > 0)
+                        env(pay(acct, gw, balance));
+                };
+
+                zeroBalance(alice, EUR);
+                zeroBalance(alice, USD);
+                zeroBalance(bob, EUR);
+                zeroBalance(bob, USD);
+                env.close();
+            }
+
+            // If fixReducedOffersV1 is enabled, then none of the test cases
+            // should produce a potentially blocking rate.
+            //
+            // Also verify that if fixReducedOffersV1 is not enabled then
+            // some of the test cases produced a potentially blocking rate.
+            if (features[fixReducedOffersV1])
+            {
+                BEAST_EXPECT(blockedOrderBookCount == 0);
+            }
+            else
+            {
+                BEAST_EXPECT(blockedOrderBookCount > 20);
+            }
+        }
+    }
+
+    void
+    run() override
+    {
+        testPartialCrossNewXrpIouQChange();
+        testPartialCrossOldXrpIouQChange();
+        testUnderFundedXrpIouQChange();
+        testUnderFundedIouIouQChange();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE_PRIO(ReducedOffer, tx, ripple, 2);
+
+}  // namespace test
+}  // namespace ripple

--- a/src/test/app/ReducedOffer_test.cpp
+++ b/src/test/app/ReducedOffer_test.cpp
@@ -200,7 +200,7 @@ public:
             }
             else
             {
-                BEAST_EXPECT(blockedCount >= 180);
+                BEAST_EXPECT(blockedCount >= 170);
             }
         }
     }
@@ -343,7 +343,7 @@ public:
             // ledger should increase with each iteration.
             unsigned int blockedCount = 0;
             for (std::uint64_t mantissaReduce = 1'000'000'000ull;
-                 mantissaReduce < 4'000'000'000ull;
+                 mantissaReduce <= 4'000'000'000ull;
                  mantissaReduce += 20'000'000ull)
             {
                 STAmount bobUSD{
@@ -412,7 +412,7 @@ public:
                 env(offer(bob, drops(2), USD(1)));
                 env.close();
 
-                // alice places an offer would cross bob's if bob's were
+                // alice places an offer that would cross bob's if bob's were
                 // well funded.
                 std::uint32_t const aliceOfferSeq = env.seq(alice);
                 env(offer(alice, USD(1), drops(2)));


### PR DESCRIPTION
## High Level Overview of Change

The goal of this amendment is to curtail the occurrence of order books that are blocked by reduced offers.

This commit identifies three ways in which offers can be reduced:

1. A new offer can be partially crossed by existing offers, so the new offer is reduced when placed in the ledger.

2. An in-ledger offer can be partially crossed by a new offer in a transaction.  So the in-ledger offer is reduced by the new offer.

3. An in-ledger offer may be under-funded.  In this case the in-ledger offer is scaled down to match the available funds.

Reduced offers can block order books if the effective quality of the reduced offer is worse than the quality of the original
offer (from the perspective of the taker).  It turns out that, for small values, the quality of the reduced offer can be significantly affected by the rounding mode used during scaling computations.

This commit adjusts some rounding modes so that the quality of a reduced offer is always at least as good (from the taker's perspective) as the original offer.

These rounding changes are on an amendment because they will affect transaction outcomes.  The amendment is titled `fixReducedOffersV1` because additional ways of producing reduced offers may come to light.  So there may be a future need for a `V2` amendment.

### Context of Change

Occasional blocked order books have been a long-standing low-level irritant with the DEX.  There has been at least one patch that helped to manage the problem.  But the patch did not really make the problem go away.  This pull request goes to the root of these blockages and just makes them go away.

First, it's important to recognize that both XRP and IOUs have finite representations in the ledger.  For example, it is not possible to represent fractions of drops.  IOUs also have a finite representation that becomes apparent with very small or very large numbers.  So when a number cannot be precisely represented in XRP or by an IOU it must be rounded.

This pull request changes the rounding mode that is used when calculating a reduced offer.  The rounding is changed so that the quality of the reduced offer is always the same or better than the quality of the original offer (viewing the offer's quality from the taker's perspective).

Note that this change affects the values that offers in the ledger contain.  However the change in representation is at most either...

1. One drop of XRP or
2. 1e-81 of an IOU.

As the values in offers get tiny, rounding effects can have an outsize influence on the quality of an offer.  But the offers are only being adjusted by minute amounts of actual funds.

### Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tests (tests for the changes are included in this pull request)
- [x] Documentation Updates

I'm calling this a breaking change because outcomes on the DEX are affected.  People who care deeply about the specifics of DEX corner cases would do well to understand the consequences of this pull request.  The pull request also includes an amendment, which can cause amendment blockage.

I'm unsure whether the Doc team will want to include discussion of the details of this change.  But they should be aware of the change and decide for themselves.

### Interactions with `Number`

It turns out that this pull request interacts with the new `Number` integration with `STAmount`.  There are three specific things to note:

**`STAmount::canonicalize rounding`**  The rounding characteristics of `STAmount::canonicalize()` changed when `Number` was integrated.  The new default `canonicalize` rounding interacted badly with the rounding that `fixReducedOffersV1` requires.  Fortunately, `Number` provides a way to remotely control its rounding mode.  This pull request uses that capability.

**`Number` Rounding Modes**  The rounding modes that `Number` provides do not align precisely with the rounding that `STAmount` operations use.  `STAmount` uses a `bool` named `roundUp`.  But, what that `bool` really means is `roundAwayFromZero`.  So the rounding direction reverses for negative numbers.  If the `bool` is `true` `STAmount` rounds away from zero, and `false` rounds toward zero.

`Number` provides a `towards_zero` rounding mode.  So that's covered.  But `Number` does not provide an `away_from_zero` rounding mode.  So I faked this with `Number`'s `upward` rounding mode.  This should usually work.  And it works in all of my tests because `STAmount` values are _usually_ positive.

But it would be nice if `Number` provided an `away_from_zero` rounding mode.  That would remove the compromise of faking it with `upward`.

**`Number::RoundModeGuard`**.  As I was surgically controlling the `Number` rounding mode to get the behavior I wanted out of `STAmount::canonicalize()` I introduced a bug.  I wanted a way to change the `Number` rounding mode only while I was in a scope and have that mode revert when I left scope.  I thought that `Number` provided that precise tool with `saveNumberRoundMode`.  But I was wrong.  I did not read the code carefully enough and made assumptions about the behavior.  So I misused `saveNumberRoundMode` and @HowardHinnant set me right.

@HowardHinnant ended up implementing `NumberRoundModeGuard` to give me exactly the behavior that I wanted.  You can see that (almost trivial) implementation in STAmount.cpp of this pull request.

In general I personally think `NumberRoundModeGuard` is exactly the tool that folks should reach for when surgically adjusting the rounding mode.  I'd like to suggest that it should be a permanent fixture in `Number`.

**`Number` Request Summary**  Here are the changes I'm hoping for:

1. Add an `away_from_zero` rounding mode to `Number`.
2. Make `Number::RoundModeGuard` a part of the `Number` implementation similar to `saveNumberRoundMode`.

I'll be curious what @gregtatcam and @HowardHinnant think regarding these requests.

I'm requesting @gregtatcam and @HowardHinnant as reviewers since they have the most experience with `Number`.  I'm _hoping_ that @seelabs will also take a gander since these changes are integrated into the payment engine.