### PR TITLE
feat: add user version of `feature` RPC

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -28,6 +28,12 @@ The `network_id` field was added in the `server_info` response in version 1.5.0 
 
 ## XRP Ledger server version 2.0.0
 
+### Additions in 2.2
+
+Additions are intended to be non-breaking (because they are purely additive).
+
+- `feature`: A non-admin mode that uses the same formatting as admin RPC, but hides potentially-sensitive data.
+
 ### Additions in 2.0
 
 Additions are intended to be non-breaking (because they are purely additive).
@@ -35,7 +41,6 @@ Additions are intended to be non-breaking (because they are purely additive).
 - `server_definitions`: A new RPC that generates a `definitions.json`-like output that can be used in XRPL libraries.
 - In `Payment` transactions, `DeliverMax` has been added. This is a replacement for the `Amount` field, which should not be used. Typically, the `delivered_amount` (in transaction metadata) should be used. To ease the transition, `DeliverMax` is present regardless of API version, since adding a field is non-breaking.
 - API version 2 has been moved from beta to supported, meaning that it is generally available (regardless of the `beta_rpc_api` setting).
-
 
 ## XRP Ledger server version 1.12.0
 

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -81,11 +81,11 @@ public:
     firstUnsupportedExpected() const = 0;
 
     virtual Json::Value
-    getJson() const = 0;
+    getJson(bool isAdmin) const = 0;
 
     /** Returns a Json::objectValue. */
     virtual Json::Value
-    getJson(uint256 const& amendment) const = 0;
+    getJson(uint256 const& amendment, bool isAdmin) const = 0;
 
     /** Called when a new fully-validated ledger is accepted. */
     void

--- a/src/ripple/rpc/handlers/Feature1.cpp
+++ b/src/ripple/rpc/handlers/Feature1.cpp
@@ -22,6 +22,7 @@
 #include <ripple/app/misc/AmendmentTable.h>
 #include <ripple/net/RPCErr.h>
 #include <ripple/protocol/ErrorCodes.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/jss.h>
 #include <ripple/rpc/Context.h>
 
@@ -37,6 +38,7 @@ doFeature(RPC::JsonContext& context)
     if (context.app.config().reporting())
         return rpcError(rpcREPORTING_UNSUPPORTED);
 
+    bool const isAdmin = context.role == Role::ADMIN;
     // Get majority amendment status
     majorityAmendments_t majorities;
 
@@ -47,7 +49,7 @@ doFeature(RPC::JsonContext& context)
 
     if (!context.params.isMember(jss::feature))
     {
-        auto features = table.getJson();
+        auto features = table.getJson(isAdmin);
 
         for (auto const& [h, t] : majorities)
         {
@@ -69,13 +71,18 @@ doFeature(RPC::JsonContext& context)
 
     if (context.params.isMember(jss::vetoed))
     {
+        if (!isAdmin)
+            return rpcError(rpcNO_PERMISSION);
+
         if (context.params[jss::vetoed].asBool())
             table.veto(feature);
         else
             table.unVeto(feature);
     }
 
-    Json::Value jvReply = table.getJson(feature);
+    Json::Value jvReply = table.getJson(feature, isAdmin);
+    if (!jvReply)
+        return rpcError(rpcBAD_FEATURE);
 
     auto m = majorities.find(feature);
     if (m != majorities.end())

--- a/src/ripple/rpc/impl/Handler.cpp
+++ b/src/ripple/rpc/impl/Handler.cpp
@@ -105,6 +105,9 @@ Handler const handlerArray[]{
      Role::USER,
      NO_CONDITION},
     {"download_shard", byRef(&doDownloadShard), Role::ADMIN, NO_CONDITION},
+    {"feature", byRef(&doFeature), Role::USER, NO_CONDITION},
+    {"fee", byRef(&doFee), Role::USER, NEEDS_CURRENT_LEDGER},
+    {"fetch_info", byRef(&doFetchInfo), Role::ADMIN, NO_CONDITION},
 #ifdef RIPPLED_REPORTING
     {"gateway_balances", byRef(&doGatewayBalances), Role::ADMIN, NO_CONDITION},
 #else
@@ -115,9 +118,6 @@ Handler const handlerArray[]{
      byRef(&doGetAggregatePrice),
      Role::USER,
      NO_CONDITION},
-    {"feature", byRef(&doFeature), Role::ADMIN, NO_CONDITION},
-    {"fee", byRef(&doFee), Role::USER, NEEDS_CURRENT_LEDGER},
-    {"fetch_info", byRef(&doFetchInfo), Role::ADMIN, NO_CONDITION},
     {"ledger_accept",
      byRef(&doLedgerAccept),
      Role::ADMIN,

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -288,7 +288,7 @@ public:
         uint256 const unsupportedID = amendmentId(unsupported_[0]);
         {
             Json::Value const unsupp =
-                table->getJson(unsupportedID)[to_string(unsupportedID)];
+                table->getJson(unsupportedID, true)[to_string(unsupportedID)];
             BEAST_EXPECT(unsupp.size() == 0);
         }
 
@@ -296,7 +296,7 @@ public:
         table->veto(unsupportedID);
         {
             Json::Value const unsupp =
-                table->getJson(unsupportedID)[to_string(unsupportedID)];
+                table->getJson(unsupportedID, true)[to_string(unsupportedID)];
             BEAST_EXPECT(unsupp[jss::vetoed].asBool());
         }
     }
@@ -637,6 +637,22 @@ public:
         BEAST_EXPECT(ourVotes.empty());
         BEAST_EXPECT(enabled.empty());
         BEAST_EXPECT(majority.empty());
+
+        uint256 const unsupportedID = amendmentId(unsupported_[0]);
+        {
+            Json::Value const unsupp =
+                table->getJson(unsupportedID, false)[to_string(unsupportedID)];
+            BEAST_EXPECT(unsupp.size() == 0);
+        }
+
+        table->veto(unsupportedID);
+        {
+            Json::Value const unsupp =
+                table->getJson(unsupportedID, false)[to_string(unsupportedID)];
+            BEAST_EXPECT(!unsupp[jss::vetoed].asBool());
+        }
+
+        votes.emplace_back(testAmendment, validators.size());
 
         votes.emplace_back(testAmendment, validators.size());
 


### PR DESCRIPTION
## High Level Overview of Change

This PR modifies the `feature` RPC to have a non-admin mode that allows conversion from the hex encodings of amendments to human-readable strings.

Example:
```
> {
    "command": "feature",
    "feature": "2E2FB9CF8A44EB80F4694D38AADAE9B8B7ADAFD2F092E10068E61C98C4F092B0"
  }
< {
    "result": {
      "2E2FB9CF8A44EB80F4694D38AADAE9B8B7ADAFD2F092E10068E61C98C4F092B0": {
        "enabled": false,
        "name": "fixUniversalNumber",
        "supported": true
      }
    },
    "type": "response"
  }
```

### Context of Change

This has been requested by many explorer operators, so that the on-ledger hex amendment names can be decoded.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### API Impact

- [x] Public API: New feature (new methods and/or new fields)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

## Test Plan
Added tests to handle this case.