### PR TITLE
Fix sidechain reward share rounding with new number class

### DIFF
--- a/src/ripple/app/tx/impl/XChainBridge.cpp
+++ b/src/ripple/app/tx/impl/XChainBridge.cpp
@@ -22,6 +22,7 @@
 #include <ripple/app/tx/impl/Transactor.h>
 #include <ripple/app/tx/impl/XChainBridge.h>
 #include <ripple/basics/Log.h>
+#include <ripple/basics/Number.h>
 #include <ripple/basics/XRPAmount.h>
 #include <ripple/basics/chrono.h>
 #include <ripple/beast/utility/Journal.h>
@@ -41,7 +42,6 @@
 #include <ripple/protocol/XChainAttestations.h>
 #include <ripple/protocol/digest.h>
 #include <ripple/protocol/st.h>
-
 #include <unordered_map>
 #include <unordered_set>
 
@@ -672,6 +672,12 @@ finalizeClaimHelper(
             // if the transfer failed, distribute the pool for "OnTransferFail"
             // cases (the attesters did their job)
             STAmount const share = [&] {
+                auto const round_mode =
+                    innerSb.rules().enabled(fixXChainRewardRounding)
+                    ? Number::rounding_mode::downward
+                    : Number::getround();
+                saveNumberRoundMode _{Number::setround(round_mode)};
+
                 STAmount const den{rewardAccounts.size()};
                 return divide(rewardPool, den, rewardPool.issue());
             }();

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -74,7 +74,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 69;
+static constexpr std::size_t numFeatures = 70;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -356,6 +356,7 @@ extern uint256 const fixNFTokenReserve;
 extern uint256 const fixInnerObjTemplate;
 extern uint256 const featurePriceOracle;
 extern uint256 const fixEmptyDID;
+extern uint256 const fixXChainRewardRounding;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -463,6 +463,7 @@ REGISTER_FIX    (fixNFTokenReserve,             Supported::yes, VoteBehavior::De
 REGISTER_FIX    (fixInnerObjTemplate,           Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FEATURE(PriceOracle,                   Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixEmptyDID,                   Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FIX    (fixXChainRewardRounding,       Supported::yes, VoteBehavior::DefaultNo);
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.


### PR DESCRIPTION
## High Level Overview of Change

When calculating reward shares, the amount should always be rounded
down. If the `fixUniversalNumber` amendment is not active, this works
correctly. If it is not active, then the amount is incorrectly rounded
up. This patch introduces an amendment so it will be rounded down.

### Type of Change

- [ X] Bug fix (non-breaking change which fixes an issue)