### PR TITLE
Destroy tx sets outside of lock.

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.h
+++ b/src/ripple/app/consensus/RCLConsensus.h
@@ -24,6 +24,7 @@
 #include <ripple/app/consensus/RCLCxLedger.h>
 #include <ripple/app/consensus/RCLCxPeerPos.h>
 #include <ripple/app/consensus/RCLCxTx.h>
+#include <ripple/app/main/Application.h>
 #include <ripple/app/misc/FeeVote.h>
 #include <ripple/app/misc/NegativeUNLVote.h>
 #include <ripple/basics/CountedObject.h>
@@ -281,6 +282,28 @@ class RCLConsensus
             std::optional<std::chrono::milliseconds> td = std::nullopt)
         {
             timerDelay_ = td;
+        }
+
+        /** Destroy Object On Job Queue
+         *
+         * For an object that is time-consuming to destroy, this is an easy
+         * way to ensure that it's destroyed outside of a lock or other
+         * performance critical code path.
+         *
+         * @tparam T Any type.
+         * @param garbage Object to be destroyed.
+         */
+        template <class T>
+        void
+        dispose(T&& garbage)
+        {
+            app_.getJobQueue().addJob(
+                jtGARBAGE, "disposeGarbage", [g = std::move(garbage)]() {
+                    static_assert(
+                        std::is_rvalue_reference_v<decltype(garbage)>);
+                    // Postpone the destruction of the contents of g until
+                    // the closure's destructor runs on the job queue.
+                });
         }
 
     private:

--- a/src/ripple/core/Job.h
+++ b/src/ripple/core/Job.h
@@ -41,6 +41,7 @@ enum JobType {
     // insert a job at a specific priority, simply add it at the right location.
 
     jtPACK,               // Make a fetch pack for a peer
+    jtGARBAGE,            // Destroy object(s)
     jtPUBOLDLEDGER,       // An old ledger has been accepted
     jtCLIENT,             // A placeholder for the priority of all jtCLIENT jobs
     jtCLIENT_SUBSCRIBE,   // A websocket subscription by a client

--- a/src/ripple/core/JobTypes.h
+++ b/src/ripple/core/JobTypes.h
@@ -70,6 +70,7 @@ private:
         //                                                           avg     peak
         //  JobType               name                    limit    latency  latency
         add(jtPACK,              "makeFetchPack",               1,     0ms,     0ms);
+        add(jtGARBAGE,           "disposeGarbage",       maxLimit,     0ms,     0ms);
         add(jtPUBOLDLEDGER,      "publishAcqLedger",            2, 10000ms, 15000ms);
         add(jtVALIDATION_ut,     "untrustedValidation",  maxLimit,  2000ms,  5000ms);
         add(jtMANIFEST,          "manifest",             maxLimit,  2000ms,  5000ms);

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -1077,6 +1077,15 @@ struct Peer
         std::optional<std::chrono::milliseconds> vd = std::nullopt) const
     {
     }
+
+    template <class T>
+    void
+    dispose([[maybe_unused]] T&& garbage)
+    {
+        static_assert(std::is_rvalue_reference_v<decltype(garbage)>);
+        // This "empty" function runs the destructor on the garbage argument
+        // as a way to clean up accumulated garbage.
+    }
 };
 
 }  // namespace csf


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change
This is a performance enhancement that moves destruction of objects that are time consuming to destroy outside of locks.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->
As transaction volume increases, so does the size of transaction sets for each ledger. This makes it more time-consuming to destroy. Prior to the change, they were destroyed synchronously while in consensus operations, which directly caused consensus to take longer. This change moves unused tx sets into a function that executes on the job queue. Destruction is automatic that way.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [X] Performance Improvement
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

Throughput increases after the change. Also, the duration of consensus is reduced under high volumes, such as >4000/s.

<!--
## Future Tasks
For future tasks related to PR.
-->

Note: This depends on re-introduction of #4505.