### PR TITLE
Fix output of remote step in nix workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -79,7 +79,8 @@ jobs:
       - name: try to authenticate to ripple Conan remote
         id: remote
         run: |
-          echo outcome=$(conan user --remote ripple ${{ secrets.CONAN_USERNAME }} --password ${{ secrets.CONAN_TOKEN }} && echo success || echo failure) | tee ${GITHUB_OUTPUT}
+          echo outcome=$(conan user --remote ripple ${{ secrets.CONAN_USERNAME }} --password ${{ secrets.CONAN_TOKEN }} && tee conanuser.txt && echo success || echo failure) | tee ${GITHUB_OUTPUT}
+          cat conanuser.txt
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar -C ~/.conan .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -79,8 +79,8 @@ jobs:
       - name: try to authenticate to ripple Conan remote
         id: remote
         run: |
-          echo outcome=$(conan user --remote ripple ${{ secrets.CONAN_USERNAME }} --password ${{ secrets.CONAN_TOKEN }} && tee conanuser.txt && echo success || echo failure) | tee ${GITHUB_OUTPUT}
-          cat conanuser.txt
+          conan user --remote ripple ${{ secrets.CONAN_USERNAME }} --password ${{ secrets.CONAN_TOKEN }}
+          echo outcome=$([ $? -eq 0 ] && echo success || echo failure) | tee ${GITHUB_OUTPUT}
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar -C ~/.conan .


### PR DESCRIPTION
This pull request updates the nix CI runner. Although the builds are successful, the binaries are not uploaded to the internal artifactory. This PR attempts to fix this issue and I have borrowed the idea from @ximinez 

After successful authentication, `outcome` variable contains a string. In the upload step, we are checking if `outcome == success` as a prerequisite for uploading the binary.

This PR updates the contents of the `outcome` variable in the CI.

Example of a breaking Github Actions workflow (thanks to @thejohnfreeman): https://github.com/XRPLF/rippled/actions/runs/6264131645/job/17010134246

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
- [x] None of the above
This does not modify any of the source code files. The CI runner condition is updated to ensure uploads of binaries upon successful builds.

This change as motivated from this slack discussion: https://ripple-enterprise.slack.com/archives/C02GE9NBA/p1695051230548129

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
