### PR TITLE
[TRIVIAL] Remove incorrect assert

### DIFF
--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -538,7 +538,6 @@ PathRequest::findPaths(
             continueCallback);
         if (!pathfinder)
         {
-            assert(continueCallback && !continueCallback());
             JLOG(m_journal.debug()) << iIdentifier << " No paths found";
             continue;
         }


### PR DESCRIPTION
## High Level Overview of Change

An assert in PathRequest.cpp at line 541 can fire falsely in some circumstances:

The assert is saying that the only reason `pathFinder` would be null is if the request was aborted (connection dropped, etc.). That's what `continueCallback()` checks. But that is very clearly not true [if you look at `getPathFinder`](https://github.com/ximinez/rippled/blob/d93a7147af945e2905480371a330c4813fb1dd04/src/ripple/app/paths/PathRequest.cpp#L487-L490), which calls `findPaths`, which can return false for all kinds of reasons.

This PR removes that assert.

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)

Resolved #4744 
