### PR TITLE
Disallow the same bridge on one chain:

### DIFF
--- a/src/ripple/app/tx/impl/XChainBridge.cpp
+++ b/src/ripple/app/tx/impl/XChainBridge.cpp
@@ -1452,13 +1452,19 @@ XChainCreateBridge::preclaim(PreclaimContext const& ctx)
 {
     auto const account = ctx.tx[sfAccount];
     auto const bridgeSpec = ctx.tx[sfXChainBridge];
-
     STXChainBridge::ChainType const chainType =
         STXChainBridge::srcChain(account == bridgeSpec.lockingChainDoor());
 
-    if (ctx.view.read(keylet::bridge(bridgeSpec, chainType)))
     {
-        return tecDUPLICATE;
+        auto hasBridge = [&](STXChainBridge::ChainType ct) -> bool {
+            return ctx.view.exists(keylet::bridge(bridgeSpec, ct));
+        };
+
+        if (hasBridge(STXChainBridge::ChainType::issuing) ||
+            hasBridge(STXChainBridge::ChainType::locking))
+        {
+            return tecDUPLICATE;
+        }
     }
 
     if (!isXRP(bridgeSpec.issue(chainType)))


### PR DESCRIPTION
Before this patch, two door accounts on the same chain could could own the same bridge spec (of course, one would have to be the issuer and one would have to be the locker). While this is silly, it does not violate any bridge invariants. However, on further review if we allow this then the `claim` transactions would need to change. Since it's hard to see a use case for two doors to own the same bridge, this patch disallows it. (The transaction will return tecDUPLICATE).


- [x ] Bug fix (non-breaking change which fixes an issue)
