### PR TITLE
Use unity builds to speed up Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -89,7 +89,7 @@ jobs:
           generator: '${{ matrix.generator }}'
           configuration: ${{ matrix.configuration }}
           # Hard code for now. Move to the matrix if varied options are needed
-          cmake-args: '-Dassert=ON -Dreporting=OFF -Dunity=OFF'
+          cmake-args: '-Dassert=ON -Dreporting=OFF -Dunity=ON'
       - name: test (permitted to silently fail)
         shell: bash
         # Github runners are resource limited, which causes unit tests to fail


### PR DESCRIPTION
## High Level Overview of Change

Reduces Windows CI build time by up to 50%.

### Context of Change

As described in #4596 , the automatic Windows builds take a very long time. [Nearly an hour and a half on the latest `develop`.](https://github.com/XRPLF/rippled/actions/runs/6578392383/job/17872050444)

Unity builds, while they do have issues of their own, are significantly faster - [about 45 minutes on the most recent run from this branch](https://github.com/ximinez/rippled/actions/runs/6581322465/job/17881007455), much closer to the typical MacOS ([35-40 minutes](https://github.com/XRPLF/rippled/actions/workflows/macos.yml?query=is%3Asuccess+branch%3Adevelop)) and `nix` ([~30 minutes](https://github.com/XRPLF/rippled/actions/workflows/nix.yml?query=is%3Asuccess+branch%3Adevelop)) run times.

I think this would make a good stopgap solution until a more resourced and reliable runner is available.

### Type of Change

- [X ] Refactor (non-breaking change that only restructures code)

## Test Plan

No C++ code was changed. This only affects CI, so there is nothing to test.

## Future Tasks

As mentioned in https://github.com/XRPLF/rippled/pull/4596, future tasks include making this job run on heavy Windows runners, so it doesn't take so dang long.