### PR TITLE
Proposed 2.0.0-rc4

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2181,8 +2181,10 @@ NetworkOPsImp::pubValidation(std::shared_ptr<STValidation> const& val)
         if (masterKey != signerPublic)
             jvObj[jss::master_key] = toBase58(TokenType::NodePublic, masterKey);
 
+        // NOTE *seq is a number, but old API versions used string. We replace
+        // number with a string using MultiApiJson near end of this function
         if (auto const seq = (*val)[~sfLedgerSequence])
-            jvObj[jss::ledger_index] = to_string(*seq);
+            jvObj[jss::ledger_index] = *seq;
 
         if (val->isFieldPresent(sfAmendments))
         {
@@ -2220,12 +2222,28 @@ NetworkOPsImp::pubValidation(std::shared_ptr<STValidation> const& val)
             reserveIncXRP && reserveIncXRP->native())
             jvObj[jss::reserve_inc] = reserveIncXRP->xrp().jsonClipped();
 
+        // NOTE Use MultiApiJson to publish two slightly different JSON objects
+        // for consumers supporting different API versions
+        MultiApiJson multiObj{jvObj};
+        visit<RPC::apiMinimumSupportedVersion, RPC::apiMaximumValidVersion>(
+            multiObj,  //
+            [](Json::Value& jvTx, unsigned int apiVersion) {
+                // Type conversion for older API versions to string
+                if (jvTx.isMember(jss::ledger_index) && apiVersion < 2)
+                {
+                    jvTx[jss::ledger_index] =
+                        std::to_string(jvTx[jss::ledger_index].asUInt());
+                }
+            });
+
         for (auto i = mStreamMaps[sValidations].begin();
              i != mStreamMaps[sValidations].end();)
         {
             if (auto p = i->second.lock())
             {
-                p->send(jvObj, true);
+                p->send(
+                    multiObj.select(apiVersionSelector(p->getApiVersion())),
+                    true);
                 ++i;
             }
             else
@@ -3159,25 +3177,10 @@ NetworkOPsImp::transJson(
     }
 
     std::string const hash = to_string(transaction->getTransactionID());
-    MultiApiJson multiObj({jvObj, jvObj});
-    // Minimum supported API version must match index 0 in MultiApiJson
-    static_assert(apiVersionSelector(RPC::apiMinimumSupportedVersion)() == 0);
-    // Last valid (possibly beta) API ver. must match last index in MultiApiJson
-    static_assert(
-        apiVersionSelector(RPC::apiMaximumValidVersion)() + 1  //
-        == MultiApiJson::size);
-    for (unsigned apiVersion = RPC::apiMinimumSupportedVersion,
-                  lastIndex = MultiApiJson::size;
-         apiVersion <= RPC::apiMaximumValidVersion;
-         ++apiVersion)
-    {
-        unsigned const index = apiVersionSelector(apiVersion)();
-        assert(index < MultiApiJson::size);
-        if (index != lastIndex)
-        {
-            lastIndex = index;
-
-            Json::Value& jvTx = multiObj.val[index];
+    MultiApiJson multiObj{jvObj};
+    visit<RPC::apiMinimumSupportedVersion, RPC::apiMaximumValidVersion>(
+        multiObj,  //
+        [&](Json::Value& jvTx, unsigned int apiVersion) {
             RPC::insertDeliverMax(
                 jvTx[jss::transaction], transaction->getTxnType(), apiVersion);
 
@@ -3190,8 +3193,7 @@ NetworkOPsImp::transJson(
             {
                 jvTx[jss::transaction][jss::hash] = hash;
             }
-        }
-    }
+        });
 
     return multiObj;
 }

--- a/src/ripple/json/MultivarJson.h
+++ b/src/ripple/json/MultivarJson.h
@@ -26,13 +26,23 @@
 #include <cassert>
 #include <concepts>
 #include <cstdlib>
+#include <type_traits>
+#include <utility>
 
 namespace ripple {
 template <std::size_t Size>
 struct MultivarJson
 {
-    std::array<Json::Value, Size> val;
+    std::array<Json::Value, Size> val = {};
     constexpr static std::size_t size = Size;
+
+    explicit MultivarJson(Json::Value const& init = {})
+    {
+        if (init == Json::Value{})
+            return;  // All elements are already default-initialized
+        for (auto& v : val)
+            v = init;
+    }
 
     Json::Value const&
     select(auto&& selector) const
@@ -68,7 +78,7 @@ struct MultivarJson
 };
 
 // Wrapper for Json for all supported API versions.
-using MultiApiJson = MultivarJson<2>;
+using MultiApiJson = MultivarJson<3>;
 
 /*
 
@@ -78,20 +88,16 @@ If a future API version change adds another possible format, change the size of
 `MultiApiJson`, and update `apiVersionSelector()` to return the appropriate
 selection value for the new `apiVersion` and higher.
 
-e.g. There are 2 formats now, the first, for version one, the second for
-versions > 1. Hypothetically, if API version 4 adds a new format, `MultiApiJson`
-would be MultivarJson<3>, and `apiVersionSelector` would return
-`static_cast<std::size_t>(apiVersion < 2 ? 0u : (apiVersion < 4 ? 1u : 2u))`
-
-NOTE:
-
 The more different JSON formats we support, the more CPU cycles we need to
-pre-build JSON for different API versions e.g. when publishing streams to
+prepare JSON for different API versions e.g. when publishing streams to
 `subscribe` clients. Hence it is desirable to keep MultiApiJson small and
 instead fully deprecate and remove support for old API versions. For example, if
 we removed support for API version 1 and added a different format for API
 version 3, the `apiVersionSelector` would change to
 `static_cast<std::size_t>(apiVersion > 2)`
+
+Such hypothetical change should correspond with change in RPCHelpers.h
+`apiMinimumSupportedVersion = 2;`
 
 */
 
@@ -101,10 +107,42 @@ apiVersionSelector(unsigned int apiVersion) noexcept
 {
     return [apiVersion]() constexpr
     {
-        // apiVersion <= 1 returns 0
-        // apiVersion > 1  returns 1
-        return static_cast<std::size_t>(apiVersion > 1);
+        return static_cast<std::size_t>(
+            apiVersion <= 1         //
+                ? 0                 //
+                : (apiVersion <= 2  //
+                       ? 1          //
+                       : 2));
     };
+}
+
+// Helper to execute a callback for every version. Want both min and max version
+// provided explicitly, so user will know to do update `size` when they change
+template <
+    unsigned int minVer,
+    unsigned int maxVer,
+    std::size_t size,
+    typename Fn>
+    requires                                       //
+    (maxVer >= minVer) &&                          //
+    (size == maxVer + 1 - minVer) &&               //
+    (apiVersionSelector(minVer)() == 0) &&         //
+    (apiVersionSelector(maxVer)() + 1 == size) &&  //
+    requires(Json::Value& json, Fn fn)
+{
+    fn(json, static_cast<unsigned int>(1));
+}
+void
+visit(MultivarJson<size>& json, Fn fn)
+{
+    [&]<std::size_t... offset>(std::index_sequence<offset...>)
+    {
+        static_assert(((apiVersionSelector(minVer + offset)() >= 0) && ...));
+        static_assert(((apiVersionSelector(minVer + offset)() < size) && ...));
+        (fn(json.val[apiVersionSelector(minVer + offset)()], minVer + offset),
+         ...);
+    }
+    (std::make_index_sequence<size>{});
 }
 
 }  // namespace ripple

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.0.0-rc3"
+char const* const versionString = "2.0.0-rc4"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -20,6 +20,7 @@
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/ledger/OpenLedger.h>
 #include <ripple/app/main/Application.h>
+#include <ripple/app/misc/DeliverMax.h>
 #include <ripple/app/misc/LoadFeeTrack.h>
 #include <ripple/app/misc/Transaction.h>
 #include <ripple/app/misc/TxQ.h>
@@ -658,6 +659,11 @@ transactionFormatResultImpl(Transaction::pointer tpTrans, unsigned apiVersion)
         }
         else
             jvResult[jss::tx_json] = tpTrans->getJson(JsonOptions::none);
+
+        RPC::insertDeliverMax(
+            jvResult[jss::tx_json],
+            tpTrans->getSTransaction()->getTxnType(),
+            apiVersion);
 
         jvResult[jss::tx_blob] =
             strHex(tpTrans->getSTransaction()->getSerializer().peekData());


### PR DESCRIPTION
Includes the two API fixes that we've been discussing.

Due to the lack of "2 weeks" of test time, @manojsdoshi has the right to reject this release candidate in favor of 2.0.0-rc3. However, these changes only impact the RPC API and are considered to be well-reviewed and low-risk bug fixes.