### PR TITLE
Proposed 1.12.0-rc2

### DIFF
--- a/Builds/levelization/results/ordering.txt
+++ b/Builds/levelization/results/ordering.txt
@@ -14,7 +14,6 @@ ripple.consensus > ripple.basics
 ripple.consensus > ripple.beast
 ripple.consensus > ripple.json
 ripple.consensus > ripple.protocol
-ripple.consensus > ripple.shamap
 ripple.core > ripple.beast
 ripple.core > ripple.json
 ripple.core > ripple.protocol
@@ -126,13 +125,11 @@ test.core > ripple.server
 test.core > test.jtx
 test.core > test.toplevel
 test.core > test.unit_test
-test.csf > ripple.app
 test.csf > ripple.basics
 test.csf > ripple.beast
 test.csf > ripple.consensus
 test.csf > ripple.json
 test.csf > ripple.protocol
-test.csf > test.jtx
 test.json > ripple.beast
 test.json > ripple.json
 test.json > test.jtx

--- a/src/ripple/app/consensus/RCLCxPeerPos.h
+++ b/src/ripple/app/consensus/RCLCxPeerPos.h
@@ -26,7 +26,6 @@
 #include <ripple/consensus/ConsensusProposal.h>
 #include <ripple/json/json_value.h>
 #include <ripple/protocol/HashPrefix.h>
-#include <ripple/protocol/Protocol.h>
 #include <ripple/protocol/PublicKey.h>
 #include <ripple/protocol/SecretKey.h>
 #include <boost/container/static_vector.hpp>
@@ -45,7 +44,7 @@ class RCLCxPeerPos
 {
 public:
     //< The type of the proposed position
-    using Proposal = ConsensusProposal<NodeID, uint256, uint256, LedgerIndex>;
+    using Proposal = ConsensusProposal<NodeID, uint256, uint256>;
 
     /** Constructor
 

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -292,27 +292,6 @@ public:
     std::optional<LedgerIndex>
     minSqlSeq();
 
-    //! Whether we are in standalone mode.
-    bool
-    standalone() const
-    {
-        return standalone_;
-    }
-
-    /** Wait up to a specified duration for the next validated ledger.
-     *
-     * @tparam Rep std::chrono duration Rep.
-     * @tparam Period std::chrono duration Period.
-     * @param dur Duration to wait.
-     */
-    template <class Rep, class Period>
-    void
-    waitForValidated(std::chrono::duration<Rep, Period> const& dur)
-    {
-        std::unique_lock<std::mutex> lock(validMutex_);
-        validCond_.wait_for(lock, dur);
-    }
-
     // Iff a txn exists at the specified ledger and offset then return its txnid
     std::optional<uint256>
     txnIdFromIndex(uint32_t ledgerSeq, uint32_t txnIndex);
@@ -433,10 +412,7 @@ private:
     // Time that the previous upgrade warning was issued.
     TimeKeeper::time_point upgradeWarningPrevTime_{};
 
-    // mutex and condition variable for waiting for next validated ledger
-    std::mutex validMutex_;
-    std::condition_variable validCond_;
-
+private:
     struct Stats
     {
         template <class Handler>
@@ -458,6 +434,7 @@ private:
 
     Stats m_stats;
 
+private:
     void
     collect_metrics()
     {

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -367,8 +367,6 @@ LedgerMaster::setValidLedger(std::shared_ptr<Ledger const> const& l)
     }
 
     mValidLedger.set(l);
-    // In case we're waiting for a valid before proceeding with Consensus.
-    validCond_.notify_one();
     mValidLedgerSign = signTime.time_since_epoch().count();
     assert(
         mValidLedgerSeq || !app_.getMaxDisallowedLedger() ||

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -947,24 +947,9 @@ NetworkOPsImp::setTimer(
 void
 NetworkOPsImp::setHeartbeatTimer()
 {
-    // timerDelay is to optimize the timer interval such as for phase establish.
-    // Setting a max of ledgerGRANULARITY allows currently in-flight proposals
-    // to be accounted for at the very beginning of the phase.
-    std::chrono::milliseconds timerDelay;
-    auto td = mConsensus.getTimerDelay();
-    if (td)
-    {
-        timerDelay = std::min(*td, mConsensus.parms().ledgerGRANULARITY);
-        mConsensus.setTimerDelay();
-    }
-    else
-    {
-        timerDelay = mConsensus.parms().ledgerGRANULARITY;
-    }
-
     setTimer(
         heartbeatTimer_,
-        timerDelay,
+        mConsensus.parms().ledgerGRANULARITY,
         [this]() {
             m_job_queue.addJob(jtNETOP_TIMER, "NetOPs.heartbeat", [this]() {
                 processHeartbeatTimer();

--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -24,7 +24,6 @@
 #include <ripple/basics/Slice.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/basics/base64.h>
-#include <ripple/consensus/ConsensusParms.h>
 #include <ripple/json/json_reader.h>
 #include <ripple/overlay/Overlay.h>
 #include <ripple/protocol/STValidation.h>
@@ -1762,10 +1761,8 @@ ValidatorList::calculateQuorum(
     // Note that the negative UNL protocol introduced the
     // AbsoluteMinimumQuorum which is 60% of the original UNL size. The
     // effective quorum should not be lower than it.
-    static ConsensusParms const parms;
     return static_cast<std::size_t>(std::max(
-        std::ceil(effectiveUnlSize * parms.minCONSENSUS_FACTOR),
-        std::ceil(unlSize * parms.negUNL_MIN_CONSENSUS_FACTOR)));
+        std::ceil(effectiveUnlSize * 0.8f), std::ceil(unlSize * 0.6f)));
 }
 
 TrustChanges

--- a/src/ripple/beast/container/detail/aged_unordered_container.h
+++ b/src/ripple/beast/container/detail/aged_unordered_container.h
@@ -1184,12 +1184,9 @@ public:
         beast::detail::aged_container_iterator<is_const, Iterator> first,
         beast::detail::aged_container_iterator<is_const, Iterator> last);
 
-    /*
-     * This is broken as of at least gcc 11.3.0
     template <class K>
     auto
     erase(K const& k) -> size_type;
-     */
 
     void
     swap(aged_unordered_container& other) noexcept;
@@ -3065,7 +3062,6 @@ aged_unordered_container<
         first.iterator());
 }
 
-/*
 template <
     bool IsMulti,
     bool IsMap,
@@ -3105,7 +3101,6 @@ aged_unordered_container<
     }
     return n;
 }
-*/
 
 template <
     bool IsMulti,

--- a/src/ripple/consensus/ConsensusParms.h
+++ b/src/ripple/consensus/ConsensusParms.h
@@ -70,16 +70,8 @@ struct ConsensusParms
     // Consensus durations are relative to the internal Consensus clock and use
     // millisecond resolution.
 
-    //! The percentage threshold and floating point factor above which we can
-    //! declare consensus.
+    //! The percentage threshold above which we can declare consensus.
     std::size_t minCONSENSUS_PCT = 80;
-    float minCONSENSUS_FACTOR = static_cast<float>(minCONSENSUS_PCT / 100.0f);
-
-    //! The percentage threshold and floating point factor above which we can
-    //! declare consensus based on nodes having fallen off of the UNL.
-    std::size_t negUNL_MIN_CONSENSUS_PCT = 60;
-    float negUNL_MIN_CONSENSUS_FACTOR =
-        static_cast<float>(negUNL_MIN_CONSENSUS_PCT / 100.0f);
 
     //! The duration a ledger may remain idle before closing
     std::chrono::milliseconds ledgerIDLE_INTERVAL = std::chrono::seconds{15};

--- a/src/ripple/consensus/ConsensusTypes.h
+++ b/src/ripple/consensus/ConsensusTypes.h
@@ -21,6 +21,7 @@
 #define RIPPLE_CONSENSUS_CONSENSUS_TYPES_H_INCLUDED
 
 #include <ripple/basics/chrono.h>
+#include <ripple/consensus/ConsensusProposal.h>
 #include <ripple/consensus/DisputedTx.h>
 #include <chrono>
 #include <map>
@@ -188,8 +189,6 @@ enum class ConsensusState {
     Yes       //!< We have consensus along with the network
 };
 
-template <class NodeID_t, class LedgerID_t, class Position_t, class Seq>
-class ConsensusProposal;
 /** Encapsulates the result of consensus.
 
     Stores all relevant data for the outcome of consensus on a single
@@ -209,8 +208,7 @@ struct ConsensusResult
     using Proposal_t = ConsensusProposal<
         NodeID_t,
         typename Ledger_t::ID,
-        typename TxSet_t::ID,
-        typename Ledger_t::Seq>;
+        typename TxSet_t::ID>;
     using Dispute_t = DisputedTx<Tx_t, NodeID_t>;
 
     ConsensusResult(TxSet_t&& s, Proposal_t&& p)

--- a/src/ripple/consensus/DisputedTx.h
+++ b/src/ripple/consensus/DisputedTx.h
@@ -152,19 +152,19 @@ DisputedTx<Tx_t, NodeID_t>::setVote(NodeID_t const& peer, bool votesYes)
     {
         if (votesYes)
         {
-            JLOG(j_.trace()) << "Peer " << peer << " votes YES on " << tx_.id();
+            JLOG(j_.debug()) << "Peer " << peer << " votes YES on " << tx_.id();
             ++yays_;
         }
         else
         {
-            JLOG(j_.trace()) << "Peer " << peer << " votes NO on " << tx_.id();
+            JLOG(j_.debug()) << "Peer " << peer << " votes NO on " << tx_.id();
             ++nays_;
         }
     }
     // changes vote to yes
     else if (votesYes && !it->second)
     {
-        JLOG(j_.trace()) << "Peer " << peer << " now votes YES on " << tx_.id();
+        JLOG(j_.debug()) << "Peer " << peer << " now votes YES on " << tx_.id();
         --nays_;
         ++yays_;
         it->second = true;
@@ -172,7 +172,7 @@ DisputedTx<Tx_t, NodeID_t>::setVote(NodeID_t const& peer, bool votesYes)
     // changes vote to no
     else if (!votesYes && it->second)
     {
-        JLOG(j_.trace()) << "Peer " << peer << " now votes NO on " << tx_.id();
+        JLOG(j_.debug()) << "Peer " << peer << " now votes NO on " << tx_.id();
         ++nays_;
         --yays_;
         it->second = false;
@@ -238,17 +238,17 @@ DisputedTx<Tx_t, NodeID_t>::updateVote(
 
     if (newPosition == ourVote_)
     {
-        JLOG(j_.trace()) << "No change (" << (ourVote_ ? "YES" : "NO")
-                         << ") : weight " << weight << ", percent "
-                         << percentTime;
-        JLOG(j_.trace()) << Json::Compact{getJson()};
+        JLOG(j_.info()) << "No change (" << (ourVote_ ? "YES" : "NO")
+                        << ") : weight " << weight << ", percent "
+                        << percentTime;
+        JLOG(j_.debug()) << Json::Compact{getJson()};
         return false;
     }
 
     ourVote_ = newPosition;
-    JLOG(j_.trace()) << "We now vote " << (ourVote_ ? "YES" : "NO") << " on "
+    JLOG(j_.debug()) << "We now vote " << (ourVote_ ? "YES" : "NO") << " on "
                      << tx_.id();
-    JLOG(j_.trace()) << Json::Compact{getJson()};
+    JLOG(j_.debug()) << Json::Compact{getJson()};
     return true;
 }
 

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -33,7 +33,6 @@
 #include <ripple/basics/base64.h>
 #include <ripple/basics/random.h>
 #include <ripple/basics/safe_cast.h>
-#include <ripple/beast/clock/abstract_clock.h>
 #include <ripple/beast/core/LexicalCast.h>
 #include <ripple/beast/core/SemanticVersion.h>
 #include <ripple/nodestore/DatabaseShard.h>
@@ -1995,10 +1994,6 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMProposeSet> const& m)
     JLOG(p_journal_.trace())
         << "Proposal: " << (isTrusted ? "trusted" : "untrusted");
 
-    std::optional<LedgerIndex> ledgerSeq;
-    if (set.has_ledgerseq())
-        ledgerSeq = set.ledgerseq();
-
     auto proposal = RCLCxPeerPos(
         publicKey,
         sig,
@@ -2009,9 +2004,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMProposeSet> const& m)
             proposeHash,
             closeTime,
             app_.timeKeeper().closeTime(),
-            calcNodeID(app_.validatorManifests().getMasterKey(publicKey)),
-            ledgerSeq,
-            beast::get_abstract_clock<std::chrono::steady_clock>()});
+            calcNodeID(app_.validatorManifests().getMasterKey(publicKey))});
 
     std::weak_ptr<PeerImp> weak = shared_from_this();
     app_.getJobQueue().addJob(

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -231,8 +231,6 @@ message TMProposeSet
 
     // Number of hops traveled
     optional uint32 hops                = 12    [deprecated=true];
-
-    optional uint32 ledgerSeq           = 14;    // sequence of the ledger we are proposing
 }
 
 enum TxSetStatus

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "1.12.0-rc1"
+char const* const versionString = "1.12.0-rc2"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/test/consensus/Consensus_test.cpp
+++ b/src/test/consensus/Consensus_test.cpp
@@ -44,35 +44,34 @@ public:
         // Use default parameters
         ConsensusParms const p{};
 
-        std::optional<std::chrono::milliseconds> delay;
         // Bizarre times forcibly close
         BEAST_EXPECT(shouldCloseLedger(
-            true, 10, 10, 10, -10s, 10s, 1s, delay, 1s, p, journal_));
+            true, 10, 10, 10, -10s, 10s, 1s, 1s, p, journal_));
         BEAST_EXPECT(shouldCloseLedger(
-            true, 10, 10, 10, 100h, 10s, 1s, delay, 1s, p, journal_));
+            true, 10, 10, 10, 100h, 10s, 1s, 1s, p, journal_));
         BEAST_EXPECT(shouldCloseLedger(
-            true, 10, 10, 10, 10s, 100h, 1s, delay, 1s, p, journal_));
+            true, 10, 10, 10, 10s, 100h, 1s, 1s, p, journal_));
 
         // Rest of network has closed
-        BEAST_EXPECT(shouldCloseLedger(
-            true, 10, 3, 5, 10s, 10s, 10s, delay, 10s, p, journal_));
+        BEAST_EXPECT(
+            shouldCloseLedger(true, 10, 3, 5, 10s, 10s, 10s, 10s, p, journal_));
 
         // No transactions means wait until end of internval
-        BEAST_EXPECT(!shouldCloseLedger(
-            false, 10, 0, 0, 1s, 1s, 1s, delay, 10s, p, journal_));
-        BEAST_EXPECT(shouldCloseLedger(
-            false, 10, 0, 0, 1s, 10s, 1s, delay, 10s, p, journal_));
+        BEAST_EXPECT(
+            !shouldCloseLedger(false, 10, 0, 0, 1s, 1s, 1s, 10s, p, journal_));
+        BEAST_EXPECT(
+            shouldCloseLedger(false, 10, 0, 0, 1s, 10s, 1s, 10s, p, journal_));
 
         // Enforce minimum ledger open time
-        BEAST_EXPECT(!shouldCloseLedger(
-            true, 10, 0, 0, 10s, 10s, 1s, delay, 10s, p, journal_));
+        BEAST_EXPECT(
+            !shouldCloseLedger(true, 10, 0, 0, 10s, 10s, 1s, 10s, p, journal_));
 
         // Don't go too much faster than last time
-        BEAST_EXPECT(!shouldCloseLedger(
-            true, 10, 0, 0, 10s, 10s, 3s, delay, 10s, p, journal_));
+        BEAST_EXPECT(
+            !shouldCloseLedger(true, 10, 0, 0, 10s, 10s, 3s, 10s, p, journal_));
 
-        BEAST_EXPECT(shouldCloseLedger(
-            true, 10, 0, 0, 10s, 10s, 10s, delay, 10s, p, journal_));
+        BEAST_EXPECT(
+            shouldCloseLedger(true, 10, 0, 0, 10s, 10s, 10s, 10s, p, journal_));
     }
 
     void

--- a/src/test/csf/Proposal.h
+++ b/src/test/csf/Proposal.h
@@ -30,7 +30,7 @@ namespace csf {
 /** Proposal is a position taken in the consensus process and is represented
     directly from the generic types.
 */
-using Proposal = ConsensusProposal<PeerID, Ledger::ID, TxSet::ID, Ledger::Seq>;
+using Proposal = ConsensusProposal<PeerID, Ledger::ID, TxSet::ID>;
 
 }  // namespace csf
 }  // namespace test


### PR DESCRIPTION
## High Level Overview of Change

Compared to rc1, this version reverts e8a7b2a.

### Context of Change

Additional testing shows that e8a7b2a may cause an increase in time taken in the proposal phase of consensus. For now, it is being reverted. The changes will be revised and tested independently for potential future inclusion (e.g. in version 1.13 or 2.0).

### Type of Change

- [x] Release

## Test Plan

QA team will test adding new wallets to the ledger and see if `tefPAST_SEQ` occurs.