### PR TITLE
Add .build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ pkg
 CMakeUserPresets.json
 bld.rippled/
 .vscode
+
+# Suggested in-tree build directory
+/.build/


### PR DESCRIPTION
Suggested in-tree build directory should be automatically excluded from git workspace, so users aren't confused when following instructions

### Type of Change

Non-functional change