### PR TITLE
Merge `release` into `develop`

### DIFF
--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.0.0-b4"
+char const* const versionString = "2.0.0-rc2"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)


### PR DESCRIPTION
## High Level Overview of Change

Currently, the `release` branch is 2 commits ahead, 5 commits behind `develop`. This merges the two commits from `release` into `develop`:

- https://github.com/XRPLF/rippled/commit/cf4e9e55781cad2e24b7bbe0ade4d0d4efe34e5d
- https://github.com/XRPLF/rippled/commit/4977a5d43ce5e4d159aada628f021b0332708780

### Context of Change

Identical to https://github.com/XRPLF/rippled/pull/4823 but adds the merge commit.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [x] Release
