### PR TITLE
[TRIVIAL] chore: Default validator-keys-tool to build from master branch

### DIFF
--- a/Builds/CMake/RippledValidatorKeys.cmake
+++ b/Builds/CMake/RippledValidatorKeys.cmake
@@ -2,9 +2,9 @@ option (validator_keys "Enables building of validator-keys-tool as a separate ta
 
 if (validator_keys)
   git_branch (current_branch)
-  # default to tracking VK develop branch unless we are on master/release
-  if (NOT (current_branch STREQUAL "master" OR current_branch STREQUAL "release"))
-    set (current_branch "develop")
+  # default to tracking VK master branch unless we are on release
+  if (NOT (current_branch STREQUAL "release"))
+    set (current_branch "master")
   endif ()
   message (STATUS "tracking ValidatorKeys branch: ${current_branch}")
 


### PR DESCRIPTION
## High Level Overview of Change

`master` is the default branch for that project. There's no point in using `develop`.

### Context of Change

https://github.com/ripple/validator-keys-tool/pull/40#issuecomment-1984374109
> I just rebased develop onto master. After resolving conflicts, the branches were identical.
> 
> If there are no objections, I'm going to close this PR and force push that updated develop.
> 
> I think the correct solution is to update the check in rippled to default to use the master branch, and delete this develop branch entirely.

### Type of Change

- [X ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)

## Before / After

These changes only matter when building https://github.com/ripple/validator-keys-tool from within the rippled repo.
e.g.
```
git checkout develop
cmake -Dvalidator-keys=ON [...] <build dir>
cmake --build <build dir> --target validator-keys
```

### Before:
If building from any `rippled` branch other than `master` or `release`, `validator-keys` will be built from its `develop` branch.

### After:
If building from any `rippled` branch other than `release`, `validator-keys` will be built from its `master` branch.

## Future Tasks

If this PR is merged, the `develop` branch can be deleted from **https://github.com/ripple/validator-keys-tool**.
