### PR TITLE
Remove include <ranges>

### DIFF
--- a/src/test/jtx/TestHelpers.h
+++ b/src/test/jtx/TestHelpers.h
@@ -35,15 +35,15 @@ namespace jtx {
 
 // Helper to make vector from iterable
 template <typename T>
-concept iterable = requires(T& v) {
-                       std::begin(v);
-                       std::end(v);
-                   };
+concept iterable = requires(T& v)
+{
+    std::begin(v);
+    std::end(v);
+};
 
 template <typename Input>
 auto
-make_vector(Input const& input)
-    requires iterable<Input>
+make_vector(Input const& input) requires iterable<Input>
 {
     return std::vector(std::begin(input), std::end(input));
 }

--- a/src/test/jtx/TestHelpers.h
+++ b/src/test/jtx/TestHelpers.h
@@ -27,17 +27,25 @@
 #include <ripple/protocol/jss.h>
 #include <test/jtx/Env.h>
 
-#include <ranges>
+#include <vector>
 
 namespace ripple {
 namespace test {
 namespace jtx {
 
 // Helper to make vector from iterable
+template <typename T>
+concept iterable = requires(T& v) {
+                       std::begin(v);
+                       std::end(v);
+                   };
+
+template <typename Input>
 auto
-make_vector(auto const& input) requires std::ranges::range<decltype(input)>
+make_vector(Input const& input)
+    requires iterable<Input>
 {
-    return std::vector(std::ranges::begin(input), std::ranges::end(input));
+    return std::vector(std::begin(input), std::end(input));
 }
 
 // Functions used in debugging

--- a/src/test/jtx/TestHelpers.h
+++ b/src/test/jtx/TestHelpers.h
@@ -33,17 +33,17 @@ namespace ripple {
 namespace test {
 namespace jtx {
 
-// Helper to make vector from iterable
-template <typename T>
-concept iterable = requires(T& v)
+// TODO We only need this long "requires" clause as polyfill, for C++20
+// implementations which are missing <ranges> header. Replace with
+// `std::ranges::range<Input>`, and accordingly use std::ranges::begin/end
+// when we have moved to better compilers.
+template <typename Input>
+auto
+make_vector(Input const& input) requires requires(Input& v)
 {
     std::begin(v);
     std::end(v);
-};
-
-template <typename Input>
-auto
-make_vector(Input const& input) requires iterable<Input>
+}
 {
     return std::vector(std::begin(input), std::end(input));
 }


### PR DESCRIPTION
## High Level Overview of Change

Remove dependency on `<ranges>` header, since it is not implemented by all compilers which we want to support. Resolves https://github.com/XRPLF/rippled/issues/4787 

### Context of Change

We only use ranges for `std::ranges::begin` and `std::ranges::end`, and for a matching concept. This can be trivially replaced with `std::begin` , `std::end` and an equivalent, trivial to write, concept.

The code change in question only affects unit tests.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)
