### PR TITLE
Reformat code according to clang-format-15

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,4 @@
 # To use it by default in git blame:
 # git config blame.ignoreRevsFile .git-blame-ignore-revs
 50760c693510894ca368e90369b0cc2dabfd07f3
+27917f71f312182685963f79db2204df16c68e9e

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -4,9 +4,9 @@ on: [push, pull_request]
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
-      CLANG_VERSION: 10
+      CLANG_VERSION: 15
     steps:
     - uses: actions/checkout@v3
     - name: Install clang-format
@@ -19,10 +19,8 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add
         sudo apt-get update
         sudo apt-get install clang-format-${CLANG_VERSION}
-    - name: Format src/ripple
-      run: find src/ripple -type f \( -name '*.cpp' -o -name '*.h' -o -name '*.ipp' \) -print0 | xargs -0 clang-format-${CLANG_VERSION} -i
-    - name: Format src/test
-      run: find src/test -type f \( -name '*.cpp' -o -name '*.h' -o -name '*.ipp' \) -print0 | xargs -0 clang-format-${CLANG_VERSION} -i
+    - name: Format first-party sources
+      run: find src/ripple src/test -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -o -name '*.ipp' \) -print0 | xargs -0 clang-format-${CLANG_VERSION} -i
     - name: Check for differences
       id: assert
       run: |
@@ -52,7 +50,7 @@ jobs:
           To fix it, you can do one of two things:
           1. Download and apply the patch generated as an artifact of this
              job to your repo, commit, and push.
-          2. Run 'git-clang-format --extensions c,cpp,h,cxx,ipp develop'
+          2. Run 'git-clang-format --extensions cpp,h,hpp,ipp develop'
              in your repo, commit, and push.
       run: |
         echo "${PREAMBLE}"

--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -687,8 +687,7 @@ ValidatorList::sendValidatorList(
     beast::Journal j)
 {
     std::size_t const messageVersion =
-        peer.supportsFeature(ProtocolFeature::ValidatorList2Propagation)
-        ? 2
+        peer.supportsFeature(ProtocolFeature::ValidatorList2Propagation)  ? 2
         : peer.supportsFeature(ProtocolFeature::ValidatorListPropagation) ? 1
                                                                           : 0;
     if (!messageVersion)

--- a/src/ripple/app/paths/impl/DirectStep.cpp
+++ b/src/ripple/app/paths/impl/DirectStep.cpp
@@ -236,7 +236,8 @@ public:
     using DirectStepI<DirectIPaymentStep>::DirectStepI;
     using DirectStepI<DirectIPaymentStep>::check;
 
-    bool verifyPrevStepDebtDirection(DebtDirection) const
+    bool
+    verifyPrevStepDebtDirection(DebtDirection) const
     {
         // A payment doesn't care whether or not prevStepRedeems.
         return true;

--- a/src/ripple/basics/Expected.h
+++ b/src/ripple/basics/Expected.h
@@ -136,39 +136,43 @@ class [[nodiscard]] Expected
 
 public:
     template <typename U>
-    requires std::convertible_to<U, T> constexpr Expected(U && r)
-        : Base(T(std::forward<U>(r)))
+        requires std::convertible_to<U, T>
+    constexpr Expected(U&& r) : Base(T(std::forward<U>(r)))
     {
     }
 
     template <typename U>
-        requires std::convertible_to<U, E> &&
-        (!std::is_reference_v<U>)constexpr Expected(Unexpected<U> e)
-        : Base(E(std::move(e.value())))
+        requires std::convertible_to<U, E> && (!std::is_reference_v<U>)
+    constexpr Expected(Unexpected<U> e) : Base(E(std::move(e.value())))
     {
     }
 
-    constexpr bool has_value() const
+    constexpr bool
+    has_value() const
     {
         return Base::has_value();
     }
 
-    constexpr T const& value() const
+    constexpr T const&
+    value() const
     {
         return Base::value();
     }
 
-    constexpr T& value()
+    constexpr T&
+    value()
     {
         return Base::value();
     }
 
-    constexpr E const& error() const
+    constexpr E const&
+    error() const
     {
         return Base::error();
     }
 
-    constexpr E& error()
+    constexpr E&
+    error()
     {
         return Base::error();
     }
@@ -181,22 +185,26 @@ public:
     // Add operator* and operator-> so the Expected API looks a bit more like
     // what std::expected is likely to look like.  See:
     // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0323r10.html
-    [[nodiscard]] constexpr T& operator*()
+    [[nodiscard]] constexpr T&
+    operator*()
     {
         return this->value();
     }
 
-    [[nodiscard]] constexpr T const& operator*() const
+    [[nodiscard]] constexpr T const&
+    operator*() const
     {
         return this->value();
     }
 
-    [[nodiscard]] constexpr T* operator->()
+    [[nodiscard]] constexpr T*
+    operator->()
     {
         return &this->value();
     }
 
-    [[nodiscard]] constexpr T const* operator->() const
+    [[nodiscard]] constexpr T const*
+    operator->() const
     {
         return &this->value();
     }
@@ -218,18 +226,19 @@ public:
     }
 
     template <typename U>
-        requires std::convertible_to<U, E> &&
-        (!std::is_reference_v<U>)constexpr Expected(Unexpected<U> e)
-        : Base(E(std::move(e.value())))
+        requires std::convertible_to<U, E> && (!std::is_reference_v<U>)
+    constexpr Expected(Unexpected<U> e) : Base(E(std::move(e.value())))
     {
     }
 
-    constexpr E const& error() const
+    constexpr E const&
+    error() const
     {
         return Base::error();
     }
 
-    constexpr E& error()
+    constexpr E&
+    error()
     {
         return Base::error();
     }

--- a/src/ripple/basics/FeeUnits.h
+++ b/src/ripple/basics/FeeUnits.h
@@ -84,13 +84,13 @@ private:
 protected:
     template <class Other>
     static constexpr bool is_compatible_v =
-        std::is_arithmetic_v<Other>&& std::is_arithmetic_v<value_type>&&
-            std::is_convertible_v<Other, value_type>;
+        std::is_arithmetic_v<Other> && std::is_arithmetic_v<value_type> &&
+        std::is_convertible_v<Other, value_type>;
 
     template <class OtherFee, class = enable_if_unit_t<OtherFee>>
     static constexpr bool is_compatiblefee_v =
-        is_compatible_v<typename OtherFee::value_type>&&
-            std::is_same_v<UnitTag, typename OtherFee::unit_type>;
+        is_compatible_v<typename OtherFee::value_type> &&
+        std::is_same_v<UnitTag, typename OtherFee::unit_type>;
 
     template <class Other>
     using enable_if_compatible_t =
@@ -110,7 +110,8 @@ public:
     {
     }
 
-    constexpr TaggedFee& operator=(beast::Zero)
+    constexpr TaggedFee&
+    operator=(beast::Zero)
     {
         fee_ = 0;
         return *this;
@@ -344,8 +345,8 @@ constexpr bool can_muldiv_source_v =
 
 template <class Dest, class = enable_if_unit_t<Dest>>
 constexpr bool can_muldiv_dest_v =
-    can_muldiv_source_v<Dest>&&  // Dest is also a source
-        std::is_convertible_v<std::uint64_t, typename Dest::value_type> &&
+    can_muldiv_source_v<Dest> &&  // Dest is also a source
+    std::is_convertible_v<std::uint64_t, typename Dest::value_type> &&
     sizeof(typename Dest::value_type) >= sizeof(std::uint64_t);
 
 template <
@@ -354,8 +355,8 @@ template <
     class = enable_if_unit_t<Source1>,
     class = enable_if_unit_t<Source2>>
 constexpr bool can_muldiv_sources_v =
-    can_muldiv_source_v<Source1>&& can_muldiv_source_v<Source2>&& std::
-        is_same_v<typename Source1::unit_type, typename Source2::unit_type>;
+    can_muldiv_source_v<Source1> && can_muldiv_source_v<Source2> &&
+    std::is_same_v<typename Source1::unit_type, typename Source2::unit_type>;
 
 template <
     class Source1,
@@ -365,7 +366,7 @@ template <
     class = enable_if_unit_t<Source2>,
     class = enable_if_unit_t<Dest>>
 constexpr bool can_muldiv_v =
-    can_muldiv_sources_v<Source1, Source2>&& can_muldiv_dest_v<Dest>;
+    can_muldiv_sources_v<Source1, Source2> && can_muldiv_dest_v<Dest>;
 // Source and Dest can be the same by default
 
 template <

--- a/src/ripple/basics/IOUAmount.h
+++ b/src/ripple/basics/IOUAmount.h
@@ -109,7 +109,8 @@ inline IOUAmount::IOUAmount(std::int64_t mantissa, int exponent)
     normalize();
 }
 
-inline IOUAmount& IOUAmount::operator=(beast::Zero)
+inline IOUAmount&
+IOUAmount::operator=(beast::Zero)
 {
     // The -100 is used to allow 0 to sort less than small positive values
     // which will have a large negative exponent.

--- a/src/ripple/basics/XRPAmount.h
+++ b/src/ripple/basics/XRPAmount.h
@@ -65,7 +65,8 @@ public:
     {
     }
 
-    constexpr XRPAmount& operator=(beast::Zero)
+    constexpr XRPAmount&
+    operator=(beast::Zero)
     {
         drops_ = 0;
         return *this;

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -521,7 +521,8 @@ public:
         return bytes;
     }
 
-    base_uint<Bits, Tag>& operator=(beast::Zero)
+    base_uint<Bits, Tag>&
+    operator=(beast::Zero)
     {
         data_.fill(0);
         return *this;

--- a/src/ripple/basics/impl/ResolverAsio.cpp
+++ b/src/ripple/basics/impl/ResolverAsio.cpp
@@ -232,7 +232,8 @@ public:
 
     //-------------------------------------------------------------------------
     // Resolver
-    void do_stop(CompletionCounter)
+    void
+    do_stop(CompletionCounter)
     {
         assert(m_stop_called == true);
 
@@ -330,7 +331,8 @@ public:
             std::string(port_first, port_last));
     }
 
-    void do_work(CompletionCounter)
+    void
+    do_work(CompletionCounter)
     {
         if (m_stop_called == true)
             return;

--- a/src/ripple/beast/insight/impl/NullCollector.cpp
+++ b/src/ripple/beast/insight/impl/NullCollector.cpp
@@ -41,7 +41,8 @@ class NullCounterImpl : public CounterImpl
 public:
     explicit NullCounterImpl() = default;
 
-    void increment(value_type) override
+    void
+    increment(value_type) override
     {
     }
 
@@ -74,11 +75,13 @@ class NullGaugeImpl : public GaugeImpl
 public:
     explicit NullGaugeImpl() = default;
 
-    void set(value_type) override
+    void
+    set(value_type) override
     {
     }
 
-    void increment(difference_type) override
+    void
+    increment(difference_type) override
     {
     }
 
@@ -94,7 +97,8 @@ class NullMeterImpl : public MeterImpl
 public:
     explicit NullMeterImpl() = default;
 
-    void increment(value_type) override
+    void
+    increment(value_type) override
     {
     }
 

--- a/src/ripple/beast/test/fail_counter.hpp
+++ b/src/ripple/beast/test/fail_counter.hpp
@@ -8,16 +8,13 @@
 #ifndef BEAST_TEST_FAIL_COUNTER_HPP
 #define BEAST_TEST_FAIL_COUNTER_HPP
 
-#include <beast/core/error.hpp>
 #include <boost/throw_exception.hpp>
+#include <beast/core/error.hpp>
 
 namespace beast {
 namespace test {
 
-enum class error
-{
-    fail_error = 1
-};
+enum class error { fail_error = 1 };
 
 namespace detail {
 
@@ -33,11 +30,11 @@ public:
     std::string
     message(int ev) const override
     {
-        switch(static_cast<error>(ev))
+        switch (static_cast<error>(ev))
         {
-        default:
-        case error::fail_error:
-            return "test error";
+            default:
+            case error::fail_error:
+                return "test error";
         }
     }
 
@@ -48,39 +45,34 @@ public:
     }
 
     bool
-    equivalent(int ev,
-        boost::system::error_condition const& condition
-            ) const noexcept override
+    equivalent(int ev, boost::system::error_condition const& condition)
+        const noexcept override
     {
-        return condition.value() == ev &&
-            &condition.category() == this;
+        return condition.value() == ev && &condition.category() == this;
     }
 
     bool
     equivalent(error_code const& error, int ev) const noexcept override
     {
-        return error.value() == ev &&
-            &error.category() == this;
+        return error.value() == ev && &error.category() == this;
     }
 };
 
-inline
-boost::system::error_category const&
+inline boost::system::error_category const&
 get_error_category()
 {
     static fail_error_category const cat{};
     return cat;
 }
 
-} // detail
+}  // namespace detail
 
-inline
-error_code
+inline error_code
 make_error_code(error ev)
 {
     return error_code{
         static_cast<std::underlying_type<error>::type>(ev),
-            detail::get_error_category()};
+        detail::get_error_category()};
 }
 
 /** An error code with an error set on default construction
@@ -91,12 +83,11 @@ make_error_code(error ev)
 */
 struct fail_error_code : error_code
 {
-    fail_error_code()
-        : error_code(make_error_code(error::fail_error))
+    fail_error_code() : error_code(make_error_code(error::fail_error))
     {
     }
 
-    template<class Arg0, class... ArgN>
+    template <class Arg0, class... ArgN>
     fail_error_code(Arg0&& arg0, ArgN&&... argn)
         : error_code(arg0, std::forward<ArgN>(argn)...)
     {
@@ -120,11 +111,10 @@ public:
 
         @param The 0-based index of the operation to fail on or after.
     */
-    explicit
-    fail_counter(std::size_t n,
-            error_code ev = make_error_code(error::fail_error))
-        : n_(n)
-        , ec_(ev)
+    explicit fail_counter(
+        std::size_t n,
+        error_code ev = make_error_code(error::fail_error))
+        : n_(n), ec_(ev)
     {
     }
 
@@ -132,9 +122,9 @@ public:
     void
     fail()
     {
-        if(n_ > 0)
+        if (n_ > 0)
             --n_;
-        if(! n_)
+        if (!n_)
             BOOST_THROW_EXCEPTION(system_error{ec_});
     }
 
@@ -142,9 +132,9 @@ public:
     bool
     fail(error_code& ec)
     {
-        if(n_ > 0)
+        if (n_ > 0)
             --n_;
-        if(! n_)
+        if (!n_)
         {
             ec = ec_;
             return true;
@@ -154,17 +144,17 @@ public:
     }
 };
 
-} // test
-} // beast
+}  // namespace test
+}  // namespace beast
 
 namespace boost {
 namespace system {
-template<>
+template <>
 struct is_error_code_enum<beast::test::error>
 {
     static bool const value = true;
 };
-} // system
-} // boost
+}  // namespace system
+}  // namespace boost
 
 #endif

--- a/src/ripple/beast/test/pipe_stream.hpp
+++ b/src/ripple/beast/test/pipe_stream.hpp
@@ -8,17 +8,17 @@
 #ifndef BEAST_TEST_PIPE_STREAM_HPP
 #define BEAST_TEST_PIPE_STREAM_HPP
 
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/assert.hpp>
+#include <boost/throw_exception.hpp>
 #include <beast/core/async_result.hpp>
 #include <beast/core/bind_handler.hpp>
 #include <beast/core/flat_buffer.hpp>
 #include <beast/core/string.hpp>
 #include <beast/core/type_traits.hpp>
-#include <beast/websocket/teardown.hpp>
 #include <beast/test/fail_counter.hpp>
-#include <boost/asio/buffer.hpp>
-#include <boost/asio/io_service.hpp>
-#include <boost/assert.hpp>
-#include <boost/throw_exception.hpp>
+#include <beast/websocket/teardown.hpp>
 #include <condition_variable>
 #include <limits>
 #include <mutex>
@@ -46,7 +46,8 @@ private:
     struct read_op
     {
         virtual ~read_op() = default;
-        virtual void operator()() = 0;
+        virtual void
+        operator()() = 0;
     };
 
     struct state
@@ -69,24 +70,18 @@ public:
     {
         friend class pipe;
 
-        template<class Handler, class Buffers>
+        template <class Handler, class Buffers>
         class read_op_impl;
 
         state& in_;
         state& out_;
         boost::asio::io_service& ios_;
         fail_counter* fc_ = nullptr;
-        std::size_t read_max_ =
-            (std::numeric_limits<std::size_t>::max)();
-        std::size_t write_max_ =
-            (std::numeric_limits<std::size_t>::max)();
+        std::size_t read_max_ = (std::numeric_limits<std::size_t>::max)();
+        std::size_t write_max_ = (std::numeric_limits<std::size_t>::max)();
 
-        stream(state& in, state& out,
-                boost::asio::io_service& ios)
-            : in_(in)
-            , out_(out)
-            , ios_(ios)
-            , buffer(in_.b)
+        stream(state& in, state& out, boost::asio::io_service& ios)
+            : in_(in), out_(out), ios_(ios), buffer(in_.b)
         {
         }
 
@@ -148,8 +143,7 @@ public:
         void
         clear()
         {
-            in_.b.consume((std::numeric_limits<
-                std::size_t>::max)());
+            in_.b.consume((std::numeric_limits<std::size_t>::max)());
         }
 
         /** Close the stream.
@@ -157,57 +151,56 @@ public:
             The other end of the pipe will see
             `boost::asio::error::eof` on read.
         */
-        template<class = void>
+        template <class = void>
         void
         close();
 
-        template<class MutableBufferSequence>
+        template <class MutableBufferSequence>
         std::size_t
         read_some(MutableBufferSequence const& buffers);
 
-        template<class MutableBufferSequence>
+        template <class MutableBufferSequence>
         std::size_t
-        read_some(MutableBufferSequence const& buffers,
-            error_code& ec);
+        read_some(MutableBufferSequence const& buffers, error_code& ec);
 
-        template<class MutableBufferSequence, class ReadHandler>
-        async_return_type<
-            ReadHandler, void(error_code, std::size_t)>
-        async_read_some(MutableBufferSequence const& buffers,
+        template <class MutableBufferSequence, class ReadHandler>
+        async_return_type<ReadHandler, void(error_code, std::size_t)>
+        async_read_some(
+            MutableBufferSequence const& buffers,
             ReadHandler&& handler);
 
-        template<class ConstBufferSequence>
+        template <class ConstBufferSequence>
         std::size_t
         write_some(ConstBufferSequence const& buffers);
 
-        template<class ConstBufferSequence>
+        template <class ConstBufferSequence>
         std::size_t
-        write_some(
-            ConstBufferSequence const& buffers, error_code&);
+        write_some(ConstBufferSequence const& buffers, error_code&);
 
-        template<class ConstBufferSequence, class WriteHandler>
-        async_return_type<
-            WriteHandler, void(error_code, std::size_t)>
-        async_write_some(ConstBufferSequence const& buffers,
+        template <class ConstBufferSequence, class WriteHandler>
+        async_return_type<WriteHandler, void(error_code, std::size_t)>
+        async_write_some(
+            ConstBufferSequence const& buffers,
             WriteHandler&& handler);
 
-        friend
-        void
-        teardown(websocket::teardown_tag,
-            stream&, boost::system::error_code& ec)
+        friend void
+        teardown(
+            websocket::teardown_tag,
+            stream&,
+            boost::system::error_code& ec)
         {
             ec.assign(0, ec.category());
         }
 
-        template<class TeardownHandler>
-        friend
-        void
-        async_teardown(websocket::teardown_tag,
-            stream& s, TeardownHandler&& handler)
+        template <class TeardownHandler>
+        friend void
+        async_teardown(
+            websocket::teardown_tag,
+            stream& s,
+            TeardownHandler&& handler)
         {
             s.get_io_service().post(
-                bind_handler(std::move(handler),
-                    error_code{}));
+                bind_handler(std::move(handler), error_code{}));
         }
     };
 
@@ -215,10 +208,8 @@ public:
 
         The client and server endpoints will use the same `io_service`.
     */
-    explicit
-    pipe(boost::asio::io_service& ios)
-        : client(s_[0], s_[1], ios)
-        , server(s_[1], s_[0], ios)
+    explicit pipe(boost::asio::io_service& ios)
+        : client(s_[0], s_[1], ios), server(s_[1], s_[0], ios)
     {
     }
 
@@ -226,11 +217,8 @@ public:
 
         The client and server endpoints will different `io_service` objects.
     */
-    explicit
-    pipe(boost::asio::io_service& ios1,
-            boost::asio::io_service& ios2)
-        : client(s_[0], s_[1], ios1)
-        , server(s_[1], s_[0], ios2)
+    explicit pipe(boost::asio::io_service& ios1, boost::asio::io_service& ios2)
+        : client(s_[0], s_[1], ios1), server(s_[1], s_[0], ios2)
     {
     }
 
@@ -243,28 +231,21 @@ public:
 
 //------------------------------------------------------------------------------
 
-template<class Handler, class Buffers>
-class pipe::stream::read_op_impl :
-    public pipe::read_op
+template <class Handler, class Buffers>
+class pipe::stream::read_op_impl : public pipe::read_op
 {
     stream& s_;
     Buffers b_;
     Handler h_;
 
 public:
-    read_op_impl(stream& s,
-            Buffers const& b, Handler&& h)
-        : s_(s)
-        , b_(b)
-        , h_(std::move(h))
+    read_op_impl(stream& s, Buffers const& b, Handler&& h)
+        : s_(s), b_(b), h_(std::move(h))
     {
     }
 
-    read_op_impl(stream& s,
-            Buffers const& b, Handler const& h)
-        : s_(s)
-        , b_(b)
-        , h_(h)
+    read_op_impl(stream& s, Buffers const& b, Handler const& h)
+        : s_(s), b_(b), h_(h)
     {
     }
 
@@ -274,103 +255,89 @@ public:
 
 //------------------------------------------------------------------------------
 
-template<class Handler, class Buffers>
+template <class Handler, class Buffers>
 void
-pipe::stream::
-read_op_impl<Handler, Buffers>::operator()()
+pipe::stream::read_op_impl<Handler, Buffers>::operator()()
 {
     using boost::asio::buffer_copy;
     using boost::asio::buffer_size;
-    s_.ios_.post(
-        [&]()
+    s_.ios_.post([&]() {
+        BOOST_ASSERT(s_.in_.op);
+        std::unique_lock<std::mutex> lock{s_.in_.m};
+        if (s_.in_.b.size() > 0)
         {
-            BOOST_ASSERT(s_.in_.op);
-            std::unique_lock<std::mutex> lock{s_.in_.m};
-            if(s_.in_.b.size() > 0)
-            {
-                auto const bytes_transferred = buffer_copy(
-                    b_, s_.in_.b.data(), s_.read_max_);
-                s_.in_.b.consume(bytes_transferred);
-                auto& s = s_;
-                Handler h{std::move(h_)};
-                lock.unlock();
-                s.in_.op.reset(nullptr);
-                ++s.nread;
-                s.ios_.post(bind_handler(std::move(h),
-                    error_code{}, bytes_transferred));
-            }
-            else
-            {
-                BOOST_ASSERT(s_.in_.eof);
-                auto& s = s_;
-                Handler h{std::move(h_)};
-                lock.unlock();
-                s.in_.op.reset(nullptr);
-                ++s.nread;
-                s.ios_.post(bind_handler(std::move(h),
-                    boost::asio::error::eof, 0));
-            }
-        });
+            auto const bytes_transferred =
+                buffer_copy(b_, s_.in_.b.data(), s_.read_max_);
+            s_.in_.b.consume(bytes_transferred);
+            auto& s = s_;
+            Handler h{std::move(h_)};
+            lock.unlock();
+            s.in_.op.reset(nullptr);
+            ++s.nread;
+            s.ios_.post(
+                bind_handler(std::move(h), error_code{}, bytes_transferred));
+        }
+        else
+        {
+            BOOST_ASSERT(s_.in_.eof);
+            auto& s = s_;
+            Handler h{std::move(h_)};
+            lock.unlock();
+            s.in_.op.reset(nullptr);
+            ++s.nread;
+            s.ios_.post(bind_handler(std::move(h), boost::asio::error::eof, 0));
+        }
+    });
 }
 
 //------------------------------------------------------------------------------
 
-template<class>
+template <class>
 void
-pipe::stream::
-close()
+pipe::stream::close()
 {
     std::lock_guard lock{out_.m};
     out_.eof = true;
-    if(out_.op)
+    if (out_.op)
         out_.op.get()->operator()();
     else
         out_.cv.notify_all();
 }
 
-
-template<class MutableBufferSequence>
+template <class MutableBufferSequence>
 std::size_t
-pipe::stream::
-read_some(MutableBufferSequence const& buffers)
+pipe::stream::read_some(MutableBufferSequence const& buffers)
 {
-    static_assert(is_mutable_buffer_sequence<
-            MutableBufferSequence>::value,
+    static_assert(
+        is_mutable_buffer_sequence<MutableBufferSequence>::value,
         "MutableBufferSequence requirements not met");
     error_code ec;
     auto const n = read_some(buffers, ec);
-    if(ec)
+    if (ec)
         BOOST_THROW_EXCEPTION(system_error{ec});
     return n;
 }
 
-template<class MutableBufferSequence>
+template <class MutableBufferSequence>
 std::size_t
-pipe::stream::
-read_some(MutableBufferSequence const& buffers,
-    error_code& ec)
+pipe::stream::read_some(MutableBufferSequence const& buffers, error_code& ec)
 {
-    static_assert(is_mutable_buffer_sequence<
-            MutableBufferSequence>::value,
+    static_assert(
+        is_mutable_buffer_sequence<MutableBufferSequence>::value,
         "MutableBufferSequence requirements not met");
     using boost::asio::buffer_copy;
     using boost::asio::buffer_size;
-    BOOST_ASSERT(! in_.op);
+    BOOST_ASSERT(!in_.op);
     BOOST_ASSERT(buffer_size(buffers) > 0);
-    if(fc_ && fc_->fail(ec))
+    if (fc_ && fc_->fail(ec))
         return 0;
     std::unique_lock<std::mutex> lock{in_.m};
-    in_.cv.wait(lock,
-        [&]()
-        {
-            return in_.b.size() > 0 || in_.eof;
-        });
+    in_.cv.wait(lock, [&]() { return in_.b.size() > 0 || in_.eof; });
     std::size_t bytes_transferred;
-    if(in_.b.size() > 0)
-    {   
+    if (in_.b.size() > 0)
+    {
         ec.assign(0, ec.category());
-        bytes_transferred = buffer_copy(
-            buffers, in_.b.data(), read_max_);
+        bytes_transferred = buffer_copy(buffers, in_.b.data(), read_max_);
         in_.b.consume(bytes_transferred);
     }
     else
@@ -383,99 +350,90 @@ read_some(MutableBufferSequence const& buffers,
     return bytes_transferred;
 }
 
-template<class MutableBufferSequence, class ReadHandler>
-async_return_type<
-    ReadHandler, void(error_code, std::size_t)>
-pipe::stream::
-async_read_some(MutableBufferSequence const& buffers,
+template <class MutableBufferSequence, class ReadHandler>
+async_return_type<ReadHandler, void(error_code, std::size_t)>
+pipe::stream::async_read_some(
+    MutableBufferSequence const& buffers,
     ReadHandler&& handler)
 {
-    static_assert(is_mutable_buffer_sequence<
-            MutableBufferSequence>::value,
+    static_assert(
+        is_mutable_buffer_sequence<MutableBufferSequence>::value,
         "MutableBufferSequence requirements not met");
     using boost::asio::buffer_copy;
     using boost::asio::buffer_size;
-    BOOST_ASSERT(! in_.op);
+    BOOST_ASSERT(!in_.op);
     BOOST_ASSERT(buffer_size(buffers) > 0);
-    async_completion<ReadHandler,
-        void(error_code, std::size_t)> init{handler};
-    if(fc_)
+    async_completion<ReadHandler, void(error_code, std::size_t)> init{handler};
+    if (fc_)
     {
         error_code ec;
-        if(fc_->fail(ec))
-            return ios_.post(bind_handler(
-                init.completion_handler, ec, 0));
+        if (fc_->fail(ec))
+            return ios_.post(bind_handler(init.completion_handler, ec, 0));
     }
     {
         std::unique_lock<std::mutex> lock{in_.m};
-        if(in_.eof)
+        if (in_.eof)
         {
             lock.unlock();
             ++nread;
-            ios_.post(bind_handler(init.completion_handler,
-                boost::asio::error::eof, 0));
+            ios_.post(bind_handler(
+                init.completion_handler, boost::asio::error::eof, 0));
         }
-        else if(buffer_size(buffers) == 0 ||
-            buffer_size(in_.b.data()) > 0)
+        else if (buffer_size(buffers) == 0 || buffer_size(in_.b.data()) > 0)
         {
-            auto const bytes_transferred = buffer_copy(
-                buffers, in_.b.data(), read_max_);
+            auto const bytes_transferred =
+                buffer_copy(buffers, in_.b.data(), read_max_);
             in_.b.consume(bytes_transferred);
             lock.unlock();
             ++nread;
-            ios_.post(bind_handler(init.completion_handler,
-                error_code{}, bytes_transferred));
+            ios_.post(bind_handler(
+                init.completion_handler, error_code{}, bytes_transferred));
         }
         else
         {
-            in_.op.reset(new read_op_impl<handler_type<
-                ReadHandler, void(error_code, std::size_t)>,
-                    MutableBufferSequence>{*this, buffers,
-                        init.completion_handler});
+            in_.op.reset(
+                new read_op_impl<
+                    handler_type<ReadHandler, void(error_code, std::size_t)>,
+                    MutableBufferSequence>{
+                    *this, buffers, init.completion_handler});
         }
     }
     return init.result.get();
 }
 
-template<class ConstBufferSequence>
+template <class ConstBufferSequence>
 std::size_t
-pipe::stream::
-write_some(ConstBufferSequence const& buffers)
+pipe::stream::write_some(ConstBufferSequence const& buffers)
 {
-    static_assert(is_const_buffer_sequence<
-            ConstBufferSequence>::value,
+    static_assert(
+        is_const_buffer_sequence<ConstBufferSequence>::value,
         "ConstBufferSequence requirements not met");
-    BOOST_ASSERT(! out_.eof);
+    BOOST_ASSERT(!out_.eof);
     error_code ec;
-    auto const bytes_transferred =
-        write_some(buffers, ec);
-    if(ec)
+    auto const bytes_transferred = write_some(buffers, ec);
+    if (ec)
         BOOST_THROW_EXCEPTION(system_error{ec});
     return bytes_transferred;
 }
 
-template<class ConstBufferSequence>
+template <class ConstBufferSequence>
 std::size_t
-pipe::stream::
-write_some(
-    ConstBufferSequence const& buffers, error_code& ec)
+pipe::stream::write_some(ConstBufferSequence const& buffers, error_code& ec)
 {
-    static_assert(is_const_buffer_sequence<
-            ConstBufferSequence>::value,
+    static_assert(
+        is_const_buffer_sequence<ConstBufferSequence>::value,
         "ConstBufferSequence requirements not met");
     using boost::asio::buffer_copy;
     using boost::asio::buffer_size;
-    BOOST_ASSERT(! out_.eof);
-    if(fc_ && fc_->fail(ec))
+    BOOST_ASSERT(!out_.eof);
+    if (fc_ && fc_->fail(ec))
         return 0;
-    auto const n = (std::min)(
-        buffer_size(buffers), write_max_);
+    auto const n = (std::min)(buffer_size(buffers), write_max_);
     std::unique_lock<std::mutex> lock{out_.m};
-    auto const bytes_transferred =
-        buffer_copy(out_.b.prepare(n), buffers);
+    auto const bytes_transferred = buffer_copy(out_.b.prepare(n), buffers);
     out_.b.commit(bytes_transferred);
     lock.unlock();
-    if(out_.op)
+    if (out_.op)
         out_.op.get()->operator()();
     else
         out_.cv.notify_all();
@@ -484,46 +442,41 @@ write_some(
     return bytes_transferred;
 }
 
-template<class ConstBufferSequence, class WriteHandler>
-async_return_type<
-    WriteHandler, void(error_code, std::size_t)>
-pipe::stream::
-async_write_some(ConstBufferSequence const& buffers,
+template <class ConstBufferSequence, class WriteHandler>
+async_return_type<WriteHandler, void(error_code, std::size_t)>
+pipe::stream::async_write_some(
+    ConstBufferSequence const& buffers,
     WriteHandler&& handler)
 {
-    static_assert(is_const_buffer_sequence<
-            ConstBufferSequence>::value,
+    static_assert(
+        is_const_buffer_sequence<ConstBufferSequence>::value,
         "ConstBufferSequence requirements not met");
     using boost::asio::buffer_copy;
     using boost::asio::buffer_size;
-    BOOST_ASSERT(! out_.eof);
-    async_completion<WriteHandler,
-        void(error_code, std::size_t)> init{handler};
-    if(fc_)
+    BOOST_ASSERT(!out_.eof);
+    async_completion<WriteHandler, void(error_code, std::size_t)> init{handler};
+    if (fc_)
     {
         error_code ec;
-        if(fc_->fail(ec))
-            return ios_.post(bind_handler(
-                init.completion_handler, ec, 0));
+        if (fc_->fail(ec))
+            return ios_.post(bind_handler(init.completion_handler, ec, 0));
     }
-    auto const n =
-        (std::min)(buffer_size(buffers), write_max_);
+    auto const n = (std::min)(buffer_size(buffers), write_max_);
     std::unique_lock<std::mutex> lock{out_.m};
-    auto const bytes_transferred =
-        buffer_copy(out_.b.prepare(n), buffers);
+    auto const bytes_transferred = buffer_copy(out_.b.prepare(n), buffers);
     out_.b.commit(bytes_transferred);
     lock.unlock();
-    if(out_.op)
+    if (out_.op)
         out_.op.get()->operator()();
     else
         out_.cv.notify_all();
     ++nwrite;
-    ios_.post(bind_handler(init.completion_handler,
-        error_code{}, bytes_transferred));
+    ios_.post(
+        bind_handler(init.completion_handler, error_code{}, bytes_transferred));
     return init.result.get();
 }
 
-} // test
-} // beast
+}  // namespace test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/test/sig_wait.hpp
+++ b/src/ripple/beast/test/sig_wait.hpp
@@ -14,21 +14,16 @@ namespace beast {
 namespace test {
 
 /// Block until SIGINT or SIGTERM is received.
-inline
-void
+inline void
 sig_wait()
 {
     boost::asio::io_service ios;
-    boost::asio::signal_set signals(
-        ios, SIGINT, SIGTERM);
-    signals.async_wait(
-        [&](boost::system::error_code const&, int)
-        {
-        });
+    boost::asio::signal_set signals(ios, SIGINT, SIGTERM);
+    signals.async_wait([&](boost::system::error_code const&, int) {});
     ios.run();
 }
 
-} // test
-} // beast
+}  // namespace test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/test/string_iostream.hpp
+++ b/src/ripple/beast/test/string_iostream.hpp
@@ -8,20 +8,21 @@
 #ifndef BEAST_TEST_STRING_IOSTREAM_HPP
 #define BEAST_TEST_STRING_IOSTREAM_HPP
 
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/throw_exception.hpp>
 #include <beast/core/async_result.hpp>
 #include <beast/core/bind_handler.hpp>
 #include <beast/core/buffer_prefix.hpp>
 #include <beast/core/error.hpp>
 #include <beast/websocket/teardown.hpp>
-#include <boost/asio/buffer.hpp>
-#include <boost/asio/io_service.hpp>
-#include <boost/throw_exception.hpp>
 #include <string>
 
 namespace beast {
 namespace test {
 
-/** A SyncStream and AsyncStream that reads from a string and writes to another string.
+/** A SyncStream and AsyncStream that reads from a string and writes to another
+   string.
 
     This class behaves like a socket, except that written data is
     appended to a string exposed as a public data member, and when
@@ -37,9 +38,10 @@ class string_iostream
 public:
     std::string str;
 
-    string_iostream(boost::asio::io_service& ios,
-            std::string s, std::size_t read_max =
-                (std::numeric_limits<std::size_t>::max)())
+    string_iostream(
+        boost::asio::io_service& ios,
+        std::string s,
+        std::size_t read_max = (std::numeric_limits<std::size_t>::max)())
         : s_(std::move(s))
         , cb_(boost::asio::buffer(s_))
         , ios_(ios)
@@ -53,25 +55,24 @@ public:
         return ios_;
     }
 
-    template<class MutableBufferSequence>
+    template <class MutableBufferSequence>
     std::size_t
     read_some(MutableBufferSequence const& buffers)
     {
         error_code ec;
         auto const n = read_some(buffers, ec);
-        if(ec)
+        if (ec)
             BOOST_THROW_EXCEPTION(system_error{ec});
         return n;
     }
 
-    template<class MutableBufferSequence>
+    template <class MutableBufferSequence>
     std::size_t
-    read_some(MutableBufferSequence const& buffers,
-        error_code& ec)
+    read_some(MutableBufferSequence const& buffers, error_code& ec)
     {
-        auto const n = boost::asio::buffer_copy(
-            buffers, buffer_prefix(read_max_, cb_));
-        if(n > 0)
+        auto const n =
+            boost::asio::buffer_copy(buffers, buffer_prefix(read_max_, cb_));
+        if (n > 0)
         {
             ec.assign(0, ec.category());
             cb_ = cb_ + n;
@@ -83,91 +84,83 @@ public:
         return n;
     }
 
-    template<class MutableBufferSequence, class ReadHandler>
-    async_return_type<
-        ReadHandler, void(error_code, std::size_t)>
-    async_read_some(MutableBufferSequence const& buffers,
-        ReadHandler&& handler)
+    template <class MutableBufferSequence, class ReadHandler>
+    async_return_type<ReadHandler, void(error_code, std::size_t)>
+    async_read_some(MutableBufferSequence const& buffers, ReadHandler&& handler)
     {
-        auto const n = boost::asio::buffer_copy(
-            buffers, boost::asio::buffer(s_));
+        auto const n =
+            boost::asio::buffer_copy(buffers, boost::asio::buffer(s_));
         error_code ec;
-        if(n > 0)
+        if (n > 0)
             s_.erase(0, n);
         else
             ec = boost::asio::error::eof;
-        async_completion<ReadHandler,
-            void(error_code, std::size_t)> init{handler};
-        ios_.post(bind_handler(
-            init.completion_handler, ec, n));
+        async_completion<ReadHandler, void(error_code, std::size_t)> init{
+            handler};
+        ios_.post(bind_handler(init.completion_handler, ec, n));
         return init.result.get();
     }
 
-    template<class ConstBufferSequence>
+    template <class ConstBufferSequence>
     std::size_t
     write_some(ConstBufferSequence const& buffers)
     {
         error_code ec;
         auto const n = write_some(buffers, ec);
-        if(ec)
+        if (ec)
             BOOST_THROW_EXCEPTION(system_error{ec});
         return n;
     }
 
-    template<class ConstBufferSequence>
+    template <class ConstBufferSequence>
     std::size_t
-    write_some(
-        ConstBufferSequence const& buffers, error_code& ec)
+    write_some(ConstBufferSequence const& buffers, error_code& ec)
     {
         ec.assign(0, ec.category());
-        using boost::asio::buffer_size;
         using boost::asio::buffer_cast;
+        using boost::asio::buffer_size;
         auto const n = buffer_size(buffers);
         str.reserve(str.size() + n);
-        for(boost::asio::const_buffer buffer : buffers)
-            str.append(buffer_cast<char const*>(buffer),
-                buffer_size(buffer));
+        for (boost::asio::const_buffer buffer : buffers)
+            str.append(buffer_cast<char const*>(buffer), buffer_size(buffer));
         return n;
     }
 
-    template<class ConstBufferSequence, class WriteHandler>
-    async_return_type<
-        WriteHandler, void(error_code, std::size_t)>
-    async_write_some(ConstBufferSequence const& buffers,
-        WriteHandler&& handler)
+    template <class ConstBufferSequence, class WriteHandler>
+    async_return_type<WriteHandler, void(error_code, std::size_t)>
+    async_write_some(ConstBufferSequence const& buffers, WriteHandler&& handler)
     {
         error_code ec;
         auto const bytes_transferred = write_some(buffers, ec);
-        async_completion<WriteHandler,
-            void(error_code, std::size_t)> init{handler};
+        async_completion<WriteHandler, void(error_code, std::size_t)> init{
+            handler};
         get_io_service().post(
             bind_handler(init.completion_handler, ec, bytes_transferred));
         return init.result.get();
     }
 
-    friend
-    void
-    teardown(websocket::teardown_tag,
+    friend void
+    teardown(
+        websocket::teardown_tag,
         string_iostream&,
-            boost::system::error_code& ec)
+        boost::system::error_code& ec)
     {
         ec.assign(0, ec.category());
     }
 
-    template<class TeardownHandler>
-    friend
-    void
-    async_teardown(websocket::teardown_tag,
+    template <class TeardownHandler>
+    friend void
+    async_teardown(
+        websocket::teardown_tag,
         string_iostream& stream,
-            TeardownHandler&& handler)
+        TeardownHandler&& handler)
     {
         stream.get_io_service().post(
-            bind_handler(std::move(handler),
-                error_code{}));
+            bind_handler(std::move(handler), error_code{}));
     }
 };
 
-} // test
-} // beast
+}  // namespace test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/test/string_istream.hpp
+++ b/src/ripple/beast/test/string_istream.hpp
@@ -8,13 +8,13 @@
 #ifndef BEAST_TEST_STRING_ISTREAM_HPP
 #define BEAST_TEST_STRING_ISTREAM_HPP
 
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/throw_exception.hpp>
 #include <beast/core/async_result.hpp>
 #include <beast/core/bind_handler.hpp>
 #include <beast/core/error.hpp>
 #include <beast/websocket/teardown.hpp>
-#include <boost/asio/buffer.hpp>
-#include <boost/asio/io_service.hpp>
-#include <boost/throw_exception.hpp>
 #include <string>
 
 namespace beast {
@@ -34,9 +34,10 @@ class string_istream
     std::size_t read_max_;
 
 public:
-    string_istream(boost::asio::io_service& ios,
-            std::string s, std::size_t read_max =
-                (std::numeric_limits<std::size_t>::max)())
+    string_istream(
+        boost::asio::io_service& ios,
+        std::string s,
+        std::size_t read_max = (std::numeric_limits<std::size_t>::max)())
         : s_(std::move(s))
         , cb_(boost::asio::buffer(s_))
         , ios_(ios)
@@ -50,25 +51,23 @@ public:
         return ios_;
     }
 
-    template<class MutableBufferSequence>
+    template <class MutableBufferSequence>
     std::size_t
     read_some(MutableBufferSequence const& buffers)
     {
         error_code ec;
         auto const n = read_some(buffers, ec);
-        if(ec)
+        if (ec)
             BOOST_THROW_EXCEPTION(system_error{ec});
         return n;
     }
 
-    template<class MutableBufferSequence>
+    template <class MutableBufferSequence>
     std::size_t
-    read_some(MutableBufferSequence const& buffers,
-        error_code& ec)
+    read_some(MutableBufferSequence const& buffers, error_code& ec)
     {
-        auto const n = boost::asio::buffer_copy(
-            buffers, cb_, read_max_);
-        if(n > 0)
+        auto const n = boost::asio::buffer_copy(buffers, cb_, read_max_);
+        if (n > 0)
         {
             ec.assign(0, ec.category());
             cb_ = cb_ + n;
@@ -80,82 +79,77 @@ public:
         return n;
     }
 
-    template<class MutableBufferSequence, class ReadHandler>
-    async_return_type<
-        ReadHandler, void(error_code, std::size_t)>
-    async_read_some(MutableBufferSequence const& buffers,
-        ReadHandler&& handler)
+    template <class MutableBufferSequence, class ReadHandler>
+    async_return_type<ReadHandler, void(error_code, std::size_t)>
+    async_read_some(MutableBufferSequence const& buffers, ReadHandler&& handler)
     {
-        auto const n = boost::asio::buffer_copy(
-            buffers, boost::asio::buffer(s_));
+        auto const n =
+            boost::asio::buffer_copy(buffers, boost::asio::buffer(s_));
         error_code ec;
-        if(n > 0)
+        if (n > 0)
             s_.erase(0, n);
         else
             ec = boost::asio::error::eof;
-        async_completion<ReadHandler,
-            void(error_code, std::size_t)> init{handler};
-        ios_.post(bind_handler(
-            init.completion_handler, ec, n));
+        async_completion<ReadHandler, void(error_code, std::size_t)> init{
+            handler};
+        ios_.post(bind_handler(init.completion_handler, ec, n));
         return init.result.get();
     }
 
-    template<class ConstBufferSequence>
+    template <class ConstBufferSequence>
     std::size_t
     write_some(ConstBufferSequence const& buffers)
     {
         error_code ec;
         auto const n = write_some(buffers, ec);
-        if(ec)
+        if (ec)
             BOOST_THROW_EXCEPTION(system_error{ec});
         return n;
     }
 
-    template<class ConstBufferSequence>
+    template <class ConstBufferSequence>
     std::size_t
-    write_some(ConstBufferSequence const& buffers,
-        error_code& ec)
+    write_some(ConstBufferSequence const& buffers, error_code& ec)
     {
         ec.assign(0, ec.category());
         return boost::asio::buffer_size(buffers);
     }
 
-    template<class ConstBuffeSequence, class WriteHandler>
-    async_return_type<
-        WriteHandler, void(error_code, std::size_t)>
-    async_write_some(ConstBuffeSequence const& buffers,
-        WriteHandler&& handler)
+    template <class ConstBuffeSequence, class WriteHandler>
+    async_return_type<WriteHandler, void(error_code, std::size_t)>
+    async_write_some(ConstBuffeSequence const& buffers, WriteHandler&& handler)
     {
-        async_completion<WriteHandler,
-            void(error_code, std::size_t)> init{handler};
-        ios_.post(bind_handler(init.completion_handler,
-            error_code{}, boost::asio::buffer_size(buffers)));
+        async_completion<WriteHandler, void(error_code, std::size_t)> init{
+            handler};
+        ios_.post(bind_handler(
+            init.completion_handler,
+            error_code{},
+            boost::asio::buffer_size(buffers)));
         return init.result.get();
     }
 
-    friend
-    void
-    teardown(websocket::teardown_tag,
+    friend void
+    teardown(
+        websocket::teardown_tag,
         string_istream&,
-            boost::system::error_code& ec)
+        boost::system::error_code& ec)
     {
         ec.assign(0, ec.category());
     }
 
-    template<class TeardownHandler>
-    friend
-    void
-    async_teardown(websocket::teardown_tag,
+    template <class TeardownHandler>
+    friend void
+    async_teardown(
+        websocket::teardown_tag,
         string_istream& stream,
-            TeardownHandler&& handler)
+        TeardownHandler&& handler)
     {
         stream.get_io_service().post(
-            bind_handler(std::move(handler),
-                error_code{}));
+            bind_handler(std::move(handler), error_code{}));
     }
 };
 
-} // test
-} // beast
+}  // namespace test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/test/string_ostream.hpp
+++ b/src/ripple/beast/test/string_ostream.hpp
@@ -8,14 +8,14 @@
 #ifndef BEAST_TEST_STRING_OSTREAM_HPP
 #define BEAST_TEST_STRING_OSTREAM_HPP
 
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/throw_exception.hpp>
 #include <beast/core/async_result.hpp>
 #include <beast/core/bind_handler.hpp>
 #include <beast/core/buffer_prefix.hpp>
 #include <beast/core/error.hpp>
 #include <beast/websocket/teardown.hpp>
-#include <boost/asio/buffer.hpp>
-#include <boost/asio/io_service.hpp>
-#include <boost/throw_exception.hpp>
 #include <string>
 
 namespace beast {
@@ -29,12 +29,10 @@ class string_ostream
 public:
     std::string str;
 
-    explicit
-    string_ostream(boost::asio::io_service& ios,
-        std::size_t write_max =
-                (std::numeric_limits<std::size_t>::max)())
-        : ios_(ios)
-        , write_max_(write_max)
+    explicit string_ostream(
+        boost::asio::io_service& ios,
+        std::size_t write_max = (std::numeric_limits<std::size_t>::max)())
+        : ios_(ios), write_max_(write_max)
     {
     }
 
@@ -44,106 +42,96 @@ public:
         return ios_;
     }
 
-    template<class MutableBufferSequence>
+    template <class MutableBufferSequence>
     std::size_t
     read_some(MutableBufferSequence const& buffers)
     {
         error_code ec;
         auto const n = read_some(buffers, ec);
-        if(ec)
+        if (ec)
             BOOST_THROW_EXCEPTION(system_error{ec});
         return n;
     }
 
-    template<class MutableBufferSequence>
+    template <class MutableBufferSequence>
     std::size_t
-    read_some(MutableBufferSequence const&,
-        error_code& ec)
+    read_some(MutableBufferSequence const&, error_code& ec)
     {
         ec = boost::asio::error::eof;
         return 0;
     }
 
-    template<class MutableBufferSequence, class ReadHandler>
-    async_return_type<
-        ReadHandler, void(error_code, std::size_t)>
-    async_read_some(MutableBufferSequence const&,
-        ReadHandler&& handler)
+    template <class MutableBufferSequence, class ReadHandler>
+    async_return_type<ReadHandler, void(error_code, std::size_t)>
+    async_read_some(MutableBufferSequence const&, ReadHandler&& handler)
     {
-        async_completion<ReadHandler,
-            void(error_code, std::size_t)> init{handler};
-        ios_.post(bind_handler(init.completion_handler,
-            boost::asio::error::eof, 0));
+        async_completion<ReadHandler, void(error_code, std::size_t)> init{
+            handler};
+        ios_.post(
+            bind_handler(init.completion_handler, boost::asio::error::eof, 0));
         return init.result.get();
     }
 
-    template<class ConstBufferSequence>
+    template <class ConstBufferSequence>
     std::size_t
     write_some(ConstBufferSequence const& buffers)
     {
         error_code ec;
         auto const n = write_some(buffers, ec);
-        if(ec)
+        if (ec)
             BOOST_THROW_EXCEPTION(system_error{ec});
         return n;
     }
 
-    template<class ConstBufferSequence>
+    template <class ConstBufferSequence>
     std::size_t
-    write_some(
-        ConstBufferSequence const& buffers, error_code& ec)
+    write_some(ConstBufferSequence const& buffers, error_code& ec)
     {
         ec.assign(0, ec.category());
-        using boost::asio::buffer_size;
         using boost::asio::buffer_cast;
-        auto const n =
-            (std::min)(buffer_size(buffers), write_max_);
+        using boost::asio::buffer_size;
+        auto const n = (std::min)(buffer_size(buffers), write_max_);
         str.reserve(str.size() + n);
-        for(boost::asio::const_buffer buffer :
-                buffer_prefix(n, buffers))
-            str.append(buffer_cast<char const*>(buffer),
-                buffer_size(buffer));
+        for (boost::asio::const_buffer buffer : buffer_prefix(n, buffers))
+            str.append(buffer_cast<char const*>(buffer), buffer_size(buffer));
         return n;
     }
 
-    template<class ConstBufferSequence, class WriteHandler>
-    async_return_type<
-        WriteHandler, void(error_code, std::size_t)>
-    async_write_some(ConstBufferSequence const& buffers,
-        WriteHandler&& handler)
+    template <class ConstBufferSequence, class WriteHandler>
+    async_return_type<WriteHandler, void(error_code, std::size_t)>
+    async_write_some(ConstBufferSequence const& buffers, WriteHandler&& handler)
     {
         error_code ec;
         auto const bytes_transferred = write_some(buffers, ec);
-        async_completion<WriteHandler,
-            void(error_code, std::size_t)> init{handler};
+        async_completion<WriteHandler, void(error_code, std::size_t)> init{
+            handler};
         get_io_service().post(
             bind_handler(init.completion_handler, ec, bytes_transferred));
         return init.result.get();
     }
 
-    friend
-    void
-    teardown(websocket::teardown_tag,
+    friend void
+    teardown(
+        websocket::teardown_tag,
         string_ostream&,
-            boost::system::error_code& ec)
+        boost::system::error_code& ec)
     {
         ec.assign(0, ec.category());
     }
 
-    template<class TeardownHandler>
-    friend
-    void
-    async_teardown(websocket::teardown_tag,
+    template <class TeardownHandler>
+    friend void
+    async_teardown(
+        websocket::teardown_tag,
         string_ostream& stream,
-            TeardownHandler&& handler)
+        TeardownHandler&& handler)
     {
         stream.get_io_service().post(
-            bind_handler(std::move(handler),
-                error_code{}));
+            bind_handler(std::move(handler), error_code{}));
     }
 };
 
-} // test
-} // beast
+}  // namespace test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/test/yield_to.hpp
+++ b/src/ripple/beast/test/yield_to.hpp
@@ -40,23 +40,19 @@ private:
 
 public:
     /// The type of yield context passed to functions.
-    using yield_context =
-        boost::asio::yield_context;
+    using yield_context = boost::asio::yield_context;
 
-    explicit
-    enable_yield_to(std::size_t concurrency = 1)
-        : work_(ios_)
+    explicit enable_yield_to(std::size_t concurrency = 1) : work_(ios_)
     {
         threads_.reserve(concurrency);
-        while(concurrency--)
-            threads_.emplace_back(
-                [&]{ ios_.run(); });
+        while (concurrency--)
+            threads_.emplace_back([&] { ios_.run(); });
     }
 
     ~enable_yield_to()
     {
         work_ = boost::none;
-        for(auto& t : threads_)
+        for (auto& t : threads_)
             t.join();
     }
 
@@ -79,56 +75,51 @@ public:
         @param fn... One or more functions to invoke.
     */
 #if BEAST_DOXYGEN
-    template<class... FN>
+    template <class... FN>
     void
     yield_to(FN&&... fn)
 #else
-    template<class F0, class... FN>
+    template <class F0, class... FN>
     void
     yield_to(F0&& f0, FN&&... fn);
 #endif
 
-private:
-    void
-    spawn()
+        private : void spawn()
     {
     }
 
-    template<class F0, class... FN>
+    template <class F0, class... FN>
     void
     spawn(F0&& f, FN&&... fn);
 };
 
-template<class F0, class... FN>
+template <class F0, class... FN>
 void
-enable_yield_to::
-yield_to(F0&& f0, FN&&... fn)
+enable_yield_to::yield_to(F0&& f0, FN&&... fn)
 {
     running_ = 1 + sizeof...(FN);
     spawn(f0, fn...);
     std::unique_lock<std::mutex> lock{m_};
-    cv_.wait(lock, [&]{ return running_ == 0; });
+    cv_.wait(lock, [&] { return running_ == 0; });
 }
 
-template<class F0, class... FN>
-inline
-void
-enable_yield_to::
-spawn(F0&& f, FN&&... fn)
+template <class F0, class... FN>
+inline void
+enable_yield_to::spawn(F0&& f, FN&&... fn)
 {
-    boost::asio::spawn(ios_,
-        [&](yield_context yield)
-        {
+    boost::asio::spawn(
+        ios_,
+        [&](yield_context yield) {
             f(yield);
             std::lock_guard lock{m_};
-            if(--running_ == 0)
+            if (--running_ == 0)
                 cv_.notify_all();
-        }
-        , boost::coroutines::attributes(2 * 1024 * 1024));
+        },
+        boost::coroutines::attributes(2 * 1024 * 1024));
     spawn(fn...);
 }
 
-} // test
-} // beast
+}  // namespace test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/unit_test.h
+++ b/src/ripple/beast/unit_test.h
@@ -34,7 +34,7 @@
 #ifndef BEAST_EXPECT
 #define BEAST_EXPECT_S1(x) #x
 #define BEAST_EXPECT_S2(x) BEAST_EXPECT_S1(x)
-//#define BEAST_EXPECT(cond) {expect(cond, __FILE__ ":" ##
+// #define BEAST_EXPECT(cond) {expect(cond, __FILE__ ":" ##
 //__LINE__);}while(false){}
 #define BEAST_EXPECT(cond) expect(cond, __FILE__ ":" BEAST_EXPECT_S2(__LINE__))
 #endif

--- a/src/ripple/beast/unit_test/amount.hpp
+++ b/src/ripple/beast/unit_test/amount.hpp
@@ -24,32 +24,29 @@ private:
 
 public:
     amount(amount const&) = default;
-    amount& operator=(amount const&) = delete;
+    amount&
+    operator=(amount const&) = delete;
 
-    template<class = void>
+    template <class = void>
     amount(std::size_t n, std::string const& what);
 
-    friend
-    std::ostream&
+    friend std::ostream&
     operator<<(std::ostream& s, amount const& t);
 };
 
-template<class>
-amount::amount(std::size_t n, std::string const& what)
-    : n_(n)
-    , what_(what)
+template <class>
+amount::amount(std::size_t n, std::string const& what) : n_(n), what_(what)
 {
 }
 
-inline
-std::ostream&
+inline std::ostream&
 operator<<(std::ostream& s, amount const& t)
 {
-    s << t.n_ << " " << t.what_ <<((t.n_ != 1) ? "s" : "");
+    s << t.n_ << " " << t.what_ << ((t.n_ != 1) ? "s" : "");
     return s;
 }
 
-} // unit_test
-} // beast
+}  // namespace unit_test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/unit_test/detail/const_container.hpp
+++ b/src/ripple/beast/unit_test/detail/const_container.hpp
@@ -16,7 +16,7 @@ namespace detail {
     The interface allows for limited read only operations. Derived classes
     provide additional behavior.
 */
-template<class Container>
+template <class Container>
 class const_container
 {
 private:
@@ -25,12 +25,14 @@ private:
     cont_type m_cont;
 
 protected:
-    cont_type& cont()
+    cont_type&
+    cont()
     {
         return m_cont;
     }
 
-    cont_type const& cont() const
+    cont_type const&
+    cont() const
     {
         return m_cont;
     }
@@ -84,8 +86,8 @@ public:
     /** @} */
 };
 
-} // detail
-} // unit_test
-} // beast
+}  // namespace detail
+}  // namespace unit_test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/unit_test/dstream.hpp
+++ b/src/ripple/beast/unit_test/dstream.hpp
@@ -17,7 +17,7 @@
 
 #ifdef BOOST_WINDOWS
 #include <boost/detail/winapi/basic_types.hpp>
-//#include <boost/detail/winapi/debugapi.hpp>
+// #include <boost/detail/winapi/debugapi.hpp>
 #endif
 
 namespace beast {
@@ -27,37 +27,37 @@ namespace unit_test {
 
 namespace detail {
 
-template<class CharT, class Traits, class Allocator>
-class dstream_buf
-    : public std::basic_stringbuf<CharT, Traits, Allocator>
+template <class CharT, class Traits, class Allocator>
+class dstream_buf : public std::basic_stringbuf<CharT, Traits, Allocator>
 {
     using ostream = std::basic_ostream<CharT, Traits>;
 
     bool dbg_;
     ostream& os_;
 
-    template<class T>
-    void write(T const*) = delete;
+    template <class T>
+    void
+    write(T const*) = delete;
 
-    void write(char const* s)
+    void
+    write(char const* s)
     {
-        if(dbg_)
-            /*boost::detail::winapi*/::OutputDebugStringA(s);
+        if (dbg_)
+            /*boost::detail::winapi*/ ::OutputDebugStringA(s);
         os_ << s;
     }
 
-    void write(wchar_t const* s)
+    void
+    write(wchar_t const* s)
     {
-        if(dbg_)
-            /*boost::detail::winapi*/::OutputDebugStringW(s);
+        if (dbg_)
+            /*boost::detail::winapi*/ ::OutputDebugStringW(s);
         os_ << s;
     }
 
 public:
-    explicit
-    dstream_buf(ostream& os)
-        : os_(os)
-        , dbg_(/*boost::detail::winapi*/::IsDebuggerPresent() != 0)
+    explicit dstream_buf(ostream& os)
+        : os_(os), dbg_(/*boost::detail::winapi*/ ::IsDebuggerPresent() != 0)
     {
     }
 
@@ -75,7 +75,7 @@ public:
     }
 };
 
-} // detail
+}  // namespace detail
 
 /** std::ostream with Visual Studio IDE redirection.
 
@@ -84,28 +84,23 @@ public:
     is attached when the stream is created, output will be
     additionally copied to the Visual Studio Output window.
 */
-template<
+template <
     class CharT,
     class Traits = std::char_traits<CharT>,
-    class Allocator = std::allocator<CharT>
->
-class basic_dstream
-    : public std::basic_ostream<CharT, Traits>
+    class Allocator = std::allocator<CharT>>
+class basic_dstream : public std::basic_ostream<CharT, Traits>
 {
-    detail::dstream_buf<
-        CharT, Traits, Allocator> buf_;
+    detail::dstream_buf<CharT, Traits, Allocator> buf_;
 
 public:
     /** Construct a stream.
 
         @param os The output stream to wrap.
     */
-    explicit
-    basic_dstream(std::ostream& os)
-        : std::basic_ostream<CharT, Traits>(&buf_)
-        , buf_(os)
+    explicit basic_dstream(std::ostream& os)
+        : std::basic_ostream<CharT, Traits>(&buf_), buf_(os)
     {
-        if(os.flags() & std::ios::unitbuf)
+        if (os.flags() & std::ios::unitbuf)
             std::unitbuf(*this);
     }
 };
@@ -120,7 +115,7 @@ using dwstream = std::wostream&;
 
 #endif
 
-} // unit_test
-} // beast
+}  // namespace unit_test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/unit_test/global_suites.hpp
+++ b/src/ripple/beast/unit_test/global_suites.hpp
@@ -16,36 +16,37 @@ namespace unit_test {
 namespace detail {
 
 /// Holds test suites registered during static initialization.
-inline
-suite_list&
+inline suite_list&
 global_suites()
 {
     static suite_list s;
     return s;
 }
 
-template<class Suite>
+template <class Suite>
 struct insert_suite
 {
-    insert_suite(char const* name, char const* module,
-        char const* library, bool manual, int priority)
+    insert_suite(
+        char const* name,
+        char const* module,
+        char const* library,
+        bool manual,
+        int priority)
     {
-        global_suites().insert<Suite>(
-            name, module, library, manual, priority);
+        global_suites().insert<Suite>(name, module, library, manual, priority);
     }
 };
 
-} // detail
+}  // namespace detail
 
 /// Holds test suites registered during static initialization.
-inline
-suite_list const&
+inline suite_list const&
 global_suites()
 {
     return detail::global_suites();
 }
 
-} // unit_test
-} // beast
+}  // namespace unit_test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/unit_test/match.hpp
+++ b/src/ripple/beast/unit_test/match.hpp
@@ -18,8 +18,7 @@ namespace unit_test {
 class selector
 {
 public:
-    enum mode_t
-    {
+    enum mode_t {
         // Run all tests except manual ones
         all,
 
@@ -45,83 +44,81 @@ private:
     std::string library_;
 
 public:
-    template<class = void>
-    explicit
-    selector(mode_t mode, std::string const& pattern = "");
+    template <class = void>
+    explicit selector(mode_t mode, std::string const& pattern = "");
 
-    template<class = void>
+    template <class = void>
     bool
     operator()(suite_info const& s);
 };
 
 //------------------------------------------------------------------------------
 
-template<class>
+template <class>
 selector::selector(mode_t mode, std::string const& pattern)
-    : mode_(mode)
-    , pat_(pattern)
+    : mode_(mode), pat_(pattern)
 {
-    if(mode_ == automatch && pattern.empty())
+    if (mode_ == automatch && pattern.empty())
         mode_ = all;
 }
 
-template<class>
+template <class>
 bool
 selector::operator()(suite_info const& s)
 {
-    switch(mode_)
+    switch (mode_)
     {
-    case automatch:
-        // suite or full name
-        if(s.name() == pat_ || s.full_name() == pat_)
-        {
-            mode_ = none;
-            return true;
-        }
+        case automatch:
+            // suite or full name
+            if (s.name() == pat_ || s.full_name() == pat_)
+            {
+                mode_ = none;
+                return true;
+            }
 
-        // check module
-        if(pat_ == s.module())
-        {
-            mode_ = module;
-            library_ = s.library();
-            return ! s.manual();
-        }
+            // check module
+            if (pat_ == s.module())
+            {
+                mode_ = module;
+                library_ = s.library();
+                return !s.manual();
+            }
 
-        // check library
-        if(pat_ == s.library())
-        {
-            mode_ = library;
-            return ! s.manual();
-        }
+            // check library
+            if (pat_ == s.library())
+            {
+                mode_ = library;
+                return !s.manual();
+            }
 
-        // check start of name
-        if (s.name().starts_with(pat_) || s.full_name().starts_with(pat_))
-        {
-            // Don't change the mode so that the partial pattern can match
-            // more than once
-            return !s.manual();
-        }
+            // check start of name
+            if (s.name().starts_with(pat_) || s.full_name().starts_with(pat_))
+            {
+                // Don't change the mode so that the partial pattern can match
+                // more than once
+                return !s.manual();
+            }
 
-        return false;
+            return false;
 
-    case suite:
-        return pat_ == s.name();
+        case suite:
+            return pat_ == s.name();
 
-    case module:
-        return pat_ == s.module() && ! s.manual();
+        case module:
+            return pat_ == s.module() && !s.manual();
 
-    case library:
-        return pat_ == s.library() && ! s.manual();
+        case library:
+            return pat_ == s.library() && !s.manual();
 
-    case none:
-        return false;
+        case none:
+            return false;
 
-    case all:
-    default:
-        break;
+        case all:
+        default:
+            break;
     };
 
-    return ! s.manual();
+    return !s.manual();
 }
 
 //------------------------------------------------------------------------------
@@ -143,38 +140,34 @@ selector::operator()(suite_info const& s)
         not marked manual are selected from then on.
 
 */
-inline
-selector
+inline selector
 match_auto(std::string const& name)
 {
     return selector(selector::automatch, name);
 }
 
 /** Return a predicate that matches all suites not marked manual. */
-inline
-selector
+inline selector
 match_all()
 {
     return selector(selector::all);
 }
 
 /** Returns a predicate that matches a specific suite. */
-inline
-selector
+inline selector
 match_suite(std::string const& name)
 {
     return selector(selector::suite, name);
 }
 
 /** Returns a predicate that matches all suites in a library. */
-inline
-selector
+inline selector
 match_library(std::string const& name)
 {
     return selector(selector::library, name);
 }
 
-} // unit_test
-} // beast
+}  // namespace unit_test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/unit_test/recorder.hpp
+++ b/src/ripple/beast/unit_test/recorder.hpp
@@ -33,58 +33,51 @@ public:
     }
 
 private:
-    virtual
-    void
+    virtual void
     on_suite_begin(suite_info const& info) override
     {
         m_suite = suite_results(info.full_name());
     }
 
-    virtual
-    void
+    virtual void
     on_suite_end() override
     {
         m_results.insert(std::move(m_suite));
     }
 
-    virtual
-    void
+    virtual void
     on_case_begin(std::string const& name) override
     {
         m_case = case_results(name);
     }
 
-    virtual
-    void
+    virtual void
     on_case_end() override
     {
-        if(m_case.tests.size() > 0)
+        if (m_case.tests.size() > 0)
             m_suite.insert(std::move(m_case));
     }
 
-    virtual
-    void
+    virtual void
     on_pass() override
     {
         m_case.tests.pass();
     }
 
-    virtual
-    void
+    virtual void
     on_fail(std::string const& reason) override
     {
         m_case.tests.fail(reason);
     }
 
-    virtual
-    void
+    virtual void
     on_log(std::string const& s) override
     {
         m_case.log.insert(s);
     }
 };
 
-} // unit_test
-} // beast
+}  // namespace unit_test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/unit_test/reporter.hpp
+++ b/src/ripple/beast/unit_test/reporter.hpp
@@ -29,7 +29,7 @@ namespace detail {
 /** A simple test runner that writes everything to a stream in real time.
     The totals are output when the object is destroyed.
 */
-template<class = void>
+template <class = void>
 class reporter : public runner
 {
 private:
@@ -41,9 +41,7 @@ private:
         std::size_t total = 0;
         std::size_t failed = 0;
 
-        explicit
-        case_results(std::string name_ = "")
-            : name(std::move(name_))
+        explicit case_results(std::string name_ = "") : name(std::move(name_))
         {
         }
     };
@@ -56,9 +54,7 @@ private:
         std::size_t failed = 0;
         typename clock_type::time_point start = clock_type::now();
 
-        explicit
-        suite_results(std::string name_ = "")
-            : name(std::move(name_))
+        explicit suite_results(std::string name_ = "") : name(std::move(name_))
         {
         }
 
@@ -68,13 +64,9 @@ private:
 
     struct results
     {
-        using run_time = std::pair<std::string,
-            typename clock_type::duration>;
+        using run_time = std::pair<std::string, typename clock_type::duration>;
 
-        enum
-        {
-            max_top = 10
-        };
+        enum { max_top = 10 };
 
         std::size_t suites = 0;
         std::size_t cases = 0;
@@ -94,85 +86,75 @@ private:
 
 public:
     reporter(reporter const&) = delete;
-    reporter& operator=(reporter const&) = delete;
+    reporter&
+    operator=(reporter const&) = delete;
 
     ~reporter();
 
-    explicit
-    reporter(std::ostream& os = std::cout);
+    explicit reporter(std::ostream& os = std::cout);
 
 private:
-    static
-    std::string
+    static std::string
     fmtdur(typename clock_type::duration const& d);
 
-    virtual
-    void
+    virtual void
     on_suite_begin(suite_info const& info) override;
 
-    virtual
-    void
+    virtual void
     on_suite_end() override;
 
-    virtual
-    void
+    virtual void
     on_case_begin(std::string const& name) override;
 
-    virtual
-    void
+    virtual void
     on_case_end() override;
 
-    virtual
-    void
+    virtual void
     on_pass() override;
 
-    virtual
-    void
+    virtual void
     on_fail(std::string const& reason) override;
 
-    virtual
-    void
+    virtual void
     on_log(std::string const& s) override;
 };
 
 //------------------------------------------------------------------------------
 
-template<class _>
+template <class _>
 void
-reporter<_>::
-suite_results::add(case_results const& r)
+reporter<_>::suite_results::add(case_results const& r)
 {
     ++cases;
     total += r.total;
     failed += r.failed;
 }
 
-template<class _>
+template <class _>
 void
-reporter<_>::
-results::add(suite_results const& r)
+reporter<_>::results::add(suite_results const& r)
 {
     ++suites;
     total += r.total;
     cases += r.cases;
     failed += r.failed;
     auto const elapsed = clock_type::now() - r.start;
-    if(elapsed >= std::chrono::seconds{1})
+    if (elapsed >= std::chrono::seconds{1})
     {
-        auto const iter = std::lower_bound(top.begin(),
-            top.end(), elapsed,
-            [](run_time const& t1,
-                typename clock_type::duration const& t2)
-            {
+        auto const iter = std::lower_bound(
+            top.begin(),
+            top.end(),
+            elapsed,
+            [](run_time const& t1, typename clock_type::duration const& t2) {
                 return t1.second > t2;
             });
-        if(iter != top.end())
+        if (iter != top.end())
         {
-            if(top.size() == max_top)
+            if (top.size() == max_top)
                 top.resize(top.size() - 1);
             top.emplace(iter, r.name, elapsed);
         }
-        else if(top.size() < max_top)
+        else if (top.size() < max_top)
         {
             top.emplace_back(r.name, elapsed);
         }
@@ -181,115 +163,100 @@ results::add(suite_results const& r)
 
 //------------------------------------------------------------------------------
 
-template<class _>
-reporter<_>::
-reporter(std::ostream& os)
-    : os_(os)
+template <class _>
+reporter<_>::reporter(std::ostream& os) : os_(os)
 {
 }
 
-template<class _>
+template <class _>
 reporter<_>::~reporter()
 {
-    if(results_.top.size() > 0)
+    if (results_.top.size() > 0)
     {
         os_ << "Longest suite times:\n";
-        for(auto const& i : results_.top)
-            os_ << std::setw(8) <<
-                fmtdur(i.second) << " " << i.first << '\n';
+        for (auto const& i : results_.top)
+            os_ << std::setw(8) << fmtdur(i.second) << " " << i.first << '\n';
     }
     auto const elapsed = clock_type::now() - results_.start;
-    os_ <<
-        fmtdur(elapsed) << ", " <<
-        amount{results_.suites, "suite"} << ", " <<
-        amount{results_.cases, "case"} << ", " <<
-        amount{results_.total, "test"} << " total, " <<
-        amount{results_.failed, "failure"} <<
-        std::endl;
+    os_ << fmtdur(elapsed) << ", " << amount{results_.suites, "suite"} << ", "
+        << amount{results_.cases, "case"} << ", "
+        << amount{results_.total, "test"} << " total, "
+        << amount{results_.failed, "failure"} << std::endl;
 }
 
-template<class _>
+template <class _>
 std::string
 reporter<_>::fmtdur(typename clock_type::duration const& d)
 {
     using namespace std::chrono;
     auto const ms = duration_cast<milliseconds>(d);
-    if(ms < seconds{1})
-        return boost::lexical_cast<std::string>(
-            ms.count()) + "ms";
+    if (ms < seconds{1})
+        return boost::lexical_cast<std::string>(ms.count()) + "ms";
     std::stringstream ss;
-    ss << std::fixed << std::setprecision(1) <<
-       (ms.count()/1000.) << "s";
+    ss << std::fixed << std::setprecision(1) << (ms.count() / 1000.) << "s";
     return ss.str();
 }
 
-template<class _>
+template <class _>
 void
-reporter<_>::
-on_suite_begin(suite_info const& info)
+reporter<_>::on_suite_begin(suite_info const& info)
 {
     suite_results_ = suite_results{info.full_name()};
 }
 
-template<class _>
+template <class _>
 void
 reporter<_>::on_suite_end()
 {
     results_.add(suite_results_);
 }
 
-template<class _>
+template <class _>
 void
-reporter<_>::
-on_case_begin(std::string const& name)
+reporter<_>::on_case_begin(std::string const& name)
 {
     case_results_ = case_results(name);
-    os_ << suite_results_.name <<
-        (case_results_.name.empty() ? "" :
-            (" " + case_results_.name)) << std::endl;
+    os_ << suite_results_.name
+        << (case_results_.name.empty() ? "" : (" " + case_results_.name))
+        << std::endl;
 }
 
-template<class _>
+template <class _>
 void
-reporter<_>::
-on_case_end()
+reporter<_>::on_case_end()
 {
     suite_results_.add(case_results_);
 }
 
-template<class _>
+template <class _>
 void
-reporter<_>::
-on_pass()
+reporter<_>::on_pass()
 {
     ++case_results_.total;
 }
 
-template<class _>
+template <class _>
 void
-reporter<_>::
-on_fail(std::string const& reason)
+reporter<_>::on_fail(std::string const& reason)
 {
     ++case_results_.failed;
     ++case_results_.total;
-    os_ <<
-        "#" << case_results_.total << " failed" <<
-       (reason.empty() ? "" : ": ") << reason << std::endl;
+    os_ << "#" << case_results_.total << " failed"
+        << (reason.empty() ? "" : ": ") << reason << std::endl;
 }
 
-template<class _>
+template <class _>
 void
-reporter<_>::
-on_log(std::string const& s)
+reporter<_>::on_log(std::string const& s)
 {
     os_ << s;
 }
 
-} // detail
+}  // namespace detail
 
 using reporter = detail::reporter<>;
 
-} // unit_test
-} // beast
+}  // namespace unit_test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/unit_test/results.hpp
+++ b/src/ripple/beast/unit_test/results.hpp
@@ -23,14 +23,12 @@ public:
     /** Holds the result of evaluating one test condition. */
     struct test
     {
-        explicit test(bool pass_)
-            : pass(pass_)
+        explicit test(bool pass_) : pass(pass_)
         {
         }
 
         test(bool pass_, std::string const& reason_)
-            : pass(pass_)
-            , reason(reason_)
+            : pass(pass_), reason(reason_)
         {
         }
 
@@ -39,15 +37,13 @@ public:
     };
 
 private:
-    class tests_t
-        : public detail::const_container <std::vector <test>>
+    class tests_t : public detail::const_container<std::vector<test>>
     {
     private:
         std::size_t failed_;
 
     public:
-        tests_t()
-            : failed_(0)
+        tests_t() : failed_(0)
         {
         }
 
@@ -81,8 +77,7 @@ private:
         }
     };
 
-    class log_t
-        : public detail::const_container <std::vector <std::string>>
+    class log_t : public detail::const_container<std::vector<std::string>>
     {
     public:
         /** Insert a string into the log. */
@@ -96,8 +91,7 @@ private:
     std::string name_;
 
 public:
-    explicit case_results(std::string const& name = "")
-        : name_(name)
+    explicit case_results(std::string const& name = "") : name_(name)
     {
     }
 
@@ -118,8 +112,7 @@ public:
 //--------------------------------------------------------------------------
 
 /** Holds the set of testcase results in a suite. */
-class suite_results
-    : public detail::const_container <std::vector <case_results>>
+class suite_results : public detail::const_container<std::vector<case_results>>
 {
 private:
     std::string name_;
@@ -127,8 +120,7 @@ private:
     std::size_t failed_ = 0;
 
 public:
-    explicit suite_results(std::string const& name = "")
-        : name_(name)
+    explicit suite_results(std::string const& name = "") : name_(name)
     {
     }
 
@@ -177,8 +169,7 @@ public:
 
 // VFALCO TODO Make this a template class using scoped allocators
 /** Holds the results of running a set of testsuites. */
-class results
-    : public detail::const_container <std::vector <suite_results>>
+class results : public detail::const_container<std::vector<suite_results>>
 {
 private:
     std::size_t m_cases;
@@ -186,10 +177,7 @@ private:
     std::size_t failed_;
 
 public:
-    results()
-        : m_cases(0)
-        , total_(0)
-        , failed_(0)
+    results() : m_cases(0), total_(0), failed_(0)
     {
     }
 
@@ -236,7 +224,7 @@ public:
     /** @} */
 };
 
-} // unit_test
-} // beast
+}  // namespace unit_test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/unit_test/runner.hpp
+++ b/src/ripple/beast/unit_test/runner.hpp
@@ -34,7 +34,8 @@ public:
     runner() = default;
     virtual ~runner() = default;
     runner(runner const&) = delete;
-    runner& operator=(runner const&) = delete;
+    runner&
+    operator=(runner const&) = delete;
 
     /** Set the argument string.
 
@@ -59,7 +60,7 @@ public:
     /** Run the specified suite.
         @return `true` if any conditions failed.
     */
-    template<class = void>
+    template <class = void>
     bool
     run(suite_info const& s);
 
@@ -69,7 +70,7 @@ public:
         must be convertible to `suite_info`.
         @return `true` if any conditions failed.
     */
-    template<class FwdIter>
+    template <class FwdIter>
     bool
     run(FwdIter first, FwdIter last);
 
@@ -80,14 +81,14 @@ public:
         @endcode
         @return `true` if any conditions failed.
     */
-    template<class FwdIter, class Pred>
+    template <class FwdIter, class Pred>
     bool
     run_if(FwdIter first, FwdIter last, Pred pred = Pred{});
 
     /** Run all suites in a container.
         @return `true` if any conditions failed.
     */
-    template<class SequenceContainer>
+    template <class SequenceContainer>
     bool
     run_each(SequenceContainer const& c);
 
@@ -98,56 +99,49 @@ public:
         @endcode
         @return `true` if any conditions failed.
     */
-    template<class SequenceContainer, class Pred>
+    template <class SequenceContainer, class Pred>
     bool
     run_each_if(SequenceContainer const& c, Pred pred = Pred{});
 
 protected:
     /// Called when a new suite starts.
-    virtual
-    void
+    virtual void
     on_suite_begin(suite_info const&)
     {
     }
 
     /// Called when a suite ends.
-    virtual
-    void
+    virtual void
     on_suite_end()
     {
     }
 
     /// Called when a new case starts.
-    virtual
-    void
+    virtual void
     on_case_begin(std::string const&)
     {
     }
 
     /// Called when a new case ends.
-    virtual
-    void
+    virtual void
     on_case_end()
     {
     }
 
     /// Called for each passing condition.
-    virtual
-    void
+    virtual void
     on_pass()
     {
     }
 
     /// Called for each failing condition.
-    virtual
-    void
+    virtual void
     on_fail(std::string const&)
     {
     }
 
     /// Called when a test logs output.
-    virtual
-    void
+    virtual void
     on_log(std::string const&)
     {
     }
@@ -156,26 +150,26 @@ private:
     friend class suite;
 
     // Start a new testcase.
-    template<class = void>
+    template <class = void>
     void
     testcase(std::string const& name);
 
-    template<class = void>
+    template <class = void>
     void
     pass();
 
-    template<class = void>
+    template <class = void>
     void
     fail(std::string const& reason);
 
-    template<class = void>
+    template <class = void>
     void
     log(std::string const& s);
 };
 
 //------------------------------------------------------------------------------
 
-template<class>
+template <class>
 bool
 runner::run(suite_info const& s)
 {
@@ -191,98 +185,98 @@ runner::run(suite_info const& s)
     return failed_;
 }
 
-template<class FwdIter>
+template <class FwdIter>
 bool
 runner::run(FwdIter first, FwdIter last)
 {
     bool failed(false);
-    for(;first != last; ++first)
+    for (; first != last; ++first)
         failed = run(*first) || failed;
     return failed;
 }
 
-template<class FwdIter, class Pred>
+template <class FwdIter, class Pred>
 bool
 runner::run_if(FwdIter first, FwdIter last, Pred pred)
 {
     bool failed(false);
-    for(;first != last; ++first)
-        if(pred(*first))
+    for (; first != last; ++first)
+        if (pred(*first))
             failed = run(*first) || failed;
     return failed;
 }
 
-template<class SequenceContainer>
+template <class SequenceContainer>
 bool
 runner::run_each(SequenceContainer const& c)
 {
     bool failed(false);
-    for(auto const& s : c)
+    for (auto const& s : c)
         failed = run(s) || failed;
     return failed;
 }
 
-template<class SequenceContainer, class Pred>
+template <class SequenceContainer, class Pred>
 bool
 runner::run_each_if(SequenceContainer const& c, Pred pred)
 {
     bool failed(false);
-    for(auto const& s : c)
-        if(pred(s))
+    for (auto const& s : c)
+        if (pred(s))
             failed = run(s) || failed;
     return failed;
 }
 
-template<class>
+template <class>
 void
 runner::testcase(std::string const& name)
 {
     std::lock_guard lock(mutex_);
     // Name may not be empty
-    BOOST_ASSERT(default_ || ! name.empty());
+    BOOST_ASSERT(default_ || !name.empty());
     // Forgot to call pass or fail
     BOOST_ASSERT(default_ || cond_);
-    if(! default_)
+    if (!default_)
         on_case_end();
     default_ = false;
     cond_ = false;
     on_case_begin(name);
 }
 
-template<class>
+template <class>
 void
 runner::pass()
 {
     std::lock_guard lock(mutex_);
-    if(default_)
+    if (default_)
         testcase("");
     on_pass();
     cond_ = true;
 }
 
-template<class>
+template <class>
 void
 runner::fail(std::string const& reason)
 {
     std::lock_guard lock(mutex_);
-    if(default_)
+    if (default_)
         testcase("");
     on_fail(reason);
     failed_ = true;
     cond_ = true;
 }
 
-template<class>
+template <class>
 void
 runner::log(std::string const& s)
 {
     std::lock_guard lock(mutex_);
-    if(default_)
+    if (default_)
         testcase("");
     on_log(s);
 }
 
-} // unit_test
-} // beast
+}  // namespace unit_test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/unit_test/suite.hpp
+++ b/src/ripple/beast/unit_test/suite.hpp
@@ -21,14 +21,12 @@ namespace unit_test {
 
 namespace detail {
 
-template<class String>
-static
-std::string
-make_reason(String const& reason,
-    char const* file, int line)
+template <class String>
+static std::string
+make_reason(String const& reason, char const* file, int line)
 {
     std::string s(reason);
-    if(! s.empty())
+    if (!s.empty())
         s.append(": ");
     namespace fs = boost::filesystem;
     s.append(fs::path{file}.filename().string());
@@ -38,15 +36,11 @@ make_reason(String const& reason,
     return s;
 }
 
-} // detail
+}  // namespace detail
 
 class thread;
 
-enum abort_t
-{
-    no_abort_on_fail,
-    abort_on_fail
-};
+enum abort_t { no_abort_on_fail, abort_on_fail };
 
 /** A testsuite class.
 
@@ -73,16 +67,13 @@ private:
         }
     };
 
-    template<class CharT, class Traits, class Allocator>
-    class log_buf
-        : public std::basic_stringbuf<CharT, Traits, Allocator>
+    template <class CharT, class Traits, class Allocator>
+    class log_buf : public std::basic_stringbuf<CharT, Traits, Allocator>
     {
         suite& suite_;
 
     public:
-        explicit
-        log_buf(suite& self)
-            : suite_(self)
+        explicit log_buf(suite& self) : suite_(self)
         {
         }
 
@@ -95,27 +86,24 @@ private:
         sync() override
         {
             auto const& s = this->str();
-            if(s.size() > 0)
+            if (s.size() > 0)
                 suite_.runner_->log(s);
             this->str("");
             return 0;
         }
     };
 
-    template<
+    template <
         class CharT,
         class Traits = std::char_traits<CharT>,
-        class Allocator = std::allocator<CharT>
-    >
+        class Allocator = std::allocator<CharT>>
     class log_os : public std::basic_ostream<CharT, Traits>
     {
         log_buf<CharT, Traits, Allocator> buf_;
 
     public:
-        explicit
-        log_os(suite& self)
-            : std::basic_ostream<CharT, Traits>(&buf_)
-            , buf_(self)
+        explicit log_os(suite& self)
+            : std::basic_ostream<CharT, Traits>(&buf_), buf_(self)
         {
         }
     };
@@ -128,9 +116,7 @@ private:
         std::stringstream ss_;
 
     public:
-        explicit
-        testcase_t(suite& self)
-            : suite_(self)
+        explicit testcase_t(suite& self) : suite_(self)
         {
         }
 
@@ -145,13 +131,12 @@ private:
             @param abort Determines if suite continues running after a failure.
         */
         void
-        operator()(std::string const& name,
-            abort_t abort = no_abort_on_fail);
+        operator()(std::string const& name, abort_t abort = no_abort_on_fail);
 
         scoped_testcase
         operator()(abort_t abort);
 
-        template<class T>
+        template <class T>
         scoped_testcase
         operator<<(T const& t);
     };
@@ -170,22 +155,20 @@ public:
     /** Returns the "current" running suite.
         If no suite is running, nullptr is returned.
     */
-    static
-    suite*
+    static suite*
     this_suite()
     {
         return *p_this_suite();
     }
 
-    suite()
-        : log(*this)
-        , testcase(*this)
+    suite() : log(*this), testcase(*this)
     {
     }
 
     virtual ~suite() = default;
     suite(suite const&) = delete;
-    suite& operator=(suite const&) = delete;
+    suite&
+    operator=(suite const&) = delete;
 
     /** Invokes the test using the specified runner.
 
@@ -194,12 +177,12 @@ public:
         forwarded constructor arguments to the base.
         Normally this is called by the framework for you.
     */
-    template<class = void>
+    template <class = void>
     void
     operator()(runner& r);
 
     /** Record a successful test condition. */
-    template<class = void>
+    template <class = void>
     void
     pass();
 
@@ -212,11 +195,11 @@ public:
         @param line The source code line number where the test failed.
     */
     /** @{ */
-    template<class String>
+    template <class String>
     void
     fail(String const& reason, char const* file, int line);
 
-    template<class = void>
+    template <class = void>
     void
     fail(std::string const& reason = "");
     /** @} */
@@ -239,57 +222,59 @@ public:
         @return `true` if the test condition indicates success.
     */
     /** @{ */
-    template<class Condition>
+    template <class Condition>
     bool
     expect(Condition const& shouldBeTrue)
     {
         return expect(shouldBeTrue, "");
     }
 
-    template<class Condition, class String>
+    template <class Condition, class String>
     bool
     expect(Condition const& shouldBeTrue, String const& reason);
 
-    template<class Condition>
+    template <class Condition>
     bool
-    expect(Condition const& shouldBeTrue,
-        char const* file, int line)
+    expect(Condition const& shouldBeTrue, char const* file, int line)
     {
         return expect(shouldBeTrue, "", file, line);
     }
 
-    template<class Condition, class String>
+    template <class Condition, class String>
     bool
-    expect(Condition const& shouldBeTrue,
-        String const& reason, char const* file, int line);
+    expect(
+        Condition const& shouldBeTrue,
+        String const& reason,
+        char const* file,
+        int line);
     /** @} */
 
     //
     // DEPRECATED
     //
     // Expect an exception from f()
-    template<class F, class String>
+    template <class F, class String>
     bool
     except(F&& f, String const& reason);
-    template<class F>
+    template <class F>
     bool
     except(F&& f)
     {
         return except(f, "");
     }
-    template<class E, class F, class String>
+    template <class E, class F, class String>
     bool
     except(F&& f, String const& reason);
-    template<class E, class F>
+    template <class E, class F>
     bool
     except(F&& f)
     {
         return except<E>(f, "");
     }
-    template<class F, class String>
+    template <class F, class String>
     bool
     unexcept(F&& f, String const& reason);
-    template<class F>
+    template <class F>
     bool
     unexcept(F&& f)
     {
@@ -305,12 +290,11 @@ public:
 
     // DEPRECATED
     // @return `true` if the test condition indicates success(a false value)
-    template<class Condition, class String>
+    template <class Condition, class String>
     bool
-    unexpected(Condition shouldBeFalse,
-        String const& reason);
+    unexpected(Condition shouldBeFalse, String const& reason);
 
-    template<class Condition>
+    template <class Condition>
     bool
     unexpected(Condition shouldBeFalse)
     {
@@ -320,8 +304,7 @@ public:
 private:
     friend class thread;
 
-    static
-    suite**
+    static suite**
     p_this_suite()
     {
         static suite* pts = nullptr;
@@ -329,14 +312,13 @@ private:
     }
 
     /** Runs the suite. */
-    virtual
-    void
+    virtual void
     run() = 0;
 
     void
     propagate_abort();
 
-    template<class = void>
+    template <class = void>
     void
     run(runner& r);
 };
@@ -351,35 +333,32 @@ private:
     std::stringstream& ss_;
 
 public:
-    scoped_testcase& operator=(scoped_testcase const&) = delete;
+    scoped_testcase&
+    operator=(scoped_testcase const&) = delete;
 
     ~scoped_testcase()
     {
         auto const& name = ss_.str();
-        if(! name.empty())
+        if (!name.empty())
             suite_.runner_->testcase(name);
     }
 
-    scoped_testcase(suite& self, std::stringstream& ss)
-        : suite_(self)
-        , ss_(ss)
+    scoped_testcase(suite& self, std::stringstream& ss) : suite_(self), ss_(ss)
     {
         ss_.clear();
         ss_.str({});
     }
 
-    template<class T>
-    scoped_testcase(suite& self,
-            std::stringstream& ss, T const& t)
-        : suite_(self)
-        , ss_(ss)
+    template <class T>
+    scoped_testcase(suite& self, std::stringstream& ss, T const& t)
+        : suite_(self), ss_(ss)
     {
         ss_.clear();
         ss_.str({});
         ss_ << t;
     }
 
-    template<class T>
+    template <class T>
     scoped_testcase&
     operator<<(T const& t)
     {
@@ -390,37 +369,32 @@ public:
 
 //------------------------------------------------------------------------------
 
-inline
-void
-suite::testcase_t::operator()(
-    std::string const& name, abort_t abort)
+inline void
+suite::testcase_t::operator()(std::string const& name, abort_t abort)
 {
     suite_.abort_ = abort == abort_on_fail;
     suite_.runner_->testcase(name);
 }
 
-inline
-suite::scoped_testcase
+inline suite::scoped_testcase
 suite::testcase_t::operator()(abort_t abort)
 {
     suite_.abort_ = abort == abort_on_fail;
-    return { suite_, ss_ };
+    return {suite_, ss_};
 }
 
-template<class T>
-inline
-suite::scoped_testcase
+template <class T>
+inline suite::scoped_testcase
 suite::testcase_t::operator<<(T const& t)
 {
-    return { suite_, ss_, t };
+    return {suite_, ss_, t};
 }
 
 //------------------------------------------------------------------------------
 
-template<class>
+template <class>
 void
-suite::
-operator()(runner& r)
+suite::operator()(runner& r)
 {
     *p_this_suite() = this;
     try
@@ -428,20 +402,18 @@ operator()(runner& r)
         run(r);
         *p_this_suite() = nullptr;
     }
-    catch(...)
+    catch (...)
     {
         *p_this_suite() = nullptr;
         throw;
     }
 }
 
-template<class Condition, class String>
+template <class Condition, class String>
 bool
-suite::
-expect(
-    Condition const& shouldBeTrue, String const& reason)
+suite::expect(Condition const& shouldBeTrue, String const& reason)
 {
-    if(shouldBeTrue)
+    if (shouldBeTrue)
     {
         pass();
         return true;
@@ -450,13 +422,15 @@ expect(
     return false;
 }
 
-template<class Condition, class String>
+template <class Condition, class String>
 bool
-suite::
-expect(Condition const& shouldBeTrue,
-    String const& reason, char const* file, int line)
+suite::expect(
+    Condition const& shouldBeTrue,
+    String const& reason,
+    char const* file,
+    int line)
 {
-    if(shouldBeTrue)
+    if (shouldBeTrue)
     {
         pass();
         return true;
@@ -467,10 +441,9 @@ expect(Condition const& shouldBeTrue,
 
 // DEPRECATED
 
-template<class F, class String>
+template <class F, class String>
 bool
-suite::
-except(F&& f, String const& reason)
+suite::except(F&& f, String const& reason)
 {
     try
     {
@@ -478,17 +451,16 @@ except(F&& f, String const& reason)
         fail(reason);
         return false;
     }
-    catch(...)
+    catch (...)
     {
         pass();
     }
     return true;
 }
 
-template<class E, class F, class String>
+template <class E, class F, class String>
 bool
-suite::
-except(F&& f, String const& reason)
+suite::except(F&& f, String const& reason)
 {
     try
     {
@@ -496,17 +468,16 @@ except(F&& f, String const& reason)
         fail(reason);
         return false;
     }
-    catch(E const&)
+    catch (E const&)
     {
         pass();
     }
     return true;
 }
 
-template<class F, class String>
+template <class F, class String>
 bool
-suite::
-unexcept(F&& f, String const& reason)
+suite::unexcept(F&& f, String const& reason)
 {
     try
     {
@@ -514,73 +485,64 @@ unexcept(F&& f, String const& reason)
         pass();
         return true;
     }
-    catch(...)
+    catch (...)
     {
         fail(reason);
     }
     return false;
 }
 
-template<class Condition, class String>
+template <class Condition, class String>
 bool
-suite::
-unexpected(
-    Condition shouldBeFalse, String const& reason)
+suite::unexpected(Condition shouldBeFalse, String const& reason)
 {
-    bool const b =
-        static_cast<bool>(shouldBeFalse);
-    if(! b)
+    bool const b = static_cast<bool>(shouldBeFalse);
+    if (!b)
         pass();
     else
         fail(reason);
-    return ! b;
+    return !b;
 }
 
-template<class>
+template <class>
 void
-suite::
-pass()
+suite::pass()
 {
     propagate_abort();
     runner_->pass();
 }
 
 // ::fail
-template<class>
+template <class>
 void
-suite::
-fail(std::string const& reason)
+suite::fail(std::string const& reason)
 {
     propagate_abort();
     runner_->fail(reason);
-    if(abort_)
+    if (abort_)
     {
         aborted_ = true;
         BOOST_THROW_EXCEPTION(abort_exception());
     }
 }
 
-template<class String>
+template <class String>
 void
-suite::
-fail(String const& reason, char const* file, int line)
+suite::fail(String const& reason, char const* file, int line)
 {
     fail(detail::make_reason(reason, file, line));
 }
 
-inline
-void
-suite::
-propagate_abort()
+inline void
+suite::propagate_abort()
 {
-    if(abort_ && aborted_)
+    if (abort_ && aborted_)
         BOOST_THROW_EXCEPTION(abort_exception());
 }
 
-template<class>
+template <class>
 void
-suite::
-run(runner& r)
+suite::run(runner& r)
 {
     runner_ = &r;
 
@@ -588,16 +550,15 @@ run(runner& r)
     {
         run();
     }
-    catch(abort_exception const&)
+    catch (abort_exception const&)
     {
         // ends the suite
     }
-    catch(std::exception const& e)
+    catch (std::exception const& e)
     {
-        runner_->fail("unhandled exception: " +
-            std::string(e.what()));
+        runner_->fail("unhandled exception: " + std::string(e.what()));
     }
-    catch(...)
+    catch (...)
     {
         runner_->fail("unhandled exception");
     }
@@ -616,20 +577,21 @@ run(runner& r)
 
     If the condition is false, the file and line number are reported.
 */
-#define BEAST_EXPECTS(cond, reason) ((cond) ? (pass(), true) : \
-        (fail((reason), __FILE__, __LINE__), false))
+#define BEAST_EXPECTS(cond, reason) \
+    ((cond) ? (pass(), true) : (fail((reason), __FILE__, __LINE__), false))
 #endif
 
-} // unit_test
-} // beast
+}  // namespace unit_test
+}  // namespace beast
 
 //------------------------------------------------------------------------------
 
 // detail:
 // This inserts the suite with the given manual flag
-#define BEAST_DEFINE_TESTSUITE_INSERT(Class,Module,Library,manual,priority) \
-    static beast::unit_test::detail::insert_suite <Class##_test>   \
-        Library ## Module ## Class ## _test_instance(             \
+#define BEAST_DEFINE_TESTSUITE_INSERT(                          \
+    Class, Module, Library, manual, priority)                   \
+    static beast::unit_test::detail::insert_suite<Class##_test> \
+        Library##Module##Class##_test_instance(                 \
             #Class, #Module, #Library, manual, priority)
 
 //------------------------------------------------------------------------------
@@ -678,21 +640,21 @@ run(runner& r)
 */
 
 #if BEAST_NO_UNIT_TEST_INLINE
-#define BEAST_DEFINE_TESTSUITE(Class,Module,Library)
-#define BEAST_DEFINE_TESTSUITE_MANUAL(Class,Module,Library)
-#define BEAST_DEFINE_TESTSUITE_PRIO(Class,Module,Library,Priority)
-#define BEAST_DEFINE_TESTSUITE_MANUAL_PRIO(Class,Module,Library,Priority)
+#define BEAST_DEFINE_TESTSUITE(Class, Module, Library)
+#define BEAST_DEFINE_TESTSUITE_MANUAL(Class, Module, Library)
+#define BEAST_DEFINE_TESTSUITE_PRIO(Class, Module, Library, Priority)
+#define BEAST_DEFINE_TESTSUITE_MANUAL_PRIO(Class, Module, Library, Priority)
 
 #else
 #include <ripple/beast/unit_test/global_suites.hpp>
-#define BEAST_DEFINE_TESTSUITE(Class,Module,Library) \
-        BEAST_DEFINE_TESTSUITE_INSERT(Class,Module,Library,false,0)
-#define BEAST_DEFINE_TESTSUITE_MANUAL(Class,Module,Library) \
-        BEAST_DEFINE_TESTSUITE_INSERT(Class,Module,Library,true,0)
-#define BEAST_DEFINE_TESTSUITE_PRIO(Class,Module,Library,Priority) \
-        BEAST_DEFINE_TESTSUITE_INSERT(Class,Module,Library,false,Priority)
-#define BEAST_DEFINE_TESTSUITE_MANUAL_PRIO(Class,Module,Library,Priority) \
-        BEAST_DEFINE_TESTSUITE_INSERT(Class,Module,Library,true,Priority)
+#define BEAST_DEFINE_TESTSUITE(Class, Module, Library) \
+    BEAST_DEFINE_TESTSUITE_INSERT(Class, Module, Library, false, 0)
+#define BEAST_DEFINE_TESTSUITE_MANUAL(Class, Module, Library) \
+    BEAST_DEFINE_TESTSUITE_INSERT(Class, Module, Library, true, 0)
+#define BEAST_DEFINE_TESTSUITE_PRIO(Class, Module, Library, Priority) \
+    BEAST_DEFINE_TESTSUITE_INSERT(Class, Module, Library, false, Priority)
+#define BEAST_DEFINE_TESTSUITE_MANUAL_PRIO(Class, Module, Library, Priority) \
+    BEAST_DEFINE_TESTSUITE_INSERT(Class, Module, Library, true, Priority)
 #endif
 
 #endif

--- a/src/ripple/beast/unit_test/suite_info.hpp
+++ b/src/ripple/beast/unit_test/suite_info.hpp
@@ -32,12 +32,12 @@ class suite_info
 
 public:
     suite_info(
-            std::string name,
-            std::string module,
-            std::string library,
-            bool manual,
-            int priority,
-            run_type run)
+        std::string name,
+        std::string module,
+        std::string library,
+        bool manual,
+        int priority,
+        run_type run)
         : name_(std::move(name))
         , module_(std::move(module))
         , library_(std::move(library))
@@ -86,21 +86,22 @@ public:
         run_(r);
     }
 
-    friend
-    bool
+    friend bool
     operator<(suite_info const& lhs, suite_info const& rhs)
     {
         // we want higher priority suites sorted first, thus the negation
         // of priority value here
-        return std::forward_as_tuple(-lhs.priority_, lhs.library_, lhs.module_, lhs.name_) <
-               std::forward_as_tuple(-rhs.priority_, rhs.library_, rhs.module_, rhs.name_);
+        return std::forward_as_tuple(
+                   -lhs.priority_, lhs.library_, lhs.module_, lhs.name_) <
+            std::forward_as_tuple(
+                   -rhs.priority_, rhs.library_, rhs.module_, rhs.name_);
     }
 };
 
 //------------------------------------------------------------------------------
 
 /// Convenience for producing suite_info for a given test type.
-template<class Suite>
+template <class Suite>
 suite_info
 make_suite_info(
     std::string name,
@@ -115,14 +116,10 @@ make_suite_info(
         std::move(library),
         manual,
         priority,
-        [](runner& r)
-        {
-            Suite{}(r);
-        }
-    );
+        [](runner& r) { Suite{}(r); });
 }
 
-} // unit_test
-} // beast
+}  // namespace unit_test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/unit_test/suite_list.hpp
+++ b/src/ripple/beast/unit_test/suite_list.hpp
@@ -8,19 +8,18 @@
 #ifndef BEAST_UNIT_TEST_SUITE_LIST_HPP
 #define BEAST_UNIT_TEST_SUITE_LIST_HPP
 
-#include <ripple/beast/unit_test/suite_info.hpp>
 #include <ripple/beast/unit_test/detail/const_container.hpp>
+#include <ripple/beast/unit_test/suite_info.hpp>
 #include <boost/assert.hpp>
-#include <typeindex>
 #include <set>
+#include <typeindex>
 #include <unordered_set>
 
 namespace beast {
 namespace unit_test {
 
 /// A container of test suites.
-class suite_list
-    : public detail::const_container <std::set <suite_info>>
+class suite_list : public detail::const_container<std::set<suite_info>>
 {
 private:
 #ifndef NDEBUG
@@ -33,7 +32,7 @@ public:
 
         The suite must not already exist.
     */
-    template<class Suite>
+    template <class Suite>
     void
     insert(
         char const* name,
@@ -45,7 +44,7 @@ public:
 
 //------------------------------------------------------------------------------
 
-template<class Suite>
+template <class Suite>
 void
 suite_list::insert(
     char const* name,
@@ -59,20 +58,19 @@ suite_list::insert(
         std::string s;
         s = std::string(library) + "." + module + "." + name;
         auto const result(names_.insert(s));
-        BOOST_ASSERT(result.second); // Duplicate name
+        BOOST_ASSERT(result.second);  // Duplicate name
     }
 
     {
-        auto const result(classes_.insert(
-            std::type_index(typeid(Suite))));
-        BOOST_ASSERT(result.second); // Duplicate type
+        auto const result(classes_.insert(std::type_index(typeid(Suite))));
+        BOOST_ASSERT(result.second);  // Duplicate type
     }
 #endif
-    cont().emplace(make_suite_info<Suite>(
-        name, module, library, manual, priority));
+    cont().emplace(
+        make_suite_info<Suite>(name, module, library, manual, priority));
 }
 
-} // unit_test
-} // beast
+}  // namespace unit_test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/unit_test/thread.hpp
+++ b/src/ripple/beast/unit_test/thread.hpp
@@ -29,31 +29,27 @@ public:
 
     thread() = default;
     thread(thread const&) = delete;
-    thread& operator=(thread const&) = delete;
+    thread&
+    operator=(thread const&) = delete;
 
-    thread(thread&& other)
-        : s_(other.s_)
-        , t_(std::move(other.t_))
+    thread(thread&& other) : s_(other.s_), t_(std::move(other.t_))
     {
     }
 
-    thread& operator=(thread&& other)
+    thread&
+    operator=(thread&& other)
     {
         s_ = other.s_;
         t_ = std::move(other.t_);
         return *this;
     }
 
-    template<class F, class... Args>
-    explicit
-    thread(suite& s, F&& f, Args&&... args)
-        : s_(&s)
+    template <class F, class... Args>
+    explicit thread(suite& s, F&& f, Args&&... args) : s_(&s)
     {
         std::function<void(void)> b =
-            std::bind(std::forward<F>(f),
-                std::forward<Args>(args)...);
-        t_ = std::thread(&thread::run, this,
-            std::move(b));
+            std::bind(std::forward<F>(f), std::forward<Args>(args)...);
+        t_ = std::thread(&thread::run, this, std::move(b));
     }
 
     bool
@@ -68,8 +64,7 @@ public:
         return t_.get_id();
     }
 
-    static
-    unsigned
+    static unsigned
     hardware_concurrency() noexcept
     {
         return std::thread::hardware_concurrency();
@@ -97,28 +92,27 @@ public:
 
 private:
     void
-    run(std::function <void(void)> f)
+    run(std::function<void(void)> f)
     {
         try
         {
             f();
         }
-        catch(suite::abort_exception const&)
+        catch (suite::abort_exception const&)
         {
         }
-        catch(std::exception const& e)
+        catch (std::exception const& e)
         {
-            s_->fail("unhandled exception: " +
-                std::string(e.what()));
+            s_->fail("unhandled exception: " + std::string(e.what()));
         }
-        catch(...)
+        catch (...)
         {
             s_->fail("unhandled exception");
         }
     }
 };
 
-} // unit_test
-} // beast
+}  // namespace unit_test
+}  // namespace beast
 
 #endif

--- a/src/ripple/beast/utility/src/beast_Journal.cpp
+++ b/src/ripple/beast/utility/src/beast_Journal.cpp
@@ -34,7 +34,8 @@ public:
 
     ~NullJournalSink() override = default;
 
-    bool active(severities::Severity) const override
+    bool
+    active(severities::Severity) const override
     {
         return false;
     }
@@ -56,7 +57,8 @@ public:
         return severities::kDisabled;
     }
 
-    void threshold(severities::Severity) override
+    void
+    threshold(severities::Severity) override
     {
     }
 

--- a/src/ripple/conditions/impl/PreimageSha256.h
+++ b/src/ripple/conditions/impl/PreimageSha256.h
@@ -137,7 +137,8 @@ public:
         return {type(), cost(), fingerprint()};
     }
 
-    bool validate(Slice) const override
+    bool
+    validate(Slice) const override
     {
         // Perhaps counterintuitively, the message isn't
         // relevant.

--- a/src/ripple/core/impl/DatabaseCon.cpp
+++ b/src/ripple/core/impl/DatabaseCon.cpp
@@ -176,7 +176,7 @@ setup_DatabaseCon(Config const& c, std::optional<beast::Journal> j)
             }
 
             {
-                //#synchronous Valid values : off, normal, full, extra
+                // #synchronous Valid values : off, normal, full, extra
                 if (set(synchronous, "synchronous", sqlite) &&
                     !safety_level.empty())
                 {

--- a/src/ripple/json/MultivarJson.h
+++ b/src/ripple/json/MultivarJson.h
@@ -54,9 +54,8 @@ struct MultivarJson
     }
 
     void
-    set(const char* key,
-        auto const&
-            v) requires std::constructible_from<Json::Value, decltype(v)>
+    set(const char* key, auto const& v)
+        requires std::constructible_from<Json::Value, decltype(v)>
     {
         for (auto& a : this->val)
             a[key] = v;
@@ -105,8 +104,7 @@ Such hypothetical change should correspond with change in RPCHelpers.h
 constexpr auto
 apiVersionSelector(unsigned int apiVersion) noexcept
 {
-    return [apiVersion]() constexpr
-    {
+    return [apiVersion]() constexpr {
         return static_cast<std::size_t>(
             apiVersion <= 1         //
                 ? 0                 //
@@ -128,12 +126,10 @@ template <
     (size == maxVer + 1 - minVer) &&               //
     (apiVersionSelector(minVer)() == 0) &&         //
     (apiVersionSelector(maxVer)() + 1 == size) &&  //
-    requires(Json::Value& json, Fn fn)
-{
-    fn(json, static_cast<unsigned int>(1));
-}
-void
-visit(MultivarJson<size>& json, Fn fn)
+    requires(Json::Value& json, Fn fn) {
+        fn(json, static_cast<unsigned int>(1));
+    }
+void visit(MultivarJson<size>& json, Fn fn)
 {
     [&]<std::size_t... offset>(std::index_sequence<offset...>)
     {

--- a/src/ripple/json/impl/Writer.cpp
+++ b/src/ripple/json/impl/Writer.cpp
@@ -285,7 +285,8 @@ Writer::output(double f)
     impl_->output({s.data(), lengthWithoutTrailingZeros(s)});
 }
 
-void Writer::output(std::nullptr_t)
+void
+Writer::output(std::nullptr_t)
 {
     impl_->output("null");
 }

--- a/src/ripple/nodestore/impl/DatabaseNodeImp.h
+++ b/src/ripple/nodestore/impl/DatabaseNodeImp.h
@@ -106,7 +106,8 @@ public:
     store(NodeObjectType type, Blob&& data, uint256 const& hash, std::uint32_t)
         override;
 
-    bool isSameDB(std::uint32_t, std::uint32_t) override
+    bool
+    isSameDB(std::uint32_t, std::uint32_t) override
     {
         // only one database
         return true;

--- a/src/ripple/nodestore/impl/DatabaseRotatingImp.h
+++ b/src/ripple/nodestore/impl/DatabaseRotatingImp.h
@@ -60,7 +60,8 @@ public:
     void
     importDatabase(Database& source) override;
 
-    bool isSameDB(std::uint32_t, std::uint32_t) override
+    bool
+    isSameDB(std::uint32_t, std::uint32_t) override
     {
         // rotating store acts as one logical database
         return true;

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -603,7 +603,7 @@ PeerImp::fail(std::string const& reason)
         return post(
             strand_,
             std::bind(
-                (void (Peer::*)(std::string const&)) & PeerImp::fail,
+                (void(Peer::*)(std::string const&)) & PeerImp::fail,
                 shared_from_this(),
                 reason));
     if (journal_.active(beast::severities::kWarning) && socket_.is_open())

--- a/src/ripple/overlay/impl/ProtocolVersion.cpp
+++ b/src/ripple/overlay/impl/ProtocolVersion.cpp
@@ -45,7 +45,7 @@ constexpr ProtocolVersion const supportedProtocolList[]
 // ascending order and doesn't contain any duplicates.
 // FIXME: With C++20 we can use std::is_sorted with an appropriate comparator
 static_assert(
-    []() constexpr->bool {
+    []() constexpr -> bool {
         auto const len = std::distance(
             std::begin(supportedProtocolList), std::end(supportedProtocolList));
 

--- a/src/ripple/protocol/AccountID.h
+++ b/src/ripple/protocol/AccountID.h
@@ -22,7 +22,7 @@
 
 #include <ripple/protocol/tokens.h>
 // VFALCO Uncomment when the header issues are resolved
-//#include <ripple/protocol/PublicKey.h>
+// #include <ripple/protocol/PublicKey.h>
 #include <ripple/basics/UnorderedContainers.h>
 #include <ripple/basics/base_uint.h>
 #include <ripple/json/json_value.h>

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -388,7 +388,8 @@ inline STAmount::operator Number() const
     return iou();
 }
 
-inline STAmount& STAmount::operator=(beast::Zero)
+inline STAmount&
+STAmount::operator=(beast::Zero)
 {
     clear();
     return *this;

--- a/src/ripple/protocol/digest.h
+++ b/src/ripple/protocol/digest.h
@@ -191,11 +191,13 @@ public:
     }
 
 private:
-    inline void erase(std::false_type)
+    inline void
+    erase(std::false_type)
     {
     }
 
-    inline void erase(std::true_type)
+    inline void
+    erase(std::true_type)
     {
         secure_erase(&h_, sizeof(h_));
     }

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -650,7 +650,8 @@ STAmount::getText() const
     return ret;
 }
 
-Json::Value STAmount::getJson(JsonOptions) const
+Json::Value
+STAmount::getJson(JsonOptions) const
 {
     Json::Value elem;
     setJson(elem);

--- a/src/ripple/protocol/impl/STBase.cpp
+++ b/src/ripple/protocol/impl/STBase.cpp
@@ -96,7 +96,8 @@ STBase::getText() const
     return std::string();
 }
 
-Json::Value STBase::getJson(JsonOptions /*options*/) const
+Json::Value
+STBase::getJson(JsonOptions /*options*/) const
 {
     return getText();
 }

--- a/src/ripple/protocol/impl/STCurrency.cpp
+++ b/src/ripple/protocol/impl/STCurrency.cpp
@@ -50,7 +50,8 @@ STCurrency::getText() const
     return to_string(currency_);
 }
 
-Json::Value STCurrency::getJson(JsonOptions) const
+Json::Value
+STCurrency::getJson(JsonOptions) const
 {
     return to_string(currency_);
 }

--- a/src/ripple/protocol/impl/STInteger.cpp
+++ b/src/ripple/protocol/impl/STInteger.cpp
@@ -61,7 +61,8 @@ STUInt8::getText() const
 }
 
 template <>
-Json::Value STUInt8::getJson(JsonOptions) const
+Json::Value
+STUInt8::getJson(JsonOptions) const
 {
     if (getFName() == sfTransactionResult)
     {
@@ -118,7 +119,8 @@ STUInt16::getText() const
 }
 
 template <>
-Json::Value STUInt16::getJson(JsonOptions) const
+Json::Value
+STUInt16::getJson(JsonOptions) const
 {
     if (getFName() == sfLedgerEntryType)
     {
@@ -164,7 +166,8 @@ STUInt32::getText() const
 }
 
 template <>
-Json::Value STUInt32::getJson(JsonOptions) const
+Json::Value
+STUInt32::getJson(JsonOptions) const
 {
     return value_;
 }
@@ -192,7 +195,8 @@ STUInt64::getText() const
 }
 
 template <>
-Json::Value STUInt64::getJson(JsonOptions) const
+Json::Value
+STUInt64::getJson(JsonOptions) const
 {
     std::string str(16, 0);
     auto ret = std::to_chars(str.data(), str.data() + str.size(), value_, 16);

--- a/src/ripple/protocol/impl/STIssue.cpp
+++ b/src/ripple/protocol/impl/STIssue.cpp
@@ -71,7 +71,8 @@ STIssue::getText() const
     return issue_.getText();
 }
 
-Json::Value STIssue::getJson(JsonOptions) const
+Json::Value
+STIssue::getJson(JsonOptions) const
 {
     return to_json(issue_);
 }

--- a/src/ripple/protocol/impl/STPathSet.cpp
+++ b/src/ripple/protocol/impl/STPathSet.cpp
@@ -163,7 +163,8 @@ STPath::hasSeen(
     return false;
 }
 
-Json::Value STPath::getJson(JsonOptions) const
+Json::Value
+STPath::getJson(JsonOptions) const
 {
     Json::Value ret(Json::arrayValue);
 

--- a/src/ripple/protocol/impl/STVector256.cpp
+++ b/src/ripple/protocol/impl/STVector256.cpp
@@ -80,7 +80,8 @@ STVector256::isEquivalent(const STBase& t) const
     return v && (mValue == v->mValue);
 }
 
-Json::Value STVector256::getJson(JsonOptions) const
+Json::Value
+STVector256::getJson(JsonOptions) const
 {
     Json::Value ret(Json::arrayValue);
 

--- a/src/ripple/rpc/impl/ServerHandler.cpp
+++ b/src/ripple/rpc/impl/ServerHandler.cpp
@@ -386,9 +386,9 @@ logDuration(
     beast::Journal& journal)
 {
     using namespace std::chrono_literals;
-    auto const level = (duration >= 10s)
-        ? journal.error()
-        : (duration >= 1s) ? journal.warn() : journal.debug();
+    auto const level = (duration >= 10s) ? journal.error()
+        : (duration >= 1s)               ? journal.warn()
+                                         : journal.debug();
 
     JLOG(level) << "RPC request processing duration = "
                 << std::chrono::duration_cast<std::chrono::microseconds>(

--- a/src/ripple/server/impl/BaseHTTPPeer.h
+++ b/src/ripple/server/impl/BaseHTTPPeer.h
@@ -244,7 +244,7 @@ BaseHTTPPeer<Handler, Impl>::close()
         return post(
             strand_,
             std::bind(
-                (void (BaseHTTPPeer::*)(void)) & BaseHTTPPeer::close,
+                (void(BaseHTTPPeer::*)(void)) & BaseHTTPPeer::close,
                 impl().shared_from_this()));
     boost::beast::get_lowest_layer(impl().stream_).close();
 }
@@ -507,7 +507,7 @@ BaseHTTPPeer<Handler, Impl>::close(bool graceful)
         return post(
             strand_,
             std::bind(
-                (void (BaseHTTPPeer::*)(bool)) &
+                (void(BaseHTTPPeer::*)(bool)) &
                     BaseHTTPPeer<Handler, Impl>::close,
                 impl().shared_from_this(),
                 graceful));

--- a/src/ripple/shamap/NodeFamily.h
+++ b/src/ripple/shamap/NodeFamily.h
@@ -66,12 +66,14 @@ public:
         return false;
     }
 
-    std::shared_ptr<FullBelowCache> getFullBelowCache(std::uint32_t) override
+    std::shared_ptr<FullBelowCache>
+    getFullBelowCache(std::uint32_t) override
     {
         return fbCache_;
     }
 
-    std::shared_ptr<TreeNodeCache> getTreeNodeCache(std::uint32_t) override
+    std::shared_ptr<TreeNodeCache>
+    getTreeNodeCache(std::uint32_t) override
     {
         return tnCache_;
     }

--- a/src/ripple/shamap/impl/TaggedPointer.ipp
+++ b/src/ripple/shamap/impl/TaggedPointer.ipp
@@ -55,8 +55,8 @@ constexpr size_t elementSizeBytes =
 constexpr size_t blockSizeBytes = kilobytes(512);
 
 template <std::size_t... I>
-constexpr std::array<size_t, boundaries.size()> initArrayChunkSizeBytes(
-    std::index_sequence<I...>)
+constexpr std::array<size_t, boundaries.size()>
+initArrayChunkSizeBytes(std::index_sequence<I...>)
 {
     return std::array<size_t, boundaries.size()>{
         boundaries[I] * elementSizeBytes...,
@@ -66,8 +66,8 @@ constexpr auto arrayChunkSizeBytes =
     initArrayChunkSizeBytes(std::make_index_sequence<boundaries.size()>{});
 
 template <std::size_t... I>
-constexpr std::array<size_t, boundaries.size()> initArrayChunksPerBlock(
-    std::index_sequence<I...>)
+constexpr std::array<size_t, boundaries.size()>
+initArrayChunksPerBlock(std::index_sequence<I...>)
 {
     return std::array<size_t, boundaries.size()>{
         blockSizeBytes / arrayChunkSizeBytes[I]...,
@@ -93,8 +93,8 @@ boundariesIndex(std::uint8_t numChildren)
 }
 
 template <std::size_t... I>
-std::array<std::function<void*()>, boundaries.size()> initAllocateArrayFuns(
-    std::index_sequence<I...>)
+std::array<std::function<void*()>, boundaries.size()>
+initAllocateArrayFuns(std::index_sequence<I...>)
 {
     return std::array<std::function<void*()>, boundaries.size()>{
         boost::singleton_pool<
@@ -110,8 +110,8 @@ std::array<std::function<void*()>, boundaries.size()> const allocateArrayFuns =
     initAllocateArrayFuns(std::make_index_sequence<boundaries.size()>{});
 
 template <std::size_t... I>
-std::array<std::function<void(void*)>, boundaries.size()> initFreeArrayFuns(
-    std::index_sequence<I...>)
+std::array<std::function<void(void*)>, boundaries.size()>
+initFreeArrayFuns(std::index_sequence<I...>)
 {
     return std::array<std::function<void(void*)>, boundaries.size()>{
         static_cast<void (*)(void*)>(boost::singleton_pool<
@@ -127,8 +127,8 @@ std::array<std::function<void(void*)>, boundaries.size()> const freeArrayFuns =
     initFreeArrayFuns(std::make_index_sequence<boundaries.size()>{});
 
 template <std::size_t... I>
-std::array<std::function<bool(void*)>, boundaries.size()> initIsFromArrayFuns(
-    std::index_sequence<I...>)
+std::array<std::function<bool(void*)>, boundaries.size()>
+initIsFromArrayFuns(std::index_sequence<I...>)
 {
     return std::array<std::function<bool(void*)>, boundaries.size()>{
         boost::singleton_pool<

--- a/src/ripple/unity/rocksdb.h
+++ b/src/ripple/unity/rocksdb.h
@@ -21,7 +21,7 @@
 #define RIPPLE_UNITY_ROCKSDB_H_INCLUDED
 
 #if RIPPLE_ROCKSDB_AVAILABLE
-//#include <rocksdb2/port/port_posix.h>
+// #include <rocksdb2/port/port_posix.h>
 #include <rocksdb/cache.h>
 #include <rocksdb/compaction_filter.h>
 #include <rocksdb/comparator.h>

--- a/src/test/app/NFTokenBurn_test.cpp
+++ b/src/test/app/NFTokenBurn_test.cpp
@@ -256,7 +256,8 @@ class NFTokenBurnBaseUtil_test : public beast::unit_test::suite
             // Otherwise either alice or minter can burn.
             AcctStat& burner = owner.acct == becky.acct
                 ? *(stats[acctDist(engine)])
-                : mintDist(engine) ? alice : minter;
+                : mintDist(engine) ? alice
+                                   : minter;
 
             if (owner.acct == burner.acct)
                 env(token::burn(burner, nft));

--- a/src/test/beast/beast_Zero_test.cpp
+++ b/src/test/beast/beast_Zero_test.cpp
@@ -27,7 +27,8 @@ struct adl_tester
 {
 };
 
-int signum(adl_tester)
+int
+signum(adl_tester)
 {
     return 0;
 }
@@ -38,7 +39,8 @@ struct adl_tester2
 {
 };
 
-int signum(adl_tester2)
+int
+signum(adl_tester2)
 {
     return 0;
 }

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -644,7 +644,8 @@ struct Peer
     }
 
     // Not interested in tracking consensus mode changes for now
-    void onModeChange(ConsensusMode, ConsensusMode)
+    void
+    onModeChange(ConsensusMode, ConsensusMode)
     {
     }
 

--- a/src/test/json/MultivarJson_test.cpp
+++ b/src/test/json/MultivarJson_test.cpp
@@ -104,42 +104,31 @@ struct MultivarJson_test : beast::unit_test::suite
 
             // Tests of requires clause - these are expected to match
             static_assert([](auto&& v) {
-                return requires
-                {
-                    v.select([]() -> std::size_t { return 0; });
-                };
+                return requires {
+                           v.select([]() -> std::size_t { return 0; });
+                       };
             }(subject));
             static_assert([](auto&& v) {
-                return requires
-                {
-                    v.select([]() constexpr->std::size_t { return 0; });
-                };
+                return requires {
+                           v.select(
+                               []() constexpr -> std::size_t { return 0; });
+                       };
             }(subject));
             static_assert([](auto&& v) {
-                return requires
-                {
-                    v.select([]() mutable -> std::size_t { return 0; });
-                };
+                return requires {
+                           v.select([]() mutable -> std::size_t { return 0; });
+                       };
             }(subject));
 
             // Tests of requires clause - these are expected NOT to match
             static_assert([](auto&& a) {
-                return !requires
-                {
-                    subject.select([]() -> int { return 0; });
-                };
+                return !requires { subject.select([]() -> int { return 0; }); };
             }(subject));
             static_assert([](auto&& v) {
-                return !requires
-                {
-                    v.select([]() -> void {});
-                };
+                return !requires { v.select([]() -> void {}); };
             }(subject));
             static_assert([](auto&& v) {
-                return !requires
-                {
-                    v.select([]() -> bool { return false; });
-                };
+                return !requires { v.select([]() -> bool { return false; }); };
             }(subject));
         }
 
@@ -165,45 +154,25 @@ struct MultivarJson_test : beast::unit_test::suite
 
             // Tests of requires clause - these are expected to match
             static_assert([](auto&& v) {
-                return requires
-                {
-                    v.set("name", Json::nullValue);
-                };
+                return requires { v.set("name", Json::nullValue); };
             }(x));
             static_assert([](auto&& v) {
-                return requires
-                {
-                    v.set("name", "value");
-                };
+                return requires { v.set("name", "value"); };
             }(x));
-            static_assert([](auto&& v) {
-                return requires
-                {
-                    v.set("name", true);
-                };
-            }(x));
-            static_assert([](auto&& v) {
-                return requires
-                {
-                    v.set("name", 42);
-                };
-            }(x));
+            static_assert(
+                [](auto&& v) { return requires { v.set("name", true); }; }(x));
+            static_assert(
+                [](auto&& v) { return requires { v.set("name", 42); }; }(x));
 
             // Tests of requires clause - these are expected NOT to match
             struct foo_t final
             {
             };
             static_assert([](auto&& v) {
-                return !requires
-                {
-                    v.set("name", foo_t{});
-                };
+                return !requires { v.set("name", foo_t{}); };
             }(x));
             static_assert([](auto&& v) {
-                return !requires
-                {
-                    v.set("name", std::nullopt);
-                };
+                return !requires { v.set("name", std::nullopt); };
             }(x));
         }
 
@@ -253,10 +222,7 @@ struct MultivarJson_test : beast::unit_test::suite
             static_assert(
                 std::is_same_v<decltype(apiVersionSelector(1)()), std::size_t>);
             static_assert([](auto&& v) {
-                return requires
-                {
-                    v.select(apiVersionSelector(1));
-                };
+                return requires { v.select(apiVersionSelector(1)); };
             }(x));
 
             BEAST_EXPECT(x.select(apiVersionSelector(0)) == obj1);
@@ -310,72 +276,65 @@ struct MultivarJson_test : beast::unit_test::suite
 
             // Can use fn with constexpr functor
             static_assert([](auto&& v) {
-                return requires
-                {
-                    ripple::visit<1, 3>(
-                        v, [](Json::Value&, unsigned int) constexpr {});
-                };
+                return requires {
+                           ripple::visit<1, 3>(
+                               v, [](Json::Value&, unsigned int) constexpr {});
+                       };
             }(s1));
 
             // Can use fn with deduction over all parameters
             static_assert([](auto&& v) {
-                return requires
-                {
-                    ripple::visit<1, 3>(v, [](auto&, auto) constexpr {});
-                };
+                return requires {
+                           ripple::visit<1, 3>(v, [](auto&, auto) constexpr {});
+                       };
             }(s1));
 
             // Can use fn with conversion of version parameter
             static_assert([](auto&& v) {
-                return requires
-                {
-                    ripple::visit<1, 3>(v, [](auto&, std::size_t) constexpr {});
-                };
+                return requires {
+                           ripple::visit<1, 3>(
+                               v, [](auto&, std::size_t) constexpr {});
+                       };
             }(s1));
 
             // Cannot use fn with const parameter
             static_assert([](auto&& v) {
-                return !requires
-                {
-                    ripple::visit<1, 3>(
-                        v, [](Json::Value const&, auto) constexpr {});
-                };
+                return !requires {
+                            ripple::visit<1, 3>(
+                                v, [](Json::Value const&, auto) constexpr {});
+                        };
             }(const_cast<MultivarJson<3> const&>(s1)));
 
             // Cannot call visit with size mismatch
             static_assert([](auto&& v) {
-                return !requires
-                {
-                    ripple::visit<1, 2>(
-                        v, [](Json::Value&, unsigned int) constexpr {});
-                };
+                return !requires {
+                            ripple::visit<1, 2>(
+                                v, [](Json::Value&, unsigned int) constexpr {});
+                        };
             }(s1));
 
             // Cannot call visit with version offset
             static_assert([](auto&& v) {
-                return !requires
-                {
-                    ripple::visit<0, 2>(
-                        v, [](Json::Value&, unsigned int) constexpr {});
-                };
+                return !requires {
+                            ripple::visit<0, 2>(
+                                v, [](Json::Value&, unsigned int) constexpr {});
+                        };
             }(s1));
 
             // Cannot call visit with size mismatch
             static_assert([](auto&& v) {
-                return !requires
-                {
-                    ripple::visit<1, 4>(
-                        v, [](Json::Value&, unsigned int) constexpr {});
-                };
+                return !requires {
+                            ripple::visit<1, 4>(
+                                v, [](Json::Value&, unsigned int) constexpr {});
+                        };
             }(s1));
 
             // Cannot call visit with wrong order of versions
             static_assert([](auto&& v) {
-                return !requires
-                {
-                    ripple::visit<3, 1>(
-                        v, [](Json::Value&, unsigned int) constexpr {});
-                };
+                return !requires {
+                            ripple::visit<3, 1>(
+                                v, [](Json::Value&, unsigned int) constexpr {});
+                        };
             }(s1));
         }
     }

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -759,13 +759,12 @@ Env::rpc(std::string const& cmd, Args&&... args)
  * an unsigned integer as its argument and returns void.
  */
 template <class T>
-concept SingleVersionedTestCallable = requires(T callable, unsigned int version)
-{
-    {
-        callable(version)
-    }
-    ->std::same_as<void>;
-};
+concept SingleVersionedTestCallable =
+    requires(T callable, unsigned int version) {
+        {
+            callable(version)
+            } -> std::same_as<void>;
+    };
 
 /**
  * The VersionedTestCallable concept checks if a set of callables all satisfy

--- a/src/test/jtx/TestHelpers.h
+++ b/src/test/jtx/TestHelpers.h
@@ -39,11 +39,11 @@ namespace jtx {
 // when we have moved to better compilers.
 template <typename Input>
 auto
-make_vector(Input const& input) requires requires(Input& v)
-{
-    std::begin(v);
-    std::end(v);
-}
+make_vector(Input const& input)
+    requires requires(Input& v) {
+                 std::begin(v);
+                 std::end(v);
+             }
 {
     return std::vector(std::begin(input), std::end(input));
 }

--- a/src/test/jtx/amount.h
+++ b/src/test/jtx/amount.h
@@ -126,7 +126,7 @@ public:
         return amount_;
     }
 
-    operator STAmount const &() const
+    operator STAmount const&() const
     {
         return amount_;
     }
@@ -211,7 +211,8 @@ struct XRP_t
     /** @} */
 
     /** Returns None-of-XRP */
-    None operator()(none_t) const
+    None
+    operator()(none_t) const
     {
         return {xrpIssue()};
     }
@@ -334,7 +335,8 @@ public:
     // STAmount operator()(char const* s) const;
 
     /** Returns None-of-Issue */
-    None operator()(none_t) const
+    None
+    operator()(none_t) const
     {
         return {issue()};
     }

--- a/src/test/jtx/impl/AMM.cpp
+++ b/src/test/jtx/impl/AMM.cpp
@@ -42,8 +42,8 @@ static IOUAmount
 initialTokens(STAmount const& asset1, STAmount const& asset2)
 {
     auto const product = number(asset1) * number(asset2);
-    return (IOUAmount)(
-        product.mantissa() >= 0 ? root2(product) : root2(-product));
+    return (
+        IOUAmount)(product.mantissa() >= 0 ? root2(product) : root2(-product));
 }
 
 AMM::AMM(

--- a/src/test/jtx/impl/amount.cpp
+++ b/src/test/jtx/impl/amount.cpp
@@ -104,7 +104,8 @@ operator<<(std::ostream& os, PrettyAmount const& amount)
 
 XRP_t const XRP{};
 
-PrettyAmount IOU::operator()(epsilon_t) const
+PrettyAmount
+IOU::operator()(epsilon_t) const
 {
     return {STAmount(issue(), 1, -81), account.name()};
 }

--- a/src/test/shamap/common.h
+++ b/src/test/shamap/common.h
@@ -81,12 +81,14 @@ public:
         return j_;
     }
 
-    std::shared_ptr<FullBelowCache> getFullBelowCache(std::uint32_t) override
+    std::shared_ptr<FullBelowCache>
+    getFullBelowCache(std::uint32_t) override
     {
         return fbCache_;
     }
 
-    std::shared_ptr<TreeNodeCache> getTreeNodeCache(std::uint32_t) override
+    std::shared_ptr<TreeNodeCache>
+    getTreeNodeCache(std::uint32_t) override
     {
         return tnCache_;
     }


### PR DESCRIPTION
clang-format-10 is no longer available on the latest version of Ubuntu (23.10). clang-format-15 is the latest version available on the latest [Ubuntu GitHub runner image](https://github.com/actions/runner-images?tab=readme-ov-file#available-images) (22.04). It does a much better job formatting requires clauses, for one.

We weren't formatting the few headers ending in `.hpp` either, which this PR corrects.