### PR TITLE
[Trivial] Fix build references to deleted ServerHandlerImp

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -602,7 +602,7 @@ public:
         return *m_networkOPs;
     }
 
-    virtual ServerHandlerImp&
+    virtual ServerHandler&
     getServerHandler() override
     {
         assert(serverHandler_);

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -89,7 +89,7 @@ class Overlay;
 class PathRequests;
 class PendingSaves;
 class PublicKey;
-class ServerHandlerImp;
+class ServerHandler;
 class SecretKey;
 class STLedgerEntry;
 class TimeKeeper;
@@ -232,7 +232,7 @@ public:
     getOPs() = 0;
     virtual OrderBookDB&
     getOrderBookDB() = 0;
-    virtual ServerHandlerImp&
+    virtual ServerHandler&
     getServerHandler() = 0;
     virtual TransactionMaster&
     getMasterTransaction() = 0;

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -64,8 +64,8 @@
 #include <ripple/resource/ResourceManager.h>
 #include <ripple/rpc/BookChanges.h>
 #include <ripple/rpc/DeliveredAmount.h>
+#include <ripple/rpc/ServerHandler.h>
 #include <ripple/rpc/impl/RPCHelpers.h>
-#include <ripple/rpc/impl/ServerHandlerImp.h>
 #include <boost/asio/ip/host_name.hpp>
 #include <boost/asio/steady_timer.hpp>
 


### PR DESCRIPTION
## High Level Overview of Change

* Fixes the build by changing references to `ServerHandlerImp` to the more correct `ServerHandler`.

### Context of Change

* Commits 0b812cd (#4427) and 11e914f (#4516) conflict. The first added references to `ServerHandlerImp` in files outside of that class's organizational unit (which is technically incorrect). The second removed `ServerHandlerImp`, but was not up to date with develop. This results in the build failing in all circumstances.

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)

## Before / After

Before: `rippled` doesn't build.
After: It does.

## Future Tasks

Dedicating resources to wiping out all of the levelization issues across the board would help with this kind of thing.