### PR TITLE
Improve Slab Allocator & `SHAMapItem` slabber:

### DIFF
--- a/src/ripple/app/ledger/TransactionMaster.h
+++ b/src/ripple/app/ledger/TransactionMaster.h
@@ -68,7 +68,7 @@ public:
 
     std::shared_ptr<STTx const>
     fetch(
-        boost::intrusive_ptr<SHAMapItem> const& item,
+        boost::intrusive_ptr<SHAMapItem const> const& item,
         SHAMapNodeType type,
         std::uint32_t uCommitLedger);
 

--- a/src/ripple/app/ledger/impl/TransactionMaster.cpp
+++ b/src/ripple/app/ledger/impl/TransactionMaster.cpp
@@ -107,7 +107,7 @@ TransactionMaster::fetch(
 
 std::shared_ptr<STTx const>
 TransactionMaster::fetch(
-    boost::intrusive_ptr<SHAMapItem> const& item,
+    boost::intrusive_ptr<SHAMapItem const> const& item,
     SHAMapNodeType type,
     std::uint32_t uCommitLedger)
 {

--- a/src/ripple/shamap/SHAMapItem.h
+++ b/src/ripple/shamap/SHAMapItem.h
@@ -181,9 +181,6 @@ make_shamapitem(uint256 const& tag, Slice data)
         false};
 }
 
-static_assert(alignof(SHAMapItem) != 40);
-static_assert(alignof(SHAMapItem) == 8 || alignof(SHAMapItem) == 4);
-
 inline boost::intrusive_ptr<SHAMapItem const>
 make_shamapitem(SHAMapItem const& other)
 {

--- a/src/test/shamap/FetchPack_test.cpp
+++ b/src/test/shamap/FetchPack_test.cpp
@@ -85,7 +85,7 @@ public:
         beast::Journal mJournal;
     };
 
-    boost::intrusive_ptr<Item>
+    boost::intrusive_ptr<Item const>
     make_random_item(beast::xor_shift_engine& r)
     {
         Serializer s;

--- a/src/test/shamap/SHAMapSync_test.cpp
+++ b/src/test/shamap/SHAMapSync_test.cpp
@@ -34,7 +34,7 @@ class SHAMapSync_test : public beast::unit_test::suite
 public:
     beast::xor_shift_engine eng_;
 
-    boost::intrusive_ptr<SHAMapItem>
+    boost::intrusive_ptr<SHAMapItem const>
     makeRandomAS()
     {
         Serializer s;


### PR DESCRIPTION
The existing slab allocator has significant performance advantages over normal dynamic memory allocation codepaths (e.g. via `new` or `malloc`) but sacrifices the ability to release memory back to the system.

As a result, otherwise transient spikes in memory usage might result in increased memory usage for the lifetime of the process.

This commit retains the lock-free management of individual slabs, while also making it possible to reclamation memory from slabs that are empty and improving the slab selection strategy to favor fuller slabs.

The commit also adjusts the sizes of slabs used to back `SHAMapItem` to better match the characteristics of the XRP Ledger "mainnet."