### PR TITLE
Add unit-tests to verify CLOB/AMM offer and strand selection logic with the transfer fee

### DIFF
--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -4142,6 +4142,10 @@ private:
         auto const ETH = gw1["ETH"];
         auto const CAN = gw1["CAN"];
 
+        // These tests are expected to fail if the OwnerPaysFee feature
+        // is ever supported. Updates will need to be made to AMM handling
+        // in the payment engine, and these tests will need to be updated.
+
         auto prep = [&](Env& env, auto gwRate, auto gw1Rate) {
             fund(env, gw, {alice, carol, bob, ed}, XRP(2'000), {USD(2'000)});
             env.fund(XRP(2'000), gw1);

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -4175,19 +4175,17 @@ private:
                 {
                     Env env(*this);
                     prep(env, rates.first, rates.second);
-                    std::shared_ptr<AMM> amm;
+                    std::optional<AMM> amm;
                     if (i == 0 || i == 2)
                     {
                         env(offer(ed, ETH(400), USD(400)), txflags(tfPassive));
                         env.close();
                     }
                     if (i > 0)
-                        amm = std::make_shared<AMM>(
-                            env, ed, USD(1'000), ETH(1'000));
+                        amm.emplace(env, ed, USD(1'000), ETH(1'000));
                     env(pay(carol, bob, USD(100)),
                         path(~USD),
-                        sendmax(ETH(500)),
-                        txflags(tfPartialPayment));
+                        sendmax(ETH(500)));
                     env.close();
                     // CLOB and AMM, AMM is not selected
                     if (i == 2)
@@ -4213,15 +4211,14 @@ private:
             {
                 Env env(*this);
                 prep(env, rates.first, rates.second);
-                std::shared_ptr<AMM> amm;
+                std::optional<AMM> amm;
                 if (i == 0 || i == 2)
                 {
                     env(offer(ed, ETH(400), USD(400)), txflags(tfPassive));
                     env.close();
                 }
                 if (i > 0)
-                    amm =
-                        std::make_shared<AMM>(env, ed, USD(1'000), ETH(1'000));
+                    amm.emplace(env, ed, USD(1'000), ETH(1'000));
                 env(offer(alice, USD(400), ETH(400)));
                 env.close();
                 // AMM is not selected
@@ -4233,7 +4230,6 @@ private:
                 if (i == 0 || i == 2)
                 {
                     // Fully crosses
-                    BEAST_EXPECT(expectOffers(env, ed, 0));
                     BEAST_EXPECT(expectOffers(env, alice, 0));
                 }
                 // Fails to cross because AMM is not selected
@@ -4241,8 +4237,8 @@ private:
                 {
                     BEAST_EXPECT(expectOffers(
                         env, alice, 1, {Amounts{USD(400), ETH(400)}}));
-                    BEAST_EXPECT(expectOffers(env, ed, 0));
                 }
+                BEAST_EXPECT(expectOffers(env, ed, 0));
             }
 
             // Show that the CLOB quality reduction
@@ -4255,19 +4251,17 @@ private:
                 {
                     Env env(*this);
                     prep(env, rates.first, rates.second);
-                    std::shared_ptr<AMM> amm;
+                    std::optional<AMM> amm;
                     if (i == 0 || i == 2)
                     {
                         env(offer(ed, ETH(400), USD(300)), txflags(tfPassive));
                         env.close();
                     }
                     if (i > 0)
-                        amm = std::make_shared<AMM>(
-                            env, ed, USD(1'000), ETH(1'000));
+                        amm.emplace(env, ed, USD(1'000), ETH(1'000));
                     env(pay(carol, bob, USD(100)),
                         path(~USD),
-                        sendmax(ETH(500)),
-                        txflags(tfPartialPayment));
+                        sendmax(ETH(500)));
                     env.close();
                     // AMM and CLOB are selected
                     if (i > 0)
@@ -4322,15 +4316,14 @@ private:
             {
                 Env env(*this);
                 prep(env, rates.first, rates.second);
-                std::shared_ptr<AMM> amm;
+                std::optional<AMM> amm;
                 if (i == 0 || i == 2)
                 {
                     env(offer(ed, ETH(400), USD(250)), txflags(tfPassive));
                     env.close();
                 }
                 if (i > 0)
-                    amm =
-                        std::make_shared<AMM>(env, ed, USD(1'000), ETH(1'000));
+                    amm.emplace(env, ed, USD(1'000), ETH(1'000));
                 env(offer(alice, USD(250), ETH(400)));
                 env.close();
                 // AMM is selected in both cases
@@ -4392,7 +4385,7 @@ private:
                 {
                     Env env(*this);
                     prep(env, rates.first, rates.second);
-                    std::shared_ptr<AMM> amm;
+                    std::optional<AMM> amm;
 
                     if (i == 0 || i == 2)
                     {
@@ -4402,23 +4395,21 @@ private:
                     }
 
                     if (i > 0)
-                        amm = std::make_shared<AMM>(
-                            env, ed, ETH(1'000), USD(1'000));
+                        amm.emplace(env, ed, ETH(1'000), USD(1'000));
 
                     env(pay(carol, bob, USD(100)),
                         path(~USD),
                         path(~CAN, ~USD),
-                        sendmax(ETH(600)),
-                        txflags(tfPartialPayment));
+                        sendmax(ETH(600)));
                     env.close();
 
                     BEAST_EXPECT(expectLine(env, bob, USD(2'100)));
 
                     if (i == 2)
                     {
-                        // Liquidity is consumed from AMM strand only
                         if (rates.first == 1.5)
                         {
+                            // Liquidity is consumed from AMM strand only
                             BEAST_EXPECT(amm->expectBalances(
                                 STAmount{ETH, UINT64_C(1'176'66038955758), -11},
                                 USD(850),


### PR DESCRIPTION
## High Level Overview of Change

This PR includes only the unit-tests to verify the payment engine logic to select AMM/CLOB offer and to select the best quality strand when the transfer fee is set.

### Context of Change

The transfer fee changes the offer quality and therefore has to be considered when selecting CLOB/AMM offer or the best quality strand. The `transfer in` rate can be optimized out since it is applied to both CLOB and AMM offer. The `transfer out` rate is set to one in case of the cross currency payment. The quality adjustment for the transfer fee in case of the offer crossing is disabled. Therefore the transfer fee adjustment cancels itself out. 

### Type of Change

- [x] Tests

## Test Plan

The unit-tests consider two cases: 

- If AMM has the same spot price quality as CLOB offer, then AMM can't generate an offer with a better quality than CLOB offer. Therefore, CLOB offer has to be selected over AMM offer and consequently a strand with CLOB offer has to be selected over a strand with AMM offer regardless of the transfer fee.
- If AMM has a slightly better spot price quality than CLOB offer, then AMM can generate an offer with a better quality than CLOB offer. Therefore, AMM offer has to be selected over CLOB offer and consequently a strand with AMM offer has to be selected over a strand with CLOB offer regardless of the transfer fee.

Both cases are considered for the cross-currency payment and the offer crossing.

## Future Tasks

If `ownerPaysFee` amendment is enabled that the transfer fee adjustment has to be reconsidered.
