### PR TITLE
Proposed 2.2.0-b2

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -28,6 +28,12 @@ The `network_id` field was added in the `server_info` response in version 1.5.0 
 
 ## XRP Ledger server version 2.0.0
 
+### Additions in 2.2
+
+Additions are intended to be non-breaking (because they are purely additive).
+
+- `feature`: A non-admin mode that uses the same formatting as admin RPC, but hides potentially-sensitive data.
+
 ### Additions in 2.0
 
 Additions are intended to be non-breaking (because they are purely additive).
@@ -35,7 +41,6 @@ Additions are intended to be non-breaking (because they are purely additive).
 - `server_definitions`: A new RPC that generates a `definitions.json`-like output that can be used in XRPL libraries.
 - In `Payment` transactions, `DeliverMax` has been added. This is a replacement for the `Amount` field, which should not be used. Typically, the `delivered_amount` (in transaction metadata) should be used. To ease the transition, `DeliverMax` is present regardless of API version, since adding a field is non-breaking.
 - API version 2 has been moved from beta to supported, meaning that it is generally available (regardless of the `beta_rpc_api` setting).
-
 
 ## XRP Ledger server version 1.12.0
 

--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -305,8 +305,10 @@ install (
   DESTINATION include/ripple/protocol)
 install (
   FILES
+    src/ripple/protocol/impl/b58_utils.h
     src/ripple/protocol/impl/STVar.h
     src/ripple/protocol/impl/secp256k1.h
+    src/ripple/protocol/impl/token_errors.h
   DESTINATION include/ripple/protocol/impl)
 install (
     FILES
@@ -887,6 +889,7 @@ if (tests)
     src/test/basics/StringUtilities_test.cpp
     src/test/basics/TaggedCache_test.cpp
     src/test/basics/XRPAmount_test.cpp
+    src/test/basics/base58_test.cpp
     src/test/basics/base64_test.cpp
     src/test/basics/base_uint_test.cpp
     src/test/basics/contract_test.cpp

--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -269,6 +269,7 @@ install (
     src/ripple/protocol/SOTemplate.h
     src/ripple/protocol/STAccount.h
     src/ripple/protocol/STAmount.h
+    src/ripple/protocol/STCurrency.h
     src/ripple/protocol/STIssue.h
     src/ripple/protocol/STArray.h
     src/ripple/protocol/STBase.h

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -242,7 +242,7 @@ public:
     virtual std::pair<PublicKey, SecretKey> const&
     nodeIdentity() = 0;
 
-    virtual PublicKey const&
+    virtual std::optional<PublicKey const>
     getValidationPublicKey() const = 0;
 
     virtual Resource::Manager&

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -81,11 +81,11 @@ public:
     firstUnsupportedExpected() const = 0;
 
     virtual Json::Value
-    getJson() const = 0;
+    getJson(bool isAdmin) const = 0;
 
     /** Returns a Json::objectValue. */
     virtual Json::Value
-    getJson(uint256 const& amendment) const = 0;
+    getJson(uint256 const& amendment, bool isAdmin) const = 0;
 
     /** Called when a new fully-validated ledger is accepted. */
     void

--- a/src/ripple/app/misc/NegativeUNLVote.cpp
+++ b/src/ripple/app/misc/NegativeUNLVote.cpp
@@ -90,7 +90,7 @@ NegativeUNLVote::doVoting(
             auto n =
                 choose(prevLedger->info().hash, candidates.toDisableCandidates);
             assert(nidToKeyMap.count(n));
-            addTx(seq, nidToKeyMap[n], ToDisable, initialSet);
+            addTx(seq, nidToKeyMap.at(n), ToDisable, initialSet);
         }
 
         if (!candidates.toReEnableCandidates.empty())
@@ -98,7 +98,7 @@ NegativeUNLVote::doVoting(
             auto n = choose(
                 prevLedger->info().hash, candidates.toReEnableCandidates);
             assert(nidToKeyMap.count(n));
-            addTx(seq, nidToKeyMap[n], ToReEnable, initialSet);
+            addTx(seq, nidToKeyMap.at(n), ToReEnable, initialSet);
         }
     }
 }

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1970,9 +1970,9 @@ NetworkOPsImp::pubManifest(Manifest const& mo)
 
         jvObj[jss::type] = "manifestReceived";
         jvObj[jss::master_key] = toBase58(TokenType::NodePublic, mo.masterKey);
-        if (!mo.signingKey.empty())
+        if (mo.signingKey)
             jvObj[jss::signing_key] =
-                toBase58(TokenType::NodePublic, mo.signingKey);
+                toBase58(TokenType::NodePublic, *mo.signingKey);
         jvObj[jss::seq] = Json::UInt(mo.sequence);
         if (auto sig = mo.getSignature())
             jvObj[jss::signature] = strHex(*sig);
@@ -2456,10 +2456,11 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
 
     if (admin)
     {
-        if (!app_.getValidationPublicKey().empty())
+        if (auto const localPubKey = app_.validators().localPublicKey();
+            localPubKey && app_.getValidationPublicKey())
         {
-            info[jss::pubkey_validator] = toBase58(
-                TokenType::NodePublic, app_.validators().localPublicKey());
+            info[jss::pubkey_validator] =
+                toBase58(TokenType::NodePublic, localPubKey.value());
         }
         else
         {

--- a/src/ripple/app/misc/ValidatorKeys.h
+++ b/src/ripple/app/misc/ValidatorKeys.h
@@ -36,13 +36,35 @@ class Config;
 class ValidatorKeys
 {
 public:
-    PublicKey masterPublicKey;
-    PublicKey publicKey;
-    SecretKey secretKey;
+    // Group all keys in a struct. Either all keys are valid or none are.
+    struct Keys
+    {
+        PublicKey masterPublicKey;
+        PublicKey publicKey;
+        SecretKey secretKey;
+
+        Keys() = delete;
+        Keys(
+            PublicKey const& masterPublic_,
+            PublicKey const& public_,
+            SecretKey const& secret_)
+            : masterPublicKey(masterPublic_)
+            , publicKey(public_)
+            , secretKey(secret_)
+        {
+        }
+    };
+
+    // Note: The existence of keys cannot be used as a proxy for checking the
+    // validity of a configuration. It is possible to have a valid
+    // configuration while not setting the keys, as per the constructor of
+    // the ValidatorKeys class.
+    std::optional<Keys> keys;
     NodeID nodeID;
     std::string manifest;
     std::uint32_t sequence = 0;
 
+    ValidatorKeys() = delete;
     ValidatorKeys(Config const& config, beast::Journal j);
 
     bool

--- a/src/ripple/app/misc/ValidatorList.h
+++ b/src/ripple/app/misc/ValidatorList.h
@@ -247,7 +247,17 @@ class ValidatorList
     // a seed, the signing key is the same as the master key.
     hash_set<PublicKey> trustedSigningKeys_;
 
-    PublicKey localPubKey_;
+    std::optional<PublicKey> localPubKey_;
+
+    // The below variable contains the Publisher list specified in the local
+    // config file under the title of SECTION_VALIDATORS or [validators].
+    // This list is not associated with the masterKey of any publisher.
+
+    // Appropos PublisherListCollection fields, localPublisherList does not
+    // have any "remaining" manifests. It is assumed to be perennially
+    // "available". The "validUntil" field is set to the highest possible
+    // value of the field, hence this list is always valid.
+    PublisherList localPublisherList;
 
     // The master public keys of the current negative UNL
     hash_set<PublicKey> negativeUNL_;
@@ -331,7 +341,7 @@ public:
     */
     bool
     load(
-        PublicKey const& localSigningKey,
+        std::optional<PublicKey> const& localSigningKey,
         std::vector<std::string> const& configKeys,
         std::vector<std::string> const& publisherKeys);
 
@@ -553,13 +563,14 @@ public:
     bool
     trustedPublisher(PublicKey const& identity) const;
 
-    /** Returns local validator public key
+    /** This function returns the local validator public key
+     * or a std::nullopt
 
         @par Thread Safety
 
         May be called concurrently
     */
-    PublicKey
+    std::optional<PublicKey>
     localPublicKey() const;
 
     /** Invokes the callback once for every listed validation public key.
@@ -766,6 +777,8 @@ private:
         std::optional<uint256> const& hash,
         lock_guard const&);
 
+    // This function updates the keyListings_ counts for all the trusted
+    // master keys
     void
     updatePublisherList(
         PublicKey const& pubKey,
@@ -849,11 +862,10 @@ private:
 
         Calling public member function is expected to lock mutex
     */
-    ListDisposition
+    std::pair<ListDisposition, std::optional<PublicKey>>
     verify(
         lock_guard const&,
         Json::Value& list,
-        PublicKey& pubKey,
         std::string const& manifest,
         std::string const& blob,
         std::string const& signature);

--- a/src/ripple/app/misc/impl/Manifest.cpp
+++ b/src/ripple/app/misc/impl/Manifest.cpp
@@ -22,8 +22,6 @@
 #include <ripple/basics/Log.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/basics/base64.h>
-#include <ripple/basics/contract.h>
-#include <ripple/beast/rfc2616.h>
 #include <ripple/core/DatabaseCon.h>
 #include <ripple/json/json_reader.h>
 #include <ripple/protocol/PublicKey.h>
@@ -32,7 +30,6 @@
 #include <boost/algorithm/string/trim.hpp>
 
 #include <numeric>
-#include <shared_mutex>
 #include <stdexcept>
 
 namespace ripple {
@@ -45,8 +42,11 @@ to_string(Manifest const& m)
     if (m.revoked())
         return "Revocation Manifest " + mk;
 
+    if (!m.signingKey)
+        Throw<std::runtime_error>("No SigningKey in manifest " + mk);
+
     return "Manifest " + mk + " (" + std::to_string(m.sequence) + ": " +
-        toBase58(TokenType::NodePublic, m.signingKey) + ")";
+        toBase58(TokenType::NodePublic, *m.signingKey) + ")";
 }
 
 std::optional<Manifest>
@@ -96,25 +96,27 @@ deserializeManifest(Slice s, beast::Journal journal)
         if (!publicKeyType(makeSlice(pk)))
             return std::nullopt;
 
-        Manifest m;
-        m.serialized.assign(reinterpret_cast<char const*>(s.data()), s.size());
-        m.masterKey = PublicKey(makeSlice(pk));
-        m.sequence = st.getFieldU32(sfSequence);
+        PublicKey const masterKey = PublicKey(makeSlice(pk));
+        std::uint32_t const seq = st.getFieldU32(sfSequence);
+
+        std::string domain;
+
+        std::optional<PublicKey> signingKey;
 
         if (st.isFieldPresent(sfDomain))
         {
             auto const d = st.getFieldVL(sfDomain);
 
-            m.domain.assign(reinterpret_cast<char const*>(d.data()), d.size());
+            domain.assign(reinterpret_cast<char const*>(d.data()), d.size());
 
-            if (!isProperlyFormedTomlDomain(m.domain))
+            if (!isProperlyFormedTomlDomain(domain))
                 return std::nullopt;
         }
 
         bool const hasEphemeralKey = st.isFieldPresent(sfSigningPubKey);
         bool const hasEphemeralSig = st.isFieldPresent(sfSignature);
 
-        if (m.revoked())
+        if (Manifest::revoked(seq))
         {
             // Revocation manifests should not specify a new signing key
             // or a signing key signature.
@@ -139,14 +141,18 @@ deserializeManifest(Slice s, beast::Journal journal)
             if (!publicKeyType(makeSlice(spk)))
                 return std::nullopt;
 
-            m.signingKey = PublicKey(makeSlice(spk));
+            signingKey.emplace(makeSlice(spk));
 
             // The signing and master keys can't be the same
-            if (m.signingKey == m.masterKey)
+            if (*signingKey == masterKey)
                 return std::nullopt;
         }
 
-        return m;
+        std::string const serialized(
+            reinterpret_cast<char const*>(s.data()), s.size());
+
+        // If the manifest is revoked, then the signingKey will be unseated
+        return Manifest(serialized, masterKey, signingKey, seq, domain);
     }
     catch (std::exception const& ex)
     {
@@ -192,9 +198,14 @@ Manifest::verify() const
     SerialIter sit(serialized.data(), serialized.size());
     st.set(sit);
 
+    // The manifest must either have a signing key or be revoked.  This check
+    // prevents us from accessing an unseated signingKey in the next check.
+    if (!revoked() && !signingKey)
+        return false;
+
     // Signing key and signature are not required for
     // master key revocations
-    if (!revoked() && !ripple::verify(st, HashPrefix::manifest, signingKey))
+    if (!revoked() && !ripple::verify(st, HashPrefix::manifest, *signingKey))
         return false;
 
     return ripple::verify(
@@ -217,6 +228,14 @@ Manifest::revoked() const
         The maximum possible sequence number means that the master key
         has been revoked.
     */
+    return revoked(sequence);
+}
+
+bool
+Manifest::revoked(std::uint32_t sequence)
+{
+    // The maximum possible sequence number means that the master key has
+    // been revoked.
     return sequence == std::numeric_limits<std::uint32_t>::max();
 }
 
@@ -287,7 +306,7 @@ loadValidatorToken(std::vector<std::string> const& blob, beast::Journal journal)
     }
 }
 
-PublicKey
+std::optional<PublicKey>
 ManifestCache::getSigningKey(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
@@ -423,9 +442,18 @@ ManifestCache::applyManifest(Manifest m)
 
         if (!revoked)
         {
+            if (!m.signingKey)
+            {
+                JLOG(j_.warn()) << to_string(m)
+                                << ": is not revoked and the manifest has no "
+                                   "signing key. Hence, the manifest is "
+                                   "invalid";
+                return ManifestDisposition::invalid;
+            }
+
             // Sanity check: the ephemeral key of this manifest should not be
             // used as the master or ephemeral key of another manifest:
-            if (auto const x = signingToMasterKeys_.find(m.signingKey);
+            if (auto const x = signingToMasterKeys_.find(*m.signingKey);
                 x != signingToMasterKeys_.end())
             {
                 JLOG(j_.warn())
@@ -436,7 +464,7 @@ ManifestCache::applyManifest(Manifest m)
                 return ManifestDisposition::badEphemeralKey;
             }
 
-            if (auto const x = map_.find(m.signingKey); x != map_.end())
+            if (auto const x = map_.find(*m.signingKey); x != map_.end())
             {
                 JLOG(j_.warn())
                     << to_string(m) << ": Ephemeral key used as master key for "
@@ -479,7 +507,7 @@ ManifestCache::applyManifest(Manifest m)
             logMftAct(stream, "AcceptedNew", m.masterKey, m.sequence);
 
         if (!revoked)
-            signingToMasterKeys_[m.signingKey] = m.masterKey;
+            signingToMasterKeys_.emplace(*m.signingKey, m.masterKey);
 
         auto masterKey = m.masterKey;
         map_.emplace(std::move(masterKey), std::move(m));
@@ -496,10 +524,10 @@ ManifestCache::applyManifest(Manifest m)
             m.sequence,
             iter->second.sequence);
 
-    signingToMasterKeys_.erase(iter->second.signingKey);
+    signingToMasterKeys_.erase(*iter->second.signingKey);
 
     if (!revoked)
-        signingToMasterKeys_[m.signingKey] = m.masterKey;
+        signingToMasterKeys_.emplace(*m.signingKey, m.masterKey);
 
     iter->second = std::move(m);
 

--- a/src/ripple/app/misc/impl/ValidatorKeys.cpp
+++ b/src/ripple/app/misc/impl/ValidatorKeys.cpp
@@ -56,9 +56,7 @@ ValidatorKeys::ValidatorKeys(Config const& config, beast::Journal j)
             }
             else
             {
-                secretKey = token->validationSecret;
-                publicKey = pk;
-                masterPublicKey = m->masterKey;
+                keys.emplace(m->masterKey, pk, token->validationSecret);
                 nodeID = calcNodeID(m->masterKey);
                 sequence = m->sequence;
                 manifest = std::move(token->manifest);
@@ -83,10 +81,10 @@ ValidatorKeys::ValidatorKeys(Config const& config, beast::Journal j)
         }
         else
         {
-            secretKey = generateSecretKey(KeyType::secp256k1, *seed);
-            publicKey = derivePublicKey(KeyType::secp256k1, secretKey);
-            masterPublicKey = publicKey;
-            nodeID = calcNodeID(publicKey);
+            SecretKey const sk = generateSecretKey(KeyType::secp256k1, *seed);
+            PublicKey const pk = derivePublicKey(KeyType::secp256k1, sk);
+            keys.emplace(pk, pk, sk);
+            nodeID = calcNodeID(pk);
             sequence = 0;
         }
     }

--- a/src/ripple/basics/impl/contract.cpp
+++ b/src/ripple/basics/impl/contract.cpp
@@ -20,7 +20,6 @@
 #include <ripple/basics/Log.h>
 #include <ripple/basics/contract.h>
 #include <cstdlib>
-#include <exception>
 #include <iostream>
 
 namespace ripple {

--- a/src/ripple/json/impl/json_reader.cpp
+++ b/src/ripple/json/impl/json_reader.cpp
@@ -22,7 +22,6 @@
 
 #include <algorithm>
 #include <cctype>
-#include <cstdint>
 #include <istream>
 #include <string>
 

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -473,7 +473,7 @@ OverlayImpl::start()
     PeerFinder::Config config = PeerFinder::Config::makeConfig(
         app_.config(),
         serverHandler_.setup().overlay.port,
-        !app_.getValidationPublicKey().empty(),
+        app_.getValidationPublicKey().has_value(),
         setup_.ipLimit);
 
     m_peerFinder->setConfig(config);

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1574,7 +1574,9 @@ PeerImp::handleTransaction(
                 flags |= SF_TRUSTED;
             }
 
-            if (app_.getValidationPublicKey().empty())
+            // for non-validator nodes only -- localPublicKey is set for
+            // validators only
+            if (!app_.getValidationPublicKey())
             {
                 // For now, be paranoid and have each validator
                 // check each transaction, regardless of source

--- a/src/ripple/protocol/PublicKey.h
+++ b/src/ripple/protocol/PublicKey.h
@@ -61,13 +61,17 @@ namespace ripple {
 class PublicKey
 {
 protected:
-    std::size_t size_ = 0;
-    std::uint8_t buf_[33];  // should be large enough
+    // All the constructed public keys are valid, non-empty and contain 33
+    // bytes of data.
+    static constexpr std::size_t size_ = 33;
+    std::uint8_t buf_[size_];  // should be large enough
 
 public:
     using const_iterator = std::uint8_t const*;
 
-    PublicKey() = default;
+public:
+    PublicKey() = delete;
+
     PublicKey(PublicKey const& other);
     PublicKey&
     operator=(PublicKey const& other);
@@ -115,12 +119,6 @@ public:
         return buf_ + size_;
     }
 
-    bool
-    empty() const noexcept
-    {
-        return size_ == 0;
-    }
-
     Slice
     slice() const noexcept
     {
@@ -141,8 +139,7 @@ operator<<(std::ostream& os, PublicKey const& pk);
 inline bool
 operator==(PublicKey const& lhs, PublicKey const& rhs)
 {
-    return lhs.size() == rhs.size() &&
-        std::memcmp(lhs.data(), rhs.data(), rhs.size()) == 0;
+    return std::memcmp(lhs.data(), rhs.data(), rhs.size()) == 0;
 }
 
 inline bool

--- a/src/ripple/protocol/SecretKey.h
+++ b/src/ripple/protocol/SecretKey.h
@@ -41,7 +41,7 @@ private:
 public:
     using const_iterator = std::uint8_t const*;
 
-    SecretKey() = default;
+    SecretKey() = delete;
     SecretKey(SecretKey const&) = default;
     SecretKey&
     operator=(SecretKey const&) = default;

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.2.0-b1"
+char const* const versionString = "2.2.0-b2"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/ripple/protocol/impl/PublicKey.cpp
+++ b/src/ripple/protocol/impl/PublicKey.cpp
@@ -24,7 +24,6 @@
 #include <ripple/protocol/impl/secp256k1.h>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <ed25519.h>
-#include <type_traits>
 
 namespace ripple {
 
@@ -176,16 +175,19 @@ ed25519Canonical(Slice const& sig)
 
 PublicKey::PublicKey(Slice const& slice)
 {
+    if (slice.size() < size_)
+        LogicError(
+            "PublicKey::PublicKey - Input slice cannot be an undersized "
+            "buffer");
+
     if (!publicKeyType(slice))
         LogicError("PublicKey::PublicKey invalid type");
-    size_ = slice.size();
     std::memcpy(buf_, slice.data(), size_);
 }
 
-PublicKey::PublicKey(PublicKey const& other) : size_(other.size_)
+PublicKey::PublicKey(PublicKey const& other)
 {
-    if (size_)
-        std::memcpy(buf_, other.buf_, size_);
+    std::memcpy(buf_, other.buf_, size_);
 }
 
 PublicKey&
@@ -193,9 +195,7 @@ PublicKey::operator=(PublicKey const& other)
 {
     if (this != &other)
     {
-        size_ = other.size_;
-        if (size_)
-            std::memcpy(buf_, other.buf_, size_);
+        std::memcpy(buf_, other.buf_, size_);
     }
 
     return *this;

--- a/src/ripple/protocol/impl/b58_utils.h
+++ b/src/ripple/protocol/impl/b58_utils.h
@@ -1,0 +1,192 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_PROTOCOL_B58_UTILS_H_INCLUDED
+#define RIPPLE_PROTOCOL_B58_UTILS_H_INCLUDED
+
+#include <ripple/basics/contract.h>
+
+#include <boost/outcome.hpp>
+#include <boost/outcome/result.hpp>
+
+#include <cassert>
+#include <cinttypes>
+#include <span>
+#include <system_error>
+#include <tuple>
+
+namespace ripple {
+
+template <class T>
+using Result = boost::outcome_v2::result<T, std::error_code>;
+
+#ifndef _MSC_VER
+namespace b58_fast {
+namespace detail {
+
+// This optimizes to what hand written asm would do (single divide)
+[[nodiscard]] inline std::tuple<std::uint64_t, std::uint64_t>
+div_rem(std::uint64_t a, std::uint64_t b)
+{
+    return {a / b, a % b};
+}
+
+// This optimizes to what hand written asm would do (single multiply)
+[[nodiscard]] inline std::tuple<std::uint64_t, std::uint64_t>
+carrying_mul(std::uint64_t a, std::uint64_t b, std::uint64_t carry)
+{
+    unsigned __int128 const x = a;
+    unsigned __int128 const y = b;
+    unsigned __int128 const c = x * y + carry;
+    return {c & 0xffff'ffff'ffff'ffff, c >> 64};
+}
+
+[[nodiscard]] inline std::tuple<std::uint64_t, std::uint64_t>
+carrying_add(std::uint64_t a, std::uint64_t b)
+{
+    unsigned __int128 const x = a;
+    unsigned __int128 const y = b;
+    unsigned __int128 const c = x + y;
+    return {c & 0xffff'ffff'ffff'ffff, c >> 64};
+}
+
+// Add a u64 to a "big uint" value inplace.
+// The bigint value is stored with the smallest coefficients first
+// (i.e a[0] is the 2^0 coefficient, a[n] is the 2^(64*n) coefficient)
+// panics if overflows (this is a specialized adder for b58 decoding.
+// it should never overflow).
+inline void
+inplace_bigint_add(std::span<std::uint64_t> a, std::uint64_t b)
+{
+    if (a.size() <= 1)
+    {
+        ripple::LogicError("Input span too small for inplace_bigint_add");
+    }
+
+    std::uint64_t carry;
+    std::tie(a[0], carry) = carrying_add(a[0], b);
+
+    for (auto& v : a.subspan(1))
+    {
+        if (!carry)
+        {
+            return;
+        }
+        std::tie(v, carry) = carrying_add(v, 1);
+    }
+    if (carry)
+    {
+        LogicError("Overflow in inplace_bigint_add");
+    }
+}
+
+inline void
+inplace_bigint_mul(std::span<std::uint64_t> a, std::uint64_t b)
+{
+    if (a.empty())
+    {
+        LogicError("Empty span passed to inplace_bigint_mul");
+    }
+
+    auto const last_index = a.size() - 1;
+    if (a[last_index] != 0)
+    {
+        LogicError("Non-zero element in inplace_bigint_mul last index");
+    }
+
+    std::uint64_t carry = 0;
+    for (auto& coeff : a.subspan(0, last_index))
+    {
+        std::tie(coeff, carry) = carrying_mul(coeff, b, carry);
+    }
+    a[last_index] = carry;
+}
+// divide a "big uint" value inplace and return the mod
+// numerator is stored so smallest coefficients come first
+[[nodiscard]] inline std::uint64_t
+inplace_bigint_div_rem(std::span<uint64_t> numerator, std::uint64_t divisor)
+{
+    if (numerator.size() == 0)
+    {
+        // should never happen, but if it does then it seems natural to define
+        // the a null set of numbers to be zero, so the remainder is also zero.
+        assert(0);
+        return 0;
+    }
+
+    auto to_u128 = [](std::uint64_t high,
+                      std::uint64_t low) -> unsigned __int128 {
+        unsigned __int128 const high128 = high;
+        unsigned __int128 const low128 = low;
+        return ((high128 << 64) | low128);
+    };
+    auto div_rem_64 =
+        [](unsigned __int128 num,
+           std::uint64_t denom) -> std::tuple<std::uint64_t, std::uint64_t> {
+        unsigned __int128 const denom128 = denom;
+        unsigned __int128 const d = num / denom128;
+        unsigned __int128 const r = num - (denom128 * d);
+        assert(d >> 64 == 0);
+        assert(r >> 64 == 0);
+        return {static_cast<std::uint64_t>(d), static_cast<std::uint64_t>(r)};
+    };
+
+    std::uint64_t prev_rem = 0;
+    int const last_index = numerator.size() - 1;
+    std::tie(numerator[last_index], prev_rem) =
+        div_rem(numerator[last_index], divisor);
+    for (int i = last_index - 1; i >= 0; --i)
+    {
+        unsigned __int128 const cur_num = to_u128(prev_rem, numerator[i]);
+        std::tie(numerator[i], prev_rem) = div_rem_64(cur_num, divisor);
+    }
+    return prev_rem;
+}
+
+// convert from base 58^10 to base 58
+// put largest coeffs first
+// the `_be` suffix stands for "big endian"
+[[nodiscard]] inline std::array<std::uint8_t, 10>
+b58_10_to_b58_be(std::uint64_t input)
+{
+    constexpr std::uint64_t B_58_10 = 430804206899405824;  // 58^10;
+    if (input >= B_58_10)
+    {
+        LogicError("Input to b58_10_to_b58_be equals or exceeds 58^10.");
+    }
+
+    constexpr std::size_t resultSize = 10;
+    std::array<std::uint8_t, resultSize> result{};
+    int i = 0;
+    while (input > 0)
+    {
+        std::uint64_t rem;
+        std::tie(input, rem) = div_rem(input, 58);
+        result[resultSize - 1 - i] = rem;
+        i += 1;
+    }
+
+    return result;
+}
+}  // namespace detail
+}  // namespace b58_fast
+#endif
+
+}  // namespace ripple
+#endif  // RIPPLE_PROTOCOL_B58_UTILS_H_INCLUDED

--- a/src/ripple/protocol/impl/token_errors.h
+++ b/src/ripple/protocol/impl/token_errors.h
@@ -1,0 +1,101 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_PROTOCOL_TOKEN_ERRORS_H_INCLUDED
+#define RIPPLE_PROTOCOL_TOKEN_ERRORS_H_INCLUDED
+
+#include <system_error>
+
+namespace ripple {
+enum class TokenCodecErrc {
+    success = 0,
+    inputTooLarge,
+    inputTooSmall,
+    badB58Character,
+    outputTooSmall,
+    mismatchedTokenType,
+    mismatchedChecksum,
+    invalidEncodingChar,
+    unknown,
+};
+}
+
+namespace std {
+template <>
+struct is_error_code_enum<ripple::TokenCodecErrc> : true_type
+{
+};
+}  // namespace std
+
+namespace ripple {
+namespace detail {
+class TokenCodecErrcCategory : public std::error_category
+{
+public:
+    // Return a short descriptive name for the category
+    virtual const char*
+    name() const noexcept override final
+    {
+        return "TokenCodecError";
+    }
+    // Return what each enum means in text
+    virtual std::string
+    message(int c) const override final
+    {
+        switch (static_cast<TokenCodecErrc>(c))
+        {
+            case TokenCodecErrc::success:
+                return "conversion successful";
+            case TokenCodecErrc::inputTooLarge:
+                return "input too large";
+            case TokenCodecErrc::inputTooSmall:
+                return "input too small";
+            case TokenCodecErrc::badB58Character:
+                return "bad base 58 character";
+            case TokenCodecErrc::outputTooSmall:
+                return "output too small";
+            case TokenCodecErrc::mismatchedTokenType:
+                return "mismatched token type";
+            case TokenCodecErrc::mismatchedChecksum:
+                return "mismatched checksum";
+            case TokenCodecErrc::invalidEncodingChar:
+                return "invalid encoding char";
+            case TokenCodecErrc::unknown:
+                return "unknown";
+            default:
+                return "unknown";
+        }
+    }
+};
+}  // namespace detail
+
+inline const ripple::detail::TokenCodecErrcCategory&
+TokenCodecErrcCategory()
+{
+    static ripple::detail::TokenCodecErrcCategory c;
+    return c;
+}
+
+inline std::error_code
+make_error_code(ripple::TokenCodecErrc e)
+{
+    return {static_cast<int>(e), TokenCodecErrcCategory()};
+}
+}  // namespace ripple
+#endif  // TOKEN_ERRORS_H_

--- a/src/ripple/protocol/impl/tokens.cpp
+++ b/src/ripple/protocol/impl/tokens.cpp
@@ -16,17 +16,122 @@
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 //==============================================================================
+//
+/* The base58 encoding & decoding routines in the b58_ref namespace are taken
+ * from Bitcoin but have been modified from the original.
+ *
+ * Copyright (c) 2014 The Bitcoin Core developers
+ * Distributed under the MIT software license, see the accompanying
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ */
+
+#include <ripple/protocol/tokens.h>
 
 #include <ripple/basics/safe_cast.h>
 #include <ripple/protocol/digest.h>
-#include <ripple/protocol/tokens.h>
+#include <ripple/protocol/impl/b58_utils.h>
+
 #include <boost/container/small_vector.hpp>
+#include <boost/endian.hpp>
+#include <boost/endian/conversion.hpp>
+
 #include <cassert>
 #include <cstring>
 #include <memory>
 #include <type_traits>
 #include <utility>
 #include <vector>
+
+/*
+Converting between bases is straight forward. First, some background:
+
+Given the coefficients C[m], ... ,C[0] and base B, those coefficients represent
+the number C[m]*B^m + ... + C[0]*B^0; The following pseudo-code converts the
+coefficients to the (infinite precision) integer N:
+
+```
+N = 0;
+i = m ;; N.B. m is the index of the largest coefficient
+while (i>=0)
+    N = N + C[i]*B^i
+    i = i - 1
+```
+
+For example, in base 10, the number 437 represents the integer 4*10^2 + 3*10^1 +
+7*10^0. In base 16, 437 is the same as 4*16^2 + 3*16^1 + 7*16^0.
+
+To find the coefficients that represent the integer N in base B, we start by
+computing the lowest order coefficients and work up to the highest order
+coefficients. The following pseudo-code converts the (infinite precision)
+integer N to the correct coefficients:
+
+```
+i = 0
+while(N)
+    C[i] = N mod B
+    N = floor(N/B)
+    i = i + 1
+```
+
+For example, to find the coefficients of the integer 437 in base 10:
+
+C[0] is 437 mod 10; C[0] = 7;
+N is floor(437/10); N = 43;
+C[1] is 43 mod 10; C[1] = 3;
+N is floor(43/10); N = 4;
+C[2] is 4 mod 10; C[2] = 4;
+N is floor(4/10); N = 0;
+Since N is 0, the algorithm stops.
+
+
+To convert between a number represented with coefficients from base B1 to that
+same number represented with coefficients from base B2, we can use the algorithm
+that converts coefficients from base B1 to an integer, and then use the
+algorithm that converts a number to coefficients from base B2.
+
+There is a useful shortcut that can be used if one of the bases is a power of
+the other base. If B1 == B2^G, then each coefficient from base B1 can be
+converted to base B2 independently to create a a group of "G" B2 coefficient.
+These coefficients can be simply concatenated together. Since 16 == 2^4, this
+property is what makes base 16 useful when dealing with binary numbers. For
+example consider converting the base 16 number "93" to binary. The base 16
+coefficient 9 is represented in base 2 with the coefficients 1,0,0,1. The base
+16 coefficient 3 is represented in base 2 with the coefficients 0,0,1,1. To get
+the final answer, just concatenate those two independent conversions together.
+The base 16 number "93" is the binary number "10010011".
+
+The original (now reference) algorithm to convert from base 58 to a binary
+number used the
+
+```
+N = 0;
+for i in m to 0 inclusive
+    N = N + C[i]*B^i
+```
+
+algorithm.
+
+However, the algorithm above is pseudo-code. In particular, the variable "N" is
+an infinite precision integer in that pseudo-code. Real computers do
+computations on registers, and these registers have limited length. Modern
+computers use 64-bit general purpose registers, and can multiply two 64 bit
+numbers and obtain a 128 bit result (in two registers).
+
+The original algorithm in essence converted from base 58 to base 256 (base
+2^8). The new, faster algorithm converts from base 58 to base 58^10 (this is
+fast using the shortcut described above), then from base 58^10 to base 2^64
+(this is slow, and requires multi-precision arithmetic), and then from base 2^64
+to base 2^8 (this is fast, using the shortcut described above). Base 58^10 is
+chosen because it is the largest power of 58 that will fit into a 64-bit
+register.
+
+While it may seem counter-intuitive that converting from base 58 -> base 58^10
+-> base 2^64 -> base 2^8 is faster than directly converting from base 58 -> base
+2^8, it is actually 10x-15x faster. The reason for the speed increase is two of
+the conversions are trivial (converting between bases where one base is a power
+of another base), and doing the multi-precision computations with larger
+coefficients sizes greatly speeds up the multi-precision computations.
+*/
 
 namespace ripple {
 
@@ -86,16 +191,31 @@ checksum(void* out, void const* message, std::size_t size)
     std::memcpy(out, h.data(), 4);
 }
 
+[[nodiscard]] std::string
+encodeBase58Token(TokenType type, void const* token, std::size_t size)
+{
+#ifndef _MSC_VER
+    return b58_fast::encodeBase58Token(type, token, size);
+#else
+    return b58_ref::encodeBase58Token(type, token, size);
+#endif
+}
+
+[[nodiscard]] std::string
+decodeBase58Token(std::string const& s, TokenType type)
+{
+#ifndef _MSC_VER
+    return b58_fast::decodeBase58Token(s, type);
+#else
+    return b58_ref::decodeBase58Token(s, type);
+#endif
+}
+
+namespace b58_ref {
+
 namespace detail {
 
-/* The base58 encoding & decoding routines in this namespace are taken from
- * Bitcoin but have been modified from the original.
- *
- * Copyright (c) 2014 The Bitcoin Core developers
- * Distributed under the MIT software license, see the accompanying
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.
- */
-static std::string
+std::string
 encodeBase58(
     void const* message,
     std::size_t size,
@@ -146,7 +266,7 @@ encodeBase58(
     return str;
 }
 
-static std::string
+std::string
 decodeBase58(std::string const& s)
 {
     auto psz = reinterpret_cast<unsigned char const*>(s.c_str());
@@ -241,5 +361,367 @@ decodeBase58Token(std::string const& s, TokenType type)
     // Skip the leading type byte and the trailing checksum.
     return ret.substr(1, ret.size() - 1 - guard.size());
 }
+}  // namespace b58_ref
 
+#ifndef _MSC_VER
+// The algorithms use gcc's int128 (fast MS version will have to wait, in the
+// meantime MS falls back to the slower reference implementation)
+namespace b58_fast {
+namespace detail {
+// Note: both the input and output will be BIG ENDIAN
+B58Result<std::span<std::uint8_t>>
+b256_to_b58_be(std::span<std::uint8_t const> input, std::span<std::uint8_t> out)
+{
+    // Max valid input is 38 bytes:
+    // (33 bytes for nodepublic + 1 byte token + 4 bytes checksum)
+    if (input.size() > 38)
+    {
+        return Unexpected(TokenCodecErrc::inputTooLarge);
+    };
+
+    auto count_leading_zeros =
+        [](std::span<std::uint8_t const> const& col) -> std::size_t {
+        std::size_t count = 0;
+        for (auto const& c : col)
+        {
+            if (c != 0)
+            {
+                return count;
+            }
+            count += 1;
+        }
+        return count;
+    };
+
+    auto const input_zeros = count_leading_zeros(input);
+    input = input.subspan(input_zeros);
+
+    // Allocate enough base 2^64 coeff for encoding 38 bytes
+    // log(2^(38*8),2^64)) ~= 4.75. So 5 coeff are enough
+    std::array<std::uint64_t, 5> base_2_64_coeff_buf{};
+    std::span<std::uint64_t> const base_2_64_coeff =
+        [&]() -> std::span<std::uint64_t> {
+        // convert input from big endian to native u64, lowest coeff first
+        std::size_t num_coeff = 0;
+        for (int i = 0; i < base_2_64_coeff_buf.size(); ++i)
+        {
+            if (i * 8 >= input.size())
+            {
+                break;
+            }
+            auto const src_i_end = input.size() - i * 8;
+            if (src_i_end >= 8)
+            {
+                std::memcpy(
+                    &base_2_64_coeff_buf[num_coeff], &input[src_i_end - 8], 8);
+                boost::endian::big_to_native_inplace(
+                    base_2_64_coeff_buf[num_coeff]);
+            }
+            else
+            {
+                std::uint64_t be = 0;
+                for (int bi = 0; bi < src_i_end; ++bi)
+                {
+                    be <<= 8;
+                    be |= input[bi];
+                }
+                base_2_64_coeff_buf[num_coeff] = be;
+            };
+            num_coeff += 1;
+        }
+        return std::span(base_2_64_coeff_buf.data(), num_coeff);
+    }();
+
+    // Allocate enough base 58^10 coeff for encoding 38 bytes
+    // log(2^(38*8),58^10)) ~= 5.18. So 6 coeff are enough
+    std::array<std::uint64_t, 6> base_58_10_coeff{};
+    constexpr std::uint64_t B_58_10 = 430804206899405824;  // 58^10;
+    std::size_t num_58_10_coeffs = 0;
+    std::size_t cur_2_64_end = base_2_64_coeff.size();
+    // compute the base 58^10 coeffs
+    while (cur_2_64_end > 0)
+    {
+        base_58_10_coeff[num_58_10_coeffs] =
+            ripple::b58_fast::detail::inplace_bigint_div_rem(
+                base_2_64_coeff.subspan(0, cur_2_64_end), B_58_10);
+        num_58_10_coeffs += 1;
+        if (base_2_64_coeff[cur_2_64_end - 1] == 0)
+        {
+            cur_2_64_end -= 1;
+        }
+    }
+
+    // Translate the result into the alphabet
+    // Put all the zeros at the beginning, then all the values from the output
+    std::fill(
+        out.begin(), out.begin() + input_zeros, ::ripple::alphabetForward[0]);
+
+    // iterate through the base 58^10 coeff
+    // convert to base 58 big endian then
+    // convert to alphabet big endian
+    bool skip_zeros = true;
+    auto out_index = input_zeros;
+    for (int i = num_58_10_coeffs - 1; i >= 0; --i)
+    {
+        if (skip_zeros && base_58_10_coeff[i] == 0)
+        {
+            continue;
+        }
+        std::array<std::uint8_t, 10> const b58_be =
+            ripple::b58_fast::detail::b58_10_to_b58_be(base_58_10_coeff[i]);
+        std::size_t to_skip = 0;
+        std::span<std::uint8_t const> b58_be_s{b58_be.data(), b58_be.size()};
+        if (skip_zeros)
+        {
+            to_skip = count_leading_zeros(b58_be_s);
+            skip_zeros = false;
+            if (out.size() < (i + 1) * 10 - to_skip)
+            {
+                return Unexpected(TokenCodecErrc::outputTooSmall);
+            }
+        }
+        for (auto b58_coeff : b58_be_s.subspan(to_skip))
+        {
+            out[out_index] = ::ripple::alphabetForward[b58_coeff];
+            out_index += 1;
+        }
+    }
+
+    return out.subspan(0, out_index);
+}
+
+// Note the input is BIG ENDIAN (some fn in this module use little endian)
+B58Result<std::span<std::uint8_t>>
+b58_to_b256_be(std::string_view input, std::span<std::uint8_t> out)
+{
+    // Convert from b58 to b 58^10
+
+    // Max encoded value is 38 bytes
+    // log(2^(38*8),58) ~= 51.9
+    if (input.size() > 52)
+    {
+        return Unexpected(TokenCodecErrc::inputTooLarge);
+    };
+    if (out.size() < 8)
+    {
+        return Unexpected(TokenCodecErrc::outputTooSmall);
+    }
+
+    auto count_leading_zeros = [&](auto const& col) -> std::size_t {
+        std::size_t count = 0;
+        for (auto const& c : col)
+        {
+            if (c != ::ripple::alphabetForward[0])
+            {
+                return count;
+            }
+            count += 1;
+        }
+        return count;
+    };
+
+    auto const input_zeros = count_leading_zeros(input);
+
+    // Allocate enough base 58^10 coeff for encoding 38 bytes
+    // (33 bytes for nodepublic + 1 byte token + 4 bytes checksum)
+    // log(2^(38*8),58^10)) ~= 5.18. So 6 coeff are enough
+    std::array<std::uint64_t, 6> b_58_10_coeff{};
+    auto [num_full_coeffs, partial_coeff_len] =
+        ripple::b58_fast::detail::div_rem(input.size(), 10);
+    auto const num_partial_coeffs = partial_coeff_len ? 1 : 0;
+    auto const num_b_58_10_coeffs = num_full_coeffs + num_partial_coeffs;
+    assert(num_b_58_10_coeffs <= b_58_10_coeff.size());
+    for (auto c : input.substr(0, partial_coeff_len))
+    {
+        auto cur_val = ::ripple::alphabetReverse[c];
+        if (cur_val < 0)
+        {
+            return Unexpected(TokenCodecErrc::invalidEncodingChar);
+        }
+        b_58_10_coeff[0] *= 58;
+        b_58_10_coeff[0] += cur_val;
+    }
+    for (int i = 0; i < 10; ++i)
+    {
+        for (int j = 0; j < num_full_coeffs; ++j)
+        {
+            auto c = input[partial_coeff_len + j * 10 + i];
+            auto cur_val = ::ripple::alphabetReverse[c];
+            if (cur_val < 0)
+            {
+                return Unexpected(TokenCodecErrc::invalidEncodingChar);
+            }
+            b_58_10_coeff[num_partial_coeffs + j] *= 58;
+            b_58_10_coeff[num_partial_coeffs + j] += cur_val;
+        }
+    }
+
+    constexpr std::uint64_t B_58_10 = 430804206899405824;  // 58^10;
+
+    // log(2^(38*8),2^64) ~= 4.75)
+    std::array<std::uint64_t, 5> result{};
+    result[0] = b_58_10_coeff[0];
+    std::size_t cur_result_size = 1;
+    for (int i = 1; i < num_b_58_10_coeffs; ++i)
+    {
+        std::uint64_t const c = b_58_10_coeff[i];
+        ripple::b58_fast::detail::inplace_bigint_mul(
+            std::span(&result[0], cur_result_size + 1), B_58_10);
+        ripple::b58_fast::detail::inplace_bigint_add(
+            std::span(&result[0], cur_result_size + 1), c);
+        if (result[cur_result_size] != 0)
+        {
+            cur_result_size += 1;
+        }
+    }
+    std::fill(out.begin(), out.begin() + input_zeros, 0);
+    auto cur_out_i = input_zeros;
+    // Don't write leading zeros to the output for the most significant
+    // coeff
+    {
+        std::uint64_t const c = result[cur_result_size - 1];
+        auto skip_zero = true;
+        // start and end of output range
+        for (int i = 0; i < 8; ++i)
+        {
+            std::uint8_t const b = (c >> (8 * (7 - i))) & 0xff;
+            if (skip_zero)
+            {
+                if (b == 0)
+                {
+                    continue;
+                }
+                skip_zero = false;
+            }
+            out[cur_out_i] = b;
+            cur_out_i += 1;
+        }
+    }
+    if ((cur_out_i + 8 * (cur_result_size - 1)) > out.size())
+    {
+        return Unexpected(TokenCodecErrc::outputTooSmall);
+    }
+
+    for (int i = cur_result_size - 2; i >= 0; --i)
+    {
+        auto c = result[i];
+        boost::endian::native_to_big_inplace(c);
+        memcpy(&out[cur_out_i], &c, 8);
+        cur_out_i += 8;
+    }
+
+    return out.subspan(0, cur_out_i);
+}
+}  // namespace detail
+
+B58Result<std::span<std::uint8_t>>
+encodeBase58Token(
+    TokenType token_type,
+    std::span<std::uint8_t const> input,
+    std::span<std::uint8_t> out)
+{
+    constexpr std::size_t tmpBufSize = 128;
+    std::array<std::uint8_t, tmpBufSize> buf;
+    if (input.size() > tmpBufSize - 5)
+    {
+        return Unexpected(TokenCodecErrc::inputTooLarge);
+    }
+    if (input.size() == 0)
+    {
+        return Unexpected(TokenCodecErrc::inputTooSmall);
+    }
+    // <type (1 byte)><token (input len)><checksum (4 bytes)>
+    buf[0] = static_cast<std::uint8_t>(token_type);
+    // buf[1..=input.len()] = input;
+    memcpy(&buf[1], input.data(), input.size());
+    size_t const checksum_i = input.size() + 1;
+    // buf[checksum_i..checksum_i + 4] = checksum
+    checksum(buf.data() + checksum_i, buf.data(), checksum_i);
+    std::span<std::uint8_t const> b58Span(buf.data(), input.size() + 5);
+    return detail::b256_to_b58_be(b58Span, out);
+}
+// Convert from base 58 to base 256, largest coefficients first
+// The input is encoded in XPRL format, with the token in the first
+// byte and the checksum in the last four bytes.
+// The decoded base 256 value does not include the token type or checksum.
+// It is an error if the token type or checksum does not match.
+B58Result<std::span<std::uint8_t>>
+decodeBase58Token(
+    TokenType type,
+    std::string_view s,
+    std::span<std::uint8_t> outBuf)
+{
+    std::array<std::uint8_t, 64> tmpBuf;
+    auto const decodeResult =
+        detail::b58_to_b256_be(s, std::span(tmpBuf.data(), tmpBuf.size()));
+
+    if (!decodeResult)
+        return decodeResult;
+
+    auto const ret = decodeResult.value();
+
+    // Reject zero length tokens
+    if (ret.size() < 6)
+        return Unexpected(TokenCodecErrc::inputTooSmall);
+
+    // The type must match.
+    if (type != static_cast<TokenType>(static_cast<std::uint8_t>(ret[0])))
+        return Unexpected(TokenCodecErrc::mismatchedTokenType);
+
+    // And the checksum must as well.
+    std::array<std::uint8_t, 4> guard;
+    checksum(guard.data(), ret.data(), ret.size() - guard.size());
+    if (!std::equal(guard.rbegin(), guard.rend(), ret.rbegin()))
+    {
+        return Unexpected(TokenCodecErrc::mismatchedChecksum);
+    }
+
+    std::size_t const outSize = ret.size() - 1 - guard.size();
+    if (outBuf.size() < outSize)
+        return Unexpected(TokenCodecErrc::outputTooSmall);
+    // Skip the leading type byte and the trailing checksum.
+    std::copy(ret.begin() + 1, ret.begin() + outSize + 1, outBuf.begin());
+    return outBuf.subspan(0, outSize);
+}
+
+[[nodiscard]] std::string
+encodeBase58Token(TokenType type, void const* token, std::size_t size)
+{
+    std::string sr;
+    // The largest object encoded as base58 is 33 bytes; This will be encoded in
+    // at most ceil(log(2^256,58)) bytes, or 46 bytes. 128 is plenty (and
+    // there's not real benefit making it smaller). Note that 46 bytes may be
+    // encoded in more than 46 base58 chars. Since decode uses 64 as the
+    // over-allocation, this function uses 128 (again, over-allocation assuming
+    // 2 base 58 char per byte)
+    sr.resize(128);
+    std::span<std::uint8_t> outSp(
+        reinterpret_cast<std::uint8_t*>(sr.data()), sr.size());
+    std::span<std::uint8_t const> inSp(
+        reinterpret_cast<std::uint8_t const*>(token), size);
+    auto r = b58_fast::encodeBase58Token(type, inSp, outSp);
+    if (!r)
+        return {};
+    sr.resize(r.value().size());
+    return sr;
+}
+
+[[nodiscard]] std::string
+decodeBase58Token(std::string const& s, TokenType type)
+{
+    std::string sr;
+    // The largest object encoded as base58 is 33 bytes; 64 is plenty (and
+    // there's no benefit making it smaller)
+    sr.resize(64);
+    std::span<std::uint8_t> outSp(
+        reinterpret_cast<std::uint8_t*>(sr.data()), sr.size());
+    auto r = b58_fast::decodeBase58Token(type, s, outSp);
+    if (!r)
+        return {};
+    sr.resize(r.value().size());
+    return sr;
+}
+
+}  // namespace b58_fast
+#endif  // _MSC_VER
 }  // namespace ripple

--- a/src/ripple/rpc/handlers/Feature1.cpp
+++ b/src/ripple/rpc/handlers/Feature1.cpp
@@ -22,6 +22,7 @@
 #include <ripple/app/misc/AmendmentTable.h>
 #include <ripple/net/RPCErr.h>
 #include <ripple/protocol/ErrorCodes.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/jss.h>
 #include <ripple/rpc/Context.h>
 
@@ -37,6 +38,7 @@ doFeature(RPC::JsonContext& context)
     if (context.app.config().reporting())
         return rpcError(rpcREPORTING_UNSUPPORTED);
 
+    bool const isAdmin = context.role == Role::ADMIN;
     // Get majority amendment status
     majorityAmendments_t majorities;
 
@@ -47,7 +49,7 @@ doFeature(RPC::JsonContext& context)
 
     if (!context.params.isMember(jss::feature))
     {
-        auto features = table.getJson();
+        auto features = table.getJson(isAdmin);
 
         for (auto const& [h, t] : majorities)
         {
@@ -69,13 +71,18 @@ doFeature(RPC::JsonContext& context)
 
     if (context.params.isMember(jss::vetoed))
     {
+        if (!isAdmin)
+            return rpcError(rpcNO_PERMISSION);
+
         if (context.params[jss::vetoed].asBool())
             table.veto(feature);
         else
             table.unVeto(feature);
     }
 
-    Json::Value jvReply = table.getJson(feature);
+    Json::Value jvReply = table.getJson(feature, isAdmin);
+    if (!jvReply)
+        return rpcError(rpcBAD_FEATURE);
 
     auto m = majorities.find(feature);
     if (m != majorities.end())

--- a/src/ripple/rpc/handlers/Manifest.cpp
+++ b/src/ripple/rpc/handlers/Manifest.cpp
@@ -51,14 +51,13 @@ doManifest(RPC::JsonContext& context)
 
     // first attempt to use params as ephemeral key,
     // if this lookup succeeds master key will be returned,
-    // else pk will just be returned and we will assume that
-    // is master key anyways
+    // else an unseated optional is returned
     auto const mk = context.app.validatorManifests().getMasterKey(*pk);
 
     auto const ek = context.app.validatorManifests().getSigningKey(mk);
 
     // if ephemeral key not found, we don't have specified manifest
-    if (ek == mk)
+    if (!ek)
         return ret;
 
     if (auto const manifest = context.app.validatorManifests().getManifest(mk))
@@ -66,7 +65,7 @@ doManifest(RPC::JsonContext& context)
     Json::Value details;
 
     details[jss::master_key] = toBase58(TokenType::NodePublic, mk);
-    details[jss::ephemeral_key] = toBase58(TokenType::NodePublic, ek);
+    details[jss::ephemeral_key] = toBase58(TokenType::NodePublic, *ek);
 
     if (auto const seq = context.app.validatorManifests().getSequence(mk))
         details[jss::seq] = *seq;

--- a/src/ripple/rpc/handlers/PayChanClaim.cpp
+++ b/src/ripple/rpc/handlers/PayChanClaim.cpp
@@ -55,10 +55,15 @@ doChannelAuthorize(RPC::JsonContext& context)
         return RPC::missing_field_error(jss::secret);
 
     Json::Value result;
-    auto const [pk, sk] =
+    std::optional<std::pair<PublicKey, SecretKey>> const keyPair =
         RPC::keypairForSignature(params, result, context.apiVersion);
-    if (RPC::contains_error(result))
+
+    assert(keyPair || RPC::contains_error(result));
+    if (!keyPair || RPC::contains_error(result))
         return result;
+
+    PublicKey const& pk = keyPair->first;
+    SecretKey const& sk = keyPair->second;
 
     uint256 channelId;
     if (!channelId.parseHex(params[jss::channel_id].asString()))

--- a/src/ripple/rpc/impl/Handler.cpp
+++ b/src/ripple/rpc/impl/Handler.cpp
@@ -105,6 +105,9 @@ Handler const handlerArray[]{
      Role::USER,
      NO_CONDITION},
     {"download_shard", byRef(&doDownloadShard), Role::ADMIN, NO_CONDITION},
+    {"feature", byRef(&doFeature), Role::USER, NO_CONDITION},
+    {"fee", byRef(&doFee), Role::USER, NEEDS_CURRENT_LEDGER},
+    {"fetch_info", byRef(&doFetchInfo), Role::ADMIN, NO_CONDITION},
 #ifdef RIPPLED_REPORTING
     {"gateway_balances", byRef(&doGatewayBalances), Role::ADMIN, NO_CONDITION},
 #else
@@ -115,9 +118,6 @@ Handler const handlerArray[]{
      byRef(&doGetAggregatePrice),
      Role::USER,
      NO_CONDITION},
-    {"feature", byRef(&doFeature), Role::ADMIN, NO_CONDITION},
-    {"fee", byRef(&doFee), Role::USER, NEEDS_CURRENT_LEDGER},
-    {"fetch_info", byRef(&doFetchInfo), Role::ADMIN, NO_CONDITION},
     {"ledger_accept",
      byRef(&doLedgerAccept),
      Role::ADMIN,

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -792,7 +792,7 @@ getSeedFromRPC(Json::Value const& params, Json::Value& error)
     return seed;
 }
 
-std::pair<PublicKey, SecretKey>
+std::optional<std::pair<PublicKey, SecretKey>>
 keypairForSignature(
     Json::Value const& params,
     Json::Value& error,

--- a/src/ripple/rpc/impl/RPCHelpers.h
+++ b/src/ripple/rpc/impl/RPCHelpers.h
@@ -287,7 +287,7 @@ getAPIVersionNumber(const Json::Value& value, bool betaEnabled);
 std::variant<std::shared_ptr<Ledger const>, Json::Value>
 getLedgerByContext(RPC::JsonContext& context);
 
-std::pair<PublicKey, SecretKey>
+std::optional<std::pair<PublicKey, SecretKey>>
 keypairForSignature(
     Json::Value const& params,
     Json::Value& error,

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -53,35 +53,25 @@ class SigningForParams
 {
 private:
     AccountID const* const multiSigningAcctID_;
-    PublicKey* const multiSignPublicKey_;
-    Buffer* const multiSignature_;
+    std::optional<PublicKey> multiSignPublicKey_;
+    Buffer multiSignature_;
 
 public:
-    explicit SigningForParams()
-        : multiSigningAcctID_(nullptr)
-        , multiSignPublicKey_(nullptr)
-        , multiSignature_(nullptr)
+    explicit SigningForParams() : multiSigningAcctID_(nullptr)
     {
     }
 
     SigningForParams(SigningForParams const& rhs) = delete;
 
-    SigningForParams(
-        AccountID const& multiSigningAcctID,
-        PublicKey& multiSignPublicKey,
-        Buffer& multiSignature)
+    SigningForParams(AccountID const& multiSigningAcctID)
         : multiSigningAcctID_(&multiSigningAcctID)
-        , multiSignPublicKey_(&multiSignPublicKey)
-        , multiSignature_(&multiSignature)
     {
     }
 
     bool
     isMultiSigning() const
     {
-        return (
-            (multiSigningAcctID_ != nullptr) &&
-            (multiSignPublicKey_ != nullptr) && (multiSignature_ != nullptr));
+        return multiSigningAcctID_ != nullptr;
     }
 
     bool
@@ -97,23 +87,46 @@ public:
         return !isMultiSigning();
     }
 
+    bool
+    validMultiSign() const
+    {
+        return isMultiSigning() && multiSignPublicKey_ &&
+            multiSignature_.size();
+    }
+
     // Don't call this method unless isMultiSigning() returns true.
     AccountID const&
-    getSigner()
+    getSigner() const
     {
+        if (!multiSigningAcctID_)
+            LogicError("Accessing unknown SigningForParams::getSigner()");
         return *multiSigningAcctID_;
+    }
+
+    PublicKey const&
+    getPublicKey() const
+    {
+        if (!multiSignPublicKey_)
+            LogicError("Accessing unknown SigningForParams::getPublicKey()");
+        return *multiSignPublicKey_;
+    }
+
+    Buffer const&
+    getSignature() const
+    {
+        return multiSignature_;
     }
 
     void
     setPublicKey(PublicKey const& multiSignPublicKey)
     {
-        *multiSignPublicKey_ = multiSignPublicKey;
+        multiSignPublicKey_ = multiSignPublicKey;
     }
 
     void
     moveMultiSignature(Buffer&& multiSignature)
     {
-        *multiSignature_ = std::move(multiSignature);
+        multiSignature_ = std::move(multiSignature);
     }
 };
 
@@ -386,9 +399,13 @@ transactionPreProcessImpl(
     auto j = app.journal("RPCHandler");
 
     Json::Value jvResult;
-    auto const [pk, sk] = keypairForSignature(params, jvResult);
-    if (contains_error(jvResult))
+    std::optional<std::pair<PublicKey, SecretKey>> keyPair =
+        keypairForSignature(params, jvResult);
+    if (!keyPair || contains_error(jvResult))
         return jvResult;
+
+    PublicKey const& pk = keyPair->first;
+    SecretKey const& sk = keyPair->second;
 
     bool const verify =
         !(params.isMember(jss::offline) && params[jss::offline].asBool());
@@ -1009,10 +1026,7 @@ transactionSignFor(
     }
 
     // Add and amend fields based on the transaction type.
-    Buffer multiSignature;
-    PublicKey multiSignPubKey;
-    SigningForParams signForParams(
-        *signerAccountID, multiSignPubKey, multiSignature);
+    SigningForParams signForParams(*signerAccountID);
 
     transactionPreProcessResult preprocResult = transactionPreProcessImpl(
         jvRequest, role, signForParams, validatedLedgerAge, app);
@@ -1020,12 +1034,14 @@ transactionSignFor(
     if (!preprocResult.second)
         return preprocResult.first;
 
+    assert(signForParams.validMultiSign());
+
     {
         std::shared_ptr<SLE const> account_state =
             ledger->read(keylet::account(*signerAccountID));
         // Make sure the account and secret belong together.
-        auto const err =
-            acctMatchesPubKey(account_state, *signerAccountID, multiSignPubKey);
+        auto const err = acctMatchesPubKey(
+            account_state, *signerAccountID, signForParams.getPublicKey());
 
         if (err != rpcSUCCESS)
             return rpcError(err);
@@ -1037,8 +1053,9 @@ transactionSignFor(
         // Make the signer object that we'll inject.
         STObject signer(sfSigner);
         signer[sfAccount] = *signerAccountID;
-        signer.setFieldVL(sfTxnSignature, multiSignature);
-        signer.setFieldVL(sfSigningPubKey, multiSignPubKey.slice());
+        signer.setFieldVL(sfTxnSignature, signForParams.getSignature());
+        signer.setFieldVL(
+            sfSigningPubKey, signForParams.getPublicKey().slice());
 
         // If there is not yet a Signers array, make one.
         if (!sttx->isFieldPresent(sfSigners))

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -288,7 +288,7 @@ public:
         uint256 const unsupportedID = amendmentId(unsupported_[0]);
         {
             Json::Value const unsupp =
-                table->getJson(unsupportedID)[to_string(unsupportedID)];
+                table->getJson(unsupportedID, true)[to_string(unsupportedID)];
             BEAST_EXPECT(unsupp.size() == 0);
         }
 
@@ -296,7 +296,7 @@ public:
         table->veto(unsupportedID);
         {
             Json::Value const unsupp =
-                table->getJson(unsupportedID)[to_string(unsupportedID)];
+                table->getJson(unsupportedID, true)[to_string(unsupportedID)];
             BEAST_EXPECT(unsupp[jss::vetoed].asBool());
         }
     }
@@ -637,6 +637,22 @@ public:
         BEAST_EXPECT(ourVotes.empty());
         BEAST_EXPECT(enabled.empty());
         BEAST_EXPECT(majority.empty());
+
+        uint256 const unsupportedID = amendmentId(unsupported_[0]);
+        {
+            Json::Value const unsupp =
+                table->getJson(unsupportedID, false)[to_string(unsupportedID)];
+            BEAST_EXPECT(unsupp.size() == 0);
+        }
+
+        table->veto(unsupportedID);
+        {
+            Json::Value const unsupp =
+                table->getJson(unsupportedID, false)[to_string(unsupportedID)];
+            BEAST_EXPECT(!unsupp[jss::vetoed].asBool());
+        }
+
+        votes.emplace_back(testAmendment, validators.size());
 
         votes.emplace_back(testAmendment, validators.size());
 

--- a/src/test/app/LedgerLoad_test.cpp
+++ b/src/test/app/LedgerLoad_test.cpp
@@ -63,21 +63,21 @@ class LedgerLoad_test : public beast::unit_test::suite
         retval.ledgerFile = td.file("ledgerdata.json");
 
         Env env{*this};
-        Account prev;
+        std::optional<Account> prev;
 
         for (auto i = 0; i < 20; ++i)
         {
             Account acct{"A" + std::to_string(i)};
             env.fund(XRP(10000), acct);
             env.close();
-            if (i > 0)
+            if (i > 0 && BEAST_EXPECT(prev))
             {
-                env.trust(acct["USD"](1000), prev);
-                env(pay(acct, prev, acct["USD"](5)));
+                env.trust(acct["USD"](1000), *prev);
+                env(pay(acct, *prev, acct["USD"](5)));
             }
             env(offer(acct, XRP(100), acct["USD"](1)));
             env.close();
-            prev = std::move(acct);
+            prev.emplace(std::move(acct));
         }
 
         retval.ledger = env.rpc("ledger", "current", "full")[jss::result];

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -197,7 +197,9 @@ enum class PeerFeature {
 class TestPeer : public Peer
 {
 public:
-    TestPeer(bool enableLedgerReplay) : ledgerReplayEnabled_(enableLedgerReplay)
+    TestPeer(bool enableLedgerReplay)
+        : ledgerReplayEnabled_(enableLedgerReplay)
+        , nodePublicKey_(derivePublicKey(KeyType::ed25519, randomSecretKey()))
     {
     }
 
@@ -237,8 +239,7 @@ public:
     PublicKey const&
     getNodePublic() const override
     {
-        static PublicKey key{};
-        return key;
+        return nodePublicKey_;
     }
     Json::Value
     json() override
@@ -314,6 +315,7 @@ public:
     }
 
     bool ledgerReplayEnabled_;
+    PublicKey nodePublicKey_;
 };
 
 enum class PeerSetBehavior {

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -238,12 +238,8 @@ public:
     Manifest
     clone(Manifest const& m)
     {
-        Manifest m2;
-        m2.serialized = m.serialized;
-        m2.masterKey = m.masterKey;
-        m2.signingKey = m.signingKey;
-        m2.sequence = m.sequence;
-        m2.domain = m.domain;
+        Manifest m2(
+            m.serialized, m.masterKey, m.signingKey, m.sequence, m.domain);
         return m2;
     }
 
@@ -313,14 +309,13 @@ public:
             }
             {
                 // save should store all trusted master keys to db
-                PublicKey emptyLocalKey;
                 std::vector<std::string> s1;
                 std::vector<std::string> keys;
                 std::string cfgManifest;
                 for (auto const& man : inManifests)
                     s1.push_back(
                         toBase58(TokenType::NodePublic, man->masterKey));
-                unl->load(emptyLocalKey, s1, keys);
+                unl->load({}, s1, keys);
 
                 m.save(
                     *dbCon,
@@ -852,7 +847,10 @@ public:
 
                         BEAST_EXPECT(manifest);
                         BEAST_EXPECT(manifest->masterKey == pk);
-                        BEAST_EXPECT(manifest->signingKey == PublicKey());
+
+                        // Since this manifest is revoked, it should not have
+                        // a signingKey
+                        BEAST_EXPECT(!manifest->signingKey);
                         BEAST_EXPECT(manifest->revoked());
                         BEAST_EXPECT(manifest->domain.empty());
                         BEAST_EXPECT(manifest->serialized == m);

--- a/src/test/app/ValidatorKeys_test.cpp
+++ b/src/test/app/ValidatorKeys_test.cpp
@@ -107,7 +107,7 @@ public:
             // No config -> no key but valid
             Config c;
             ValidatorKeys k{c, journal};
-            BEAST_EXPECT(k.publicKey.size() == 0);
+            BEAST_EXPECT(!k.keys);
             BEAST_EXPECT(k.manifest.empty());
             BEAST_EXPECT(!k.configInvalid());
         }
@@ -117,8 +117,11 @@ public:
             c.section(SECTION_VALIDATION_SEED).append(seed);
 
             ValidatorKeys k{c, journal};
-            BEAST_EXPECT(k.publicKey == seedPublicKey);
-            BEAST_EXPECT(k.secretKey == seedSecretKey);
+            if (BEAST_EXPECT(k.keys))
+            {
+                BEAST_EXPECT(k.keys->publicKey == seedPublicKey);
+                BEAST_EXPECT(k.keys->secretKey == seedSecretKey);
+            }
             BEAST_EXPECT(k.nodeID == seedNodeID);
             BEAST_EXPECT(k.manifest.empty());
             BEAST_EXPECT(!k.configInvalid());
@@ -131,7 +134,7 @@ public:
 
             ValidatorKeys k{c, journal};
             BEAST_EXPECT(k.configInvalid());
-            BEAST_EXPECT(k.publicKey.size() == 0);
+            BEAST_EXPECT(!k.keys);
             BEAST_EXPECT(k.manifest.empty());
         }
 
@@ -141,8 +144,11 @@ public:
             c.section(SECTION_VALIDATOR_TOKEN).append(tokenBlob);
             ValidatorKeys k{c, journal};
 
-            BEAST_EXPECT(k.publicKey == tokenPublicKey);
-            BEAST_EXPECT(k.secretKey == tokenSecretKey);
+            if (BEAST_EXPECT(k.keys))
+            {
+                BEAST_EXPECT(k.keys->publicKey == tokenPublicKey);
+                BEAST_EXPECT(k.keys->secretKey == tokenSecretKey);
+            }
             BEAST_EXPECT(k.nodeID == tokenNodeID);
             BEAST_EXPECT(k.manifest == tokenManifest);
             BEAST_EXPECT(!k.configInvalid());
@@ -153,7 +159,7 @@ public:
             c.section(SECTION_VALIDATOR_TOKEN).append("badtoken");
             ValidatorKeys k{c, journal};
             BEAST_EXPECT(k.configInvalid());
-            BEAST_EXPECT(k.publicKey.size() == 0);
+            BEAST_EXPECT(!k.keys);
             BEAST_EXPECT(k.manifest.empty());
         }
 
@@ -165,7 +171,7 @@ public:
             ValidatorKeys k{c, journal};
 
             BEAST_EXPECT(k.configInvalid());
-            BEAST_EXPECT(k.publicKey.size() == 0);
+            BEAST_EXPECT(!k.keys);
             BEAST_EXPECT(k.manifest.empty());
         }
 
@@ -176,7 +182,7 @@ public:
             ValidatorKeys k{c, journal};
 
             BEAST_EXPECT(k.configInvalid());
-            BEAST_EXPECT(k.publicKey.size() == 0);
+            BEAST_EXPECT(!k.keys);
             BEAST_EXPECT(k.manifest.empty());
         }
     }

--- a/src/test/app/ValidatorSite_test.cpp
+++ b/src/test/app/ValidatorSite_test.cpp
@@ -172,7 +172,6 @@ private:
         test::StreamSink sink;
         beast::Journal journal{sink};
 
-        PublicKey emptyLocalKey;
         std::vector<std::string> emptyCfgKeys;
         struct publisher
         {
@@ -229,8 +228,7 @@ private:
             item.uri = uri.str();
         }
 
-        BEAST_EXPECT(
-            trustedKeys.load(emptyLocalKey, emptyCfgKeys, cfgPublishers));
+        BEAST_EXPECT(trustedKeys.load({}, emptyCfgKeys, cfgPublishers));
 
         // Normally, tests will only need a fraction of this time,
         // but sometimes DNS resolution takes an inordinate amount

--- a/src/test/app/XChain_test.cpp
+++ b/src/test/app/XChain_test.cpp
@@ -728,7 +728,7 @@ struct XChain_test : public beast::unit_test::suite,
         //   Locking chain is XRP,
         // - Issuing chain is XRP with issuing chain is the root account.
         // ---------------------------------------------------------------------
-        Account a, b;
+        Account a("a"), b("b");
         Issue ia, ib;
 
         std::tuple lcs{
@@ -5005,7 +5005,8 @@ public:
 
         // create 10 accounts + door funded on both chains, and store
         // in ChainStateTracker the initial amount of these accounts
-        Account doorXRPLocking, doorUSDLocking, doorUSDIssuing;
+        Account doorXRPLocking("doorXRPLocking"),
+            doorUSDLocking("doorUSDLocking"), doorUSDIssuing("doorUSDIssuing");
 
         constexpr size_t num_acct = 10;
         auto a = [&doorXRPLocking, &doorUSDLocking, &doorUSDIssuing]() {

--- a/src/test/basics/base58_test.cpp
+++ b/src/test/basics/base58_test.cpp
@@ -1,0 +1,439 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef _MSC_VER
+
+#include <ripple/beast/unit_test.h>
+#include <ripple/protocol/impl/b58_utils.h>
+#include <ripple/protocol/tokens.h>
+
+#include <boost/multiprecision/cpp_int.hpp>
+#include <boost/random.hpp>
+
+#include <array>
+#include <cstddef>
+#include <random>
+#include <span>
+#include <sstream>
+
+namespace ripple {
+namespace test {
+namespace {
+
+[[nodiscard]] inline auto
+randEngine() -> std::mt19937&
+{
+    static std::mt19937 r = [] {
+        std::random_device rd;
+        return std::mt19937{rd()};
+    }();
+    return r;
+}
+
+constexpr int numTokenTypeIndexes = 9;
+
+[[nodiscard]] inline auto
+tokenTypeAndSize(int i) -> std::tuple<ripple::TokenType, std::size_t>
+{
+    assert(i < numTokenTypeIndexes);
+
+    switch (i)
+    {
+        using enum ripple::TokenType;
+        case 0:
+            return {None, 20};
+        case 1:
+            return {NodePublic, 32};
+        case 2:
+            return {NodePublic, 33};
+        case 3:
+            return {NodePrivate, 32};
+        case 4:
+            return {AccountID, 20};
+        case 5:
+            return {AccountPublic, 32};
+        case 6:
+            return {AccountPublic, 33};
+        case 7:
+            return {AccountSecret, 32};
+        case 8:
+            return {FamilySeed, 16};
+        default:
+            throw std::invalid_argument(
+                "Invalid token selection passed to tokenTypeAndSize() "
+                "in " __FILE__);
+    }
+}
+
+[[nodiscard]] inline auto
+randomTokenTypeAndSize() -> std::tuple<ripple::TokenType, std::size_t>
+{
+    using namespace ripple;
+    auto& rng = randEngine();
+    std::uniform_int_distribution<> d(0, 8);
+    return tokenTypeAndSize(d(rng));
+}
+
+// Return the token type and subspan of `d` to use as test data.
+[[nodiscard]] inline auto
+randomB256TestData(std::span<std::uint8_t> d)
+    -> std::tuple<ripple::TokenType, std::span<std::uint8_t>>
+{
+    auto& rng = randEngine();
+    std::uniform_int_distribution<std::uint8_t> dist(0, 255);
+    auto [tokType, tokSize] = randomTokenTypeAndSize();
+    std::generate(d.begin(), d.begin() + tokSize, [&] { return dist(rng); });
+    return {tokType, d.subspan(0, tokSize)};
+}
+
+inline void
+printAsChar(std::span<std::uint8_t> a, std::span<std::uint8_t> b)
+{
+    auto asString = [](std::span<std::uint8_t> s) {
+        std::string r;
+        r.resize(s.size());
+        std::copy(s.begin(), s.end(), r.begin());
+        return r;
+    };
+    auto sa = asString(a);
+    auto sb = asString(b);
+    std::cerr << "\n\n" << sa << "\n" << sb << "\n";
+}
+
+inline void
+printAsInt(std::span<std::uint8_t> a, std::span<std::uint8_t> b)
+{
+    auto asString = [](std::span<std::uint8_t> s) -> std::string {
+        std::stringstream sstr;
+        for (auto i : s)
+        {
+            sstr << std::setw(3) << int(i) << ',';
+        }
+        return sstr.str();
+    };
+    auto sa = asString(a);
+    auto sb = asString(b);
+    std::cerr << "\n\n" << sa << "\n" << sb << "\n";
+}
+
+}  // namespace
+
+namespace multiprecision_utils {
+
+boost::multiprecision::checked_uint512_t
+toBoostMP(std::span<std::uint64_t> in)
+{
+    boost::multiprecision::checked_uint512_t mbp = 0;
+    for (auto i = in.rbegin(); i != in.rend(); ++i)
+    {
+        mbp <<= 64;
+        mbp += *i;
+    }
+    return mbp;
+}
+
+std::vector<std::uint64_t>
+randomBigInt(std::uint8_t minSize = 1, std::uint8_t maxSize = 5)
+{
+    auto eng = randEngine();
+    std::uniform_int_distribution<std::uint8_t> numCoeffDist(minSize, maxSize);
+    std::uniform_int_distribution<std::uint64_t> dist;
+    auto const numCoeff = numCoeffDist(eng);
+    std::vector<std::uint64_t> coeffs;
+    coeffs.reserve(numCoeff);
+    for (int i = 0; i < numCoeff; ++i)
+    {
+        coeffs.push_back(dist(eng));
+    }
+    return coeffs;
+}
+}  // namespace multiprecision_utils
+
+class base58_test : public beast::unit_test::suite
+{
+    void
+    testMultiprecision()
+    {
+        testcase("b58_multiprecision");
+
+        using namespace boost::multiprecision;
+
+        constexpr std::size_t iters = 100000;
+        auto eng = randEngine();
+        std::uniform_int_distribution<std::uint64_t> dist;
+        for (int i = 0; i < iters; ++i)
+        {
+            std::uint64_t const d = dist(eng);
+            if (!d)
+                continue;
+            auto bigInt = multiprecision_utils::randomBigInt();
+            auto const boostBigInt = multiprecision_utils::toBoostMP(
+                std::span<std::uint64_t>(bigInt.data(), bigInt.size()));
+
+            auto const refDiv = boostBigInt / d;
+            auto const refMod = boostBigInt % d;
+
+            auto const mod = b58_fast::detail::inplace_bigint_div_rem(
+                std::span<uint64_t>(bigInt.data(), bigInt.size()), d);
+            auto const foundDiv = multiprecision_utils::toBoostMP(bigInt);
+            BEAST_EXPECT(refMod.convert_to<std::uint64_t>() == mod);
+            BEAST_EXPECT(foundDiv == refDiv);
+        }
+        for (int i = 0; i < iters; ++i)
+        {
+            std::uint64_t const d = dist(eng);
+            auto bigInt = multiprecision_utils::randomBigInt(/*minSize*/ 2);
+            if (bigInt[bigInt.size() - 1] ==
+                std::numeric_limits<std::uint64_t>::max())
+            {
+                bigInt[bigInt.size() - 1] -= 1;  // Prevent overflow
+            }
+            auto const boostBigInt = multiprecision_utils::toBoostMP(
+                std::span<std::uint64_t>(bigInt.data(), bigInt.size()));
+
+            auto const refAdd = boostBigInt + d;
+
+            b58_fast::detail::inplace_bigint_add(
+                std::span<uint64_t>(bigInt.data(), bigInt.size()), d);
+            auto const foundAdd = multiprecision_utils::toBoostMP(bigInt);
+            BEAST_EXPECT(refAdd == foundAdd);
+        }
+        for (int i = 0; i < iters; ++i)
+        {
+            std::uint64_t const d = dist(eng);
+            auto bigInt = multiprecision_utils::randomBigInt(/* minSize */ 2);
+            // inplace mul requires the most significant coeff to be zero to
+            // hold the result.
+            bigInt[bigInt.size() - 1] = 0;
+            auto const boostBigInt = multiprecision_utils::toBoostMP(
+                std::span<std::uint64_t>(bigInt.data(), bigInt.size()));
+
+            auto const refMul = boostBigInt * d;
+
+            b58_fast::detail::inplace_bigint_mul(
+                std::span<uint64_t>(bigInt.data(), bigInt.size()), d);
+            auto const foundMul = multiprecision_utils::toBoostMP(bigInt);
+            BEAST_EXPECT(refMul == foundMul);
+        }
+    }
+
+    void
+    testFastMatchesRef()
+    {
+        testcase("fast_matches_ref");
+        auto testRawEncode = [&](std::span<std::uint8_t> const& b256Data) {
+            std::array<std::uint8_t, 64> b58ResultBuf[2];
+            std::array<std::span<std::uint8_t>, 2> b58Result;
+
+            std::array<std::uint8_t, 64> b256ResultBuf[2];
+            std::array<std::span<std::uint8_t>, 2> b256Result;
+            for (int i = 0; i < 2; ++i)
+            {
+                std::span const outBuf{b58ResultBuf[i]};
+                if (i == 0)
+                {
+                    auto const r = ripple::b58_fast::detail::b256_to_b58_be(
+                        b256Data, outBuf);
+                    BEAST_EXPECT(r);
+                    b58Result[i] = r.value();
+                }
+                else
+                {
+                    std::array<std::uint8_t, 128> tmpBuf;
+                    std::string const s = ripple::b58_ref::detail::encodeBase58(
+                        b256Data.data(),
+                        b256Data.size(),
+                        tmpBuf.data(),
+                        tmpBuf.size());
+                    BEAST_EXPECT(s.size());
+                    b58Result[i] = outBuf.subspan(0, s.size());
+                    std::copy(s.begin(), s.end(), b58Result[i].begin());
+                }
+            }
+            if (BEAST_EXPECT(b58Result[0].size() == b58Result[1].size()))
+            {
+                if (!BEAST_EXPECT(
+                        memcmp(
+                            b58Result[0].data(),
+                            b58Result[1].data(),
+                            b58Result[0].size()) == 0))
+                {
+                    printAsChar(b58Result[0], b58Result[1]);
+                }
+            }
+
+            for (int i = 0; i < 2; ++i)
+            {
+                std::span const outBuf{
+                    b256ResultBuf[i].data(), b256ResultBuf[i].size()};
+                if (i == 0)
+                {
+                    std::string const in(
+                        b58Result[i].data(),
+                        b58Result[i].data() + b58Result[i].size());
+                    auto const r =
+                        ripple::b58_fast::detail::b58_to_b256_be(in, outBuf);
+                    BEAST_EXPECT(r);
+                    b256Result[i] = r.value();
+                }
+                else
+                {
+                    std::string const st(
+                        b58Result[i].begin(), b58Result[i].end());
+                    std::string const s =
+                        ripple::b58_ref::detail::decodeBase58(st);
+                    BEAST_EXPECT(s.size());
+                    b256Result[i] = outBuf.subspan(0, s.size());
+                    std::copy(s.begin(), s.end(), b256Result[i].begin());
+                }
+            }
+
+            if (BEAST_EXPECT(b256Result[0].size() == b256Result[1].size()))
+            {
+                if (!BEAST_EXPECT(
+                        memcmp(
+                            b256Result[0].data(),
+                            b256Result[1].data(),
+                            b256Result[0].size()) == 0))
+                {
+                    printAsInt(b256Result[0], b256Result[1]);
+                }
+            }
+        };
+
+        auto testTokenEncode = [&](ripple::TokenType const tokType,
+                                   std::span<std::uint8_t> const& b256Data) {
+            std::array<std::uint8_t, 64> b58ResultBuf[2];
+            std::array<std::span<std::uint8_t>, 2> b58Result;
+
+            std::array<std::uint8_t, 64> b256ResultBuf[2];
+            std::array<std::span<std::uint8_t>, 2> b256Result;
+            for (int i = 0; i < 2; ++i)
+            {
+                std::span const outBuf{
+                    b58ResultBuf[i].data(), b58ResultBuf[i].size()};
+                if (i == 0)
+                {
+                    auto const r = ripple::b58_fast::encodeBase58Token(
+                        tokType, b256Data, outBuf);
+                    BEAST_EXPECT(r);
+                    b58Result[i] = r.value();
+                }
+                else
+                {
+                    std::string const s = ripple::b58_ref::encodeBase58Token(
+                        tokType, b256Data.data(), b256Data.size());
+                    BEAST_EXPECT(s.size());
+                    b58Result[i] = outBuf.subspan(0, s.size());
+                    std::copy(s.begin(), s.end(), b58Result[i].begin());
+                }
+            }
+            if (BEAST_EXPECT(b58Result[0].size() == b58Result[1].size()))
+            {
+                if (!BEAST_EXPECT(
+                        memcmp(
+                            b58Result[0].data(),
+                            b58Result[1].data(),
+                            b58Result[0].size()) == 0))
+                {
+                    printAsChar(b58Result[0], b58Result[1]);
+                }
+            }
+
+            for (int i = 0; i < 2; ++i)
+            {
+                std::span const outBuf{
+                    b256ResultBuf[i].data(), b256ResultBuf[i].size()};
+                if (i == 0)
+                {
+                    std::string const in(
+                        b58Result[i].data(),
+                        b58Result[i].data() + b58Result[i].size());
+                    auto const r = ripple::b58_fast::decodeBase58Token(
+                        tokType, in, outBuf);
+                    BEAST_EXPECT(r);
+                    b256Result[i] = r.value();
+                }
+                else
+                {
+                    std::string const st(
+                        b58Result[i].begin(), b58Result[i].end());
+                    std::string const s =
+                        ripple::b58_ref::decodeBase58Token(st, tokType);
+                    BEAST_EXPECT(s.size());
+                    b256Result[i] = outBuf.subspan(0, s.size());
+                    std::copy(s.begin(), s.end(), b256Result[i].begin());
+                }
+            }
+
+            if (BEAST_EXPECT(b256Result[0].size() == b256Result[1].size()))
+            {
+                if (!BEAST_EXPECT(
+                        memcmp(
+                            b256Result[0].data(),
+                            b256Result[1].data(),
+                            b256Result[0].size()) == 0))
+                {
+                    printAsInt(b256Result[0], b256Result[1]);
+                }
+            }
+        };
+
+        auto testIt = [&](ripple::TokenType const tokType,
+                          std::span<std::uint8_t> const& b256Data) {
+            testRawEncode(b256Data);
+            testTokenEncode(tokType, b256Data);
+        };
+
+        // test every token type with data where every byte is the same and the
+        // bytes range from 0-255
+        for (int i = 0; i < numTokenTypeIndexes; ++i)
+        {
+            std::array<std::uint8_t, 128> b256DataBuf;
+            auto const [tokType, tokSize] = tokenTypeAndSize(i);
+            for (int d = 0; d <= 255; ++d)
+            {
+                memset(b256DataBuf.data(), d, tokSize);
+                testIt(tokType, std::span(b256DataBuf.data(), tokSize));
+            }
+        }
+
+        // test with random data
+        constexpr std::size_t iters = 100000;
+        for (int i = 0; i < iters; ++i)
+        {
+            std::array<std::uint8_t, 128> b256DataBuf;
+            auto const [tokType, b256Data] = randomB256TestData(b256DataBuf);
+            testIt(tokType, b256Data);
+        }
+    }
+
+    void
+    run() override
+    {
+        testMultiprecision();
+        testFastMatchesRef();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(base58, ripple_basics, ripple);
+
+}  // namespace test
+}  // namespace ripple
+#endif  // _MSC_VER

--- a/src/test/consensus/NegativeUNL_test.cpp
+++ b/src/test/consensus/NegativeUNL_test.cpp
@@ -778,8 +778,10 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::suite
         // one add, one remove
         auto txSet = std::make_shared<SHAMap>(
             SHAMapType::TRANSACTION, env.app().getNodeFamily());
-        PublicKey toDisableKey;
-        PublicKey toReEnableKey;
+        PublicKey toDisableKey(
+            derivePublicKey(KeyType::ed25519, randomSecretKey()));
+        PublicKey toReEnableKey(
+            derivePublicKey(KeyType::ed25519, randomSecretKey()));
         LedgerIndex seq(1234);
         BEAST_EXPECT(countTx(txSet) == 0);
         vote.addTx(seq, toDisableKey, NegativeUNLVote::ToDisable, txSet);

--- a/src/test/jtx/Account.h
+++ b/src/test/jtx/Account.h
@@ -46,7 +46,7 @@ public:
     /** The master account. */
     static Account const master;
 
-    Account() = default;
+    Account() = delete;
     Account(Account&&) = default;
     Account(Account const&) = default;
     Account&

--- a/src/test/jtx/Env_test.cpp
+++ b/src/test/jtx/Env_test.cpp
@@ -50,7 +50,7 @@ public:
     {
         using namespace jtx;
         {
-            Account a;
+            Account a("chenna");
             Account b(a);
             a = b;
             a = std::move(b);

--- a/src/test/overlay/reduce_relay_test.cpp
+++ b/src/test/overlay/reduce_relay_test.cpp
@@ -58,6 +58,12 @@ static constexpr std::uint32_t MAX_MESSAGES = 200000;
 class PeerPartial : public Peer
 {
 public:
+    PeerPartial()
+        : nodePublicKey_(derivePublicKey(KeyType::ed25519, randomSecretKey()))
+    {
+    }
+
+    PublicKey nodePublicKey_;
     virtual ~PeerPartial()
     {
     }
@@ -103,8 +109,7 @@ public:
     PublicKey const&
     getNodePublic() const override
     {
-        static PublicKey key{};
-        return key;
+        return nodePublicKey_;
     }
     Json::Value
     json() override
@@ -312,9 +317,8 @@ class Validator
     using Links = std::unordered_map<Peer::id_t, LinkSPtr>;
 
 public:
-    Validator()
+    Validator() : pkey_(std::get<0>(randomKeyPair(KeyType::ed25519)))
     {
-        pkey_ = std::get<0>(randomKeyPair(KeyType::ed25519));
         protocol::TMValidation v;
         v.set_validation("validation");
         message_ = std::make_shared<Message>(v, protocol::mtVALIDATION, pkey_);
@@ -439,7 +443,7 @@ public:
 
 private:
     Links links_;
-    PublicKey pkey_{};
+    PublicKey pkey_;
     MessageSPtr message_ = nullptr;
     inline static std::uint16_t sid_ = 0;
     std::uint16_t id_ = 0;
@@ -926,7 +930,7 @@ protected:
         bool isSelected_ = false;
         Peer::id_t peer_;
         std::uint16_t validator_;
-        PublicKey key_;
+        std::optional<PublicKey> key_;
         time_point<ManualClock> time_;
         bool handled_ = false;
     };
@@ -1052,17 +1056,17 @@ protected:
                 // 4) peer is in Slot's peers_ (if not then it is deleted
                 //    by Slots::deleteIdlePeers())
                 bool mustHandle = false;
-                if (event.state_ == State::On)
+                if (event.state_ == State::On && BEAST_EXPECT(event.key_))
                 {
                     event.isSelected_ =
-                        network_.overlay().isSelected(event.key_, event.peer_);
-                    auto peers = network_.overlay().getPeers(event.key_);
+                        network_.overlay().isSelected(*event.key_, event.peer_);
+                    auto peers = network_.overlay().getPeers(*event.key_);
                     auto d = reduce_relay::epoch<milliseconds>(now).count() -
                         std::get<3>(peers[event.peer_]);
                     mustHandle = event.isSelected_ &&
                         d > milliseconds(reduce_relay::IDLED).count() &&
                         network_.overlay().inState(
-                            event.key_, reduce_relay::PeerState::Squelched) >
+                            *event.key_, reduce_relay::PeerState::Squelched) >
                             0 &&
                         peers.find(event.peer_) != peers.end();
                 }

--- a/src/test/protocol/PublicKey_test.cpp
+++ b/src/test/protocol/PublicKey_test.cpp
@@ -363,10 +363,12 @@ public:
         }
 
         // Try some random secret keys
-        std::array<PublicKey, 32> keys;
+        std::vector<PublicKey> keys;
+        keys.reserve(32);
 
-        for (std::size_t i = 0; i != keys.size(); ++i)
-            keys[i] = derivePublicKey(keyType, randomSecretKey());
+        for (std::size_t i = 0; i != keys.capacity(); ++i)
+            keys.emplace_back(derivePublicKey(keyType, randomSecretKey()));
+        BEAST_EXPECT(keys.size() == 32);
 
         for (std::size_t i = 0; i != keys.size(); ++i)
         {
@@ -447,7 +449,11 @@ public:
         BEAST_EXPECT(pk1 == pk2);
         BEAST_EXPECT(pk2 == pk1);
 
-        PublicKey pk3;
+        PublicKey pk3 = derivePublicKey(
+            KeyType::secp256k1,
+            generateSecretKey(
+                KeyType::secp256k1, generateSeed("arbitraryPassPhrase")));
+        // Testing the copy assignment operation of PublicKey class
         pk3 = pk2;
         BEAST_EXPECT(pk3 == pk2);
         BEAST_EXPECT(pk1 == pk3);

--- a/src/test/protocol/STObject_test.cpp
+++ b/src/test/protocol/STObject_test.cpp
@@ -17,7 +17,6 @@
 */
 //==============================================================================
 
-#include <ripple/basics/Log.h>
 #include <ripple/beast/unit_test.h>
 #include <ripple/json/json_reader.h>
 #include <ripple/json/to_string.h>
@@ -609,12 +608,7 @@ public:
     auto const kp =
         generateKeyPair(KeyType::secp256k1, generateSeed("masterpassphrase"));
     st[sf5] = kp.first;
-    BEAST_EXPECT(st[sf5] != PublicKey{});
     st[~sf5] = std::nullopt;
-#if 0
-            pk = st[sf5];
-            BEAST_EXPECT(pk.size() == 0);
-#endif
 }
 
 // By reference fields

--- a/src/test/protocol/SecretKey_test.cpp
+++ b/src/test/protocol/SecretKey_test.cpp
@@ -275,10 +275,12 @@ public:
         }
 
         // Try some random secret keys
-        std::array<SecretKey, 32> keys;
+        std::vector<SecretKey> keys;
+        keys.reserve(32);
 
-        for (std::size_t i = 0; i != keys.size(); ++i)
-            keys[i] = randomSecretKey();
+        for (std::size_t i = 0; i != keys.capacity(); ++i)
+            keys.emplace_back(randomSecretKey());
+        BEAST_EXPECT(keys.size() == 32);
 
         for (std::size_t i = 0; i != keys.size(); ++i)
         {

--- a/src/test/rpc/KeyGeneration_test.cpp
+++ b/src/test/rpc/KeyGeneration_test.cpp
@@ -16,8 +16,6 @@
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 //==============================================================================
-
-#include <ripple/basics/StringUtilities.h>
 #include <ripple/json/json_value.h>
 #include <ripple/json/json_writer.h>
 #include <ripple/protocol/ErrorCodes.h>
@@ -337,8 +335,11 @@ public:
 
                 auto ret = keypairForSignature(params, error);
                 BEAST_EXPECT(!contains_error(error));
-                BEAST_EXPECT(ret.first.size() != 0);
-                BEAST_EXPECT(ret.first == publicKey);
+                if (BEAST_EXPECT(ret))
+                {
+                    BEAST_EXPECT(ret->first.size() != 0);
+                    BEAST_EXPECT(ret->first == publicKey);
+                }
             }
 
             {
@@ -348,8 +349,11 @@ public:
 
                 auto ret = keypairForSignature(params, error);
                 BEAST_EXPECT(!contains_error(error));
-                BEAST_EXPECT(ret.first.size() != 0);
-                BEAST_EXPECT(ret.first == publicKey);
+                if (BEAST_EXPECT(ret))
+                {
+                    BEAST_EXPECT(ret->first.size() != 0);
+                    BEAST_EXPECT(ret->first == publicKey);
+                }
             }
 
             {
@@ -359,8 +363,11 @@ public:
 
                 auto ret = keypairForSignature(params, error);
                 BEAST_EXPECT(!contains_error(error));
-                BEAST_EXPECT(ret.first.size() != 0);
-                BEAST_EXPECT(ret.first == publicKey);
+                if (BEAST_EXPECT(ret))
+                {
+                    BEAST_EXPECT(ret->first.size() != 0);
+                    BEAST_EXPECT(ret->first == publicKey);
+                }
             }
 
             keyType.emplace("secp256k1");
@@ -375,8 +382,11 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(!contains_error(error));
-            BEAST_EXPECT(ret.first.size() != 0);
-            BEAST_EXPECT(ret.first == publicKey);
+            if (BEAST_EXPECT(ret))
+            {
+                BEAST_EXPECT(ret->first.size() != 0);
+                BEAST_EXPECT(ret->first == publicKey);
+            }
         }
 
         {
@@ -388,8 +398,11 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(!contains_error(error));
-            BEAST_EXPECT(ret.first.size() != 0);
-            BEAST_EXPECT(ret.first == publicKey);
+            if (BEAST_EXPECT(ret))
+            {
+                BEAST_EXPECT(ret->first.size() != 0);
+                BEAST_EXPECT(ret->first == publicKey);
+            }
         }
 
         {
@@ -401,8 +414,11 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(!contains_error(error));
-            BEAST_EXPECT(ret.first.size() != 0);
-            BEAST_EXPECT(ret.first == publicKey);
+            if (BEAST_EXPECT(ret))
+            {
+                BEAST_EXPECT(ret->first.size() != 0);
+                BEAST_EXPECT(ret->first == publicKey);
+            }
         }
     }
 
@@ -416,10 +432,10 @@ public:
             params[jss::secret] = 314159265;
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'secret', not string.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {
@@ -430,10 +446,10 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'secret', not string.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {
@@ -445,7 +461,7 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
-            BEAST_EXPECT(ret.first.size() == 0);
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'secret', not string.");
@@ -460,10 +476,10 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "The secret field is not allowed if key_type is used.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         // Specify unknown or bad "key_type"
@@ -475,9 +491,9 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] == "Invalid field 'key_type'.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {
@@ -488,10 +504,10 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'key_type', not string.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {
@@ -502,10 +518,10 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'key_type', not string.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         // Specify non-string passphrase
@@ -517,10 +533,10 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'passphrase', not string.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // not a passphrase: object
@@ -531,10 +547,10 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'passphrase', not string.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // not a passphrase: array
@@ -545,10 +561,10 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'passphrase', not string.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // not a passphrase: empty string
@@ -559,8 +575,8 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(error[jss::error_message] == "Disallowed seed.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         // Specify non-string or invalid seed
@@ -572,10 +588,10 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'seed', not string.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // not a string: object
@@ -586,10 +602,10 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'seed', not string.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // not a string: array
@@ -600,10 +616,10 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'seed', not string.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // not a seed: empty
@@ -614,8 +630,8 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(error[jss::error_message] == "Disallowed seed.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // not a seed: invalid characters
@@ -626,8 +642,8 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(error[jss::error_message] == "Disallowed seed.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // not a seed: random string
@@ -638,8 +654,8 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(error[jss::error_message] == "Disallowed seed.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         // Specify non-string or invalid seed_hex
@@ -651,10 +667,10 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'seed_hex', not string.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // not a string: object
@@ -665,10 +681,10 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'seed_hex', not string.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // not a string: array
@@ -679,10 +695,10 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(
                 error[jss::error_message] ==
                 "Invalid field 'seed_hex', not string.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // empty
@@ -693,8 +709,8 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(error[jss::error_message] == "Disallowed seed.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // short
@@ -705,8 +721,8 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(error[jss::error_message] == "Disallowed seed.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // not hex
@@ -717,8 +733,8 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(error[jss::error_message] == "Disallowed seed.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
 
         {  // overlong
@@ -730,8 +746,8 @@ public:
 
             auto ret = keypairForSignature(params, error);
             BEAST_EXPECT(contains_error(error));
+            BEAST_EXPECT(!ret);
             BEAST_EXPECT(error[jss::error_message] == "Disallowed seed.");
-            BEAST_EXPECT(ret.first.size() == 0);
         }
     }
 
@@ -750,8 +766,11 @@ public:
                 auto ret = keypairForSignature(params, error);
 
                 BEAST_EXPECT(!contains_error(error));
-                BEAST_EXPECT(ret.first.size() != 0);
-                BEAST_EXPECT(toBase58(calcAccountID(ret.first)) == addr);
+                if (BEAST_EXPECT(ret))
+                {
+                    BEAST_EXPECT(ret->first.size() != 0);
+                    BEAST_EXPECT(toBase58(calcAccountID(ret->first)) == addr);
+                }
             }
 
             {
@@ -779,8 +798,11 @@ public:
                 auto ret = keypairForSignature(params, error);
 
                 BEAST_EXPECT(!contains_error(error));
-                BEAST_EXPECT(ret.first.size() != 0);
-                BEAST_EXPECT(toBase58(calcAccountID(ret.first)) == addr);
+                if (BEAST_EXPECT(ret))
+                {
+                    BEAST_EXPECT(ret->first.size() != 0);
+                    BEAST_EXPECT(toBase58(calcAccountID(ret->first)) == addr);
+                }
             }
 
             {


### PR DESCRIPTION
## High Level Overview of Change

This is a beta for the 2.2.0 release.

Highlights:
- #4327
- #4781

The base branch is `release`. [All releases (including betas)](https://github.com/XRPLF/rippled/blob/develop/CONTRIBUTING.md#before-you-start) go in `release`. This PR will be merged with `--ff-only` (not squashed or rebased, and not using the GitHub UI).

### Context of Change

This introduces the fast base58 codec, which speeds up base58 encoding and decoding significantly, and a user version of the `feature` RPC command, allowing lookups without changing voting settings. It also fixes up some techincal debt, and fixes the 'install' target so that downstream projects like `clio` can build properly.

### Type of Change

- [x] Release

### API Impact

No API impact.
