### PR TITLE
[TRIVIAL] Fix broken links in documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -336,11 +336,4 @@ If you want to experiment with a new package, follow these steps:
 [6]: https://github.com/boostorg/beast/issues/2648
 [7]: https://github.com/boostorg/beast/issues/2661
 [build_type]: https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
-[runtime]: https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html
-[toolchain]: https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html
-[pcf]: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#package-configuration-file
-[pvf]: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#package-version-file
-[find_package]: https://cmake.org/cmake/help/latest/command/find_package.html
-[search]: https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure
-[prefix_path]: https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html
 [profile]: https://docs.conan.io/en/latest/reference/profiles.html

--- a/docs/build/conan.md
+++ b/docs/build/conan.md
@@ -109,6 +109,16 @@ For options, each package recipe defines its own defaults.
 You can pass every parameter to Conan on the command line,
 but it is more convenient to put them in a configuration file, once, that
 Conan can read every time it is configured.
-For Conan, that file is a [profile][profile].
+For Conan, that file is a [profile][].
 **All we must do to properly configure Conan is edit and pass the profile.**
 By default, Conan will use the profile named "default".
+
+[build_type]: https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
+[find_package]: https://cmake.org/cmake/help/latest/command/find_package.html
+[pcf]: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#package-configuration-file
+[prefix_path]: https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html
+[profile]: https://docs.conan.io/en/latest/reference/profiles.html
+[pvf]: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#package-version-file
+[runtime]: https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html
+[search]: https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure
+[toolchain]: https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html


### PR DESCRIPTION
I forgot to copy the links when I moved this text to a separate file.