### PR TITLE
[TRIVIAL] Update checkout action version to resolve warning

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -8,7 +8,7 @@ jobs:
     env:
       CLANG_VERSION: 10
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install clang-format
       run: |
         codename=$( lsb_release --codename --short )

--- a/.github/workflows/levelization.yml
+++ b/.github/workflows/levelization.yml
@@ -8,7 +8,7 @@ jobs:
     env:
       CLANG_VERSION: 10
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check levelization
       run: Builds/levelization/levelization.sh
     - name: Check for differences


### PR DESCRIPTION
## High Level Overview of Change

Update the version of the checkout action in `clang-format.yml` and `levelization.yml`

### Context of Change

I noticed recently that some of the Github Actions had warnings:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Example: 
* https://github.com/XRPLF/rippled/pull/4560/checks
* https://github.com/XRPLF/rippled/actions/runs/5248466780

The latest version is 3, so I updated the version in those jobs. I have noticed that more recent PRs don't have this warning, but I think it's worth updating the version anyway.

## Test Plan

No C++ code was changed. This only affects CI, so there is nothing to test.
