### PR TITLE
[TRIVIAL] Fix build error: `uint` is not universally defined

### DIFF
--- a/src/ripple/rpc/impl/RPCHelpers.h
+++ b/src/ripple/rpc/impl/RPCHelpers.h
@@ -296,7 +296,7 @@ std::pair<PublicKey, SecretKey>
 keypairForSignature(
     Json::Value const& params,
     Json::Value& error,
-    uint apiVersion = apiVersionIfUnspecified);
+    unsigned int apiVersion = apiVersionIfUnspecified);
 /** Helper to parse submit_mode parameter to RPC submit.
  *
  * @param params RPC parameters


### PR DESCRIPTION
## High Level Overview of Change

Fixes the Windows build

### Context of Change

Introduced by #4618

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)
