### PR TITLE
Reunify common fields:

### DIFF
--- a/src/ripple/protocol/impl/TxFormats.cpp
+++ b/src/ripple/protocol/impl/TxFormats.cpp
@@ -27,41 +27,25 @@ namespace ripple {
 
 TxFormats::TxFormats()
 {
-#pragma push_macro("PSEUDO_TXN_COMMON_FIELDS")
-
-    // clang-format off
-
-    #define PSEUDO_TXN_COMMON_FIELDS                        \
-        {sfTransactionType, soeREQUIRED},                   \
-        {sfFlags, soeOPTIONAL},                             \
-        {sfSourceTag, soeOPTIONAL},                         \
-        {sfAccount, soeREQUIRED},                           \
-        {sfSequence, soeREQUIRED},                          \
-        {sfPreviousTxnID, soeOPTIONAL}, /* emulate027 */    \
-        {sfLastLedgerSequence, soeOPTIONAL},                \
-        {sfAccountTxnID, soeOPTIONAL},                      \
-        {sfFee, soeREQUIRED},                               \
-        {sfOperationLimit, soeOPTIONAL},                    \
-        {sfMemos, soeOPTIONAL},                             \
-        {sfSigningPubKey, soeREQUIRED},                     \
-        {sfTxnSignature, soeOPTIONAL},                      \
-        {sfSigners, soeOPTIONAL}, /* submit_multisigned */  \
-        {sfNetworkID, soeOPTIONAL}
-
-    // clang-format on
-
-    // Fields shared by all pseudo-transaction txFormats:
-    static const std::initializer_list<SOElement> pseudoCommonFields{
-        PSEUDO_TXN_COMMON_FIELDS,
-    };
-
-    // Fields shared by all normal transaction txFormats:
+    // Fields shared by all txFormats:
     static const std::initializer_list<SOElement> commonFields{
-        PSEUDO_TXN_COMMON_FIELDS,
+        {sfTransactionType, soeREQUIRED},
+        {sfFlags, soeOPTIONAL},
+        {sfSourceTag, soeOPTIONAL},
+        {sfAccount, soeREQUIRED},
+        {sfSequence, soeREQUIRED},
+        {sfPreviousTxnID, soeOPTIONAL},  // emulate027
+        {sfLastLedgerSequence, soeOPTIONAL},
+        {sfAccountTxnID, soeOPTIONAL},
+        {sfFee, soeREQUIRED},
+        {sfOperationLimit, soeOPTIONAL},
+        {sfMemos, soeOPTIONAL},
+        {sfSigningPubKey, soeREQUIRED},
         {sfTicketSequence, soeOPTIONAL},
+        {sfTxnSignature, soeOPTIONAL},
+        {sfSigners, soeOPTIONAL},  // submit_multisigned
+        {sfNetworkID, soeOPTIONAL},
     };
-
-#pragma pop_macro("PSEUDO_TXN_COMMON_FIELDS")
 
     add(jss::AccountSet,
         ttACCOUNT_SET,
@@ -223,7 +207,7 @@ TxFormats::TxFormats()
             {sfLedgerSequence, soeREQUIRED},
             {sfAmendment, soeREQUIRED},
         },
-        pseudoCommonFields);
+        commonFields);
 
     add(jss::SetFee,
         ttFEE,
@@ -239,7 +223,7 @@ TxFormats::TxFormats()
             {sfReserveBaseDrops, soeOPTIONAL},
             {sfReserveIncrementDrops, soeOPTIONAL},
         },
-        pseudoCommonFields);
+        commonFields);
 
     add(jss::UNLModify,
         ttUNL_MODIFY,
@@ -248,7 +232,7 @@ TxFormats::TxFormats()
             {sfLedgerSequence, soeREQUIRED},
             {sfUNLModifyValidator, soeREQUIRED},
         },
-        pseudoCommonFields);
+        commonFields);
 
     add(jss::TicketCreate,
         ttTICKET_CREATE,


### PR DESCRIPTION
Makes transactions and pseudo-transactions share the same `commonFields` again. This change technically allows pseudo-transactions to have a `TicketSequence` field, but those transactions are only ever constructed by code paths that don't add such a field, so this is not actually a transaction processing change.

(Note, my build is not working at the moment, but the amount I was able to build so far gets past this file at least.)

### Context of Change

Fixes #4714

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Future Tasks

We could optionally add a separate check to make sure this and other fields that don't make sense on pseudo-transactions are never added to them, but I don't think that's necessary.