### PR TITLE
Clean up AMM owner dir on AMM account delete, disallow create check to AMM, and fix unconstrained AuthAccount.

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -60,6 +60,15 @@ Additions are intended to be non-breaking (because they are purely additive).
     - Adds `tfLPToken`, `tfSingleAsset`, `tfTwoAsset`, `tfOneAssetLPToken`, `tfLimitLPToken`, `tfTwoAssetIfEmpty`,
       `tfWithdrawAll`, `tfOneAssetWithdrawAll` which allow a trader to specify different fields combination 
       for `AMMDeposit` and `AMMWithdraw` transactions.
+    - Adds new transaction result codes:
+       - tecUNFUNDED_AMM: insufficient balance to fund AMM. The account does not have funds for liquidity provision.
+       -  tecAMM_BALANCE: AMM has invalid balance. Calculated balances greater than the current pool balances.
+       -  tecAMM_FAILED: AMM transaction failed. Fails due to a processing failure.
+       -  tecAMM_INVALID_TOKENS: AMM invalid LP tokens. Invalid input values, format, or calculated values.
+       -  tecAMM_EMPTY: AMM is in empty state. Transaction expects AMM in non-empty state (LP tokens > 0).
+       -  tecAMM_NOT_EMPTY: AMM is not in empty state. Transaction expects AMM in empty state (LP tokens == 0).
+       -  tecAMM_ACCOUNT: AMM account. Clawback of AMM account.
+       -  tecINCOMPLETE: Some work was completed, but more submissions required to finish. AMMDelete partially deletes the trustlines.
 
 ## XRP Ledger version 1.11.0
 

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -47,6 +47,19 @@ Additions are intended to be non-breaking (because they are purely additive).
   - Adds the [Clawback transaction type](https://github.com/XRPLF/XRPL-Standards/blob/master/XLS-39d-clawback/README.md#331-clawback-transaction), containing these fields:
     - `Account`: The issuer of the asset being clawed back. Must also be the sender of the transaction.
     - `Amount`: The amount being clawed back, with the `Amount.issuer` being the token holder's address.
+- Adds [AMM](https://github.com/XRPLF/XRPL-Standards/discussions/78) ([#4294](https://github.com/XRPLF/rippled/pull/4294), [#4626](https://github.com/XRPLF/rippled/pull/4626)) feature:
+    - Adds `amm_info` API to retrieve AMM information for a given tokens pair.
+    - Adds `AMMCreate` transaction type to create `AMM` instance.
+    - Adds `AMMDeposit` transaction type to deposit funds into `AMM` instance.
+    - Adds `AMMWithdraw` transaction type to withdraw funds from `AMM` instance.
+    - Adds `AMMVote` transaction type to vote for the trading fee of `AMM` instance.
+    - Adds `AMMBid` transaction type to bid for the Auction Slot of `AMM` instance.
+    - Adds `AMMDelete` transaction type to delete `AMM` instance.
+    - Adds `lsfAMM` `AccountRoot` flag to indicate that the account is `AMM`'s account.
+    - Adds `lsfAMMNode` `TrustLine` flag to indicate that one side of the `TrustLine` is `AMM` account.
+    - Adds `tfLPToken`, `tfSingleAsset`, `tfTwoAsset`, `tfOneAssetLPToken`, `tfLimitLPToken`, `tfTwoAssetIfEmpty`,
+      `tfWithdrawAll`, `tfOneAssetWithdrawAll` which allow a trader to specify different fields combination 
+      for `AMMDeposit` and `AMMWithdraw` transactions.
 
 ## XRP Ledger version 1.11.0
 

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -55,7 +55,7 @@ Additions are intended to be non-breaking (because they are purely additive).
     - Adds `AMMVote` transaction type to vote for the trading fee of `AMM` instance.
     - Adds `AMMBid` transaction type to bid for the Auction Slot of `AMM` instance.
     - Adds `AMMDelete` transaction type to delete `AMM` instance.
-    - Adds `lsfAMM` `AccountRoot` flag to indicate that the account is `AMM`'s account.
+    - Adds `sfAMMID` to `AccountRoot` to indicate that the account is `AMM`'s account. `AMMID` is used to fetch `ltAMM`.
     - Adds `lsfAMMNode` `TrustLine` flag to indicate that one side of the `TrustLine` is `AMM` account.
     - Adds `tfLPToken`, `tfSingleAsset`, `tfTwoAsset`, `tfOneAssetLPToken`, `tfLimitLPToken`, `tfTwoAssetIfEmpty`,
       `tfWithdrawAll`, `tfOneAssetWithdrawAll` which allow a trader to specify different fields combination 

--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -476,6 +476,7 @@ target_sources (rippled PRIVATE
   src/ripple/app/rdb/impl/Wallet.cpp
   src/ripple/app/tx/impl/AMMBid.cpp
   src/ripple/app/tx/impl/AMMCreate.cpp
+  src/ripple/app/tx/impl/AMMDelete.cpp
   src/ripple/app/tx/impl/AMMDeposit.cpp
   src/ripple/app/tx/impl/AMMVote.cpp
   src/ripple/app/tx/impl/AMMWithdraw.cpp

--- a/src/ripple/app/misc/AMMUtils.h
+++ b/src/ripple/app/misc/AMMUtils.h
@@ -103,7 +103,7 @@ deleteAMMAccount(
     Issue const& asset2,
     beast::Journal j);
 
-/** Initialize Auction and Voting slots and set the trading/disconted fee.
+/** Initialize Auction and Voting slots and set the trading/discounted fee.
  */
 void
 initializeFeeAuctionVote(

--- a/src/ripple/app/misc/AMMUtils.h
+++ b/src/ripple/app/misc/AMMUtils.h
@@ -98,7 +98,7 @@ ammAccountHolds(
  */
 TER
 deleteAMMAccount(
-    ApplyView& view,
+    Sandbox& view,
     Issue const& asset,
     Issue const& asset2,
     beast::Journal j);

--- a/src/ripple/app/misc/AMMUtils.h
+++ b/src/ripple/app/misc/AMMUtils.h
@@ -93,6 +93,26 @@ ammAccountHolds(
     AccountID const& ammAccountID,
     Issue const& issue);
 
+/** Delete trustlines to AMM. If all trustlines are deleted then
+ * AMM object and account are deleted. Otherwise tecIMPCOMPLETE is returned.
+ */
+TER
+deleteAMMAccount(
+    ApplyView& view,
+    Issue const& asset,
+    Issue const& asset2,
+    beast::Journal j);
+
+/** Initialize Auction and Voting slots and set the trading/disconted fee.
+ */
+void
+initializeFeeAuctionVote(
+    ApplyView& view,
+    std::shared_ptr<SLE>& ammSle,
+    AccountID const& account,
+    Issue const& lptIssue,
+    std::uint16_t tfee);
+
 }  // namespace ripple
 
 #endif  // RIPPLE_APP_MISC_AMMUTILS_H_INLCUDED

--- a/src/ripple/app/misc/impl/AMMUtils.cpp
+++ b/src/ripple/app/misc/impl/AMMUtils.cpp
@@ -251,7 +251,7 @@ deleteAMMAccount(
 
     if (auto const ter =
             deleteAMMTrustLines(sb, ammAccountID, maxDeletableAMMTrustLines, j);
-        ter != tesSUCCESS || ter == tecINCOMPLETE)
+        ter != tesSUCCESS)
         return ter;
 
     auto const ownerDirKeylet = keylet::ownerDir(ammAccountID);

--- a/src/ripple/app/misc/impl/AMMUtils.cpp
+++ b/src/ripple/app/misc/impl/AMMUtils.cpp
@@ -253,6 +253,14 @@ deleteAMMAccount(
     if (!done)
         return tecINCOMPLETE;
 
+    auto const ownerDirKeylet = keylet::ownerDir(ammAccountID);
+    if (sb.exists(ownerDirKeylet) && !sb.emptyDirDelete(ownerDirKeylet))
+    {
+        JLOG(j.error()) << "deleteAMMAccount: cannot delete root dir node of "
+                        << toBase58(ammAccountID);
+        return tecINTERNAL;
+    }
+
     sb.erase(ammSle);
     if (sleAMMRoot)
         sb.erase(sleAMMRoot);

--- a/src/ripple/app/misc/impl/AMMUtils.cpp
+++ b/src/ripple/app/misc/impl/AMMUtils.cpp
@@ -281,7 +281,7 @@ initializeFeeAuctionVote(
     STObject voteEntry{sfVoteEntry};
     if (tfee != 0)
         voteEntry.setFieldU16(sfTradingFee, tfee);
-    voteEntry.setFieldU32(sfVoteWeight, 100000);
+    voteEntry.setFieldU32(sfVoteWeight, VOTE_WEIGHT_SCALE_FACTOR);
     voteEntry.setAccountID(sfAccount, account);
     voteSlots.push_back(voteEntry);
     ammSle->setFieldArray(sfVoteSlots, voteSlots);

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -99,7 +99,8 @@ public:
         , ownerPaysTransferFee_(ctx.ownerPaysTransferFee)
         , j_(ctx.j)
     {
-        if (auto const ammSle = ctx.view.read(keylet::amm(in, out)))
+        if (auto const ammSle = ctx.view.read(keylet::amm(in, out));
+            ammSle && ammSle->getFieldAmount(sfLPTokenBalance) != beast::zero)
             ammLiquidity_.emplace(
                 ctx.view,
                 (*ammSle)[sfAccount],

--- a/src/ripple/app/tx/impl/AMMCreate.cpp
+++ b/src/ripple/app/tx/impl/AMMCreate.cpp
@@ -282,7 +282,6 @@ applyCreate(
         TOTAL_TIME_SLOT_SECS;
     auctionSlot.setFieldU32(sfExpiration, expiration);
     auctionSlot.setFieldAmount(sfPrice, STAmount{lpTokens.issue(), 0});
-    sb.insert(ammSle);
 
     // Add owner directory to link the root account and AMM object.
     if (auto const page = sb.dirInsert(
@@ -294,6 +293,9 @@ applyCreate(
         JLOG(j_.debug()) << "AMM Instance: failed to insert owner dir";
         return {tecDIR_FULL, false};
     }
+    else
+        ammSle->setFieldU64(sfOwnerNode, *page);
+    sb.insert(ammSle);
 
     // Send LPT to LP.
     auto res = accountSend(sb, *ammAccount, account_, lpTokens, ctx_.journal);

--- a/src/ripple/app/tx/impl/AMMCreate.cpp
+++ b/src/ripple/app/tx/impl/AMMCreate.cpp
@@ -248,6 +248,8 @@ applyCreate(
     // either an AMMDeposit, TrustSet, crossing an offer, etc.
     sleAMMRoot->setFieldU32(
         sfFlags, lsfAMM | lsfDisableMaster | lsfDefaultRipple | lsfDepositAuth);
+    // Link the root account and AMM object
+    sleAMMRoot->setFieldH256(sfAMMID, ammKeylet.key);
     sb.insert(sleAMMRoot);
 
     // Calculate initial LPT balance.
@@ -282,19 +284,6 @@ applyCreate(
         TOTAL_TIME_SLOT_SECS;
     auctionSlot.setFieldU32(sfExpiration, expiration);
     auctionSlot.setFieldAmount(sfPrice, STAmount{lpTokens.issue(), 0});
-
-    // Add owner directory to link the root account and AMM object.
-    if (auto const page = sb.dirInsert(
-            keylet::ownerDir(*ammAccount),
-            ammSle->key(),
-            describeOwnerDir(*ammAccount));
-        !page)
-    {
-        JLOG(j_.debug()) << "AMM Instance: failed to insert owner dir";
-        return {tecDIR_FULL, false};
-    }
-    else
-        ammSle->setFieldU64(sfOwnerNode, *page);
     sb.insert(ammSle);
 
     // Send LPT to LP.

--- a/src/ripple/app/tx/impl/AMMDelete.cpp
+++ b/src/ripple/app/tx/impl/AMMDelete.cpp
@@ -1,0 +1,89 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/tx/impl/AMMDelete.h>
+
+#include <ripple/app/misc/AMMUtils.h>
+#include <ripple/ledger/Sandbox.h>
+#include <ripple/protocol/AMMCore.h>
+#include <ripple/protocol/Feature.h>
+#include <ripple/protocol/STAccount.h>
+#include <ripple/protocol/TER.h>
+#include <ripple/protocol/TxFlags.h>
+
+namespace ripple {
+
+NotTEC
+AMMDelete::preflight(PreflightContext const& ctx)
+{
+    if (!ammEnabled(ctx.rules))
+        return temDISABLED;
+
+    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
+        return ret;
+
+    if (ctx.tx.getFlags() & tfUniversalMask)
+    {
+        JLOG(ctx.j.debug()) << "AMM Delete: invalid flags.";
+        return temINVALID_FLAG;
+    }
+
+    if (auto const res = invalidAMMAssetPair(ctx.tx[sfAsset], ctx.tx[sfAsset2]))
+    {
+        JLOG(ctx.j.debug()) << "AMM Delete: Invalid asset pair.";
+        return res;
+    }
+
+    return preflight2(ctx);
+}
+
+TER
+AMMDelete::preclaim(PreclaimContext const& ctx)
+{
+    auto const ammSle =
+        ctx.view.read(keylet::amm(ctx.tx[sfAsset], ctx.tx[sfAsset2]));
+    if (!ammSle)
+    {
+        JLOG(ctx.j.debug()) << "AMM Delete: Invalid asset pair.";
+        return terNO_AMM;
+    }
+
+    auto const lpTokensBalance = (*ammSle)[sfLPTokenBalance];
+    if (lpTokensBalance != beast::zero)
+        return tecAMM_EMPTY;
+
+    return tesSUCCESS;
+}
+
+TER
+AMMDelete::doApply()
+{
+    // This is the ledger view that we work against. Transactions are applied
+    // as we go on processing transactions.
+    Sandbox sb(&ctx_.view());
+
+    auto const ter =
+        deleteAMMAccount(sb, ctx_.tx[sfAsset], ctx_.tx[sfAsset2], j_);
+    if (ter == tesSUCCESS || ter == tecINCOMPLETE)
+        sb.apply(ctx_.rawView());
+
+    return ter;
+}
+
+}  // namespace ripple

--- a/src/ripple/app/tx/impl/AMMDelete.cpp
+++ b/src/ripple/app/tx/impl/AMMDelete.cpp
@@ -44,12 +44,6 @@ AMMDelete::preflight(PreflightContext const& ctx)
         return temINVALID_FLAG;
     }
 
-    if (auto const res = invalidAMMAssetPair(ctx.tx[sfAsset], ctx.tx[sfAsset2]))
-    {
-        JLOG(ctx.j.debug()) << "AMM Delete: Invalid asset pair.";
-        return res;
-    }
-
     return preflight2(ctx);
 }
 
@@ -66,7 +60,7 @@ AMMDelete::preclaim(PreclaimContext const& ctx)
 
     auto const lpTokensBalance = (*ammSle)[sfLPTokenBalance];
     if (lpTokensBalance != beast::zero)
-        return tecAMM_EMPTY;
+        return tecAMM_NOT_EMPTY;
 
     return tesSUCCESS;
 }

--- a/src/ripple/app/tx/impl/AMMDelete.h
+++ b/src/ripple/app/tx/impl/AMMDelete.h
@@ -1,0 +1,54 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2023 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_TX_AMMDELETE_H_INCLUDED
+#define RIPPLE_TX_AMMDELETE_H_INCLUDED
+
+#include <ripple/app/tx/impl/Transactor.h>
+
+namespace ripple {
+
+/** AMMDelete implements AMM delete transactor. This is a mechanism to
+ * delete AMM in an empty state when the number of LP tokens is 0.
+ * AMMDelete deletes the truslines up to configured maximum. If all
+ * trustlines are deleted then AMM ltAMM and root account are deleted.
+ * Otherwise AMMDelete should be called again.
+ */
+class AMMDelete : public Transactor
+{
+public:
+    static constexpr ConsequencesFactoryType ConsequencesFactory{Normal};
+
+    explicit AMMDelete(ApplyContext& ctx) : Transactor(ctx)
+    {
+    }
+
+    static NotTEC
+    preflight(PreflightContext const& ctx);
+
+    static TER
+    preclaim(PreclaimContext const& ctx);
+
+    TER
+    doApply() override;
+};
+
+}  // namespace ripple
+
+#endif  // RIPPLE_TX_AMMDELETE_H_INCLUDED

--- a/src/ripple/app/tx/impl/AMMDelete.h
+++ b/src/ripple/app/tx/impl/AMMDelete.h
@@ -26,7 +26,7 @@ namespace ripple {
 
 /** AMMDelete implements AMM delete transactor. This is a mechanism to
  * delete AMM in an empty state when the number of LP tokens is 0.
- * AMMDelete deletes the truslines up to configured maximum. If all
+ * AMMDelete deletes the trustlines up to configured maximum. If all
  * trustlines are deleted then AMM ltAMM and root account are deleted.
  * Otherwise AMMDelete should be called again.
  */

--- a/src/ripple/app/tx/impl/AMMDeposit.cpp
+++ b/src/ripple/app/tx/impl/AMMDeposit.cpp
@@ -52,10 +52,12 @@ AMMDeposit::preflight(PreflightContext const& ctx)
     auto const amount2 = ctx.tx[~sfAmount2];
     auto const ePrice = ctx.tx[~sfEPrice];
     auto const lpTokens = ctx.tx[~sfLPTokenOut];
+    auto const tradingFee = ctx.tx[~sfTradingFee];
     // Valid options for the flags are:
     //   tfLPTokens: LPTokenOut, [Amount, Amount2]
     //   tfSingleAsset: Amount, [LPTokenOut]
     //   tfTwoAsset: Amount, Amount2, [LPTokenOut]
+    //   tfTwoAssetIfEmpty: Amount, Amount2, [sfTradingFee]
     //   tfOnAssetLPToken: Amount and LPTokenOut
     //   tfLimitLPToken: Amount and EPrice
     if (std::popcount(flags & tfDepositSubTx) != 1)
@@ -66,29 +68,35 @@ AMMDeposit::preflight(PreflightContext const& ctx)
     if (flags & tfLPToken)
     {
         // if included then both amount and amount2 are deposit min
-        if (!lpTokens || ePrice || (amount && !amount2) || (!amount && amount2))
+        if (!lpTokens || ePrice || (amount && !amount2) ||
+            (!amount && amount2) || tradingFee)
             return temMALFORMED;
     }
     else if (flags & tfSingleAsset)
     {
         // if included then lpTokens is deposit min
-        if (!amount || amount2 || ePrice)
+        if (!amount || amount2 || ePrice || tradingFee)
             return temMALFORMED;
     }
     else if (flags & tfTwoAsset)
     {
         // if included then lpTokens is deposit min
-        if (!amount || !amount2 || ePrice)
+        if (!amount || !amount2 || ePrice || tradingFee)
             return temMALFORMED;
     }
     else if (flags & tfOneAssetLPToken)
     {
-        if (!amount || !lpTokens || amount2 || ePrice)
+        if (!amount || !lpTokens || amount2 || ePrice || tradingFee)
             return temMALFORMED;
     }
     else if (flags & tfLimitLPToken)
     {
-        if (!amount || !ePrice || lpTokens || amount2)
+        if (!amount || !ePrice || lpTokens || amount2 || tradingFee)
+            return temMALFORMED;
+    }
+    else if (flags & tfTwoAssetIfEmpty)
+    {
+        if (!amount || !amount2 || ePrice || lpTokens)
             return temMALFORMED;
     }
 
@@ -148,6 +156,12 @@ AMMDeposit::preflight(PreflightContext const& ctx)
         }
     }
 
+    if (tradingFee > TRADING_FEE_THRESHOLD)
+    {
+        JLOG(ctx.j.debug()) << "AMM Deposit: invalid trading fee.";
+        return temBAD_FEE;
+    }
+
     return preflight2(ctx);
 }
 
@@ -174,12 +188,27 @@ AMMDeposit::preclaim(PreclaimContext const& ctx)
     if (!expected)
         return expected.error();
     auto const [amountBalance, amount2Balance, lptAMMBalance] = *expected;
-    if (amountBalance <= beast::zero || amount2Balance <= beast::zero ||
-        lptAMMBalance <= beast::zero)
+    if (ctx.tx.getFlags() & tfTwoAssetIfEmpty)
     {
-        JLOG(ctx.j.debug())
-            << "AMM Deposit: reserves or tokens balance is zero.";
-        return tecINTERNAL;
+        if (lptAMMBalance != beast::zero)
+            return tecAMM_EMPTY;
+        if (amountBalance != beast::zero || amount2Balance != beast::zero)
+        {
+            JLOG(ctx.j.debug()) << "AMM Deposit: tokens balance is not zero.";
+            return tecINTERNAL;
+        }
+    }
+    else
+    {
+        if (lptAMMBalance == beast::zero)
+            return tecAMM_EMPTY;
+        if (amountBalance <= beast::zero || amount2Balance <= beast::zero ||
+            lptAMMBalance < beast::zero)
+        {
+            JLOG(ctx.j.debug())
+                << "AMM Deposit: reserves or tokens balance is zero.";
+            return tecINTERNAL;
+        }
     }
 
     // Check account has sufficient funds.
@@ -313,8 +342,6 @@ AMMDeposit::applyGuts(Sandbox& sb)
         return {tecINTERNAL, false};
     auto const ammAccountID = (*ammSle)[sfAccount];
 
-    auto const tfee = getTradingFee(ctx_.view(), *ammSle, account_);
-
     auto const expected = ammHolds(
         sb,
         *ammSle,
@@ -325,6 +352,9 @@ AMMDeposit::applyGuts(Sandbox& sb)
     if (!expected)
         return {expected.error(), false};
     auto const [amountBalance, amount2Balance, lptAMMBalance] = *expected;
+    auto const tfee = (lptAMMBalance == beast::zero)
+        ? ctx_.tx[~sfTradingFee].value_or(0)
+        : getTradingFee(ctx_.view(), *ammSle, account_);
 
     auto const subTxType = ctx_.tx.getFlags() & tfDepositSubTx;
 
@@ -382,6 +412,14 @@ AMMDeposit::applyGuts(Sandbox& sb)
                 amount,
                 amount2,
                 tfee);
+        if (subTxType & tfTwoAssetIfEmpty)
+            return equalDepositInEmptyState(
+                sb,
+                ammAccountID,
+                *amount,
+                *amount2,
+                lptAMMBalance.issue(),
+                tfee);
         // should not happen.
         JLOG(j_.error()) << "AMM Deposit: invalid options.";
         return std::make_pair(tecINTERNAL, STAmount{});
@@ -391,6 +429,12 @@ AMMDeposit::applyGuts(Sandbox& sb)
     {
         assert(newLPTokenBalance > beast::zero);
         ammSle->setFieldAmount(sfLPTokenBalance, newLPTokenBalance);
+        // LP depositing into AMM empty state gets the auction slot
+        // and the voting
+        if (lptAMMBalance == beast::zero)
+            initializeFeeAuctionVote(
+                sb, ammSle, account_, lptAMMBalance.issue(), tfee);
+
         sb.update(ammSle);
     }
 
@@ -828,6 +872,29 @@ AMMDeposit::singleDepositEPrice(
         std::nullopt,
         lptAMMBalance,
         tokens,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        tfee);
+}
+
+std::pair<TER, STAmount>
+AMMDeposit::equalDepositInEmptyState(
+    Sandbox& view,
+    AccountID const& ammAccount,
+    STAmount const& amount,
+    STAmount const& amount2,
+    Issue const& lptIssue,
+    std::uint16_t tfee)
+{
+    return deposit(
+        view,
+        ammAccount,
+        amount,
+        amount,
+        amount2,
+        STAmount{lptIssue, 0},
+        ammLPTokens(amount, amount2, lptIssue),
         std::nullopt,
         std::nullopt,
         std::nullopt,

--- a/src/ripple/app/tx/impl/AMMDeposit.cpp
+++ b/src/ripple/app/tx/impl/AMMDeposit.cpp
@@ -191,7 +191,7 @@ AMMDeposit::preclaim(PreclaimContext const& ctx)
     if (ctx.tx.getFlags() & tfTwoAssetIfEmpty)
     {
         if (lptAMMBalance != beast::zero)
-            return tecAMM_EMPTY;
+            return tecAMM_NOT_EMPTY;
         if (amountBalance != beast::zero || amount2Balance != beast::zero)
         {
             JLOG(ctx.j.debug()) << "AMM Deposit: tokens balance is not zero.";

--- a/src/ripple/app/tx/impl/AMMDeposit.h
+++ b/src/ripple/app/tx/impl/AMMDeposit.h
@@ -223,6 +223,23 @@ private:
         STAmount const& lptAMMBalance,
         STAmount const& ePrice,
         std::uint16_t tfee);
+
+    /** Equal deposit in empty AMM state (LP tokens balance is 0)
+     * @param view
+     * @param ammAccount
+     * @param amount requested asset1 deposit amount
+     * @param amount2 requested asset2 deposit amount
+     * @param tfee
+     * @return
+     */
+    std::pair<TER, STAmount>
+    equalDepositInEmptyState(
+        Sandbox& view,
+        AccountID const& ammAccount,
+        STAmount const& amount,
+        STAmount const& amount2,
+        Issue const& lptIssue,
+        std::uint16_t tfee);
 };
 
 }  // namespace ripple

--- a/src/ripple/app/tx/impl/AMMWithdraw.cpp
+++ b/src/ripple/app/tx/impl/AMMWithdraw.cpp
@@ -380,9 +380,7 @@ AMMWithdraw::applyGuts(Sandbox& sb)
         return {result, false};
 
     bool updateBalance = true;
-    // Delete only if number of trustlines is less or equal than max
-    if (newLPTokenBalance == beast::zero &&
-        accountSle->getFieldU32(sfOwnerCount) <= maxDeletableAMMTrustLines)
+    if (newLPTokenBalance == beast::zero)
     {
         if (auto const ter =
                 deleteAMMAccount(sb, ctx_.tx[sfAsset], ctx_.tx[sfAsset2], j_);

--- a/src/ripple/app/tx/impl/AMMWithdraw.cpp
+++ b/src/ripple/app/tx/impl/AMMWithdraw.cpp
@@ -409,16 +409,8 @@ AMMWithdraw::deleteAccount(Sandbox& sb, AccountID const& ammAccountID)
     if (!sleAMMRoot || !ammSle)
         return tecINTERNAL;
 
-    // Delete directory entry linking the root account and AMM object
-    Keylet const ownerDirKeylet{keylet::ownerDir(ammAccountID)};
-    if (!sb.dirRemove(
-            ownerDirKeylet, (*ammSle)[sfOwnerNode], ammSle->key(), false))
-    {
-        JLOG(j_.fatal()) << "AMM Withdraw: failed to remove dir link";
-        return tecINTERNAL;
-    }
-
     // Delete the trustlines
+    Keylet const ownerDirKeylet{keylet::ownerDir(ammAccountID)};
     std::shared_ptr<SLE> sleDirNode{};
     unsigned int uDirEntry{0};
     uint256 dirEntry{beast::zero};

--- a/src/ripple/app/tx/impl/AMMWithdraw.h
+++ b/src/ripple/app/tx/impl/AMMWithdraw.h
@@ -215,14 +215,6 @@ private:
         STAmount const& amount,
         STAmount const& ePrice,
         std::uint16_t tfee);
-
-    /** Delete AMM account.
-     * @param view
-     * @param ammAccountID
-     * @return
-     */
-    TER
-    deleteAccount(Sandbox& view, AccountID const& ammAccountID);
 };
 
 }  // namespace ripple

--- a/src/ripple/app/tx/impl/Clawback.cpp
+++ b/src/ripple/app/tx/impl/Clawback.cpp
@@ -63,6 +63,9 @@ Clawback::preclaim(PreclaimContext const& ctx)
     if (!sleIssuer || !sleHolder)
         return terNO_ACCOUNT;
 
+    if (sleHolder->isFieldPresent(sfAMMID))
+        return tecAMM_ACCOUNT;
+
     std::uint32_t const issuerFlagsIn = sleIssuer->getFieldU32(sfFlags);
 
     // If AllowTrustLineClawback is not set or NoFreeze is set, return no

--- a/src/ripple/app/tx/impl/Clawback.cpp
+++ b/src/ripple/app/tx/impl/Clawback.cpp
@@ -63,9 +63,6 @@ Clawback::preclaim(PreclaimContext const& ctx)
     if (!sleIssuer || !sleHolder)
         return terNO_ACCOUNT;
 
-    if (sleHolder->getFlags() & lsfAMM)
-        return tecAMM_ACCOUNT;
-
     std::uint32_t const issuerFlagsIn = sleIssuer->getFieldU32(sfFlags);
 
     // If AllowTrustLineClawback is not set or NoFreeze is set, return no

--- a/src/ripple/app/tx/impl/Clawback.cpp
+++ b/src/ripple/app/tx/impl/Clawback.cpp
@@ -63,6 +63,9 @@ Clawback::preclaim(PreclaimContext const& ctx)
     if (!sleIssuer || !sleHolder)
         return terNO_ACCOUNT;
 
+    if (sleHolder->getFlags() & lsfAMM)
+        return tecAMM_ACCOUNT;
+
     std::uint32_t const issuerFlagsIn = sleIssuer->getFieldU32(sfFlags);
 
     // If AllowTrustLineClawback is not set or NoFreeze is set, return no

--- a/src/ripple/app/tx/impl/CreateCheck.cpp
+++ b/src/ripple/app/tx/impl/CreateCheck.cpp
@@ -97,6 +97,10 @@ CreateCheck::preclaim(PreclaimContext const& ctx)
         (flags & lsfDisallowIncomingCheck))
         return tecNO_PERMISSION;
 
+    // AMM can not cash the check
+    if (flags & lsfAMM)
+        return tecNO_PERMISSION;
+
     if ((flags & lsfRequireDestTag) && !ctx.tx.isFieldPresent(sfDestinationTag))
     {
         // The tag is basically account-specific information we don't

--- a/src/ripple/app/tx/impl/CreateCheck.cpp
+++ b/src/ripple/app/tx/impl/CreateCheck.cpp
@@ -98,7 +98,7 @@ CreateCheck::preclaim(PreclaimContext const& ctx)
         return tecNO_PERMISSION;
 
     // AMM can not cash the check
-    if (flags & lsfAMM)
+    if (sleDst->isFieldPresent(sfAMMID))
         return tecNO_PERMISSION;
 
     if ((flags & lsfRequireDestTag) && !ctx.tx.isFieldPresent(sfDestinationTag))

--- a/src/ripple/app/tx/impl/DeleteAccount.cpp
+++ b/src/ripple/app/tx/impl/DeleteAccount.cpp
@@ -293,7 +293,7 @@ DeleteAccount::doApply()
         return tefBAD_LEDGER;
 
     Keylet const ownerDirKeylet{keylet::ownerDir(account_)};
-    auto const res = cleanupOnAccountDelete(
+    auto const ter = cleanupOnAccountDelete(
         view(),
         ownerDirKeylet,
         [&](LedgerEntryType nodeType,
@@ -313,8 +313,8 @@ DeleteAccount::doApply()
             return tecHAS_OBLIGATIONS;
         },
         ctx_.journal);
-    if (std::get<TER>(res) != tesSUCCESS)
-        return std::get<TER>(res);
+    if (ter != tesSUCCESS)
+        return ter;
 
     // Transfer any XRP remaining after the fee is paid to the destination:
     (*dst)[sfBalance] = (*dst)[sfBalance] + mSourceBalance;

--- a/src/ripple/app/tx/impl/DeleteAccount.cpp
+++ b/src/ripple/app/tx/impl/DeleteAccount.cpp
@@ -292,76 +292,29 @@ DeleteAccount::doApply()
     if (!src || !dst)
         return tefBAD_LEDGER;
 
-    // Delete all of the entries in the account directory.
     Keylet const ownerDirKeylet{keylet::ownerDir(account_)};
-    std::shared_ptr<SLE> sleDirNode{};
-    unsigned int uDirEntry{0};
-    uint256 dirEntry{beast::zero};
-
-    if (view().exists(ownerDirKeylet) &&
-        dirFirst(view(), ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry))
-    {
-        do
-        {
-            // Choose the right way to delete each directory node.
-            auto sleItem = view().peek(keylet::child(dirEntry));
-            if (!sleItem)
-            {
-                // Directory node has an invalid index.  Bail out.
-                JLOG(j_.fatal())
-                    << "DeleteAccount: Directory node in ledger "
-                    << view().seq() << " has index to object that is missing: "
-                    << to_string(dirEntry);
-                return tefBAD_LEDGER;
-            }
-
-            LedgerEntryType const nodeType{safe_cast<LedgerEntryType>(
-                sleItem->getFieldU16(sfLedgerEntryType))};
-
+    auto const res = cleanupOnAccountDelete(
+        view(),
+        ownerDirKeylet,
+        [&](LedgerEntryType nodeType,
+            uint256 const& dirEntry,
+            std::shared_ptr<SLE>& sleItem) -> TER {
             if (auto deleter = nonObligationDeleter(nodeType))
             {
                 TER const result{
                     deleter(ctx_.app, view(), account_, dirEntry, sleItem, j_)};
 
-                if (!isTesSuccess(result))
-                    return result;
-            }
-            else
-            {
-                assert(!"Undeletable entry should be found in preclaim.");
-                JLOG(j_.error())
-                    << "DeleteAccount undeletable item not found in preclaim.";
-                return tecHAS_OBLIGATIONS;
+                return result;
             }
 
-            // dirFirst() and dirNext() are like iterators with exposed
-            // internal state.  We'll take advantage of that exposed state
-            // to solve a common C++ problem: iterator invalidation while
-            // deleting elements from a container.
-            //
-            // We have just deleted one directory entry, which means our
-            // "iterator state" is invalid.
-            //
-            //  1. During the process of getting an entry from the
-            //     directory uDirEntry was incremented from 0 to 1.
-            //
-            //  2. We then deleted the entry at index 0, which means the
-            //     entry that was at 1 has now moved to 0.
-            //
-            //  3. So we verify that uDirEntry is indeed 1.  Then we jam it
-            //     back to zero to "un-invalidate" the iterator.
-            assert(uDirEntry == 1);
-            if (uDirEntry != 1)
-            {
-                JLOG(j_.error())
-                    << "DeleteAccount iterator re-validation failed.";
-                return tefBAD_LEDGER;
-            }
-            uDirEntry = 0;
-
-        } while (dirNext(
-            view(), ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry));
-    }
+            assert(!"Undeletable entry should be found in preclaim.");
+            JLOG(j_.error()) << "DeleteAccount undeletable item not "
+                                "found in preclaim.";
+            return tecHAS_OBLIGATIONS;
+        },
+        ctx_.journal);
+    if (std::get<TER>(res) != tesSUCCESS)
+        return std::get<TER>(res);
 
     // Transfer any XRP remaining after the fee is paid to the destination:
     (*dst)[sfBalance] = (*dst)[sfBalance] + mSourceBalance;

--- a/src/ripple/app/tx/impl/Escrow.cpp
+++ b/src/ripple/app/tx/impl/Escrow.cpp
@@ -162,7 +162,7 @@ EscrowCreate::preclaim(PreclaimContext const& ctx)
     auto const sled = ctx.view.read(keylet::account(ctx.tx[sfDestination]));
     if (!sled)
         return tecNO_DST;
-    if (((*sled)[sfFlags] & lsfAMM))
+    if (sled->isFieldPresent(sfAMMID))
         return tecNO_PERMISSION;
 
     return tesSUCCESS;

--- a/src/ripple/app/tx/impl/InvariantCheck.cpp
+++ b/src/ripple/app/tx/impl/InvariantCheck.cpp
@@ -321,12 +321,14 @@ AccountRootsNotDeleted::finalize(
     ReadView const&,
     beast::Journal const& j)
 {
-    // AMM account root can be deleted as the result of AMM withdraw
+    // AMM account root can be deleted as the result of AMM withdraw/delete
     // transaction when the total AMM LP Tokens balance goes to 0.
     // Not every AMM withdraw deletes the AMM account, accountsDeleted_
     // is set if it is deleted.
     if ((tx.getTxnType() == ttACCOUNT_DELETE ||
-         (tx.getTxnType() == ttAMM_WITHDRAW && accountsDeleted_ == 1)) &&
+         ((tx.getTxnType() == ttAMM_WITHDRAW ||
+           tx.getTxnType() == ttAMM_DELETE) &&
+          accountsDeleted_ == 1)) &&
         result == tesSUCCESS)
     {
         if (accountsDeleted_ == 1)

--- a/src/ripple/app/tx/impl/InvariantCheck.cpp
+++ b/src/ripple/app/tx/impl/InvariantCheck.cpp
@@ -326,9 +326,7 @@ AccountRootsNotDeleted::finalize(
     // Not every AMM withdraw deletes the AMM account, accountsDeleted_
     // is set if it is deleted.
     if ((tx.getTxnType() == ttACCOUNT_DELETE ||
-         ((tx.getTxnType() == ttAMM_WITHDRAW ||
-           tx.getTxnType() == ttAMM_DELETE) &&
-          accountsDeleted_ == 1)) &&
+         tx.getTxnType() == ttAMM_DELETE) &&
         result == tesSUCCESS)
     {
         if (accountsDeleted_ == 1)
@@ -342,6 +340,13 @@ AccountRootsNotDeleted::finalize(
                                "succeeded but deleted multiple accounts!";
         return false;
     }
+
+    // A successful AMMWithdraw MAY delete one account root
+    // when the total AMM LP Tokens balance goes to 0. Not every AMM withdraw
+    // deletes the AMM account, accountsDeleted_ is set if it is deleted.
+    if (tx.getTxnType() == ttAMM_WITHDRAW && result == tesSUCCESS &&
+        accountsDeleted_ == 1)
+        return true;
 
     if (accountsDeleted_ == 0)
         return true;

--- a/src/ripple/app/tx/impl/InvariantCheck.cpp
+++ b/src/ripple/app/tx/impl/InvariantCheck.cpp
@@ -323,8 +323,8 @@ AccountRootsNotDeleted::finalize(
 {
     // AMM account root can be deleted as the result of AMM withdraw/delete
     // transaction when the total AMM LP Tokens balance goes to 0.
-    // Not every AMM withdraw deletes the AMM account, accountsDeleted_
-    // is set if it is deleted.
+    // A successful AccountDelete or AMMDelete MUST delete exactly
+    // one account root.
     if ((tx.getTxnType() == ttACCOUNT_DELETE ||
          tx.getTxnType() == ttAMM_DELETE) &&
         result == tesSUCCESS)

--- a/src/ripple/app/tx/impl/PayChan.cpp
+++ b/src/ripple/app/tx/impl/PayChan.cpp
@@ -234,7 +234,7 @@ PayChanCreate::preclaim(PreclaimContext const& ctx)
             (flags & lsfDisallowXRP))
             return tecNO_TARGET;
 
-        if (flags & lsfAMM)
+        if (sled->isFieldPresent(sfAMMID))
             return tecNO_PERMISSION;
     }
 

--- a/src/ripple/app/tx/impl/Payment.cpp
+++ b/src/ripple/app/tx/impl/Payment.cpp
@@ -468,7 +468,7 @@ Payment::doApply()
 
     // AMMs can never receive an XRP payment.
     // Must use AMMDeposit transaction instead.
-    if (sleDst->getFlags() & lsfAMM)
+    if (sleDst->isFieldPresent(sfAMMID))
         return tecNO_PERMISSION;
 
     // The source account does have enough money.  Make sure the

--- a/src/ripple/app/tx/impl/SetTrust.cpp
+++ b/src/ripple/app/tx/impl/SetTrust.cpp
@@ -541,6 +541,10 @@ SetTrust::doApply()
             uQualityIn,
             uQualityOut,
             viewJ);
+
+        // Maintain number of AMM trustlines in AMM root account
+        if (terResult == tesSUCCESS && (sleDst->getFlags() & lsfAMM))
+            adjustOwnerCount(view(), sleDst, 1, j_);
     }
 
     return terResult;

--- a/src/ripple/app/tx/impl/SetTrust.cpp
+++ b/src/ripple/app/tx/impl/SetTrust.cpp
@@ -151,7 +151,7 @@ SetTrust::preclaim(PreclaimContext const& ctx)
         if (!sleDst)
             return tecNO_DST;
 
-        if (sleDst->getFlags() & lsfAMM &&
+        if (sleDst->isFieldPresent(sfAMMID) &&
             !ctx.view.read(keylet::line(id, uDstAccountID, currency)))
         {
             if (auto const ammSle =
@@ -547,10 +547,6 @@ SetTrust::doApply()
             uQualityIn,
             uQualityOut,
             viewJ);
-
-        // Maintain number of AMM trustlines in AMM root account
-        if (terResult == tesSUCCESS && (sleDst->getFlags() & lsfAMM))
-            adjustOwnerCount(view(), sleDst, 1, j_);
     }
 
     return terResult;

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -950,7 +950,7 @@ Transactor::operator()()
 
         if (result == tecINCOMPLETE)
             removeDeletedTrustLines(
-                view(), removedTrustLines, ctx_.app.journal("view"));
+                view(), removedTrustLines, ctx_.app.journal("View"));
 
         applied = isTecClaim(result);
     }

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -757,6 +757,25 @@ removeExpiredNFTokenOffers(
     }
 }
 
+static void
+removeDeletedTrustLines(
+    ApplyView& view,
+    std::vector<uint256> const& trustLines,
+    beast::Journal viewJ)
+{
+    std::size_t removed = 0;
+
+    for (auto const& index : trustLines)
+    {
+        if (auto const sleState = view.peek({ltRIPPLE_STATE, index}))
+        {
+            deleteAMMTrustLine(view, sleState, std::nullopt, viewJ);
+            if (++removed == maxDeletableAMMTrustLines)
+                return;
+        }
+    }
+}
+
 /** Reset the context, discarding any changes made and adjust the fee */
 std::pair<TER, XRPAmount>
 Transactor::reset(XRPAmount fee)
@@ -849,7 +868,8 @@ Transactor::operator()()
     }
     else if (
         (result == tecOVERSIZE) || (result == tecKILLED) ||
-        (result == tecEXPIRED) || (isTecClaimHardFail(result, view().flags())))
+        (result == tecINCOMPLETE) || (result == tecEXPIRED) ||
+        (isTecClaimHardFail(result, view().flags())))
     {
         JLOG(j_.trace()) << "reapplying because of " << transToken(result);
 
@@ -858,10 +878,21 @@ Transactor::operator()()
         //        should be used, making it possible to do more useful work
         //        when transactions fail with a `tec` code.
         std::vector<uint256> removedOffers;
+        std::vector<uint256> removedTrustLines;
+        std::vector<uint256> expiredNFTokenOffers;
 
-        if ((result == tecOVERSIZE) || (result == tecKILLED))
+        bool const doOffers =
+            ((result == tecOVERSIZE) || (result == tecKILLED));
+        bool const doLines = (result == tecINCOMPLETE);
+        bool const doNFTokenOffers = (result == tecEXPIRED);
+        if (doOffers || doLines || doNFTokenOffers)
         {
-            ctx_.visit([&removedOffers](
+            ctx_.visit([&doOffers,
+                        &removedOffers,
+                        &doLines,
+                        &removedTrustLines,
+                        &doNFTokenOffers,
+                        &expiredNFTokenOffers](
                            uint256 const& index,
                            bool isDelete,
                            std::shared_ptr<SLE const> const& before,
@@ -869,30 +900,23 @@ Transactor::operator()()
                 if (isDelete)
                 {
                     assert(before && after);
-                    if (before && after && (before->getType() == ltOFFER) &&
+                    if (doOffers && before && after &&
+                        (before->getType() == ltOFFER) &&
                         (before->getFieldAmount(sfTakerPays) ==
                          after->getFieldAmount(sfTakerPays)))
                     {
                         // Removal of offer found or made unfunded
                         removedOffers.push_back(index);
                     }
-                }
-            });
-        }
 
-        std::vector<uint256> expiredNFTokenOffers;
+                    if (doLines && before && after &&
+                        (before->getType() == ltRIPPLE_STATE))
+                    {
+                        // Removal of obsolete AMM trust line
+                        removedTrustLines.push_back(index);
+                    }
 
-        if (result == tecEXPIRED)
-        {
-            ctx_.visit([&expiredNFTokenOffers](
-                           uint256 const& index,
-                           bool isDelete,
-                           std::shared_ptr<SLE const> const& before,
-                           std::shared_ptr<SLE const> const& after) {
-                if (isDelete)
-                {
-                    assert(before && after);
-                    if (before && after &&
+                    if (doNFTokenOffers && before && after &&
                         (before->getType() == ltNFTOKEN_OFFER))
                         expiredNFTokenOffers.push_back(index);
                 }
@@ -916,6 +940,10 @@ Transactor::operator()()
         if (result == tecEXPIRED)
             removeExpiredNFTokenOffers(
                 view(), expiredNFTokenOffers, ctx_.app.journal("View"));
+
+        if (result == tecINCOMPLETE)
+            removeDeletedTrustLines(
+                view(), removedTrustLines, ctx_.app.journal("view"));
 
         applied = isTecClaim(result);
     }

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -763,16 +763,18 @@ removeDeletedTrustLines(
     std::vector<uint256> const& trustLines,
     beast::Journal viewJ)
 {
-    std::size_t removed = 0;
+    if (trustLines.size() > maxDeletableAMMTrustLines)
+    {
+        JLOG(viewJ.error())
+            << "removeDeletedTrustLines: deleted trustlines exceed max "
+            << trustLines.size();
+        return;
+    }
 
     for (auto const& index : trustLines)
     {
         if (auto const sleState = view.peek({ltRIPPLE_STATE, index}))
-        {
             deleteAMMTrustLine(view, sleState, std::nullopt, viewJ);
-            if (++removed == maxDeletableAMMTrustLines)
-                return;
-        }
     }
 }
 

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -773,8 +773,13 @@ removeDeletedTrustLines(
 
     for (auto const& index : trustLines)
     {
-        if (auto const sleState = view.peek({ltRIPPLE_STATE, index}))
-            deleteAMMTrustLine(view, sleState, std::nullopt, viewJ);
+        if (auto const sleState = view.peek({ltRIPPLE_STATE, index});
+            deleteAMMTrustLine(view, sleState, std::nullopt, viewJ) !=
+            tesSUCCESS)
+        {
+            JLOG(viewJ.error())
+                << "removeDeletedTrustLines: failed to delete AMM trustline";
+        }
     }
 }
 

--- a/src/ripple/app/tx/impl/applySteps.cpp
+++ b/src/ripple/app/tx/impl/applySteps.cpp
@@ -20,6 +20,7 @@
 #include <ripple/app/tx/applySteps.h>
 #include <ripple/app/tx/impl/AMMBid.h>
 #include <ripple/app/tx/impl/AMMCreate.h>
+#include <ripple/app/tx/impl/AMMDelete.h>
 #include <ripple/app/tx/impl/AMMDeposit.h>
 #include <ripple/app/tx/impl/AMMVote.h>
 #include <ripple/app/tx/impl/AMMWithdraw.h>
@@ -165,6 +166,8 @@ invoke_preflight(PreflightContext const& ctx)
             return invoke_preflight_helper<AMMVote>(ctx);
         case ttAMM_BID:
             return invoke_preflight_helper<AMMBid>(ctx);
+        case ttAMM_DELETE:
+            return invoke_preflight_helper<AMMDelete>(ctx);
         default:
             assert(false);
             return {temUNKNOWN, TxConsequences{temUNKNOWN}};
@@ -278,6 +281,8 @@ invoke_preclaim(PreclaimContext const& ctx)
             return invoke_preclaim<AMMVote>(ctx);
         case ttAMM_BID:
             return invoke_preclaim<AMMBid>(ctx);
+        case ttAMM_DELETE:
+            return invoke_preclaim<AMMDelete>(ctx);
         default:
             assert(false);
             return temUNKNOWN;
@@ -353,6 +358,8 @@ invoke_calculateBaseFee(ReadView const& view, STTx const& tx)
             return AMMVote::calculateBaseFee(view, tx);
         case ttAMM_BID:
             return AMMBid::calculateBaseFee(view, tx);
+        case ttAMM_DELETE:
+            return AMMDelete::calculateBaseFee(view, tx);
         default:
             assert(false);
             return XRPAmount{0};
@@ -527,6 +534,10 @@ invoke_apply(ApplyContext& ctx)
         }
         case ttAMM_BID: {
             AMMBid p(ctx);
+            return p();
+        }
+        case ttAMM_DELETE: {
+            AMMDelete p(ctx);
             return p();
         }
         default:

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -462,7 +462,7 @@ requireAuth(ReadView const& view, Issue const& issue, AccountID const& account);
  * Used for a regular and AMM accounts deletion. The caller
  * has to provide the deleter function, which handles details of
  * specific account-owned object deletion.
- * @return tesINCOMPLETE indicates maxNodesToDelete
+ * @return tecINCOMPLETE indicates maxNodesToDelete
  * are deleted and there remains more nodes to delete.
  */
 [[nodiscard]] TER

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -43,7 +43,6 @@
 namespace ripple {
 
 enum class WaiveTransferFee { Yes, No };
-enum class AllNodesDeleted { Yes, No };
 
 //------------------------------------------------------------------------------
 //
@@ -463,10 +462,10 @@ requireAuth(ReadView const& view, Issue const& issue, AccountID const& account);
  * Used for a regular and AMM accounts deletion. The caller
  * has to provide the deleter function, which handles details of
  * specific account deletion.
- * @return {tesSUCCESS, AllNodesDeleted::No} indicates maxNodesToDelete
+ * @return {tesSUCCESS, false} indicates maxNodesToDelete
  * are deleted and there remains more nodes to delete.
  */
-[[nodiscard]] std::pair<TER, AllNodesDeleted>
+[[nodiscard]] std::pair<TER, bool>
 cleanupOnAccountDelete(
     ApplyView& view,
     Keylet const& ownerDirKeylet,

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -461,11 +461,11 @@ requireAuth(ReadView const& view, Issue const& issue, AccountID const& account);
 /** Cleanup owner directory entries on account delete.
  * Used for a regular and AMM accounts deletion. The caller
  * has to provide the deleter function, which handles details of
- * specific account deletion.
- * @return {tesSUCCESS, false} indicates maxNodesToDelete
+ * specific account-owned object deletion.
+ * @return tesINCOMPLETE indicates maxNodesToDelete
  * are deleted and there remains more nodes to delete.
  */
-[[nodiscard]] std::pair<TER, bool>
+[[nodiscard]] TER
 cleanupOnAccountDelete(
     ApplyView& view,
     Keylet const& ownerDirKeylet,
@@ -478,8 +478,7 @@ cleanupOnAccountDelete(
  * call to view.peek(). Fail if neither side of the trustline is AMM or
  * if ammAccountID is seated and is not one of the trustline's side.
  */
-// [[nodiscard]] // nodiscard commented out so Transactor compiles.
-TER
+[[nodiscard]] TER
 deleteAMMTrustLine(
     ApplyView& view,
     std::shared_ptr<SLE> sleState,

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -42,7 +42,7 @@
 
 namespace ripple {
 
-enum class WaiveTransferFee { Yes, No };
+enum class WaiveTransferFee : bool { No = false, Yes };
 
 //------------------------------------------------------------------------------
 //

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -43,6 +43,7 @@
 namespace ripple {
 
 enum class WaiveTransferFee { Yes, No };
+enum class AllNodesDeleted { Yes, No };
 
 //------------------------------------------------------------------------------
 //
@@ -457,6 +458,34 @@ transferXRP(
  */
 [[nodiscard]] TER
 requireAuth(ReadView const& view, Issue const& issue, AccountID const& account);
+
+/** Cleanup owner directory entries on account delete.
+ * Used for a regular and AMM accounts deletion. The caller
+ * has to provide the deleter function, which handles details of
+ * specific account deletion.
+ * @return {tesSUCCESS, AllNodesDeleted::No} indicates maxNodesToDelete
+ * are deleted and there remains more nodes to delete.
+ */
+[[nodiscard]] std::pair<TER, AllNodesDeleted>
+cleanupOnAccountDelete(
+    ApplyView& view,
+    Keylet const& ownerDirKeylet,
+    std::function<TER(LedgerEntryType, uint256 const&, std::shared_ptr<SLE>&)>
+        deleter,
+    beast::Journal j,
+    std::optional<std::uint16_t> maxNodesToDelete = std::nullopt);
+
+/** Delete trustline to AMM. The passed `sle` must be obtained from a prior
+ * call to view.peek(). Fail if neither side of the trustline is AMM or
+ * if ammAccountID is seated and is not one of the trustline's side.
+ */
+// [[nodiscard]] // nodiscard commented out so Transactor compiles.
+TER
+deleteAMMTrustLine(
+    ApplyView& view,
+    std::shared_ptr<SLE> sleState,
+    std::optional<AccountID> const& ammAccountID,
+    beast::Journal j);
 
 }  // namespace ripple
 

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -1557,7 +1557,7 @@ cleanupOnAccountDelete(
     std::shared_ptr<SLE> sleDirNode{};
     unsigned int uDirEntry{0};
     uint256 dirEntry{beast::zero};
-    std::uint16_t deleted = 0;
+    std::uint32_t deleted = 0;
 
     if (view.exists(ownerDirKeylet) &&
         dirFirst(view, ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry))

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -375,7 +375,7 @@ xrpLiquid(
         view.ownerCountHook(id, sle->getFieldU32(sfOwnerCount)), ownerCountAdj);
 
     // AMMs have no reserve requirement
-    auto const reserve = (sle->getFlags() & lsfAMM)
+    auto const reserve = sle->isFieldPresent(sfAMMID)
         ? XRPAmount{0}
         : view.fees().accountReserve(ownerCount);
 
@@ -1637,8 +1637,8 @@ deleteAMMTrustLine(
     auto sleHigh = view.peek(keylet::account(high));
     if (!sleLow || !sleHigh)
         return tecINTERNAL;
-    bool const ammLow = sleLow->getFlags() & lsfAMM;
-    bool const ammHigh = sleHigh->getFlags() & lsfAMM;
+    bool const ammLow = sleLow->isFieldPresent(sfAMMID);
+    bool const ammHigh = sleHigh->isFieldPresent(sfAMMID);
 
     // can't both be AMM
     if (ammLow && ammHigh)

--- a/src/ripple/protocol/LedgerFormats.h
+++ b/src/ripple/protocol/LedgerFormats.h
@@ -249,9 +249,8 @@ enum LedgerSpecificFlags {
         0x10000000,               // True, reject new paychans
     lsfDisallowIncomingTrustline =
         0x20000000,               // True, reject new trustlines (only if no issued assets)
-    lsfAMM = 0x40000000,          // True, AMM account
     lsfAllowTrustLineClawback =
-        0x80000000,               // True, enable clawback
+        0x40000000,               // True, enable clawback
 
     // ltOFFER
     lsfPassive = 0x00010000,

--- a/src/ripple/protocol/LedgerFormats.h
+++ b/src/ripple/protocol/LedgerFormats.h
@@ -249,7 +249,7 @@ enum LedgerSpecificFlags {
         0x10000000,               // True, reject new paychans
     lsfDisallowIncomingTrustline =
         0x20000000,               // True, reject new trustlines (only if no issued assets)
-    lsfAMM [[maybe_unused]] = 0x40000000, // True, AMM account
+    lsfAMM = 0x40000000,          // True, AMM account
     lsfAllowTrustLineClawback =
         0x80000000,               // True, enable clawback
 

--- a/src/ripple/protocol/LedgerFormats.h
+++ b/src/ripple/protocol/LedgerFormats.h
@@ -249,8 +249,9 @@ enum LedgerSpecificFlags {
         0x10000000,               // True, reject new paychans
     lsfDisallowIncomingTrustline =
         0x20000000,               // True, reject new trustlines (only if no issued assets)
+    // 0x40000000 is available
     lsfAllowTrustLineClawback =
-        0x40000000,               // True, enable clawback
+        0x80000000,               // True, enable clawback
 
     // ltOFFER
     lsfPassive = 0x00010000,

--- a/src/ripple/protocol/Protocol.h
+++ b/src/ripple/protocol/Protocol.h
@@ -95,6 +95,8 @@ using LedgerIndex = std::uint32_t;
 */
 using TxID = uint256;
 
+std::size_t constexpr maxDeletableAMMTrustLines = 1500;
+
 }  // namespace ripple
 
 #endif

--- a/src/ripple/protocol/Protocol.h
+++ b/src/ripple/protocol/Protocol.h
@@ -95,7 +95,7 @@ using LedgerIndex = std::uint32_t;
 */
 using TxID = uint256;
 
-std::size_t constexpr maxDeletableAMMTrustLines = 1500;
+std::size_t constexpr maxDeletableAMMTrustLines = 512;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/Protocol.h
+++ b/src/ripple/protocol/Protocol.h
@@ -95,7 +95,10 @@ using LedgerIndex = std::uint32_t;
 */
 using TxID = uint256;
 
-std::size_t constexpr maxDeletableAMMTrustLines = 512;
+/** The maximum number of trustlines to delete as part of AMM account
+ * deletion cleanup.
+ */
+std::uint16_t constexpr maxDeletableAMMTrustLines = 512;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -301,7 +301,8 @@ enum TECcodes : TERUnderlyingType {
     tecAMM_INVALID_TOKENS = 165,
     tecAMM_EMPTY = 166,
     tecAMM_NOT_EMPTY = 167,
-    tecINCOMPLETE = 168
+    tecAMM_ACCOUNT = 168,
+    tecINCOMPLETE = 169
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -301,8 +301,7 @@ enum TECcodes : TERUnderlyingType {
     tecAMM_INVALID_TOKENS = 165,
     tecAMM_EMPTY = 166,
     tecAMM_NOT_EMPTY = 167,
-    tecAMM_ACCOUNT = 168,
-    tecINCOMPLETE = 169
+    tecINCOMPLETE = 168
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -298,7 +298,9 @@ enum TECcodes : TERUnderlyingType {
     tecUNFUNDED_AMM = 162,
     tecAMM_BALANCE = 163,
     tecAMM_FAILED = 164,
-    tecAMM_INVALID_TOKENS = 165
+    tecAMM_INVALID_TOKENS = 165,
+    tecAMM_EMPTY = 166,
+    tecINCOMPLETE = 167
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -300,7 +300,8 @@ enum TECcodes : TERUnderlyingType {
     tecAMM_FAILED = 164,
     tecAMM_INVALID_TOKENS = 165,
     tecAMM_EMPTY = 166,
-    tecINCOMPLETE = 167
+    tecAMM_NOT_EMPTY = 167,
+    tecINCOMPLETE = 168
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/TxFlags.h
+++ b/src/ripple/protocol/TxFlags.h
@@ -171,12 +171,13 @@ constexpr std::uint32_t tfSingleAsset                  = 0x00080000;
 constexpr std::uint32_t tfTwoAsset                     = 0x00100000;
 constexpr std::uint32_t tfOneAssetLPToken              = 0x00200000;
 constexpr std::uint32_t tfLimitLPToken                 = 0x00400000;
+constexpr std::uint32_t tfTwoAssetIfEmpty              = 0x00800000;
 constexpr std::uint32_t tfWithdrawSubTx =
     tfLPToken | tfSingleAsset | tfTwoAsset | tfOneAssetLPToken |
     tfLimitLPToken | tfWithdrawAll | tfOneAssetWithdrawAll;
 constexpr std::uint32_t tfDepositSubTx =
     tfLPToken | tfSingleAsset | tfTwoAsset | tfOneAssetLPToken |
-    tfLimitLPToken;
+    tfLimitLPToken | tfTwoAssetIfEmpty;
 constexpr std::uint32_t tfWithdrawMask = ~(tfUniversal | tfWithdrawSubTx);
 constexpr std::uint32_t tfDepositMask = ~(tfUniversal | tfDepositSubTx);
 

--- a/src/ripple/protocol/TxFormats.h
+++ b/src/ripple/protocol/TxFormats.h
@@ -157,6 +157,9 @@ enum TxType : std::uint16_t
     /** This transaction type bids for the auction slot */
     ttAMM_BID = 39,
 
+    /** This transaction type deletes AMM in the empty state */
+    ttAMM_DELETE = 40,
+
     /** This system-generated transaction type is used to update the status of the various amendments.
 
         For details, see: https://xrpl.org/amendments.html

--- a/src/ripple/protocol/impl/InnerObjectFormats.cpp
+++ b/src/ripple/protocol/impl/InnerObjectFormats.cpp
@@ -77,6 +77,12 @@ InnerObjectFormats::InnerObjectFormats()
             {sfPrice, soeREQUIRED},
             {sfAuthAccounts, soeOPTIONAL},
         });
+
+    add(sfAuthAccount.jsonName.c_str(),
+        sfAuthAccount.getCode(),
+        {
+            {sfAccount, soeREQUIRED},
+        });
 }
 
 InnerObjectFormats const&

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -277,7 +277,8 @@ LedgerFormats::LedgerFormats()
             {sfAuctionSlot, soeOPTIONAL},
             {sfLPTokenBalance, soeREQUIRED},
             {sfAsset, soeREQUIRED},
-            {sfAsset2, soeREQUIRED}
+            {sfAsset2, soeREQUIRED},
+            {sfOwnerNode, soeREQUIRED}
         },
         commonFields);
 

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -56,6 +56,7 @@ LedgerFormats::LedgerFormats()
             {sfMintedNFTokens,       soeDEFAULT},
             {sfBurnedNFTokens,       soeDEFAULT},
             {sfFirstNFTokenSequence, soeOPTIONAL},
+            {sfAMMID,                soeOPTIONAL},
         },
         commonFields);
 
@@ -278,7 +279,6 @@ LedgerFormats::LedgerFormats()
             {sfLPTokenBalance, soeREQUIRED},
             {sfAsset, soeREQUIRED},
             {sfAsset2, soeREQUIRED},
-            {sfOwnerNode, soeREQUIRED}
         },
         commonFields);
 

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -47,6 +47,7 @@ transResults()
         MAKE_ERROR(tecAMM_FAILED,                    "AMM transaction failed."),
         MAKE_ERROR(tecAMM_EMPTY,                     "AMM is in empty state."),
         MAKE_ERROR(tecAMM_NOT_EMPTY,                 "AMM is not in empty state."),
+        MAKE_ERROR(tecAMM_ACCOUNT,                   "AMM Account."),
         MAKE_ERROR(tecCLAIM,                         "Fee claimed. Sequence used. No action."),
         MAKE_ERROR(tecDIR_FULL,                      "Can not add entry to full directory."),
         MAKE_ERROR(tecFAILED_PROCESSING,             "Failed to correctly process transaction."),
@@ -94,7 +95,7 @@ transResults()
         MAKE_ERROR(tecINSUFFICIENT_FUNDS,            "Not enough funds available to complete requested transaction."),
         MAKE_ERROR(tecOBJECT_NOT_FOUND,              "A requested object could not be located."),
         MAKE_ERROR(tecINSUFFICIENT_PAYMENT,          "The payment is not sufficient."),
-        MAKE_ERROR(tecINCOMPLETE,                    "Transaction requires multple submissions to complete the processing."),
+        MAKE_ERROR(tecINCOMPLETE,                    "Transaction requires multiple submissions to complete the processing."),
 
         MAKE_ERROR(tefALREADY,                     "The exact transaction was already in this ledger."),
         MAKE_ERROR(tefBAD_ADD_AUTH,                "Not authorized to add account."),

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -45,6 +45,7 @@ transResults()
         MAKE_ERROR(tecAMM_BALANCE,                   "AMM has invalid balance."),
         MAKE_ERROR(tecAMM_INVALID_TOKENS,            "AMM invalid LP tokens."),
         MAKE_ERROR(tecAMM_FAILED,                    "AMM transaction failed."),
+        MAKE_ERROR(tecAMM_EMPTY,                     "AMM is in empty state."),
         MAKE_ERROR(tecCLAIM,                         "Fee claimed. Sequence used. No action."),
         MAKE_ERROR(tecDIR_FULL,                      "Can not add entry to full directory."),
         MAKE_ERROR(tecFAILED_PROCESSING,             "Failed to correctly process transaction."),
@@ -92,6 +93,7 @@ transResults()
         MAKE_ERROR(tecINSUFFICIENT_FUNDS,            "Not enough funds available to complete requested transaction."),
         MAKE_ERROR(tecOBJECT_NOT_FOUND,              "A requested object could not be located."),
         MAKE_ERROR(tecINSUFFICIENT_PAYMENT,          "The payment is not sufficient."),
+        MAKE_ERROR(tecINCOMPLETE,                    "Transaction requires multple submissions to complete the processing."),
 
         MAKE_ERROR(tefALREADY,                     "The exact transaction was already in this ledger."),
         MAKE_ERROR(tefBAD_ADD_AUTH,                "Not authorized to add account."),

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -47,7 +47,6 @@ transResults()
         MAKE_ERROR(tecAMM_FAILED,                    "AMM transaction failed."),
         MAKE_ERROR(tecAMM_EMPTY,                     "AMM is in empty state."),
         MAKE_ERROR(tecAMM_NOT_EMPTY,                 "AMM is not in empty state."),
-        MAKE_ERROR(tecAMM_ACCOUNT,                   "AMM Account."),
         MAKE_ERROR(tecCLAIM,                         "Fee claimed. Sequence used. No action."),
         MAKE_ERROR(tecDIR_FULL,                      "Can not add entry to full directory."),
         MAKE_ERROR(tecFAILED_PROCESSING,             "Failed to correctly process transaction."),
@@ -95,7 +94,7 @@ transResults()
         MAKE_ERROR(tecINSUFFICIENT_FUNDS,            "Not enough funds available to complete requested transaction."),
         MAKE_ERROR(tecOBJECT_NOT_FOUND,              "A requested object could not be located."),
         MAKE_ERROR(tecINSUFFICIENT_PAYMENT,          "The payment is not sufficient."),
-        MAKE_ERROR(tecINCOMPLETE,                    "Transaction requires multiple submissions to complete the processing."),
+        MAKE_ERROR(tecINCOMPLETE,                    "Some work was completed, but more submissions required to finish."),
 
         MAKE_ERROR(tefALREADY,                     "The exact transaction was already in this ledger."),
         MAKE_ERROR(tefBAD_ADD_AUTH,                "Not authorized to add account."),

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -47,7 +47,7 @@ transResults()
         MAKE_ERROR(tecAMM_FAILED,                    "AMM transaction failed."),
         MAKE_ERROR(tecAMM_EMPTY,                     "AMM is in empty state."),
         MAKE_ERROR(tecAMM_NOT_EMPTY,                 "AMM is not in empty state."),
-        MAKE_ERROR(tecAMM_ACCOUNT,                   "AMM Account."),
+        MAKE_ERROR(tecAMM_ACCOUNT,                   "This operation is not allowed on an AMM Account."),
         MAKE_ERROR(tecCLAIM,                         "Fee claimed. Sequence used. No action."),
         MAKE_ERROR(tecDIR_FULL,                      "Can not add entry to full directory."),
         MAKE_ERROR(tecFAILED_PROCESSING,             "Failed to correctly process transaction."),

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -47,6 +47,7 @@ transResults()
         MAKE_ERROR(tecAMM_FAILED,                    "AMM transaction failed."),
         MAKE_ERROR(tecAMM_EMPTY,                     "AMM is in empty state."),
         MAKE_ERROR(tecAMM_NOT_EMPTY,                 "AMM is not in empty state."),
+        MAKE_ERROR(tecAMM_ACCOUNT,                   "AMM Account."),
         MAKE_ERROR(tecCLAIM,                         "Fee claimed. Sequence used. No action."),
         MAKE_ERROR(tecDIR_FULL,                      "Can not add entry to full directory."),
         MAKE_ERROR(tecFAILED_PROCESSING,             "Failed to correctly process transaction."),

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -46,6 +46,7 @@ transResults()
         MAKE_ERROR(tecAMM_INVALID_TOKENS,            "AMM invalid LP tokens."),
         MAKE_ERROR(tecAMM_FAILED,                    "AMM transaction failed."),
         MAKE_ERROR(tecAMM_EMPTY,                     "AMM is in empty state."),
+        MAKE_ERROR(tecAMM_NOT_EMPTY,                 "AMM is not in empty state."),
         MAKE_ERROR(tecCLAIM,                         "Fee claimed. Sequence used. No action."),
         MAKE_ERROR(tecDIR_FULL,                      "Can not add entry to full directory."),
         MAKE_ERROR(tecFAILED_PROCESSING,             "Failed to correctly process transaction."),

--- a/src/ripple/protocol/impl/TxFormats.cpp
+++ b/src/ripple/protocol/impl/TxFormats.cpp
@@ -101,6 +101,7 @@ TxFormats::TxFormats()
             {sfEPrice, soeOPTIONAL},
             {sfLPTokenOut, soeOPTIONAL},
             {sfTicketSequence, soeOPTIONAL},
+            {sfTradingFee, soeOPTIONAL},
         },
         commonFields);
 
@@ -135,6 +136,15 @@ TxFormats::TxFormats()
             {sfBidMin, soeOPTIONAL},
             {sfBidMax, soeOPTIONAL},
             {sfAuthAccounts, soeOPTIONAL},
+            {sfTicketSequence, soeOPTIONAL},
+        },
+        commonFields);
+
+    add(jss::AMMDelete,
+        ttAMM_DELETE,
+        {
+            {sfAsset, soeREQUIRED},
+            {sfAsset2, soeREQUIRED},
             {sfTicketSequence, soeOPTIONAL},
         },
         commonFields);

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -52,6 +52,7 @@ JSS(AMMBid);               // transaction type
 JSS(AMMID);                // field
 JSS(AMMCreate);            // transaction type
 JSS(AMMDeposit);           // transaction type
+JSS(AMMDelete);            // transaction type
 JSS(AMMVote);              // transaction type
 JSS(AMMWithdraw);          // transaction type
 JSS(Amendments);           // ledger type.

--- a/src/test/app/AMMExtended_test.cpp
+++ b/src/test/app/AMMExtended_test.cpp
@@ -32,7 +32,6 @@
 #include <test/jtx/AMM.h>
 #include <test/jtx/AMMTest.h>
 #include <test/jtx/PathSet.h>
-#include <test/jtx/TestHelpers.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/sendmax.h>
 

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -4386,6 +4386,27 @@ private:
     }
 
     void
+    testClawback()
+    {
+        testcase("Clawback");
+        using namespace jtx;
+        FeatureBitset const all{supported_amendments()};
+
+        for (auto const& features : {all, all - featureClawback})
+        {
+            Env env(*this, features);
+            env.fund(XRP(2'000), gw);
+            env.fund(XRP(2'000), alice);
+            env(fset(gw, asfAllowTrustLineClawback));
+            AMM amm(env, gw, XRP(1'000), USD(1'000));
+            auto const terr = features[featureClawback] ? ter(tecAMM_ACCOUNT)
+                                                        : ter(temDISABLED);
+            env(claw(gw, STAmount{Issue(USD.currency, amm.ammAccount()), 200}),
+                terr);
+        }
+    }
+
+    void
     testCore()
     {
         testInvalidInstance();
@@ -4408,6 +4429,7 @@ private:
         testTradingFee();
         testAdjustedTokens();
         testAutoDelete();
+        testClawback();
     }
 
     void

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -4502,19 +4502,17 @@ private:
                 {
                     Env env(*this);
                     prep(env, rates.first, rates.second);
-                    std::shared_ptr<AMM> amm;
+                    std::optional<AMM> amm;
                     if (i == 0 || i == 2)
                     {
                         env(offer(ed, ETH(400), USD(400)), txflags(tfPassive));
                         env.close();
                     }
                     if (i > 0)
-                        amm = std::make_shared<AMM>(
-                            env, ed, USD(1'000), ETH(1'000));
+                        amm.emplace(env, ed, USD(1'000), ETH(1'000));
                     env(pay(carol, bob, USD(100)),
                         path(~USD),
-                        sendmax(ETH(500)),
-                        txflags(tfPartialPayment));
+                        sendmax(ETH(500)));
                     env.close();
                     // CLOB and AMM, AMM is not selected
                     if (i == 2)
@@ -4540,15 +4538,14 @@ private:
             {
                 Env env(*this);
                 prep(env, rates.first, rates.second);
-                std::shared_ptr<AMM> amm;
+                std::optional<AMM> amm;
                 if (i == 0 || i == 2)
                 {
                     env(offer(ed, ETH(400), USD(400)), txflags(tfPassive));
                     env.close();
                 }
                 if (i > 0)
-                    amm =
-                        std::make_shared<AMM>(env, ed, USD(1'000), ETH(1'000));
+                    amm.emplace(env, ed, USD(1'000), ETH(1'000));
                 env(offer(alice, USD(400), ETH(400)));
                 env.close();
                 // AMM is not selected
@@ -4560,7 +4557,6 @@ private:
                 if (i == 0 || i == 2)
                 {
                     // Fully crosses
-                    BEAST_EXPECT(expectOffers(env, ed, 0));
                     BEAST_EXPECT(expectOffers(env, alice, 0));
                 }
                 // Fails to cross because AMM is not selected
@@ -4568,8 +4564,8 @@ private:
                 {
                     BEAST_EXPECT(expectOffers(
                         env, alice, 1, {Amounts{USD(400), ETH(400)}}));
-                    BEAST_EXPECT(expectOffers(env, ed, 0));
                 }
+                BEAST_EXPECT(expectOffers(env, ed, 0));
             }
 
             // Show that the CLOB quality reduction
@@ -4582,19 +4578,17 @@ private:
                 {
                     Env env(*this);
                     prep(env, rates.first, rates.second);
-                    std::shared_ptr<AMM> amm;
+                    std::optional<AMM> amm;
                     if (i == 0 || i == 2)
                     {
                         env(offer(ed, ETH(400), USD(300)), txflags(tfPassive));
                         env.close();
                     }
                     if (i > 0)
-                        amm = std::make_shared<AMM>(
-                            env, ed, USD(1'000), ETH(1'000));
+                        amm.emplace(env, ed, USD(1'000), ETH(1'000));
                     env(pay(carol, bob, USD(100)),
                         path(~USD),
-                        sendmax(ETH(500)),
-                        txflags(tfPartialPayment));
+                        sendmax(ETH(500)));
                     env.close();
                     // AMM and CLOB are selected
                     if (i > 0)
@@ -4649,15 +4643,14 @@ private:
             {
                 Env env(*this);
                 prep(env, rates.first, rates.second);
-                std::shared_ptr<AMM> amm;
+                std::optional<AMM> amm;
                 if (i == 0 || i == 2)
                 {
                     env(offer(ed, ETH(400), USD(250)), txflags(tfPassive));
                     env.close();
                 }
                 if (i > 0)
-                    amm =
-                        std::make_shared<AMM>(env, ed, USD(1'000), ETH(1'000));
+                    amm.emplace(env, ed, USD(1'000), ETH(1'000));
                 env(offer(alice, USD(250), ETH(400)));
                 env.close();
                 // AMM is selected in both cases
@@ -4719,7 +4712,7 @@ private:
                 {
                     Env env(*this);
                     prep(env, rates.first, rates.second);
-                    std::shared_ptr<AMM> amm;
+                    std::optional<AMM> amm;
 
                     if (i == 0 || i == 2)
                     {
@@ -4729,23 +4722,21 @@ private:
                     }
 
                     if (i > 0)
-                        amm = std::make_shared<AMM>(
-                            env, ed, ETH(1'000), USD(1'000));
+                        amm.emplace(env, ed, ETH(1'000), USD(1'000));
 
                     env(pay(carol, bob, USD(100)),
                         path(~USD),
                         path(~CAN, ~USD),
-                        sendmax(ETH(600)),
-                        txflags(tfPartialPayment));
+                        sendmax(ETH(600)));
                     env.close();
 
                     BEAST_EXPECT(expectLine(env, bob, USD(2'100)));
 
                     if (i == 2)
                     {
-                        // Liquidity is consumed from AMM strand only
                         if (rates.first == 1.5)
                         {
+                            // Liquidity is consumed from AMM strand only
                             BEAST_EXPECT(amm->expectBalances(
                                 STAmount{ETH, UINT64_C(1'176'66038955758), -11},
                                 USD(850),

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -1770,8 +1770,15 @@ private:
 
         // Withdraw all tokens.
         testAMM([&](AMM& ammAlice, Env& env) {
+            env(trust(carol, STAmount{ammAlice.lptIssue(), 10000}));
+            env(trust(
+                carol,
+                STAmount{Issue{EUR.currency, ammAlice.ammAccount()}, 10000}));
+            env.close();
             ammAlice.withdrawAll(alice);
             BEAST_EXPECT(!ammAlice.ammExists());
+
+            BEAST_EXPECT(!env.le(keylet::ownerDir(ammAlice.ammAccount())));
 
             // Can create AMM for the XRP/USD pair
             AMM ammCarol(env, carol, XRP(10'000), USD(10'000));

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -27,7 +27,6 @@
 #include <test/jtx.h>
 #include <test/jtx/AMM.h>
 #include <test/jtx/AMMTest.h>
-#include <test/jtx/TestHelpers.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/sendmax.h>
 
@@ -2754,6 +2753,12 @@ private:
                     settleDelay,
                     pk,
                     cancelAfter),
+                ter(tecNO_PERMISSION));
+        });
+
+        // Can't pay into AMM with checks.
+        testAMM([&](AMM& ammAlice, Env& env) {
+            env(check::create(env.master.id(), ammAlice.ammAccount(), XRP(100)),
                 ter(tecNO_PERMISSION));
         });
 

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -4409,6 +4409,7 @@ private:
     void
     testAMMID()
     {
+        testcase("AMMID");
         using namespace jtx;
         testAMM([&](AMM& amm, Env& env) {
             amm.setClose(false);

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -108,6 +108,15 @@ private:
             env.close();
             AMM ammAlice(env, alice, XRP(10'000), USD(10'000));
         }
+
+        // Trading fee
+        testAMM(
+            [&](AMM& amm, Env&) {
+                BEAST_EXPECT(amm.expectTradingFee(1'000));
+                BEAST_EXPECT(amm.expectAuctionSlot(100, 0, IOUAmount{0}));
+            },
+            std::nullopt,
+            1'000);
     }
 
     void
@@ -415,96 +424,167 @@ private:
                 std::optional<std::uint32_t>,
                 std::optional<STAmount>,
                 std::optional<STAmount>,
-                std::optional<STAmount>>>
+                std::optional<STAmount>,
+                std::optional<std::uint16_t>>>
                 invalidOptions = {
-                    // flags, tokens, asset1In, asset2in, EPrice
-                    {tfLPToken, 1'000, std::nullopt, USD(100), std::nullopt},
-                    {tfLPToken, 1'000, XRP(100), std::nullopt, std::nullopt},
+                    // flags, tokens, asset1In, asset2in, EPrice, tfee
                     {tfLPToken,
                      1'000,
                      std::nullopt,
-                     std::nullopt,
-                     STAmount{USD, 1, -1}},
-                    {tfLPToken,
-                     std::nullopt,
                      USD(100),
                      std::nullopt,
-                     STAmount{USD, 1, -1}},
+                     std::nullopt},
                     {tfLPToken,
                      1'000,
                      XRP(100),
                      std::nullopt,
-                     STAmount{USD, 1, -1}},
+                     std::nullopt,
+                     std::nullopt},
+                    {tfLPToken,
+                     1'000,
+                     std::nullopt,
+                     std::nullopt,
+                     STAmount{USD, 1, -1},
+                     std::nullopt},
+                    {tfLPToken,
+                     std::nullopt,
+                     USD(100),
+                     std::nullopt,
+                     STAmount{USD, 1, -1},
+                     std::nullopt},
+                    {tfLPToken,
+                     1'000,
+                     XRP(100),
+                     std::nullopt,
+                     STAmount{USD, 1, -1},
+                     std::nullopt},
+                    {tfLPToken,
+                     1'000,
+                     std::nullopt,
+                     std::nullopt,
+                     std::nullopt,
+                     1'000},
                     {tfSingleAsset,
                      1'000,
                      std::nullopt,
                      std::nullopt,
+                     std::nullopt,
                      std::nullopt},
                     {tfSingleAsset,
                      std::nullopt,
                      std::nullopt,
                      USD(100),
+                     std::nullopt,
                      std::nullopt},
                     {tfSingleAsset,
                      std::nullopt,
                      std::nullopt,
                      std::nullopt,
-                     STAmount{USD, 1, -1}},
+                     STAmount{USD, 1, -1},
+                     std::nullopt},
+                    {tfSingleAsset,
+                     std::nullopt,
+                     USD(100),
+                     std::nullopt,
+                     std::nullopt,
+                     1'000},
                     {tfTwoAsset,
                      1'000,
                      std::nullopt,
                      std::nullopt,
+                     std::nullopt,
                      std::nullopt},
                     {tfTwoAsset,
                      std::nullopt,
                      XRP(100),
                      USD(100),
-                     STAmount{USD, 1, -1}},
+                     STAmount{USD, 1, -1},
+                     std::nullopt},
                     {tfTwoAsset,
                      std::nullopt,
                      XRP(100),
                      std::nullopt,
+                     std::nullopt,
                      std::nullopt},
+                    {tfTwoAsset,
+                     std::nullopt,
+                     XRP(100),
+                     USD(100),
+                     std::nullopt,
+                     1'000},
                     {tfTwoAsset,
                      std::nullopt,
                      std::nullopt,
                      USD(100),
-                     STAmount{USD, 1, -1}},
+                     STAmount{USD, 1, -1},
+                     std::nullopt},
                     {tfOneAssetLPToken,
                      1'000,
                      std::nullopt,
                      std::nullopt,
+                     std::nullopt,
                      std::nullopt},
                     {tfOneAssetLPToken,
                      std::nullopt,
                      XRP(100),
                      USD(100),
+                     std::nullopt,
                      std::nullopt},
                     {tfOneAssetLPToken,
                      std::nullopt,
                      XRP(100),
                      std::nullopt,
-                     STAmount{USD, 1, -1}},
+                     STAmount{USD, 1, -1},
+                     std::nullopt},
+                    {tfOneAssetLPToken,
+                     1'000,
+                     XRP(100),
+                     std::nullopt,
+                     std::nullopt,
+                     1'000},
                     {tfLimitLPToken,
                      1'000,
+                     std::nullopt,
                      std::nullopt,
                      std::nullopt,
                      std::nullopt},
                     {tfLimitLPToken,
                      1'000,
                      USD(100),
+                     std::nullopt,
                      std::nullopt,
                      std::nullopt},
                     {tfLimitLPToken,
                      std::nullopt,
                      USD(100),
                      XRP(100),
+                     std::nullopt,
                      std::nullopt},
                     {tfLimitLPToken,
                      std::nullopt,
+                     XRP(100),
+                     std::nullopt,
+                     STAmount{USD, 1, -1},
+                     1'000},
+                    {tfTwoAssetIfEmpty,
                      std::nullopt,
                      std::nullopt,
-                     STAmount{USD, 1, -1}}};
+                     std::nullopt,
+                     std::nullopt,
+                     1'000},
+                    {tfTwoAssetIfEmpty,
+                     1'000,
+                     std::nullopt,
+                     std::nullopt,
+                     std::nullopt,
+                     std::nullopt},
+                    {tfTwoAssetIfEmpty,
+                     std::nullopt,
+                     XRP(100),
+                     USD(100),
+                     STAmount{USD, 1, -1},
+                     std::nullopt},
+                };
             for (auto const& it : invalidOptions)
             {
                 ammAlice.deposit(
@@ -516,6 +596,7 @@ private:
                     std::get<0>(it),
                     std::nullopt,
                     std::nullopt,
+                    std::get<5>(it),
                     ter(temMALFORMED));
             }
 
@@ -541,6 +622,7 @@ private:
                     std::nullopt,
                     std::nullopt,
                     {{iss1, iss2}},
+                    std::nullopt,
                     std::nullopt,
                     ter(terNO_AMM));
             }
@@ -616,6 +698,7 @@ private:
                 std::nullopt,
                 std::nullopt,
                 seq(1),
+                std::nullopt,
                 ter(terNO_ACCOUNT));
 
             // Invalid AMM
@@ -627,6 +710,7 @@ private:
                 std::nullopt,
                 std::nullopt,
                 {{USD, GBP}},
+                std::nullopt,
                 std::nullopt,
                 ter(terNO_AMM));
 
@@ -641,6 +725,7 @@ private:
                 std::nullopt,
                 std::nullopt,
                 std::nullopt,
+                std::nullopt,
                 ter(tecAMM_FAILED));
 
             // Single deposit: 100000 tokens worth of XRP
@@ -649,6 +734,7 @@ private:
                 carol,
                 100'000,
                 XRP(200),
+                std::nullopt,
                 std::nullopt,
                 std::nullopt,
                 std::nullopt,
@@ -688,6 +774,15 @@ private:
                 std::nullopt,
                 std::nullopt,
                 ter(tecAMM_INVALID_TOKENS));
+
+            // Deposit non-empty AMM
+            ammAlice.deposit(
+                carol,
+                XRP(100),
+                USD(100),
+                std::nullopt,
+                tfTwoAssetIfEmpty,
+                ter(tecAMM_EMPTY));
         });
 
         // Invalid AMM
@@ -789,6 +884,7 @@ private:
                 std::nullopt,
                 std::nullopt,
                 std::nullopt,
+                std::nullopt,
                 ter(tecUNFUNDED_AMM));
         });
 
@@ -802,6 +898,7 @@ private:
             ammAlice.deposit(
                 bob,
                 10'000'000,
+                std::nullopt,
                 std::nullopt,
                 std::nullopt,
                 std::nullopt,
@@ -883,6 +980,7 @@ private:
                 tfTwoAsset,
                 std::nullopt,
                 std::nullopt,
+                std::nullopt,
                 ter(temBAD_AMM_TOKENS));
             // min amounts can't be <= zero
             ammAlice.deposit(
@@ -894,6 +992,7 @@ private:
                 tfTwoAsset,
                 std::nullopt,
                 std::nullopt,
+                std::nullopt,
                 ter(temBAD_AMOUNT));
             ammAlice.deposit(
                 carol,
@@ -902,6 +1001,7 @@ private:
                 USD(-1),
                 std::nullopt,
                 tfTwoAsset,
+                std::nullopt,
                 std::nullopt,
                 std::nullopt,
                 ter(temBAD_AMOUNT));
@@ -915,6 +1015,7 @@ private:
                 tfTwoAsset,
                 std::nullopt,
                 std::nullopt,
+                std::nullopt,
                 ter(temBAD_CURRENCY));
             // min amount bad token pair
             ammAlice.deposit(
@@ -926,6 +1027,7 @@ private:
                 tfTwoAsset,
                 std::nullopt,
                 std::nullopt,
+                std::nullopt,
                 ter(temBAD_AMM_TOKENS));
             ammAlice.deposit(
                 carol,
@@ -934,6 +1036,7 @@ private:
                 GBP(100),
                 std::nullopt,
                 tfTwoAsset,
+                std::nullopt,
                 std::nullopt,
                 std::nullopt,
                 ter(temBAD_AMM_TOKENS));
@@ -951,6 +1054,7 @@ private:
                 tfLPToken,
                 std::nullopt,
                 std::nullopt,
+                std::nullopt,
                 ter(tecAMM_FAILED));
             ammAlice.deposit(
                 carol,
@@ -959,6 +1063,7 @@ private:
                 USD(1'000),
                 std::nullopt,
                 tfLPToken,
+                std::nullopt,
                 std::nullopt,
                 std::nullopt,
                 ter(tecAMM_FAILED));
@@ -972,6 +1077,7 @@ private:
                 tfTwoAsset,
                 std::nullopt,
                 std::nullopt,
+                std::nullopt,
                 ter(tecAMM_FAILED));
             // Single deposit by asset
             ammAlice.deposit(
@@ -981,6 +1087,7 @@ private:
                 std::nullopt,
                 std::nullopt,
                 tfSingleAsset,
+                std::nullopt,
                 std::nullopt,
                 std::nullopt,
                 ter(tecAMM_FAILED));
@@ -1246,6 +1353,16 @@ private:
                 std::nullopt,
                 std::nullopt,
                 tfBurnable,
+                std::nullopt,
+                std::nullopt,
+                ter(temINVALID_FLAG));
+            ammAlice.withdraw(
+                alice,
+                1'000'000,
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                tfTwoAssetIfEmpty,
                 std::nullopt,
                 std::nullopt,
                 ter(temINVALID_FLAG));
@@ -1769,12 +1886,12 @@ private:
 
         // Withdraw all tokens.
         testAMM([&](AMM& ammAlice, Env& env) {
-            env(trust(carol, STAmount{ammAlice.lptIssue(), 10000}));
+            env(trust(carol, STAmount{ammAlice.lptIssue(), 10'000}));
             // Can SetTrust only for AMM LP tokens
             env(trust(
                     carol,
                     STAmount{
-                        Issue{EUR.currency, ammAlice.ammAccount()}, 10000}),
+                        Issue{EUR.currency, ammAlice.ammAccount()}, 10'000}),
                 ter(tecNO_PERMISSION));
             env.close();
             ammAlice.withdrawAll(alice);
@@ -4150,6 +4267,121 @@ private:
     }
 
     void
+    testAutoDelete()
+    {
+        testcase("Auto Delete");
+
+        using namespace jtx;
+        FeatureBitset const all{supported_amendments()};
+
+        {
+            Env env(
+                *this,
+                envconfig([](std::unique_ptr<Config> cfg) {
+                    cfg->FEES.reference_fee = XRPAmount(1);
+                    return cfg;
+                }),
+                all);
+            fund(env, gw, {alice}, XRP(20'000), {USD(10'000)});
+            AMM amm(env, gw, XRP(10'000), USD(10'000));
+            for (auto i = 0; i < 1'600; ++i)
+            {
+                Account const a{std::to_string(i)};
+                env.fund(XRP(1'000), a);
+                env(trust(a, STAmount{amm.lptIssue(), 10'000}));
+                env.close();
+            }
+            // The auto-delete deleted 1,500 trustlines and AMM is
+            // in empty state.
+            amm.withdrawAll(gw);
+            BEAST_EXPECT(amm.ammExists());
+
+            // Bid,Vote,Deposit,Withdraw,SetTrust failing with
+            // tecAMM_EMPTY. Deposit succeeds with tfTwoAssetIfEmpty option.
+            amm.bid(
+                alice,
+                1000,
+                std::nullopt,
+                {},
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                ter(tecAMM_EMPTY));
+            amm.vote(
+                std::nullopt,
+                100,
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                ter(tecAMM_EMPTY));
+            amm.withdraw(
+                alice, 100, std::nullopt, std::nullopt, ter(tecAMM_EMPTY));
+            amm.deposit(
+                alice,
+                USD(100),
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                ter(tecAMM_EMPTY));
+            env(trust(alice, STAmount{amm.lptIssue(), 10'000}),
+                ter(tecAMM_EMPTY));
+
+            // Can deposit with tfTwoAssetIfEmpty option
+            amm.deposit(
+                alice,
+                std::nullopt,
+                XRP(10'000),
+                USD(10'000),
+                std::nullopt,
+                tfTwoAssetIfEmpty,
+                std::nullopt,
+                std::nullopt,
+                1'000);
+            BEAST_EXPECT(
+                amm.expectBalances(XRP(10'000), USD(10'000), amm.tokens()));
+            BEAST_EXPECT(amm.expectTradingFee(1'000));
+            BEAST_EXPECT(amm.expectAuctionSlot(100, 0, IOUAmount{0}));
+
+            // Withdrawing all tokens deletes AMM since the number
+            // of remaining trustlines is less than 1,500.
+            amm.withdrawAll(alice);
+            BEAST_EXPECT(!amm.ammExists());
+            BEAST_EXPECT(!env.le(keylet::ownerDir(amm.ammAccount())));
+        }
+
+        {
+            Env env(
+                *this,
+                envconfig([](std::unique_ptr<Config> cfg) {
+                    cfg->FEES.reference_fee = XRPAmount(1);
+                    return cfg;
+                }),
+                all);
+            fund(env, gw, {alice}, XRP(20'000), {USD(10'000)});
+            AMM amm(env, gw, XRP(10'000), USD(10'000));
+            for (auto i = 0; i < 3'100; ++i)
+            {
+                Account const a{std::to_string(i)};
+                env.fund(XRP(1'000), a);
+                env(trust(a, STAmount{amm.lptIssue(), 10'000}));
+                env.close();
+            }
+            // Deletes 1,500 trustlines
+            amm.withdrawAll(gw);
+            BEAST_EXPECT(amm.ammExists());
+
+            // AMMDelete has to be called twice to delete AMM.
+            // Deletes 1,500 trustlines.
+            amm.ammDelete(alice, ter(tecINCOMPLETE));
+            BEAST_EXPECT(amm.ammExists());
+            // Deletes remaining trustlines and deletes AMM.
+            amm.ammDelete(alice);
+            BEAST_EXPECT(!amm.ammExists());
+            BEAST_EXPECT(!env.le(keylet::ownerDir(amm.ammAccount())));
+        }
+    }
+
+    void
     testCore()
     {
         testInvalidInstance();
@@ -4171,6 +4403,7 @@ private:
         testAMMAndCLOB();
         testTradingFee();
         testAdjustedTokens();
+        testAutoDelete();
     }
 
     void

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -4469,6 +4469,10 @@ private:
         auto const ETH = gw1["ETH"];
         auto const CAN = gw1["CAN"];
 
+        // These tests are expected to fail if the OwnerPaysFee feature
+        // is ever supported. Updates will need to be made to AMM handling
+        // in the payment engine, and these tests will need to be updated.
+
         auto prep = [&](Env& env, auto gwRate, auto gw1Rate) {
             fund(env, gw, {alice, carol, bob, ed}, XRP(2'000), {USD(2'000)});
             env.fund(XRP(2'000), gw1);

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -4460,6 +4460,341 @@ private:
     }
 
     void
+    testSelection()
+    {
+        testcase("Offer/Strand Selection");
+        using namespace jtx;
+        Account const ed("ed");
+        Account const gw1("gw1");
+        auto const ETH = gw1["ETH"];
+        auto const CAN = gw1["CAN"];
+
+        auto prep = [&](Env& env, auto gwRate, auto gw1Rate) {
+            fund(env, gw, {alice, carol, bob, ed}, XRP(2'000), {USD(2'000)});
+            env.fund(XRP(2'000), gw1);
+            fund(
+                env,
+                gw1,
+                {alice, carol, bob, ed},
+                {ETH(2'000), CAN(2'000)},
+                Fund::IOUOnly);
+            env(rate(gw, gwRate));
+            env(rate(gw1, gw1Rate));
+            env.close();
+        };
+
+        for (auto const& rates :
+             {std::make_pair(1.5, 1.9), std::make_pair(1.9, 1.5)})
+        {
+            // Offer Selection
+
+            // Cross-currency payment: AMM has the same spot price quality
+            // as CLOB's offer and can't generate a better quality offer.
+            // The transfer fee in this case doesn't change the CLOB quality
+            // because trIn is ignored on adjustment and trOut on payment is
+            // also ignored because ownerPaysTransferFee is false in this case.
+            // Run test for 0) offer, 1) AMM, 2) offer and AMM
+            // to verify that the quality is better in the first case,
+            // and CLOB is selected in the second case.
+            {
+                std::array<Quality, 3> q;
+                for (auto i = 0; i < 3; ++i)
+                {
+                    Env env(*this);
+                    prep(env, rates.first, rates.second);
+                    std::shared_ptr<AMM> amm;
+                    if (i == 0 || i == 2)
+                    {
+                        env(offer(ed, ETH(400), USD(400)), txflags(tfPassive));
+                        env.close();
+                    }
+                    if (i > 0)
+                        amm = std::make_shared<AMM>(
+                            env, ed, USD(1'000), ETH(1'000));
+                    env(pay(carol, bob, USD(100)),
+                        path(~USD),
+                        sendmax(ETH(500)),
+                        txflags(tfPartialPayment));
+                    env.close();
+                    // CLOB and AMM, AMM is not selected
+                    if (i == 2)
+                    {
+                        BEAST_EXPECT(amm->expectBalances(
+                            USD(1'000), ETH(1'000), amm->tokens()));
+                    }
+                    BEAST_EXPECT(expectLine(env, bob, USD(2'100)));
+                    q[i] = Quality(Amounts{
+                        ETH(2'000) - env.balance(carol, ETH),
+                        env.balance(bob, USD) - USD(2'000)});
+                }
+                // CLOB is better quality than AMM
+                BEAST_EXPECT(q[0] > q[1]);
+                // AMM is not selected with CLOB
+                BEAST_EXPECT(q[0] == q[2]);
+            }
+            // Offer crossing: AMM has the same spot price quality
+            // as CLOB's offer and can't generate a better quality offer.
+            // The transfer fee in this case doesn't change the CLOB quality
+            // because the quality adjustment is ignored for the offer crossing.
+            for (auto i = 0; i < 3; ++i)
+            {
+                Env env(*this);
+                prep(env, rates.first, rates.second);
+                std::shared_ptr<AMM> amm;
+                if (i == 0 || i == 2)
+                {
+                    env(offer(ed, ETH(400), USD(400)), txflags(tfPassive));
+                    env.close();
+                }
+                if (i > 0)
+                    amm =
+                        std::make_shared<AMM>(env, ed, USD(1'000), ETH(1'000));
+                env(offer(alice, USD(400), ETH(400)));
+                env.close();
+                // AMM is not selected
+                if (i > 0)
+                {
+                    BEAST_EXPECT(amm->expectBalances(
+                        USD(1'000), ETH(1'000), amm->tokens()));
+                }
+                if (i == 0 || i == 2)
+                {
+                    // Fully crosses
+                    BEAST_EXPECT(expectOffers(env, ed, 0));
+                    BEAST_EXPECT(expectOffers(env, alice, 0));
+                }
+                // Fails to cross because AMM is not selected
+                else
+                {
+                    BEAST_EXPECT(expectOffers(
+                        env, alice, 1, {Amounts{USD(400), ETH(400)}}));
+                    BEAST_EXPECT(expectOffers(env, ed, 0));
+                }
+            }
+
+            // Show that the CLOB quality reduction
+            // results in AMM offer selection.
+
+            // Same as the payment but reduced offer quality
+            {
+                std::array<Quality, 3> q;
+                for (auto i = 0; i < 3; ++i)
+                {
+                    Env env(*this);
+                    prep(env, rates.first, rates.second);
+                    std::shared_ptr<AMM> amm;
+                    if (i == 0 || i == 2)
+                    {
+                        env(offer(ed, ETH(400), USD(300)), txflags(tfPassive));
+                        env.close();
+                    }
+                    if (i > 0)
+                        amm = std::make_shared<AMM>(
+                            env, ed, USD(1'000), ETH(1'000));
+                    env(pay(carol, bob, USD(100)),
+                        path(~USD),
+                        sendmax(ETH(500)),
+                        txflags(tfPartialPayment));
+                    env.close();
+                    // AMM and CLOB are selected
+                    if (i > 0)
+                    {
+                        BEAST_EXPECT(!amm->expectBalances(
+                            USD(1'000), ETH(1'000), amm->tokens()));
+                    }
+                    if (i == 2)
+                    {
+                        if (rates.first == 1.5)
+                        {
+                            BEAST_EXPECT(expectOffers(
+                                env,
+                                ed,
+                                1,
+                                {{Amounts{
+                                    STAmount{
+                                        ETH, UINT64_C(378'6327949540823), -13},
+                                    STAmount{
+                                        USD,
+                                        UINT64_C(283'9745962155617),
+                                        -13}}}}));
+                        }
+                        else
+                        {
+                            BEAST_EXPECT(expectOffers(
+                                env,
+                                ed,
+                                1,
+                                {{Amounts{
+                                    STAmount{
+                                        ETH, UINT64_C(325'299461620749), -12},
+                                    STAmount{
+                                        USD,
+                                        UINT64_C(243'9745962155617),
+                                        -13}}}}));
+                        }
+                    }
+                    BEAST_EXPECT(expectLine(env, bob, USD(2'100)));
+                    q[i] = Quality(Amounts{
+                        ETH(2'000) - env.balance(carol, ETH),
+                        env.balance(bob, USD) - USD(2'000)});
+                }
+                // AMM is better quality
+                BEAST_EXPECT(q[1] > q[0]);
+                // AMM and CLOB produce better quality
+                BEAST_EXPECT(q[2] > q[1]);
+            }
+
+            // Same as the offer-crossing but reduced offer quality
+            for (auto i = 0; i < 3; ++i)
+            {
+                Env env(*this);
+                prep(env, rates.first, rates.second);
+                std::shared_ptr<AMM> amm;
+                if (i == 0 || i == 2)
+                {
+                    env(offer(ed, ETH(400), USD(250)), txflags(tfPassive));
+                    env.close();
+                }
+                if (i > 0)
+                    amm =
+                        std::make_shared<AMM>(env, ed, USD(1'000), ETH(1'000));
+                env(offer(alice, USD(250), ETH(400)));
+                env.close();
+                // AMM is selected in both cases
+                if (i > 0)
+                {
+                    BEAST_EXPECT(!amm->expectBalances(
+                        USD(1'000), ETH(1'000), amm->tokens()));
+                }
+                // Partially crosses, AMM is selected, CLOB fails limitQuality
+                if (i == 2)
+                {
+                    if (rates.first == 1.5)
+                    {
+                        BEAST_EXPECT(expectOffers(
+                            env, ed, 1, {{Amounts{ETH(400), USD(250)}}}));
+                        BEAST_EXPECT(expectOffers(
+                            env,
+                            alice,
+                            1,
+                            {{Amounts{
+                                STAmount{USD, UINT64_C(40'5694150420947), -13},
+                                STAmount{ETH, UINT64_C(64'91106406735152), -14},
+                            }}}));
+                    }
+                    else
+                    {
+                        // Ed offer is partially crossed.
+                        BEAST_EXPECT(expectOffers(
+                            env,
+                            ed,
+                            1,
+                            {{Amounts{
+                                STAmount{ETH, UINT64_C(335'0889359326485), -13},
+                                STAmount{USD, UINT64_C(209'4305849579053), -13},
+                            }}}));
+                        BEAST_EXPECT(expectOffers(env, alice, 0));
+                    }
+                }
+            }
+
+            // Strand selection
+
+            // Two book steps strand quality is 1.
+            // AMM strand's best quality is equal to AMM's spot price
+            // quality, which is 1. Both strands (steps) are adjusted
+            // for the transfer fee in qualityUpperBound. In case
+            // of two strands, AMM offers have better quality and are consumed
+            // first, remaining liquidity is generated by CLOB offers.
+            // Liquidity from two strands is better in this case than in case
+            // of one strand with two book steps. Liquidity from one strand
+            // with AMM has better quality than either one strand with two book
+            // steps or two strands. It may appear unintuitive, but one strand
+            // with AMM is optimized and generates one AMM offer, while in case
+            // of two strands, multiple AMM offers are generated, which results
+            // in slightly worse overall quality.
+            {
+                std::array<Quality, 3> q;
+                for (auto i = 0; i < 3; ++i)
+                {
+                    Env env(*this);
+                    prep(env, rates.first, rates.second);
+                    std::shared_ptr<AMM> amm;
+
+                    if (i == 0 || i == 2)
+                    {
+                        env(offer(ed, ETH(400), CAN(400)), txflags(tfPassive));
+                        env(offer(ed, CAN(400), USD(400))), txflags(tfPassive);
+                        env.close();
+                    }
+
+                    if (i > 0)
+                        amm = std::make_shared<AMM>(
+                            env, ed, ETH(1'000), USD(1'000));
+
+                    env(pay(carol, bob, USD(100)),
+                        path(~USD),
+                        path(~CAN, ~USD),
+                        sendmax(ETH(600)),
+                        txflags(tfPartialPayment));
+                    env.close();
+
+                    BEAST_EXPECT(expectLine(env, bob, USD(2'100)));
+
+                    if (i == 2)
+                    {
+                        // Liquidity is consumed from AMM strand only
+                        if (rates.first == 1.5)
+                        {
+                            BEAST_EXPECT(amm->expectBalances(
+                                STAmount{ETH, UINT64_C(1'176'66038955758), -11},
+                                USD(850),
+                                amm->tokens()));
+                        }
+                        else
+                        {
+                            BEAST_EXPECT(amm->expectBalances(
+                                STAmount{
+                                    ETH, UINT64_C(1'179'540094339627), -12},
+                                STAmount{USD, UINT64_C(847'7880529867501), -13},
+                                amm->tokens()));
+                            BEAST_EXPECT(expectOffers(
+                                env,
+                                ed,
+                                2,
+                                {{Amounts{
+                                      STAmount{
+                                          ETH,
+                                          UINT64_C(343'3179205198749),
+                                          -13},
+                                      STAmount{
+                                          CAN,
+                                          UINT64_C(343'3179205198749),
+                                          -13},
+                                  },
+                                  Amounts{
+                                      STAmount{
+                                          CAN,
+                                          UINT64_C(362'2119470132499),
+                                          -13},
+                                      STAmount{
+                                          USD,
+                                          UINT64_C(362'2119470132499),
+                                          -13},
+                                  }}}));
+                        }
+                    }
+                    q[i] = Quality(Amounts{
+                        ETH(2'000) - env.balance(carol, ETH),
+                        env.balance(bob, USD) - USD(2'000)});
+                }
+                BEAST_EXPECT(q[1] > q[0]);
+                BEAST_EXPECT(q[2] > q[0] && q[2] < q[1]);
+            }
+        }
+    }
+
+    void
     testCore()
     {
         testInvalidInstance();
@@ -4484,6 +4819,7 @@ private:
         testAutoDelete();
         testClawback();
         testAMMID();
+        testSelection();
     }
 
     void

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -1770,9 +1770,12 @@ private:
         // Withdraw all tokens.
         testAMM([&](AMM& ammAlice, Env& env) {
             env(trust(carol, STAmount{ammAlice.lptIssue(), 10000}));
+            // Can SetTrust only for AMM LP tokens
             env(trust(
-                carol,
-                STAmount{Issue{EUR.currency, ammAlice.ammAccount()}, 10000}));
+                    carol,
+                    STAmount{
+                        Issue{EUR.currency, ammAlice.ammAccount()}, 10000}),
+                ter(tecNO_PERMISSION));
             env.close();
             ammAlice.withdrawAll(alice);
             BEAST_EXPECT(!ammAlice.ammExists());
@@ -3620,9 +3623,11 @@ private:
             AMM amm(env, C, TSTA(5'000), TSTB(5'000));
             auto const ammIss = Issue(TSTA.currency, amm.ammAccount());
 
-            env.trust(STAmount{ammIss, 10'000}, D);
+            // Can SetTrust only for AMM LP tokens
+            env(trust(D, STAmount{ammIss, 10'000}), ter(tecNO_PERMISSION));
             env.close();
 
+            // The payment would fail because of above, but check just in case
             env(pay(C, D, STAmount{ammIss, 10}),
                 sendmax(TSTA(100)),
                 path(amm.ammAccount()),

--- a/src/test/app/CrossingLimits_test.cpp
+++ b/src/test/app/CrossingLimits_test.cpp
@@ -18,7 +18,6 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/protocol/Feature.h>
 #include <test/jtx.h>
-#include <test/jtx/TestHelpers.h>
 
 namespace ripple {
 namespace test {

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -24,7 +24,6 @@
 #include <ripple/protocol/TxFlags.h>
 #include <ripple/protocol/jss.h>
 #include <test/jtx.h>
-#include <test/jtx/TestHelpers.h>
 
 #include <algorithm>
 #include <iterator>

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -28,7 +28,6 @@
 #include <ripple/protocol/jss.h>
 #include <test/jtx.h>
 #include <test/jtx/PathSet.h>
-#include <test/jtx/TestHelpers.h>
 
 namespace ripple {
 namespace test {

--- a/src/test/app/Freeze_test.cpp
+++ b/src/test/app/Freeze_test.cpp
@@ -22,7 +22,6 @@
 #include <ripple/protocol/TxFlags.h>
 #include <ripple/protocol/jss.h>
 #include <test/jtx.h>
-#include <test/jtx/TestHelpers.h>
 
 namespace ripple {
 

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -22,7 +22,6 @@
 #include <ripple/protocol/jss.h>
 #include <test/jtx.h>
 #include <test/jtx/PathSet.h>
-#include <test/jtx/TestHelpers.h>
 #include <test/jtx/WSClient.h>
 
 namespace ripple {

--- a/src/test/app/Path_test.cpp
+++ b/src/test/app/Path_test.cpp
@@ -35,7 +35,6 @@
 #include <condition_variable>
 #include <mutex>
 #include <test/jtx.h>
-#include <test/jtx/TestHelpers.h>
 #include <test/jtx/envconfig.h>
 #include <thread>
 

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -25,7 +25,6 @@
 #include <ripple/protocol/TxFlags.h>
 #include <ripple/protocol/jss.h>
 #include <test/jtx.h>
-#include <test/jtx/TestHelpers.h>
 
 #include <chrono>
 

--- a/src/test/app/PayStrand_test.cpp
+++ b/src/test/app/PayStrand_test.cpp
@@ -29,7 +29,6 @@
 #include "ripple/app/paths/AMMContext.h"
 #include <test/jtx.h>
 #include <test/jtx/PathSet.h>
-#include <test/jtx/TestHelpers.h>
 
 namespace ripple {
 namespace test {

--- a/src/test/app/TrustAndBalance_test.cpp
+++ b/src/test/app/TrustAndBalance_test.cpp
@@ -22,7 +22,6 @@
 #include <ripple/protocol/SField.h>
 #include <ripple/protocol/jss.h>
 #include <test/jtx.h>
-#include <test/jtx/TestHelpers.h>
 #include <test/jtx/WSClient.h>
 
 namespace ripple {

--- a/src/test/jtx.h
+++ b/src/test/jtx.h
@@ -27,6 +27,7 @@
 #include <test/jtx/Env.h>
 #include <test/jtx/Env_ss.h>
 #include <test/jtx/JTx.h>
+#include <test/jtx/TestHelpers.h>
 #include <test/jtx/account_txn_id.h>
 #include <test/jtx/acctdelete.h>
 #include <test/jtx/amount.h>

--- a/src/test/jtx/AMM.h
+++ b/src/test/jtx/AMM.h
@@ -180,6 +180,7 @@ public:
         std::optional<std::uint32_t> const& flags,
         std::optional<std::pair<Issue, Issue>> const& assets,
         std::optional<jtx::seq> const& seq,
+        std::optional<std::uint16_t> const& tfee = std::nullopt,
         std::optional<ter> const& ter = std::nullopt);
 
     IOUAmount
@@ -285,6 +286,11 @@ public:
     {
         return ammRpcInfo(lp);
     }
+
+    void
+    ammDelete(
+        AccountID const& deleter,
+        std::optional<ter> const& ter = std::nullopt);
 
 private:
     void

--- a/src/test/jtx/AMM.h
+++ b/src/test/jtx/AMM.h
@@ -67,6 +67,7 @@ class AMM
     STAmount const asset2_;
     IOUAmount const initialLPTokens_;
     bool log_;
+    bool doClose_;
     // Predict next purchase price
     IOUAmount lastPurchasePrice_;
     std::optional<IOUAmount> bidMin_;
@@ -291,6 +292,18 @@ public:
     ammDelete(
         AccountID const& deleter,
         std::optional<ter> const& ter = std::nullopt);
+
+    void
+    setClose(bool close)
+    {
+        doClose_ = close;
+    }
+
+    uint256
+    ammID() const
+    {
+        return keylet::amm(asset1_.issue(), asset2_.issue()).key;
+    }
 
 private:
     void

--- a/src/test/jtx/AMM.h
+++ b/src/test/jtx/AMM.h
@@ -65,6 +65,7 @@ class AMM
     Account const creatorAccount_;
     STAmount const asset1_;
     STAmount const asset2_;
+    uint256 const ammID_;
     IOUAmount const initialLPTokens_;
     bool log_;
     bool doClose_;
@@ -302,7 +303,7 @@ public:
     uint256
     ammID() const
     {
-        return keylet::amm(asset1_.issue(), asset2_.issue()).key;
+        return ammID_;
     }
 
 private:

--- a/src/test/jtx/TestHelpers.h
+++ b/src/test/jtx/TestHelpers.h
@@ -23,6 +23,7 @@
 #include <ripple/json/json_value.h>
 #include <ripple/protocol/AccountID.h>
 #include <ripple/protocol/Quality.h>
+#include <ripple/protocol/TxFlags.h>
 #include <ripple/protocol/jss.h>
 #include <test/jtx/Env.h>
 
@@ -404,6 +405,38 @@ cpe(Currency const& c);
 STPathElement
 allpe(AccountID const& a, Issue const& iss);
 /***************************************************************/
+
+/* Check */
+/***************************************************************/
+namespace check {
+
+/** Create a check. */
+// clang-format off
+template <typename A>
+    requires std::is_same_v<A, AccountID>
+Json::Value
+create(A const& account, A const& dest, STAmount const& sendMax)
+{
+    Json::Value jv;
+    jv[sfAccount.jsonName] = to_string(account);
+    jv[sfSendMax.jsonName] = sendMax.getJson(JsonOptions::none);
+    jv[sfDestination.jsonName] = to_string(dest);
+    jv[sfTransactionType.jsonName] = jss::CheckCreate;
+    jv[sfFlags.jsonName] = tfUniversal;
+    return jv;
+}
+// clang-format on
+
+inline Json::Value
+create(
+    jtx::Account const& account,
+    jtx::Account const& dest,
+    STAmount const& sendMax)
+{
+    return create(account.id(), dest.id(), sendMax);
+}
+
+}  // namespace check
 
 }  // namespace jtx
 }  // namespace test

--- a/src/test/jtx/check.h
+++ b/src/test/jtx/check.h
@@ -31,13 +31,6 @@ namespace jtx {
 /** Check operations. */
 namespace check {
 
-/** Create a check. */
-Json::Value
-create(
-    jtx::Account const& account,
-    jtx::Account const& dest,
-    STAmount const& sendMax);
-
 /** Cash a check requiring that a specific amount be delivered. */
 Json::Value
 cash(jtx::Account const& dest, uint256 const& checkId, STAmount const& amount);

--- a/src/test/jtx/impl/AMM.cpp
+++ b/src/test/jtx/impl/AMM.cpp
@@ -382,6 +382,7 @@ AMM::deposit(
         flags,
         std::nullopt,
         std::nullopt,
+        std::nullopt,
         ter);
 }
 
@@ -404,6 +405,7 @@ AMM::deposit(
         flags,
         std::nullopt,
         std::nullopt,
+        std::nullopt,
         ter);
 }
 
@@ -417,6 +419,7 @@ AMM::deposit(
     std::optional<std::uint32_t> const& flags,
     std::optional<std::pair<Issue, Issue>> const& assets,
     std::optional<jtx::seq> const& seq,
+    std::optional<std::uint16_t> const& tfee,
     std::optional<ter> const& ter)
 {
     Json::Value jv;
@@ -428,6 +431,8 @@ AMM::deposit(
         asset2In->setJson(jv[jss::Amount2]);
     if (maxEP)
         maxEP->setJson(jv[jss::EPrice]);
+    if (tfee)
+        jv[jss::TradingFee] = *tfee;
     std::uint32_t jvflags = 0;
     if (flags)
         jvflags = *flags;
@@ -695,6 +700,18 @@ AMM::expectAuctionSlot(auto&& cb) const
         }
     }
     return false;
+}
+
+void
+AMM::ammDelete(AccountID const& deleter, std::optional<ter> const& ter)
+{
+    Json::Value jv;
+    jv[jss::Account] = to_string(deleter);
+    setTokens(jv);
+    jv[jss::TransactionType] = jss::AMMDelete;
+    if (fee_ != 0)
+        jv[jss::Fee] = std::to_string(fee_);
+    submit(jv, std::nullopt, ter);
 }
 
 namespace amm {

--- a/src/test/jtx/impl/AMM.cpp
+++ b/src/test/jtx/impl/AMM.cpp
@@ -62,6 +62,7 @@ AMM::AMM(
     , creatorAccount_(account)
     , asset1_(asset1)
     , asset2_(asset2)
+    , ammID_(keylet::amm(asset1_.issue(), asset2_.issue()).key)
     , initialLPTokens_(initialTokens(asset1, asset2))
     , log_(log)
     , doClose_(true)

--- a/src/test/jtx/impl/AMM.cpp
+++ b/src/test/jtx/impl/AMM.cpp
@@ -64,6 +64,7 @@ AMM::AMM(
     , asset2_(asset2)
     , initialLPTokens_(initialTokens(asset1, asset2))
     , log_(log)
+    , doClose_(true)
     , lastPurchasePrice_(0)
     , bidMin_()
     , bidMax_()
@@ -676,7 +677,8 @@ AMM::submit(
         env_(jv, *ter);
     else
         env_(jv);
-    env_.close();
+    if (doClose_)
+        env_.close();
 }
 
 bool

--- a/src/test/jtx/impl/check.cpp
+++ b/src/test/jtx/impl/check.cpp
@@ -27,22 +27,6 @@ namespace jtx {
 
 namespace check {
 
-// Create a check.
-Json::Value
-create(
-    jtx::Account const& account,
-    jtx::Account const& dest,
-    STAmount const& sendMax)
-{
-    Json::Value jv;
-    jv[sfAccount.jsonName] = account.human();
-    jv[sfSendMax.jsonName] = sendMax.getJson(JsonOptions::none);
-    jv[sfDestination.jsonName] = dest.human();
-    jv[sfTransactionType.jsonName] = jss::CheckCreate;
-    jv[sfFlags.jsonName] = tfUniversal;
-    return jv;
-}
-
 // Cash a check requiring that a specific amount be delivered.
 Json::Value
 cash(jtx::Account const& dest, uint256 const& checkId, STAmount const& amount)

--- a/src/test/rpc/AccountOffers_test.cpp
+++ b/src/test/rpc/AccountOffers_test.cpp
@@ -19,7 +19,6 @@
 
 #include <ripple/protocol/jss.h>
 #include <test/jtx.h>
-#include <test/jtx/TestHelpers.h>
 
 namespace ripple {
 namespace test {

--- a/src/test/rpc/LedgerData_test.cpp
+++ b/src/test/rpc/LedgerData_test.cpp
@@ -20,7 +20,6 @@
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/protocol/jss.h>
 #include <test/jtx.h>
-#include <test/jtx/TestHelpers.h>
 
 namespace ripple {
 

--- a/src/test/rpc/NoRipple_test.cpp
+++ b/src/test/rpc/NoRipple_test.cpp
@@ -20,7 +20,6 @@
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/jss.h>
 #include <test/jtx.h>
-#include <test/jtx/TestHelpers.h>
 
 namespace ripple {
 


### PR DESCRIPTION
Proposed commit message, including acknowledgement block, for when this PR is squashed and merged:

```
fix(AMM): prevent orphaned objects, inconsistent ledger state: (#4626)

When an AMM account is deleted, the owner directory entries must be
deleted in order to ensure consistent ledger state.

* When deleting AMM account:
  * Clean up AMM owner dir, linking AMM account and AMM object
  * Delete trust lines to AMM
* Disallow `CheckCreate` to AMM accounts
  * AMM cannot cash a check
* Constrain entries in AuthAccounts array to be accounts
  * AuthAccounts is an array of objects for the AMMBid transaction
* SetTrust (TrustSet): Allow on AMM only for LP tokens
  * If the destination is an AMM account and the trust line doesn't
    exist, then:
    * If the asset is not the AMM LP token, then fail the tx with
      `tecNO_PERMISSION`
    * If the AMM is in empty state, then fail the tx with `tecAMM_EMPTY`
      * This disallows trustlines to AMM in empty state
* Add AMMID to AMM root account
  * Remove lsfAMM flag and use sfAMMID instead
* Remove owner dir entry for ltAMM
* Add `AMMDelete` transaction type to handle amortized deletion
  * Limit number of trust lines to delete on final withdraw + AMMDelete
  * Put AMM in empty state when LPTokens is 0 upon final withdraw
  * Add `tfTwoAssetIfEmpty` deposit option in AMM empty state
  * Fail all AMM transactions in AMM empty state except special deposit
  * Add `tecINCOMPLETE` to indicate that not all AMM trust lines are
    deleted (i.e. partial deletion)
    * This is handled in Transactor similar to deleted offers
  * Fail AMMDelete with `tecINTERNAL` if AMM root account is nullptr
  * Don't validate for invalid asset pair in AMMDelete
* AMMWithdraw deletes AMM trust lines and AMM account/object only if the
  number of trust lines is less than max
  * Current `maxDeletableAMMTrustLines` = 512
  * Check no directory left after AMM trust lines are deleted
  * Enable partial trustline deletion in AMMWithdraw
* Add `tecAMM_NOT_EMPTY` to fail any transaction that expects an AMM in
  empty state
* Clawback considerations
  * Disallow clawback out of AMM account
  * Disallow AMM create if issuer can claw back

This patch applies to the AMM implementation in #4294.

Acknowledgements:
Richard Holland and Nik Bougalis for responsibly disclosing this issue.

Bug Bounties and Responsible Disclosures:
We welcome reviews of the project code and urge researchers to
responsibly disclose any issues they may find.

To report a bug, please send a detailed report to:

    bugs@xrpl.org
```

## High Level Overview of Change

Fixes:

- Withdrawing all funds from AMM automatically deletes AMM account. The owner directory entries must be deleted. This fix addresses:
    - Clean up AMM owner dir linking AMM account and AMM object
    - Delete trustlines to AMM
- Disallow check create to AMM
- Fix unconstrained entries in AuthAccount in Bid transaction

### Context of Change

The bugs are introduced in the merged [AMM PR](https://github.com/XRPLF/rippled/pull/4294). They result in resource leak and inconsistent ledger state.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

Fixes the resource leak and unconstrained entries

## Test Plan

Added a unit-test to disallow check create and extended withdraw all unit-test.
