### PR TITLE
Update API CHANGELOG for `XRPFees` changes

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -102,7 +102,7 @@ was released on Mar 14, 2023.
 ### Breaking changes in 1.10
 
 - If the `XRPFees` feature is enabled, the `fee_ref` field will be
-  removed from the Ledger subscription stream, because it will no longer
+  removed from the [ledger subscription stream](https://xrpl.org/subscribe.html#ledger-stream), because it will no longer
   have any meaning.
 
 # In development

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -94,6 +94,17 @@ Additions are intended to be non-breaking (because they are purely additive).
 - Added `NFTokenPages` to the `account_objects` RPC. (https://github.com/XRPLF/rippled/pull/4352)
 - Fixed: `marker` returned from the `account_lines` command would not work on subsequent commands. (https://github.com/XRPLF/rippled/pull/4361)
 
+## XRP Ledger version 1.10.0
+
+[Version 1.10.0](https://github.com/XRPLF/rippled/releases/tag/1.10.0)
+was released on Mar 14, 2023.
+
+### Breaking changes in 1.10
+
+- If the `XRPFees` feature is enabled, the `fee_ref` field will be
+  removed from the Ledger subscription stream, because it will no longer
+  have any meaning.
+
 # In development
 
 Changes below this point are in development.

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -315,7 +315,7 @@ JSS(fee_base);              // out: NetworkOPs
 JSS(fee_div_max);           // in: TransactionSign
 JSS(fee_level);             // out: AccountInfo
 JSS(fee_mult_max);          // in: TransactionSign
-JSS(fee_ref);               // out: NetworkOPs
+JSS(fee_ref);               // out: NetworkOPs, DEPRECATED
 JSS(fetch_pack);            // out: NetworkOPs
 JSS(first);                 // out: rpc/Version
 JSS(firstSequence);         // out: NodeToShardStatus

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -4843,13 +4843,13 @@ public:
                     drops[jss::base_fee] == "0");
                 BEAST_EXPECT(
                     drops.isMember(jss::median_fee) &&
-                    drops[jss::base_fee] == "0");
+                    drops[jss::median_fee] == "0");
                 BEAST_EXPECT(
                     drops.isMember(jss::minimum_fee) &&
-                    drops[jss::base_fee] == "0");
+                    drops[jss::minimum_fee] == "0");
                 BEAST_EXPECT(
                     drops.isMember(jss::open_ledger_fee) &&
-                    drops[jss::base_fee] == "0");
+                    drops[jss::open_ledger_fee] == "0");
             }
         }
 


### PR DESCRIPTION
## High Level Overview of Change

* Adds a new section for release 1.10.
* Also marks `jss::fee_ref` as deprecated in case `XRPFees` is ever retired.
* Also fixes a copy-paste error in one of the unit tests related to that fix.

### Context of Change

See also:
* https://github.com/seelabs/xbridge_witness/pull/70
* https://github.com/XRPLF/xrpl-dev-portal/pull/2183

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)
- [X ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [X ] Documentation Updates

