### PR TITLE
Move faulty assert

### DIFF
--- a/src/ripple/nodestore/impl/Shard.cpp
+++ b/src/ripple/nodestore/impl/Shard.cpp
@@ -688,9 +688,6 @@ Shard::finalize(bool writeSQLite, std::optional<uint256> const& referenceHash)
 
         ledger->stateMap().setLedgerSeq(ledgerSeq);
         ledger->txMap().setLedgerSeq(ledgerSeq);
-        assert(
-            ledger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
-            ledger->read(keylet::fees()));
         ledger->setImmutable();
         if (!ledger->stateMap().fetchRoot(
                 SHAMapHash{ledger->info().accountHash}, nullptr))
@@ -712,6 +709,11 @@ Shard::finalize(bool writeSQLite, std::optional<uint256> const& referenceHash)
 
         if (writeSQLite && !storeSQLite(ledger))
             return fail("failed storing to SQLite databases");
+
+        assert(
+            ledger->info().seq == ledgerSeq &&
+            (ledger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
+             ledger->read(keylet::fees())));
 
         hash = ledger->info().parentHash;
         next = std::move(ledger);


### PR DESCRIPTION
## High Level Overview of Change

Does what it says on the tin. One of the asserts introduced in #4319 (66627b26cfae8e1c902546f0778dd9b013aedc5a) was put in the wrong place, but wasn't triggered unless shards were configured.

This pull request, if merged, moves the assert to the right place, and updates it to ensure correctness.

Note that normally asserts are only checked in debug builds, so release packages will not be affected.

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)

## Test Plan

* Run a debug build with shards configured.
* Wait until rippled downloads some shards.
* May need to restart once the shard is downloaded, (I'm not sure, and haven't reproduced yet.)

Before this fix:
* rippled will assert in Shard.cpp line 693.

After this fix:
* rippled will not assert.