### PR TITLE
amendment: assign the serial number to the amendment list object

### DIFF
--- a/src/ripple/app/tx/impl/Change.cpp
+++ b/src/ripple/app/tx/impl/Change.cpp
@@ -329,6 +329,15 @@ Change::applyAmendment()
                              << " activated: server blocked.";
             ctx_.app.getOPs().setAmendmentBlocked();
         }
+
+        if (view().rules().enabled(featureAmendmentTableSequence) ||
+            amendment == featureAmendmentTableSequence)
+        {
+            // if amendment is enabled then we do an increase on sequence
+            // by 1
+            amendmentObject->setFieldU32(
+                sfSequence, amendmentObject->getFieldU32(sfSequence) + 1);
+        }
     }
 
     if (newMajorities.empty())

--- a/src/ripple/ledger/impl/ReadView.cpp
+++ b/src/ripple/ledger/impl/ReadView.cpp
@@ -76,14 +76,26 @@ makeRulesGivenLedger(
     DigestAwareReadView const& ledger,
     std::unordered_set<uint256, beast::uhash<>> const& presets)
 {
-    Keylet const k = keylet::amendments();
-    std::optional digest = ledger.digest(k.key);
-    if (digest)
+    if (ledger.rules().enabled(featureAmendmentTableSequence))
     {
-        auto const sle = ledger.read(k);
-        if (sle)
-            return Rules(presets, digest, sle->getFieldV256(sfAmendments));
+        if (auto const sle = ledger.read(keylet::amendments()))
+            return Rules(
+                presets,
+                sle->getFieldU32(sfSequence),
+                sle->getFieldV256(sfAmendments));
     }
+    else
+    {
+        Keylet const k = keylet::amendments();
+        std::optional digest = ledger.digest(k.key);
+        if (digest)
+        {
+            auto const sle = ledger.read(k);
+            if (sle)
+                return Rules(presets, digest, sle->getFieldV256(sfAmendments));
+        }
+    }
+
     return Rules(presets);
 }
 

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -74,7 +74,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 60;
+static constexpr std::size_t numFeatures = 61;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -347,6 +347,7 @@ extern uint256 const fixNonFungibleTokensV1_2;
 extern uint256 const fixNFTokenRemint;
 extern uint256 const fixReducedOffersV1;
 extern uint256 const featureClawback;
+extern uint256 const featureAmendmentTableSequence;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/Rules.h
+++ b/src/ripple/protocol/Rules.h
@@ -71,6 +71,11 @@ private:
         std::optional<uint256> const& digest,
         STVector256 const& amendments);
 
+    Rules(
+        std::unordered_set<uint256, beast::uhash<>> const& presets,
+        std::uint32_t sequence,
+        STVector256 const& amendments);
+
     std::unordered_set<uint256, beast::uhash<>> const&
     presets() const;
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -454,6 +454,7 @@ REGISTER_FIX    (fixNonFungibleTokensV1_2,      Supported::yes, VoteBehavior::De
 REGISTER_FIX    (fixNFTokenRemint,              Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixReducedOffersV1,            Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FEATURE(Clawback,                      Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FEATURE(AmendmentTableSequence,        Supported::yes, VoteBehavior::DefaultNo);
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -141,6 +141,7 @@ LedgerFormats::LedgerFormats()
         {
             {sfAmendments,           soeOPTIONAL},  // Enabled
             {sfMajorities,           soeOPTIONAL},
+            {sfSequence,             soeOPTIONAL},
         },
         commonFields);
 


### PR DESCRIPTION
Tracking the serial number allows for check if amendments have changed since last check without checking of the list one by one

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] amendment
- 
## Before / After
When amendment activates the new field **Sequence** in the amendments object will be increased 1. Before the field does not exist.

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
