### PR TITLE
Remove CurrentThreadName.h from RippledCore.cmake

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -309,7 +309,6 @@ install (
   DESTINATION include/ripple/beast/clock)
 install (
   FILES
-    src/ripple/beast/core/CurrentThreadName.h
     src/ripple/beast/core/LexicalCast.h
     src/ripple/beast/core/List.h
     src/ripple/beast/core/SemanticVersion.h


### PR DESCRIPTION
File was already removed from the source via https://github.com/XRPLF/rippled/commit/36cb5f90e233f975eb3f80d819b2fbadab0a9387


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
