### PR TITLE
Adjust local fees when the job queue is overloaded:

### DIFF
--- a/src/ripple/app/main/LoadManager.cpp
+++ b/src/ripple/app/main/LoadManager.cpp
@@ -168,26 +168,26 @@ LoadManager::run()
                 LogicError("Deadlock detected");
             }
         }
-    }
 
-    bool change;
+        bool change;
 
-    if (app_.getJobQueue().isOverloaded())
-    {
-        JLOG(journal_.info()) << "Raising local fee (JQ overload): "
-                              << app_.getJobQueue().getJson(0);
-        change = app_.getFeeTrack().raiseLocalFee();
-    }
-    else
-    {
-        change = app_.getFeeTrack().lowerLocalFee();
-    }
+        if (app_.getJobQueue().isOverloaded())
+        {
+            JLOG(journal_.info()) << "Raising local fee (JQ overload): "
+                                  << app_.getJobQueue().getJson(0);
+            change = app_.getFeeTrack().raiseLocalFee();
+        }
+        else
+        {
+            change = app_.getFeeTrack().lowerLocalFee();
+        }
 
-    if (change)
-    {
-        // VFALCO TODO replace this with a Listener / observer and
-        // subscribe in NetworkOPs or Application.
-        app_.getOPs().reportFeeChange();
+        if (change)
+        {
+            // VFALCO TODO replace this with a Listener / observer and
+            // subscribe in NetworkOPs or Application.
+            app_.getOPs().reportFeeChange();
+        }
     }
 }
 


### PR DESCRIPTION
Commit d36024394de079f4613f260b465f9e380a26c54d accidentally broke the logic used to raise local fees in response to a job queue overload.

This commit simply moves a block of code "up" a level, so that it runs with every loop iteration--the original intention of the code--instead of only after the loop has ended.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release