### PR TITLE
refactor: add view updates for account SLEs

### DIFF
--- a/src/ripple/app/tx/impl/SetAccount.cpp
+++ b/src/ripple/app/tx/impl/SetAccount.cpp
@@ -604,6 +604,8 @@ SetAccount::doApply()
     if (uFlagsIn != uFlagsOut)
         sle->setFieldU32(sfFlags, uFlagsOut);
 
+    ctx_.view().update(sle);
+
     return tesSUCCESS;
 }
 

--- a/src/ripple/app/tx/impl/SetRegularKey.cpp
+++ b/src/ripple/app/tx/impl/SetRegularKey.cpp
@@ -96,6 +96,8 @@ SetRegularKey::doApply()
         sle->makeFieldAbsent(sfRegularKey);
     }
 
+    ctx_.view().update(sle);
+
     return tesSUCCESS;
 }
 


### PR DESCRIPTION
## High Level Overview of Change

This PR adds a line to `SetAccount` and `SetRegularKey`:
```cpp
ctx_.view().update(sle);
```
This commits the changes of the account SLE to the ledger.

### Context of Change

The changes to the account SLE are committed in transaction processing anyways, so this isn't technically a bug and doesn't change anything about how transactions are processed. However, it does make the code more readable and understandable, especially since `AccountSet` and `SetRegularKey` are very simple transactions that devs new to rippled might be looking at to better understand how to write a new transaction.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
- [x] Documentation Updates

## Test Plan
Unit tests pass locally:
```
Longest suite times:
  226.9s ripple.tx.NFToken
  126.5s ripple.tx.NFTokenBurn
   66.8s ripple.tx.Offer
   47.9s ripple.app.TheoreticalQuality
   41.6s ripple.tx.NFTokenDir
   38.2s ripple.app.ShardArchiveHandler
   35.5s ripple.app.ValidatorSite
   33.3s ripple.app.AMMExtended
   32.3s ripple.app.AMM
   31.0s ripple.tx.ReducedOffer
989.4s, 211 suites, 1792 cases, 633788 tests total, 0 failures
```
