### PR TITLE
Use Artifactory remote in nix workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -67,11 +67,11 @@ jobs:
           conan profile update env.CC=${{ matrix.profile.cc }} default
           conan profile update env.CXX=${{ matrix.profile.cxx }} default
           conan profile update conf.tools.build:compiler_executables='{"c": "${{ matrix.profile.cc }}", "cpp": "${{ matrix.profile.cxx }}"}' default
-      - name: try to add ripple Conan remote
+          conan remote add ripple ${{ vars.CONAN_URL }} --insert 0
+      - name: try to authenticate to ripple Conan remote
         id: remote
         continue-on-error: true
         run: |
-          conan remote add ripple ${{ secrets.CONAN_URL }} --insert 0
           conan user --remote ripple ${{ secrets.CONAN_USERNAME }} --password ${{ secrets.CONAN_TOKEN }}
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,7 +12,8 @@ on: [push, pull_request]
 # and builds and caches binaries for all the dependencies.
 # If an Artifactory remote is configured, they are cached there.
 # If not, they are added to the GitHub artifact.
-# GitHub's "cache" action has a size limit that is too small.
+# GitHub's "cache" action has a size limit (10 GB) that is too small
+# to hold the binaries if they are built locally.
 # We must use the "{upload,download}-artifact" actions instead.
 #
 # The second phase has a job in the matrix for each test configuration.
@@ -74,16 +75,15 @@ jobs:
           conan remote add ripple ${{ env.CONAN_URL }} --insert 0
       - name: try to authenticate to ripple Conan remote
         id: remote
-        continue-on-error: true
         run: |
-          conan user --remote ripple ${{ secrets.CONAN_USERNAME }} --password ${{ secrets.CONAN_TOKEN }}
+          echo outcome=$(conan user --remote ripple ${{ secrets.CONAN_USERNAME }} --password ${{ secrets.CONAN_TOKEN }} && echo success || echo failure) | tee ${GITHUB_OUTPUT}
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar -C ~/.conan .
       - name: list missing binaries
         id: binaries
         # Print the list of dependencies that would need to be built locally.
-        # A non-zero number means we have "failed" to cache binaries remotely.
+        # A non-empty list means we have "failed" to cache binaries remotely.
         run: |
           echo missing=$(conan info . --build missing --json 2>/dev/null  | grep '^\[') | tee ${GITHUB_OUTPUT}
       - name: build dependencies
@@ -92,10 +92,10 @@ jobs:
         with:
           configuration: ${{ matrix.configuration }}
       - name: upload dependencies to remote
-        if: (steps.binaries.outputs.missing != '[]') && (steps.remote.outcome == 'success')
+        if: (steps.binaries.outputs.missing != '[]') && (steps.remote.outputs.outcome == 'success')
         run: conan upload --remote ripple '*' --all --parallel --confirm
       - name: recreate archive with dependencies
-        if: (steps.binaries.outputs.missing != '[]') && (steps.remote.outcome == 'failure')
+        if: (steps.binaries.outputs.missing != '[]') && (steps.remote.outputs.outcome == 'failure')
         run: tar -czf conan.tar -C ~/.conan .
       - name: upload archive
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -76,24 +76,22 @@ jobs:
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar -C ~/.conan .
-      - name: count number of missing binaries
+      - name: list missing binaries
         id: binaries
-        continue-on-error: true
-        # The subcommand here counts the number of dependencies that would
-        # need to be built locally. We exit with that number.
+        # Print the list of dependencies that would need to be built locally.
         # A non-zero number means we have "failed" to cache binaries remotely.
         run: |
-          exit $(conan info . --build missing --json 2>/dev/null  | grep '^\[' | tee /dev/tty | jq length)
+          echo missing=$(conan info . --build missing --json 2>/dev/null  | grep '^\[') | tee ${GITHUB_OUTPUT}
       - name: build dependencies
-        if: (steps.binaries.outcome == 'failure')
+        if: (steps.binaries.outputs.missing != '[]')
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
       - name: upload dependencies to remote
-        if: (steps.binaries.outcome == 'failure') && (steps.remote.outcome == 'success') 
+        if: (steps.binaries.outputs.missing != '[]') && (steps.remote.outcome == 'success')
         run: conan upload --remote ripple '*' --all --parallel --confirm
       - name: recreate archive with dependencies
-        if: (steps.binaries.outcome == 'failure') && (steps.remote.outcome == 'failure') 
+        if: (steps.binaries.outputs.missing != '[]') && (steps.remote.outcome == 'failure')
         run: tar -czf conan.tar -C ~/.conan .
       - name: upload archive
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -58,6 +58,8 @@ jobs:
           cmake --version
           env
       - name: configure Conan
+        env:
+          CONAN_URL: http://18.143.149.228:8081/artifactory/api/conan/conan-non-prod
         run: |
           conan profile new default --detect
           conan profile update settings.compiler.cppstd=20 default
@@ -67,7 +69,9 @@ jobs:
           conan profile update env.CC=${{ matrix.profile.cc }} default
           conan profile update env.CXX=${{ matrix.profile.cxx }} default
           conan profile update conf.tools.build:compiler_executables='{"c": "${{ matrix.profile.cc }}", "cpp": "${{ matrix.profile.cxx }}"}' default
-          conan remote add ripple ${{ vars.CONAN_URL }} --insert 0
+          # Do not quote the URL. An empty string will be accepted (with
+          # a non-fatal warning), but a missing argument will not.
+          conan remote add ripple ${{ env.CONAN_URL }} --insert 0
       - name: try to authenticate to ripple Conan remote
         id: remote
         continue-on-error: true

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,6 +1,24 @@
 name: nix
 on: [push, pull_request]
 
+# This workflow has two job matrixes.
+# They can be considered phases because the second matrix ("test")
+# depends on the first ("dependencies").
+#
+# The first phase has a job in the matrix for each combination of
+# variables that affects dependency ABI:
+# platform, compiler, and configuration.
+# It creates a GitHub artifact holding the Conan profile,
+# and builds and caches binaries for all the dependencies.
+# If an Artifactory remote is configured, they are cached there.
+# If not, they are added to the GitHub artifact.
+# GitHub's "cache" action has a size limit that is too small.
+# We must use the "{upload,download}-artifact" actions instead.
+#
+# The second phase has a job in the matrix for each test configuration.
+# It installs dependency binaries from the cache, whichever was used,
+# and builds and tests rippled.
+
 jobs:
 
   dependencies:
@@ -31,6 +49,8 @@ jobs:
     env:
       build_dir: .build
     steps:
+      - name: checkout
+        uses: actions/checkout@v3
       - name: check environment
         run: |
           echo ${PATH} | tr ':' '\n'
@@ -47,19 +67,40 @@ jobs:
           conan profile update env.CC=${{ matrix.profile.cc }} default
           conan profile update env.CXX=${{ matrix.profile.cxx }} default
           conan profile update conf.tools.build:compiler_executables='{"c": "${{ matrix.profile.cc }}", "cpp": "${{ matrix.profile.cxx }}"}' default
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: dependencies
+      - name: try to add ripple Conan remote
+        id: remote
+        continue-on-error: true
+        run: |
+          conan remote add ripple ${{ secrets.CONAN_URL }} --insert 0
+          conan user --remote ripple ${{ secrets.CONAN_USERNAME }} --password ${{ secrets.CONAN_TOKEN }}
+      - name: archive profile
+        # Create this archive before dependencies are added to the local cache.
+        run: tar -czf conan.tar -C ~/.conan .
+      - name: count number of missing binaries
+        id: binaries
+        continue-on-error: true
+        # The subcommand here counts the number of dependencies that would
+        # need to be built locally. We exit with that number.
+        # A non-zero number means we have "failed" to cache binaries remotely.
+        run: |
+          exit $(conan info . --build missing --json 2>/dev/null  | grep '^\[' | tee /dev/tty | jq length)
+      - name: build dependencies
+        if: (steps.binaries.outcome == 'failure')
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
-      - name: archive cache
+      - name: upload dependencies to remote
+        if: (steps.binaries.outcome == 'failure') && (steps.remote.outcome == 'success') 
+        run: conan upload --remote ripple '*' --all --parallel --confirm
+      - name: recreate archive with dependencies
+        if: (steps.binaries.outcome == 'failure') && (steps.remote.outcome == 'failure') 
         run: tar -czf conan.tar -C ~/.conan .
-      - name: upload cache
+      - name: upload archive
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.platform }}-${{ matrix.compiler }}-${{ matrix.configuration }}
           path: conan.tar
+          if-no-files-found: error
 
 
   test:


### PR DESCRIPTION
Ripple has created a semi-public Artifactory (thanks @shichengripple001 and team!) to hold dependency binaries for our builds. I was able to rewrite our `nix` workflow to use it and cut the time down to a mere [21 minutes](https://github.com/thejohnfreeman/rippled/actions/runs/5178187319). This workflow should continue to work (just more slowly) for forks that do not have access to the Artifactory.

The new bottleneck is the `macos` workflow which took [31 minutes](https://github.com/thejohnfreeman/rippled/actions/runs/5178187323). There is no low-hanging fruit to reduce that time though. AWS sells only one size of macOS instance. The next best improvement we can make is to fix parallel testing on macOS