### PR TITLE
Improve object lifetime management when creating temporary Rules object:

### DIFF
--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -1591,7 +1591,11 @@ public:
         });
         j.sign(keypair.first, keypair.second);
 
-        Rules defaultRules{{}};
+        // Rules store a reference to the presets. Create a local to guarantee
+        // proper lifetime.
+        std::unordered_set<uint256, beast::uhash<>> const presets;
+        Rules const defaultRules{presets};
+        BEAST_EXPECT(!defaultRules.enabled(featureExpandedSignerList));
 
         unexpected(
             !j.checkSign(STTx::RequireFullyCanonicalSig::yes, defaultRules),


### PR DESCRIPTION
## High Level Overview of Change

`Rules` objects store a reference to the `presets` provided to the ctor. One instance in unit tests passed a temporary to the ctor, which resulted in unit tests crashing on Windows on one of my [development branches](https://github.com/ximinez/rippled/actions/runs/7836973948/job/21487722006#step:14:1726) after it was rebased onto 2.1.0-rc1. There doesn't seem to be anything in 2.1.0-rc1 that caused the problem. In fact, when I switch back to changes based on the previous version (2.0.1), it fails, too, despite [the CI succeeding](https://github.com/ximinez/rippled/actions/runs/7703231608).

### Context of Change

Commit 01c37fe introduced a change to the `STTx` unit test where a local `defaultRules` object was created with a temporary inline `presets` value provided to the ctor. `Rules::Impl` stores a const ref to the presets provided to the ctor.  This particular call provided an inline temp variable, which goes out of scope as soon as the object is created. On Windows, attempting to use the `presets` (e.g. via the `enabled()` function) causes an access violation, which crashes the test run.

An audit of the code indicates that all other instances of Rules use the Application's `config.features` list, which will have a sufficient lifetime.

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)
- [X ] Tests (you added tests for code that already exists, or your new feature included in this PR)

### API Impact

None
