### PR TITLE
Call python to upgrade pip in Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,7 +36,7 @@ jobs:
         id: pip-cache
         shell: bash
         run: |
-          pip install --upgrade pip
+          python -m pip install --upgrade pip
           echo "dir=$(pip cache dir)" | tee ${GITHUB_OUTPUT}
       - name: restore Python cache directory
         uses: actions/cache@v3


### PR DESCRIPTION
## High Level Overview of Change

The default `pip` upgrade command doesn't work properly in Windows. It needs to call `python` to work.

This PR, if merged, changes the Github Actions Windows CI job uses the correct command to upgrade PIP.

### Context of Change

[This CI run against develop](https://github.com/ximinez/rippled/actions/runs/6501578030/job/17748250161) failed because `pip` was unable to upgrade.

The error indicated
```
ERROR: To modify pip, please run the following command:
C:\hostedtoolcache\windows\Python\3.9.13\x64\python.exe -m pip install --upgrade pip
```

I don't think this problem existed when the [original, recently merged PR](https://github.com/XRPLF/rippled/pull/4596) was open, and it was open for a long time, so you'd think we would have run into it.

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)

## Test Plan

No C++ code was changed. This only affects CI, so there is nothing to test.

## Future Tasks

As mentioned in #4596, future tasks include making this job run on heavy Windows runners, so it doesn't take so dang long.
