### PR TITLE
[TRIVIAL] Retry codecov uploads

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -222,9 +222,13 @@ jobs:
           path: coverage.xml
           retention-days: 30
       - name: upload coverage report
-        uses: codecov/codecov-action@v3
+        uses: wandalen/wretry.action@v1.3.0
         with:
-          files: coverage.xml
-          fail_ci_if_error: true
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          action: codecov/codecov-action@v3
+          with: |
+            files: coverage.xml
+            fail_ci_if_error: true
+            verbose: true
+            token: ${{ secrets.CODECOV_TOKEN }}
+          attempt_limit: 5
+          attempt_delay: 35000 # in milliseconds


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

As a workaround for spurious codecov upload errors, wrap `codecov/codecov-action@v3` into a `wandalen/wretry.action@v1.3.0`  action

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

Spurious codecov upload errors are [documented](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954) and expected in public repos which rely on PRs via forks, like we do. The underlying cause is API rate-limiting on GitHub due to the lack of access to `CODECOV_TOKEN` secret from the PR branches on forks. Although the suggested fix is to make the `CODECOV_TOKEN` effectively public, this comes with security implications which we yet need to consider. Retrying uploads is a decent workaround, which we can apply easily.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
