### PR TITLE
[TRIVIAL] docs: Fix broken `conanfile.py` link in build settings

### DIFF
--- a/docs/build/conan.md
+++ b/docs/build/conan.md
@@ -69,7 +69,7 @@ compiler and linker options for all dependencies _and_ this project.
 However, that is very tedious and error-prone, which is why we lean on tools
 like Conan.
 
-We have written a Conan configuration file ([`conanfile.py`](./conanfile.py))
+We have written a Conan configuration file ([`conanfile.py`](../../conanfile.py))
 so that Conan can be used to correctly download, configure, build, and install
 all of the dependencies for this project,
 using a single set of compiler and linker options for all of them.


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

Updates the `conanfile.py` link to where it actually is in the rippled repo.

### Context of Change

I was trying to build rippled, and was confused when this link didn't work.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [X] Documentation Updates
