### PR TITLE
Revert "Change enum values to be powers of two (fix #3417)"

### DIFF
--- a/src/ripple/rpc/impl/Handler.h
+++ b/src/ripple/rpc/impl/Handler.h
@@ -39,8 +39,8 @@ namespace RPC {
 enum Condition {
     NO_CONDITION = 0,
     NEEDS_NETWORK_CONNECTION = 1,
-    NEEDS_CURRENT_LEDGER = 1 << 1,
-    NEEDS_CLOSED_LEDGER = 1 << 2,
+    NEEDS_CURRENT_LEDGER = 2 + NEEDS_NETWORK_CONNECTION,
+    NEEDS_CLOSED_LEDGER = 4 + NEEDS_NETWORK_CONNECTION,
 };
 
 struct Handler
@@ -94,18 +94,20 @@ conditionMet(Condition condition_required, T& context)
     }
 
     if (context.app.getOPs().isAmendmentBlocked() &&
-        (condition_required != NO_CONDITION))
+        (condition_required & NEEDS_CURRENT_LEDGER ||
+         condition_required & NEEDS_CLOSED_LEDGER))
     {
         return rpcAMENDMENT_BLOCKED;
     }
 
     if (context.app.getOPs().isUNLBlocked() &&
-        (condition_required != NO_CONDITION))
+        (condition_required & NEEDS_CURRENT_LEDGER ||
+         condition_required & NEEDS_CLOSED_LEDGER))
     {
         return rpcEXPIRED_VALIDATOR_LIST;
     }
 
-    if ((condition_required != NO_CONDITION) &&
+    if ((condition_required & NEEDS_NETWORK_CONNECTION) &&
         (context.netOps.getOperatingMode() < OperatingMode::SYNCING))
     {
         JLOG(context.j.info()) << "Insufficient network mode for RPC: "
@@ -117,7 +119,7 @@ conditionMet(Condition condition_required, T& context)
     }
 
     if (!context.app.config().standalone() &&
-        condition_required != NO_CONDITION)
+        condition_required & NEEDS_CURRENT_LEDGER)
     {
         if (context.ledgerMaster.getValidatedLedgerAge() >
             Tuning::maxValidatedLedgerAge)
@@ -141,7 +143,7 @@ conditionMet(Condition condition_required, T& context)
         }
     }
 
-    if ((condition_required != NO_CONDITION) &&
+    if ((condition_required & NEEDS_CLOSED_LEDGER) &&
         !context.ledgerMaster.getClosedLedger())
     {
         if (context.apiVersion == 1)


### PR DESCRIPTION
Consider the function `conditionMet`, specifically lines 121 and 122 and 146-147 of Handler.h: 

https://github.com/XRPLF/rippled/commit/1c2ae10dc057d5c7c76d0df2c5a92fc753e4769a#diff-41d8d23b15cb894b075204dcd88d7bf9ca223fa77f43e28bb22cf38b805cabfcL121-L122

https://github.com/XRPLF/rippled/commit/1c2ae10dc057d5c7c76d0df2c5a92fc753e4769a#diff-41d8d23b15cb894b075204dcd88d7bf9ca223fa77f43e28bb22cf38b805cabfcL146-L147

The change is broken: where it previously, it checked for a _specific_ condition (e.g. `NEEDS_CLOSED_LEDGER`) and only entered the `if` block if it was met, it now executes that code if _any_ condition is set.

A prime example of a RPC request that fails is the `tx` command, which has `NEEDS_NETWORK_CONNECTION` and will now not work unless the server has _both_ a current and a closed ledger.

The problem isn't the powers of two change. It's how the checks where restructured.

_Originally posted by @nbougalis in https://github.com/XRPLF/rippled/issues/4601#issuecomment-1615494006_
            

Reverts XRPLF/rippled#4239