### PR TITLE
Fix gcc 13 compile error in Price Oracle unit-test

### DIFF
--- a/src/test/rpc/GetAggregatePrice_test.cpp
+++ b/src/test/rpc/GetAggregatePrice_test.cpp
@@ -35,10 +35,10 @@ public:
     {
         testcase("Errors");
         using namespace jtx;
+        using Oracles = std::vector<std::pair<Account, std::uint32_t>>;
         Account const owner{"owner"};
         Account const some{"some"};
-        static std::vector<std::pair<Account, std::uint32_t>> oracles = {
-            {owner, 1}};
+        static Oracles oracles = {{owner, 1}};
 
         {
             Env env(*this);
@@ -62,7 +62,7 @@ public:
                 "Missing field 'oracles'.");
 
             // empty oracles array
-            ret = Oracle::aggregatePrice(env, "XRP", "USD", {{}});
+            ret = Oracle::aggregatePrice(env, "XRP", "USD", Oracles{});
             BEAST_EXPECT(ret[jss::error].asString() == "oracleMalformed");
 
             // invalid oracle document id


### PR DESCRIPTION
## High Level Overview of Change

This fix addresses a compile error on Ubuntu gcc 13 and higher.

### Context of Change

The bug was introduced within the Price Oracle feature, specifically in the rpc unit-test `GetAggregatePrice`. The compilation fails due to an issue in the initializer list of an optional argument, which holds a vector of pairs.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release