### PR TITLE
add pre-commit hook for clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+# .pre-commit-config.yaml
+repos:
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v10.0.1
+  hooks:
+  - id: clang-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,11 @@ this:
 You can format individual files in place by running `clang-format -i <file>...`
 from any directory within this project.
 
+You can install a pre-commit hook to automatically run `clang-format` before every commit:
+```
+pip3 install pre-commit
+pre-commit install
+```
 
 ## Avoid
 


### PR DESCRIPTION
## High Level Overview of Change

This PR adds a pre-commit hook, which runs the clang-format linter locally before a commit is committed. 

There are no C++ code changes, just a new YAML file and instructions in the CONTRIBUTING for how to set up the linter.

### Context of Change

A pre-commit hook makes it easier to work with the clang-format linter, since it automatically runs before a commit is committed. It is also opt-in (you need to install it for it to do anything).

### Type of Change

- [x] Tooling

## Test Plan
This was tested locally and worked when I tried to commit a change that didn't satisfy the linter.

I also confirmed that it is indeed using the correct version of clang-format (10.0.1).
