### PR TITLE
Revert CMake changes

### DIFF
--- a/Builds/CMake/CMakeFuncs.cmake
+++ b/Builds/CMake/CMakeFuncs.cmake
@@ -18,10 +18,8 @@ macro(group_sources curdir)
 endmacro()
 
 macro (exclude_from_default target_)
-  if(target_)
-    set_target_properties (${target_} PROPERTIES EXCLUDE_FROM_ALL ON)
-    set_target_properties (${target_} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD ON)
-  endif()
+  set_target_properties (${target_} PROPERTIES EXCLUDE_FROM_ALL ON)
+  set_target_properties (${target_} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD ON)
 endmacro ()
 
 macro (exclude_if_included target_)

--- a/Builds/CMake/RippledRelease.cmake
+++ b/Builds/CMake/RippledRelease.cmake
@@ -2,12 +2,6 @@
    package/container targets - (optional)
 #]===================================================================]
 
-# Early return if the `containers` directory is missing,
-# e.g. when we are building a Conan package.
-if(NOT EXISTS containers)
-  return()
-endif()
-
 if (is_root_project)
   if (NOT DOCKER)
     find_program (DOCKER docker)

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "1.12.0"
+char const* const versionString = "2.0.0-b1"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.0.0-b1"
+char const* const versionString = "1.12.0"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)


### PR DESCRIPTION
Early return from `RippledRelease.cmake` preventing targets being created during packaging.

- [x] Bug fix (non-breaking change which fixes an issue)

