### PR TITLE
Add Debian 12 Bookworm to supported distro matrix

### DIFF
--- a/Builds/containers/gitlab-ci/push_to_artifactory.sh
+++ b/Builds/containers/gitlab-ci/push_to_artifactory.sh
@@ -20,7 +20,7 @@ RIPPLED_REPORTING_DBG_PKG=$(ls rippled-reporting-dbgsym_*.*deb)
 # TODO - where to upload src tgz?
 RIPPLED_SRC=$(ls rippled_*.orig.tar.gz)
 DEB_MATRIX=";deb.component=${COMPONENT};deb.architecture=amd64"
-for dist in buster bullseye bionic focal jammy; do
+for dist in bookworm buster bullseye bionic focal jammy; do
     DEB_MATRIX="${DEB_MATRIX};deb.distribution=${dist}"
 done
 echo "{ \"debs\": {" > "${TOPDIR}/files.info"

--- a/Builds/containers/gitlab-ci/smoketest.sh
+++ b/Builds/containers/gitlab-ci/smoketest.sh
@@ -62,9 +62,10 @@ else
     yum -y update
     if [ "${install_from}" = "repo" ] ; then
         pkgs=("yum-utils coreutils util-linux")
-        if [ "$ID" = "rocky" ]; then
-            pkgs="${pkgs[@]/coreutils}"
-        fi
+        case "$ID" in
+            rocky|almalinux)
+                pkgs="${pkgs[@]/coreutils}"
+        esac
         yum install -y $pkgs
         REPOFILE="/etc/yum.repos.d/artifactory.repo"
         echo "[Artifactory]" > ${REPOFILE}


### PR DESCRIPTION

## High Level Overview of Change

Add codename `bookworm` to the distro matrix during Artifactory uploads allowing Debian 12 clients to install `rippled` packages.

Ignore installing conflicting `core-utils` packages during almalinux package smoke tests.


<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change


- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (you added tests for code that already exists, or your new feature included in this PR)
