### PR TITLE
[TRIVIAL] docs(API-CHANGELOG): clarify account_info response

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -16,7 +16,11 @@ This version is supported by all `rippled` versions. At time of writing, it is t
 
 #### V1 account_info response
 
-In [the response to the `account_info` command](https://xrpl.org/account_info.html#response-format), there is `account_data` - which is supposed to be an `AccountRoot` object - and `signer_lists` is in this object. However, the docs say that `signer_lists` should be at the root level of the reponse - and this makes sense, since signer lists are not part of the AccountRoot object. (First reported in [xrpl-dev-portal#938](https://github.com/XRPLF/xrpl-dev-portal/issues/938).) Thanks to [rippled#3770](https://github.com/XRPLF/rippled/pull/3770), this field will be moved in `api_version: 2`, to the root level of the response.
+In [the response to the `account_info` command](https://xrpl.org/account_info.html#response-format), there is `account_data` - which is supposed to be an `AccountRoot` object - and `signer_lists` is returned in this object. However, the docs say that `signer_lists` should be at the root level of the reponse.
+
+It makes sense for `signer_lists` to be at the root level because signer lists are not part of the AccountRoot object. (First reported in [xrpl-dev-portal#938](https://github.com/XRPLF/xrpl-dev-portal/issues/938).)
+
+In `api_version: 2`, the `signer_lists` field [will be moved](#modifications-to-account_info-response-in-v2) to the root level of the account_info response. (https://github.com/XRPLF/rippled/pull/3770)
 
 #### server_info - network_id
 
@@ -108,7 +112,7 @@ Currently (prior to the release of 2.0), it is available as a "beta" version, me
 1
 ```
 
-Since `api_version` 2 is in "beta", breaking changes can be made at any time.
+Since `api_version` 2 is in "beta", breaking changes to V2 can currently be made at any time.
 
 #### Modifications to account_info response in V2
 


### PR DESCRIPTION
## High Level Overview of Change

The `signer_lists` field is being moved in api_version: 2. While re-reading the API-CHANGELOG, I thought of a way to make the wording more clear.

### Context of Change

The XRPL Explorer required a hotfix because Clio implemented the breaking change without putting it behind api_version: 2.

https://github.com/ripple/explorer/pull/834

### Type of Change

- [x] Documentation Updates
