### PR TITLE
Proposed 1.11.0-devnet

### DIFF
--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -74,7 +74,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 58;
+static constexpr std::size_t numFeatures = 60;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -345,6 +345,8 @@ extern uint256 const featureXRPFees;
 extern uint256 const fixUniversalNumber;
 extern uint256 const fixNonFungibleTokensV1_2;
 extern uint256 const fixNFTokenRemint;
+extern uint256 const fixReducedOffersV1;
+extern uint256 const featureClawback;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "1.11.0"
+char const* const versionString = "1.11.0-devnet"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -452,6 +452,8 @@ REGISTER_FEATURE(XRPFees,                       Supported::yes, VoteBehavior::De
 REGISTER_FIX    (fixUniversalNumber,            Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixNonFungibleTokensV1_2,      Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixNFTokenRemint,              Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FIX    (fixReducedOffersV1,            Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FEATURE(Clawback,                      Supported::yes, VoteBehavior::DefaultNo);
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.


### PR DESCRIPTION
## High Level Overview of Change

This is 1.11.0, but with the minimal changes necessary to prevent the server from being amendment blocked when `fixReducedOffersV1` and `featureClawback` are enabled.

### Context of Change

The QA team is attempting to reproduce a crash that has been previously observed on Devnet. The crash has been observed with 1.12.0-b1, but no other versions. In order to confirm whether the crash can be triggered in 1.11.0, this proposal can serve as a custom build to run on Devnet for testing purposes.

If a node running this code crashes, then it is possible that 1.11.0 could also crash in the same way.

### Type of Change

- [x] Custom build for Devnet testing only

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

## Test Plan

Build and run this code on Devnet and try to make it crash. This is only informative if the crash is reliably reproducible with 1.12.0-b1.

## Future Tasks

If this code cannot be made to crash, that is a strong signal that there may be a bug introduced in https://github.com/XRPLF/rippled/compare/1.11.0...beba871 - this is a list of all the changes between 1.11.0 and 1.12.0-b1.

## Reviewers

- @ximinez : to give an opinion on what may be expected to occur if this custom build, with Clawback and fixReducedOffersV1 added to the list of supported features but no other associated code, is deployed on Devnet.
- @kennyzlei : to consider allowing the server(s) to evade [amendment blocking](https://xrpl.org/amendments.html#amendment-blocked-servers) even though they do not have the actual implementation of the amendments in question

## Open Questions

- What's the expected behavior of a server running this code on Devnet?
- What happens when a Clawback tx is submitted?
- What happens when a client asks for a ledger which had a Clawback tx in it?
- What happens when a tx has a different result due to fixReducedOffersV1?
- Should this code be deployed across all Devnet servers (including validators), or only the client handler(s)?