### PR TITLE
Proposed 1.12.0-rc4

### DIFF
--- a/src/ripple/app/tx/impl/AMMBid.cpp
+++ b/src/ripple/app/tx/impl/AMMBid.cpp
@@ -223,9 +223,11 @@ applyBid(
             lptAMMBalance, toSTAmount(lptAMMBalance.issue(), burn), false);
         if (saBurn >= lptAMMBalance)
         {
-            JLOG(ctx_.journal.debug())
-                << "AMM Bid: invalid burn " << burn << " " << lptAMMBalance;
-            return tecAMM_BALANCE;
+            // This error case should never occur.
+            JLOG(ctx_.journal.fatal())
+                << "AMM Bid: LP Token burn exceeds AMM balance " << burn << " "
+                << lptAMMBalance;
+            return tecINTERNAL;
         }
         auto res =
             redeemIOU(sb, account_, saBurn, lpTokens.issue(), ctx_.journal);
@@ -316,9 +318,10 @@ applyBid(
         auto const refund = fractionRemaining * pricePurchased;
         if (refund > *payPrice)
         {
-            JLOG(ctx_.journal.debug())
-                << "AMM Bid: invalid refund " << refund << " " << *payPrice;
-            return {tecINSUFFICIENT_PAYMENT, false};
+            // This error case should never occur.
+            JLOG(ctx_.journal.fatal()) << "AMM Bid: refund exceeds payPrice "
+                                       << refund << " " << *payPrice;
+            return {tecINTERNAL, false};
         }
         res = accountSend(
             sb,

--- a/src/ripple/app/tx/impl/AMMCreate.cpp
+++ b/src/ripple/app/tx/impl/AMMCreate.cpp
@@ -279,6 +279,20 @@ applyCreate(
     // AMM creator gets the auction slot and the voting slot.
     initializeFeeAuctionVote(
         ctx_.view(), ammSle, account_, lptIss, ctx_.tx[sfTradingFee]);
+
+    // Add owner directory to link the root account and AMM object.
+    if (auto const page = sb.dirInsert(
+            keylet::ownerDir(*ammAccount),
+            ammSle->key(),
+            describeOwnerDir(*ammAccount)))
+    {
+        ammSle->setFieldU64(sfOwnerNode, *page);
+    }
+    else
+    {
+        JLOG(j_.debug()) << "AMM Instance: failed to insert owner dir";
+        return {tecDIR_FULL, false};
+    }
     sb.insert(ammSle);
 
     // Send LPT to LP.

--- a/src/ripple/app/tx/impl/DeleteAccount.cpp
+++ b/src/ripple/app/tx/impl/DeleteAccount.cpp
@@ -298,19 +298,19 @@ DeleteAccount::doApply()
         ownerDirKeylet,
         [&](LedgerEntryType nodeType,
             uint256 const& dirEntry,
-            std::shared_ptr<SLE>& sleItem) -> TER {
+            std::shared_ptr<SLE>& sleItem) -> std::pair<TER, SkipEntry> {
             if (auto deleter = nonObligationDeleter(nodeType))
             {
                 TER const result{
                     deleter(ctx_.app, view(), account_, dirEntry, sleItem, j_)};
 
-                return result;
+                return {result, SkipEntry::No};
             }
 
             assert(!"Undeletable entry should be found in preclaim.");
             JLOG(j_.error()) << "DeleteAccount undeletable item not "
                                 "found in preclaim.";
-            return tecHAS_OBLIGATIONS;
+            return {tecHAS_OBLIGATIONS, SkipEntry::No};
         },
         ctx_.journal);
     if (ter != tesSUCCESS)

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -43,6 +43,7 @@
 namespace ripple {
 
 enum class WaiveTransferFee : bool { No = false, Yes };
+enum class SkipEntry : bool { No = false, Yes };
 
 //------------------------------------------------------------------------------
 //
@@ -458,6 +459,14 @@ transferXRP(
 [[nodiscard]] TER
 requireAuth(ReadView const& view, Issue const& issue, AccountID const& account);
 
+/** Deleter function prototype. Returns the status of the entry deletion
+ * (if should not be skipped) and if the entry should be skipped. The status
+ * is always tesSUCCESS if the entry should be skipped.
+ */
+using EntryDeleter = std::function<std::pair<TER, SkipEntry>(
+    LedgerEntryType,
+    uint256 const&,
+    std::shared_ptr<SLE>&)>;
 /** Cleanup owner directory entries on account delete.
  * Used for a regular and AMM accounts deletion. The caller
  * has to provide the deleter function, which handles details of
@@ -469,8 +478,7 @@ requireAuth(ReadView const& view, Issue const& issue, AccountID const& account);
 cleanupOnAccountDelete(
     ApplyView& view,
     Keylet const& ownerDirKeylet,
-    std::function<TER(LedgerEntryType, uint256 const&, std::shared_ptr<SLE>&)>
-        deleter,
+    EntryDeleter const& deleter,
     beast::Journal j,
     std::optional<std::uint16_t> maxNodesToDelete = std::nullopt);
 

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "1.12.0-rc3"
+char const* const versionString = "1.12.0-rc4"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -279,6 +279,7 @@ LedgerFormats::LedgerFormats()
             {sfLPTokenBalance, soeREQUIRED},
             {sfAsset, soeREQUIRED},
             {sfAsset2, soeREQUIRED},
+            {sfOwnerNode, soeREQUIRED},
         },
         commonFields);
 

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -160,6 +160,7 @@ JSS(alternatives);           // out: PathRequest, RipplePathFind
 JSS(amendment_blocked);      // out: NetworkOPs
 JSS(amendments);             // in: AccountObjects, out: NetworkOPs
 JSS(amm);                    // out: amm_info
+JSS(amm_account);            // in: amm_info
 JSS(amount);                 // out: AccountChannels, amm_info
 JSS(amount2);                // out: amm_info
 JSS(api_version);            // in: many, out: Version

--- a/src/test/jtx/AMM.h
+++ b/src/test/jtx/AMM.h
@@ -105,7 +105,10 @@ public:
     ammRpcInfo(
         std::optional<AccountID> const& account = std::nullopt,
         std::optional<std::string> const& ledgerIndex = std::nullopt,
-        std::optional<std::pair<Issue, Issue>> tokens = std::nullopt) const;
+        std::optional<Issue> issue1 = std::nullopt,
+        std::optional<Issue> issue2 = std::nullopt,
+        std::optional<AccountID> const& ammAccount = std::nullopt,
+        bool ignoreParams = false) const;
 
     /** Verify the AMM balances.
      */
@@ -150,7 +153,8 @@ public:
         STAmount const& asset2,
         IOUAmount const& balance,
         std::optional<AccountID> const& account = std::nullopt,
-        std::optional<std::string> const& ledger_index = std::nullopt) const;
+        std::optional<std::string> const& ledger_index = std::nullopt,
+        std::optional<AccountID> const& ammAccount = std::nullopt) const;
 
     [[nodiscard]] bool
     ammExists() const;

--- a/src/test/rpc/AMMInfo_test.cpp
+++ b/src/test/rpc/AMMInfo_test.cpp
@@ -42,7 +42,7 @@ public:
             Account const gw("gw");
             auto const USD = gw["USD"];
             auto const jv =
-                ammAlice.ammRpcInfo({}, {}, {{USD.issue(), USD.issue()}});
+                ammAlice.ammRpcInfo({}, {}, USD.issue(), USD.issue());
             BEAST_EXPECT(jv[jss::error_message] == "Account not found.");
         });
 
@@ -50,6 +50,40 @@ public:
         testAMM([&](AMM& ammAlice, Env&) {
             Account bogie("bogie");
             auto const jv = ammAlice.ammRpcInfo(bogie.id());
+            BEAST_EXPECT(jv[jss::error_message] == "Account malformed.");
+        });
+
+        // Invalid parameters
+        testAMM([&](AMM& ammAlice, Env&) {
+            std::vector<std::tuple<
+                std::optional<Issue>,
+                std::optional<Issue>,
+                std::optional<AccountID>,
+                bool>>
+                vals = {
+                    {xrpIssue(), std::nullopt, std::nullopt, false},
+                    {std::nullopt, USD.issue(), std::nullopt, false},
+                    {xrpIssue(), std::nullopt, ammAlice.ammAccount(), false},
+                    {std::nullopt, USD.issue(), ammAlice.ammAccount(), false},
+                    {xrpIssue(), USD.issue(), ammAlice.ammAccount(), false},
+                    {std::nullopt, std::nullopt, std::nullopt, true}};
+            for (auto const& [iss1, iss2, acct, ignoreParams] : vals)
+            {
+                auto const jv = ammAlice.ammRpcInfo(
+                    std::nullopt, std::nullopt, iss1, iss2, acct, ignoreParams);
+                BEAST_EXPECT(jv[jss::error_message] == "Invalid parameters.");
+            }
+        });
+
+        // Invalid AMM account id
+        testAMM([&](AMM& ammAlice, Env&) {
+            Account bogie("bogie");
+            auto const jv = ammAlice.ammRpcInfo(
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                bogie.id());
             BEAST_EXPECT(jv[jss::error_message] == "Account malformed.");
         });
     }
@@ -63,6 +97,13 @@ public:
         testAMM([&](AMM& ammAlice, Env&) {
             BEAST_EXPECT(ammAlice.expectAmmRpcInfo(
                 XRP(10000), USD(10000), IOUAmount{10000000, 0}));
+            BEAST_EXPECT(ammAlice.expectAmmRpcInfo(
+                XRP(10000),
+                USD(10000),
+                IOUAmount{10000000, 0},
+                std::nullopt,
+                std::nullopt,
+                ammAlice.ammAccount()));
         });
     }
 
@@ -91,53 +132,71 @@ public:
             env.fund(XRP(1000), bob, ed, bill);
             ammAlice.bid(alice, 100, std::nullopt, {carol, bob, ed, bill});
             BEAST_EXPECT(ammAlice.expectAmmRpcInfo(
-                XRP(80000), USD(80000), IOUAmount{79994400}));
-            std::unordered_set<std::string> authAccounts = {
-                carol.human(), bob.human(), ed.human(), bill.human()};
-            auto const ammInfo = ammAlice.ammRpcInfo();
-            auto const& amm = ammInfo[jss::amm];
-            try
+                XRP(80000),
+                USD(80000),
+                IOUAmount{79994400},
+                std::nullopt,
+                std::nullopt,
+                ammAlice.ammAccount()));
+            for (auto i = 0; i < 2; ++i)
             {
-                // votes
-                auto const voteSlots = amm[jss::vote_slots];
-                for (std::uint8_t i = 0; i < 8; ++i)
+                std::unordered_set<std::string> authAccounts = {
+                    carol.human(), bob.human(), ed.human(), bill.human()};
+                auto const ammInfo = i ? ammAlice.ammRpcInfo()
+                                       : ammAlice.ammRpcInfo(
+                                             std::nullopt,
+                                             std::nullopt,
+                                             std::nullopt,
+                                             std::nullopt,
+                                             ammAlice.ammAccount());
+                auto const& amm = ammInfo[jss::amm];
+                try
                 {
-                    if (!BEAST_EXPECT(
-                            votes[voteSlots[i][jss::account].asString()] ==
-                                voteSlots[i][jss::trading_fee].asUInt() &&
-                            voteSlots[i][jss::vote_weight].asUInt() == 12500))
+                    // votes
+                    auto const voteSlots = amm[jss::vote_slots];
+                    auto votesCopy = votes;
+                    for (std::uint8_t i = 0; i < 8; ++i)
+                    {
+                        if (!BEAST_EXPECT(
+                                votes[voteSlots[i][jss::account].asString()] ==
+                                    voteSlots[i][jss::trading_fee].asUInt() &&
+                                voteSlots[i][jss::vote_weight].asUInt() ==
+                                    12500))
+                            return;
+                        votes.erase(voteSlots[i][jss::account].asString());
+                    }
+                    if (!BEAST_EXPECT(votes.empty()))
                         return;
-                    votes.erase(voteSlots[i][jss::account].asString());
-                }
-                if (!BEAST_EXPECT(votes.empty()))
-                    return;
+                    votes = votesCopy;
 
-                // bid
-                auto const auctionSlot = amm[jss::auction_slot];
-                for (std::uint8_t i = 0; i < 4; ++i)
-                {
-                    if (!BEAST_EXPECT(authAccounts.contains(
+                    // bid
+                    auto const auctionSlot = amm[jss::auction_slot];
+                    for (std::uint8_t i = 0; i < 4; ++i)
+                    {
+                        if (!BEAST_EXPECT(authAccounts.contains(
+                                auctionSlot[jss::auth_accounts][i][jss::account]
+                                    .asString())))
+                            return;
+                        authAccounts.erase(
                             auctionSlot[jss::auth_accounts][i][jss::account]
-                                .asString())))
+                                .asString());
+                    }
+                    if (!BEAST_EXPECT(authAccounts.empty()))
                         return;
-                    authAccounts.erase(
-                        auctionSlot[jss::auth_accounts][i][jss::account]
-                            .asString());
+                    BEAST_EXPECT(
+                        auctionSlot[jss::account].asString() == alice.human() &&
+                        auctionSlot[jss::discounted_fee].asUInt() == 17 &&
+                        auctionSlot[jss::price][jss::value].asString() ==
+                            "5600" &&
+                        auctionSlot[jss::price][jss::currency].asString() ==
+                            to_string(ammAlice.lptIssue().currency) &&
+                        auctionSlot[jss::price][jss::issuer].asString() ==
+                            to_string(ammAlice.lptIssue().account));
                 }
-                if (!BEAST_EXPECT(authAccounts.empty()))
-                    return;
-                BEAST_EXPECT(
-                    auctionSlot[jss::account].asString() == alice.human() &&
-                    auctionSlot[jss::discounted_fee].asUInt() == 17 &&
-                    auctionSlot[jss::price][jss::value].asString() == "5600" &&
-                    auctionSlot[jss::price][jss::currency].asString() ==
-                        to_string(ammAlice.lptIssue().currency) &&
-                    auctionSlot[jss::price][jss::issuer].asString() ==
-                        to_string(ammAlice.lptIssue().account));
-            }
-            catch (std::exception const& e)
-            {
-                fail(e.what(), __FILE__, __LINE__);
+                catch (std::exception const& e)
+                {
+                    fail(e.what(), __FILE__, __LINE__);
+                }
             }
         });
     }


### PR DESCRIPTION
## High Level Overview of Change

Compared to rc3, this version includes the following:
- #4674
- #4682

### Context of Change

In the process of documenting AMM, two "impossible" error cases were identified. These now return `tecINTERNAL` because they should never occur; if they occur, please [open an issue](https://github.com/XRPLF/rippled/issues) to ensure the mechanism of action is investigated and understood.

With the experience of using the AMM APIs, it was determined that it may be useful to retrieve AMM with `account_objects`, so the AMM object owner directory entry was added back in. Additionally, `amm_info` was enhanced to also allow users to retrieve an AMM object by amm account id.

### Type of Change

- [x] Release