### PR TITLE
Enable the Beta RPC API (v2) for all unit tests:

### DIFF
--- a/src/test/jtx/impl/envconfig.cpp
+++ b/src/test/jtx/impl/envconfig.cpp
@@ -49,6 +49,9 @@ setupConfigForUnitTests(Config& cfg)
     cfg.FEES.account_reserve = XRP(200).value().xrp().drops();
     cfg.FEES.owner_reserve = XRP(50).value().xrp().drops();
 
+    // The Beta API (currently v2) is always available to tests
+    cfg.BETA_RPC_API = true;
+
     cfg.overwrite(ConfigSection::nodeDatabase(), "type", "memory");
     cfg.overwrite(ConfigSection::nodeDatabase(), "path", "main");
     cfg.deprecatedClearSection(ConfigSection::importNodeDatabase());

--- a/src/test/rpc/AccountInfo_test.cpp
+++ b/src/test/rpc/AccountInfo_test.cpp
@@ -206,10 +206,7 @@ public:
     testSignerListsApiVersion2()
     {
         using namespace jtx;
-        Env env{*this, envconfig([](std::unique_ptr<Config> c) {
-                    c->loadFromString("\n[beta_rpc_api]\n1\n");
-                    return c;
-                })};
+        Env env{*this};
         Account const alice{"alice"};
         env.fund(XRP(1000), alice);
 

--- a/src/test/rpc/Version_test.cpp
+++ b/src/test/rpc/Version_test.cpp
@@ -76,11 +76,16 @@ class Version_test : public beast::unit_test::suite
                 std::to_string(RPC::apiMinimumSupportedVersion - 1) + "}");
         BEAST_EXPECT(badVersion(re));
 
+        BEAST_EXPECT(env.app().config().BETA_RPC_API);
         re = env.rpc(
             "json",
             "version",
             "{\"api_version\": " +
-                std::to_string(RPC::apiMaximumSupportedVersion + 1) + "}");
+                std::to_string(
+                    std::max(
+                        RPC::apiMaximumSupportedVersion, RPC::apiBetaVersion) +
+                    1) +
+                "}");
         BEAST_EXPECT(badVersion(re));
 
         re = env.rpc("json", "version", "{\"api_version\": \"a\"}");
@@ -190,20 +195,25 @@ class Version_test : public beast::unit_test::suite
         using namespace test::jtx;
         Env env{*this};
 
+        BEAST_EXPECT(env.app().config().BETA_RPC_API);
         auto const without_api_verion = std::string("{ ") +
             "\"jsonrpc\": \"2.0\", "
             "\"ripplerpc\": \"2.0\", "
             "\"id\": 5, "
             "\"method\": \"version\", "
             "\"params\": {}}";
-        auto const with_wrong_api_verion = std::string("{ ") +
+        auto const with_wrong_api_verion =
+            std::string("{ ") +
             "\"jsonrpc\": \"2.0\", "
             "\"ripplerpc\": \"2.0\", "
             "\"id\": 6, "
             "\"method\": \"version\", "
             "\"params\": { "
             "\"api_version\": " +
-            std::to_string(RPC::apiMaximumSupportedVersion + 1) + "}}";
+            std::to_string(
+                std::max(RPC::apiMaximumSupportedVersion, RPC::apiBetaVersion) +
+                1) +
+            "}}";
         auto re = env.rpc(
             "json2",
             '[' + without_api_verion + ", " + with_wrong_api_verion + ']');


### PR DESCRIPTION
## High Level Overview of Change

I noticed recently a handful of PRs (#4552, #4568, and #4571) that are changing the `apiMaximumSupportedVersion` value from 1 to 2, which would indicate that version two is finalized and out of beta, apparently only to enable API version testing in unit tests.

IMHO, the proper way to enable versioning in unit tests is to enable the `BETA_RPC_API` flag in the config. For simplicity, this PR sets that flag in the default unit test config, so now the beta (v2) is available to all unit tests. The default will still be 1, but any new unit tests should be able to specify an API version and work as expected without any hassle.

### Type of Change

- [X ] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Test Plan

As this code only effects unit tests, the only testing necessary should be to verify that unit tests pass.