### PR TITLE
Trivial: add comments for NFToken-related invariants

### DIFF
--- a/src/ripple/app/tx/impl/InvariantCheck.h
+++ b/src/ripple/app/tx/impl/InvariantCheck.h
@@ -318,6 +318,17 @@ public:
         beast::Journal const&);
 };
 
+/**
+ * @brief Invariant: Validates several invariants for NFToken pages.
+ *
+ * The following checks are made:
+ *  - The page is correctly associated with the owner.
+ *  - The page is correctly ordered between the next and previous links.
+ *  - The page contains a valid number of NFTokens.
+ *  - The NFTokens on this page do not belong on a lower or higher page.
+ *  - The NFTokens are correctly sorted on the page.
+ *  - Each URI, if present, is not empty.
+ */
 class ValidNFTokenPage
 {
     bool badEntry_ = false;
@@ -342,6 +353,19 @@ public:
         beast::Journal const&);
 };
 
+/**
+ * @brief Invariant: Validates counts of NFTokens after all transaction types.
+ *
+ * The following checks are made:
+ *  - The number of minted or burned tokens may only be changed by
+ *    NFTokenMint or NFTokenBurn transactions.
+ *  - A successful NFTokenMint must increase the number of NFTokens.
+ *  - A failed NFTokenMint must not change the number of minted NFTokens.
+ *  - An NFTokenMint transaction may not change the number of burned NFTokens,
+ *  - A successful NFTokenBurn must increase the number of burned NFTokens.
+ *  - A failed NFTokenBurn must not change the number of burned NFTokens.
+ *  - An NFTokenBurn transaction may not change the number of minted NFTokens.
+ */
 class NFTokenCountTracking
 {
     std::uint32_t beforeMintedTotal = 0;


### PR DESCRIPTION
## High Level Overview of Change

The docs folks rely on comments describing the invariants.  Two invariants had been added without comments.  This pull request adds the comments so they will be available for docs folks into the future.

### Context of Change

Docs folks were updating the invariants documentation and noted some information was missing.  This adds the information they need.

### Type of Change

- [X] Documentation Updates

