### PR TITLE
Change default send_queue_limit to 500

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1641,6 +1641,7 @@ port = 6006
 ip = 127.0.0.1
 admin = 127.0.0.1
 protocol = ws
+send_queue_limit = 500
 
 [port_grpc]
 port = 50051
@@ -1651,6 +1652,7 @@ secure_gateway = 127.0.0.1
 #port = 6005
 #ip = 127.0.0.1
 #protocol = wss
+#send_queue_limit = 500
 
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
Recent load on mainnet has averaged 250 txn/ledger. Clients subscribed to `transactions` over web socket are being disconnected because the traffic exceeds the default `send_queue_limit` of 100.

This changeset only touches the default configuration, not the default in code.

Fixes #4866 