### PR TITLE
Update dependencies

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -6,6 +6,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: unlock Conan
+      shell: bash
+      run: conan remove --locks
     - name: export custom recipes
       shell: bash
       run: |

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -9,7 +9,7 @@ runs:
     - name: export custom recipes
       shell: bash
       run: |
-        conan export external/snappy snappy/1.1.9@
+        conan export external/snappy snappy/1.1.10@
         conan export external/soci soci/4.0.3@
     - name: install dependencies
       shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,6 +30,10 @@ jobs:
           conan --version
           cmake --version
           env
+      - name: configure Conan
+        run : |
+          conan profile get env.CXXFLAGS default || true
+          conan profile update 'conf.tools.build:cxxflags+=["-DBOOST_ASIO_DISABLE_CONCEPTS"]' default
       - name: build
         uses: ./.github/actions/build
         with:

--- a/BUILD.md
+++ b/BUILD.md
@@ -117,7 +117,7 @@ can't build earlier Boost versions.
    which allows you to statically link it with GCC, if you want.
 
    ```
-   conan export external/snappy snappy/1.1.9@
+   conan export external/snappy snappy/1.1.10@
    ```
 
 5. Export our [Conan recipe for SOCI](./external/soci).

--- a/BUILD.md
+++ b/BUILD.md
@@ -180,7 +180,7 @@ can't build earlier Boost versions.
    `$OUTPUT_FOLDER/build/generators/conan_toolchain.cmake`.
 
     Single-config generators:
-    
+
     ```
     cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release ..
     ```
@@ -210,7 +210,7 @@ can't build earlier Boost versions.
    ```
 
    Multi-config generators:
-    
+
    ```
    cmake --build . --config Release
    cmake --build . --config Debug
@@ -279,6 +279,18 @@ conan profile update 'conf.tools.build:cxxflags+=["-DBOOST_ASIO_HAS_STD_INVOKE_R
 ```
 
 
+### call to 'async_teardown' is ambiguous
+
+If you are compiling with an early version of Clang 16, then you might hit
+a [regression][6] when compiling C++20 that manifests as an [error in a Boost
+header][7]. You can workaround it by adding this preprocessor definition:
+
+```
+conan profile update 'env.CXXFLAGS="-DBOOST_ASIO_DISABLE_CONCEPTS"' default
+conan profile update 'conf.tools.build:cxxflags+=["-DBOOST_ASIO_DISABLE_CONCEPTS"]' default
+```
+
+
 ### recompile with -fPIC
 
 If you get a linker error suggesting that you recompile Boost with
@@ -319,6 +331,8 @@ If you want to experiment with a new package, follow these steps:
 [2]: https://en.cppreference.com/w/cpp/compiler_support/20
 [3]: https://docs.conan.io/en/latest/getting_started.html
 [5]: https://en.wikipedia.org/wiki/Unity_build
+[6]: https://github.com/boostorg/beast/issues/2648
+[7]: https://github.com/boostorg/beast/issues/2661
 [build_type]: https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
 [runtime]: https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html
 [toolchain]: https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html

--- a/conanfile.py
+++ b/conanfile.py
@@ -24,18 +24,18 @@ class Xrpl(ConanFile):
     }
 
     requires = [
-        'boost/1.77.0',
+        'boost/1.82.0',
         'date/3.0.1',
-        'libarchive/3.6.0',
-        'lz4/1.9.3',
         'grpc/1.50.1',
+        'libarchive/3.6.2',
+        'lz4/1.9.3',
         'nudb/2.0.8',
-        'openssl/1.1.1m',
-        'protobuf/3.21.4',
-        'snappy/1.1.9',
+        'openssl/1.1.1u',
+        'protobuf/3.21.9',
+        'snappy/1.1.10',
         'soci/4.0.3',
-        'sqlite3/3.38.0',
-        'zlib/1.2.12',
+        'sqlite3/3.42.0',
+        'zlib/1.2.13',
     ]
 
     default_options = {
@@ -51,6 +51,7 @@ class Xrpl(ConanFile):
         'unity': False,
 
         'cassandra-cpp-driver:shared': False,
+        'cassandra-cpp-driver:use_atomic': None,
         'date:header_only': True,
         'grpc:shared': False,
         'grpc:secure': True,
@@ -101,12 +102,12 @@ class Xrpl(ConanFile):
 
     def requirements(self):
         if self.options.jemalloc:
-            self.requires('jemalloc/5.2.1')
+            self.requires('jemalloc/5.3.0')
         if self.options.reporting:
             self.requires('cassandra-cpp-driver/2.15.3')
-            self.requires('libpq/13.6')
+            self.requires('libpq/14.7')
         if self.options.rocksdb:
-            self.requires('rocksdb/6.27.3')
+            self.requires('rocksdb/6.29.5')
 
     exports_sources = (
         'CMakeLists.txt', 'Builds/*', 'bin/getRippledInfo', 'src/*', 'cfg/*'

--- a/external/snappy/conandata.yml
+++ b/external/snappy/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.10":
+    url: "https://github.com/google/snappy/archive/1.1.10.tar.gz"
+    sha256: "49d831bffcc5f3d01482340fe5af59852ca2fe76c3e05df0e67203ebbe0f1d90"
   "1.1.9":
     url: "https://github.com/google/snappy/archive/1.1.9.tar.gz"
     sha256: "75c1fbb3d618dd3a0483bff0e26d0a92b495bbe5059c8b4f1c962b478b6e06e7"
@@ -9,8 +12,29 @@ sources:
     url: "https://github.com/google/snappy/archive/1.1.7.tar.gz"
     sha256: "3dfa02e873ff51a11ee02b9ca391807f0c8ea0529a4924afa645fbf97163f9d4"
 patches:
+  "1.1.10":
+    - patch_file: "patches/1.1.10-0001-fix-inlining-failure.patch"
+      patch_description: "disable inlining for compilation error"
+      patch_type: "portability"
+    - patch_file: "patches/1.1.9-0002-no-Werror.patch"
+      patch_description: "disable 'warning as error' options"
+      patch_type: "portability"
+    - patch_file: "patches/1.1.10-0003-fix-clobber-list-older-llvm.patch"
+      patch_description: "disable inline asm on apple-clang"
+      patch_type: "portability"
+    - patch_file: "patches/1.1.9-0004-rtti-by-default.patch"
+      patch_description: "remove 'disable rtti'"
+      patch_type: "conan"
   "1.1.9":
     - patch_file: "patches/1.1.9-0001-fix-inlining-failure.patch"
+      patch_description: "disable inlining for compilation error"
+      patch_type: "portability"
     - patch_file: "patches/1.1.9-0002-no-Werror.patch"
+      patch_description: "disable 'warning as error' options"
+      patch_type: "portability"
     - patch_file: "patches/1.1.9-0003-fix-clobber-list-older-llvm.patch"
+      patch_description: "disable inline asm on apple-clang"
+      patch_type: "portability"
     - patch_file: "patches/1.1.9-0004-rtti-by-default.patch"
+      patch_description: "remove 'disable rtti'"
+      patch_type: "conan"

--- a/external/snappy/patches/1.1.10-0001-fix-inlining-failure.patch
+++ b/external/snappy/patches/1.1.10-0001-fix-inlining-failure.patch
@@ -1,0 +1,13 @@
+diff --git a/snappy-stubs-internal.h b/snappy-stubs-internal.h
+index 1548ed7..3b4a9f3 100644
+--- a/snappy-stubs-internal.h
++++ b/snappy-stubs-internal.h
+@@ -100,7 +100,7 @@
+ 
+ // Inlining hints.
+ #if HAVE_ATTRIBUTE_ALWAYS_INLINE
+-#define SNAPPY_ATTRIBUTE_ALWAYS_INLINE __attribute__((always_inline))
++#define SNAPPY_ATTRIBUTE_ALWAYS_INLINE
+ #else
+ #define SNAPPY_ATTRIBUTE_ALWAYS_INLINE
+ #endif  // HAVE_ATTRIBUTE_ALWAYS_INLINE

--- a/external/snappy/patches/1.1.10-0003-fix-clobber-list-older-llvm.patch
+++ b/external/snappy/patches/1.1.10-0003-fix-clobber-list-older-llvm.patch
@@ -1,0 +1,13 @@
+diff --git a/snappy.cc b/snappy.cc
+index d414718..e4efb59 100644
+--- a/snappy.cc
++++ b/snappy.cc
+@@ -1132,7 +1132,7 @@ inline size_t AdvanceToNextTagX86Optimized(const uint8_t** ip_p, size_t* tag) {
+   size_t literal_len = *tag >> 2;
+   size_t tag_type = *tag;
+   bool is_literal;
+-#if defined(__GCC_ASM_FLAG_OUTPUTS__) && defined(__x86_64__)
++#if defined(__GCC_ASM_FLAG_OUTPUTS__) && defined(__x86_64__) && ( (!defined(__clang__) && !defined(__APPLE__)) || (!defined(__APPLE__) && defined(__clang__) && (__clang_major__ >= 9)) || (defined(__APPLE__) && defined(__clang__) && (__clang_major__ > 11)) )
+   // TODO clang misses the fact that the (c & 3) already correctly
+   // sets the zero flag.
+   asm("and $3, %k[tag_type]\n\t"

--- a/src/ripple/basics/RangeSet.h
+++ b/src/ripple/basics/RangeSet.h
@@ -28,6 +28,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace ripple {
 

--- a/src/ripple/consensus/Consensus.h
+++ b/src/ripple/consensus/Consensus.h
@@ -30,6 +30,9 @@
 #include <ripple/consensus/LedgerTiming.h>
 #include <ripple/json/json_writer.h>
 #include <boost/logic/tribool.hpp>
+
+#include <chrono>
+#include <deque>
 #include <optional>
 #include <sstream>
 

--- a/src/ripple/json/impl/json_reader.cpp
+++ b/src/ripple/json/impl/json_reader.cpp
@@ -30,8 +30,6 @@ namespace Json {
 // Implementation of class Reader
 // ////////////////////////////////
 
-constexpr unsigned Reader::nest_limit;
-
 static std::string
 codePointToUTF8(unsigned int cp)
 {
@@ -924,8 +922,9 @@ Reader::getLocationLineAndColumn(Location location) const
 {
     int line, column;
     getLocationLineAndColumn(location, line, column);
-    char buffer[18 + 16 + 16 + 1];
-    sprintf(buffer, "Line %d, Column %d", line, column);
+    constexpr std::size_t n = 18 + 16 + 16 + 1;
+    char buffer[n];
+    snprintf(buffer, n, "Line %d, Column %d", line, column);
     return buffer;
 }
 

--- a/src/ripple/net/HTTPClient.h
+++ b/src/ripple/net/HTTPClient.h
@@ -24,7 +24,11 @@
 #include <ripple/core/Config.h>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/streambuf.hpp>
+
 #include <chrono>
+#include <deque>
+#include <functional>
+#include <string>
 
 namespace ripple {
 

--- a/src/ripple/overlay/impl/Handshake.cpp
+++ b/src/ripple/overlay/impl/Handshake.cpp
@@ -288,8 +288,8 @@ verifyHandshake(
     PublicKey const publicKey = [&headers] {
         if (auto const iter = headers.find("Public-Key"); iter != headers.end())
         {
-            auto pk = parseBase58<PublicKey>(
-                TokenType::NodePublic, iter->value());
+            auto pk =
+                parseBase58<PublicKey>(TokenType::NodePublic, iter->value());
 
             if (pk)
             {
@@ -327,8 +327,8 @@ verifyHandshake(
     if (auto const iter = headers.find("Local-IP"); iter != headers.end())
     {
         boost::system::error_code ec;
-        auto const local_ip = boost::asio::ip::address::from_string(
-            iter->value(), ec);
+        auto const local_ip =
+            boost::asio::ip::address::from_string(iter->value(), ec);
 
         if (ec)
             throw std::runtime_error("Invalid Local-IP");
@@ -342,8 +342,8 @@ verifyHandshake(
     if (auto const iter = headers.find("Remote-IP"); iter != headers.end())
     {
         boost::system::error_code ec;
-        auto const remote_ip = boost::asio::ip::address::from_string(
-            iter->value(), ec);
+        auto const remote_ip =
+            boost::asio::ip::address::from_string(iter->value(), ec);
 
         if (ec)
             throw std::runtime_error("Invalid Remote-IP");

--- a/src/ripple/overlay/impl/Handshake.cpp
+++ b/src/ripple/overlay/impl/Handshake.cpp
@@ -27,7 +27,6 @@
 #include <ripple/protocol/digest.h>
 
 #include <boost/regex.hpp>
-#include <boost/utility/string_view.hpp>
 
 #include <algorithm>
 #include <chrono>

--- a/src/ripple/overlay/impl/Handshake.cpp
+++ b/src/ripple/overlay/impl/Handshake.cpp
@@ -25,7 +25,10 @@
 #include <ripple/beast/rfc2616.h>
 #include <ripple/overlay/impl/Handshake.h>
 #include <ripple/protocol/digest.h>
+
 #include <boost/regex.hpp>
+#include <boost/utility/string_view.hpp>
+
 #include <algorithm>
 #include <chrono>
 
@@ -44,7 +47,7 @@ getFeatureValue(
         return {};
     boost::smatch match;
     boost::regex rx(feature + "=([^;\\s]+)");
-    auto const value = header->value().to_string();
+    std::string const value = header->value();
     if (boost::regex_search(value, match, rx))
         return {match[1]};
     return {};
@@ -233,7 +236,7 @@ verifyHandshake(
 {
     if (auto const iter = headers.find("Server-Domain"); iter != headers.end())
     {
-        if (!isProperlyFormedTomlDomain(iter->value().to_string()))
+        if (!isProperlyFormedTomlDomain(iter->value()))
             throw std::runtime_error("Invalid server domain");
     }
 
@@ -241,7 +244,7 @@ verifyHandshake(
     {
         std::uint32_t nid;
 
-        if (!beast::lexicalCastChecked(nid, iter->value().to_string()))
+        if (!beast::lexicalCastChecked(nid, std::string(iter->value())))
             throw std::runtime_error("Invalid peer network identifier");
 
         if (networkID && nid != *networkID)
@@ -251,7 +254,7 @@ verifyHandshake(
     if (auto const iter = headers.find("Network-Time"); iter != headers.end())
     {
         auto const netTime =
-            [str = iter->value().to_string()]() -> TimeKeeper::time_point {
+            [str = std::string(iter->value())]() -> TimeKeeper::time_point {
             TimeKeeper::duration::rep val;
 
             if (beast::lexicalCastChecked(val, str))
@@ -287,7 +290,7 @@ verifyHandshake(
         if (auto const iter = headers.find("Public-Key"); iter != headers.end())
         {
             auto pk = parseBase58<PublicKey>(
-                TokenType::NodePublic, iter->value().to_string());
+                TokenType::NodePublic, iter->value());
 
             if (pk)
             {
@@ -313,7 +316,7 @@ verifyHandshake(
         if (iter == headers.end())
             throw std::runtime_error("No session signature specified");
 
-        auto sig = base64_decode(iter->value().to_string());
+        auto sig = base64_decode(iter->value());
 
         if (!verifyDigest(publicKey, sharedValue, makeSlice(sig), false))
             throw std::runtime_error("Failed to verify session");
@@ -326,7 +329,7 @@ verifyHandshake(
     {
         boost::system::error_code ec;
         auto const local_ip = boost::asio::ip::address::from_string(
-            iter->value().to_string(), ec);
+            iter->value(), ec);
 
         if (ec)
             throw std::runtime_error("Invalid Local-IP");
@@ -341,7 +344,7 @@ verifyHandshake(
     {
         boost::system::error_code ec;
         auto const remote_ip = boost::asio::ip::address::from_string(
-            iter->value().to_string(), ec);
+            iter->value(), ec);
 
         if (ec)
             throw std::runtime_error("Invalid Remote-IP");

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -176,7 +176,7 @@ PeerImp::run()
     if (auto const iter = headers_.find("Closed-Ledger");
         iter != headers_.end())
     {
-        closed = parseLedgerHash(iter->value().to_string());
+        closed = parseLedgerHash(iter->value());
 
         if (!closed)
             fail("Malformed handshake data (1)");
@@ -185,7 +185,7 @@ PeerImp::run()
     if (auto const iter = headers_.find("Previous-Ledger");
         iter != headers_.end())
     {
-        previous = parseLedgerHash(iter->value().to_string());
+        previous = parseLedgerHash(iter->value());
 
         if (!previous)
             fail("Malformed handshake data (2)");
@@ -372,8 +372,8 @@ std::string
 PeerImp::getVersion() const
 {
     if (inbound_)
-        return headers_["User-Agent"].to_string();
-    return headers_["Server"].to_string();
+        return headers_["User-Agent"];
+    return headers_["Server"];
 }
 
 Json::Value
@@ -399,8 +399,8 @@ PeerImp::json()
     if (auto const d = domain(); !d.empty())
         ret[jss::server_domain] = domain();
 
-    if (auto const nid = headers_["Network-ID"].to_string(); !nid.empty())
-        ret[jss::network_id] = nid;
+    if (auto const nid = headers_["Network-ID"]; !nid.empty())
+        ret[jss::network_id] = std::string(nid);
 
     ret[jss::load] = usage_.balance();
 
@@ -839,7 +839,7 @@ PeerImp::name() const
 std::string
 PeerImp::domain() const
 {
-    return headers_["Server-Domain"].to_string();
+    return headers_["Server-Domain"];
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/rpc/impl/ServerHandler.cpp
+++ b/src/ripple/rpc/impl/ServerHandler.cpp
@@ -248,11 +248,11 @@ build_map(boost::beast::http::fields const& h)
     std::map<std::string, std::string> c;
     for (auto const& e : h)
     {
-        auto key(e.name_string().to_string());
+        std::string key(e.name_string());
         std::transform(key.begin(), key.end(), key.begin(), [](auto kc) {
             return std::tolower(static_cast<unsigned char>(kc));
         });
-        c[key] = e.value().to_string();
+        c[key] = e.value();
     }
     return c;
 }

--- a/src/ripple/rpc/impl/WSInfoSub.h
+++ b/src/ripple/rpc/impl/WSInfoSub.h
@@ -50,7 +50,7 @@ public:
         {
             auto it = h.find("X-User");
             if (it != h.end())
-                user_ = it->value().to_string();
+                user_ = it->value();
             fwdfor_ = std::string(forwardedFor(h));
         }
     }

--- a/src/test/app/LedgerLoad_test.cpp
+++ b/src/test/app/LedgerLoad_test.cpp
@@ -154,7 +154,7 @@ class LedgerLoad_test : public beast::unit_test::suite
         copy_file(
             sd.ledgerFile,
             ledgerFileCorrupt,
-            copy_option::overwrite_if_exists,
+            copy_options::overwrite_existing,
             ec);
         if (!BEAST_EXPECTS(!ec, ec.message()))
             return;

--- a/src/test/jtx/TrustedPublisherServer.h
+++ b/src/test/jtx/TrustedPublisherServer.h
@@ -574,7 +574,7 @@ private:
                 if (ec)
                     break;
 
-                auto path = req.target().to_string();
+                std::string path = req.target();
                 res.insert("Server", "TrustedPublisherServer");
                 res.version(req.version());
                 res.keep_alive(req.keep_alive());
@@ -642,7 +642,7 @@ private:
                     auto const sleep_sec =
                         boost::lexical_cast<unsigned int>(path.substr(7));
                     std::this_thread::sleep_for(
-                        std::chrono::seconds{sleep_sec});
+                        std::chrono::seconds(sleep_sec));
                 }
                 else if (boost::starts_with(path, "/redirect"))
                 {


### PR DESCRIPTION
This change updates our dependencies to the most recent versions in Conan Center. `cassandra-cpp-driver` cannot compile as C++20. I don't know how the Clio team is doing it.

The only code changes required are related to (a) missing includes and (b) multiple `string_view`s in Boost. rippled uses Boost.Beast which [now uses](https://github.com/boostorg/beast/commit/9d23bec2bc523223a377582302bd28d04cb514ed) a `boost::core::string_view` that is different from `boost::utility::string_view`. `boost::core::string_view` was added to Boost on Oct 4, 2021, after the release of 1.77 which we had been using, and before the release of 1.78. It is missing the `to_string()` method that `boost::utility::string_view` has and that we had been calling.