### PR TITLE
[TRIVIAL] Add missing includes

### DIFF
--- a/src/ripple/basics/StringUtilities.h
+++ b/src/ripple/basics/StringUtilities.h
@@ -25,7 +25,9 @@
 
 #include <boost/format.hpp>
 #include <boost/utility/string_view.hpp>
+
 #include <array>
+#include <cstdint>
 #include <optional>
 #include <sstream>
 #include <string>

--- a/src/ripple/basics/base64.h
+++ b/src/ripple/basics/base64.h
@@ -57,6 +57,7 @@
 #ifndef RIPPLE_BASICS_BASE64_H_INCLUDED
 #define RIPPLE_BASICS_BASE64_H_INCLUDED
 
+#include <cstdint>
 #include <string>
 
 namespace ripple {

--- a/src/ripple/json/impl/json_reader.cpp
+++ b/src/ripple/json/impl/json_reader.cpp
@@ -19,8 +19,10 @@
 
 #include <ripple/basics/contract.h>
 #include <ripple/json/json_reader.h>
+
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <istream>
 #include <string>
 


### PR DESCRIPTION
gcc 13.1 failed to compile rippled due to missing headers. This patch adds the needed headers.


- [ X] Bug fix (non-breaking change which fixes an issue)
