### PR TITLE
Add the fixEnforceNFTokenTrustline amendment:

### DIFF
--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -80,7 +80,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 75;
+static constexpr std::size_t numFeatures = 76;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -368,6 +368,7 @@ extern uint256 const fixPreviousTxnID;
 extern uint256 const fixAMMv1_1;
 extern uint256 const featureNFTokenMintOffer;
 extern uint256 const fixReducedOffersV2;
+extern uint256 const fixEnforceNFTokenTrustline;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -495,6 +495,7 @@ REGISTER_FIX    (fixPreviousTxnID,              Supported::yes, VoteBehavior::De
 REGISTER_FIX    (fixAMMv1_1,                    Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FEATURE(NFTokenMintOffer,              Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixReducedOffersV2,            Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FIX    (fixEnforceNFTokenTrustline,    Supported::yes, VoteBehavior::DefaultNo);
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -5467,12 +5467,12 @@ class Offer_manual_test : public OfferBaseUtil_test
     }
 };
 
-BEAST_DEFINE_TESTSUITE_PRIO(OfferBaseUtil, tx, ripple, 4);
-BEAST_DEFINE_TESTSUITE_PRIO(OfferWOFlowCross, tx, ripple, 4);
-BEAST_DEFINE_TESTSUITE_PRIO(OfferWTakerDryOffer, tx, ripple, 4);
-BEAST_DEFINE_TESTSUITE_PRIO(OfferWOSmallQOffers, tx, ripple, 4);
-BEAST_DEFINE_TESTSUITE_PRIO(OfferWOFillOrKill, tx, ripple, 4);
-BEAST_DEFINE_TESTSUITE_PRIO(OfferAllFeatures, tx, ripple, 4);
+BEAST_DEFINE_TESTSUITE_PRIO(OfferBaseUtil, tx, ripple, 2);
+BEAST_DEFINE_TESTSUITE_PRIO(OfferWOFlowCross, tx, ripple, 2);
+BEAST_DEFINE_TESTSUITE_PRIO(OfferWTakerDryOffer, tx, ripple, 2);
+BEAST_DEFINE_TESTSUITE_PRIO(OfferWOSmallQOffers, tx, ripple, 2);
+BEAST_DEFINE_TESTSUITE_PRIO(OfferWOFillOrKill, tx, ripple, 2);
+BEAST_DEFINE_TESTSUITE_PRIO(OfferAllFeatures, tx, ripple, 2);
 BEAST_DEFINE_TESTSUITE_MANUAL_PRIO(Offer_manual, tx, ripple, 20);
 
 }  // namespace test


### PR DESCRIPTION
## High Level Overview of Change

Introduces the `fixEnforceNFTokenTrustline ` amendment which fixes bugs in interactions between NFTokenOffers and trust lines.

Resolves #4925.
Resolves #4941.

### Context of Change

#### #4925

This issue describes a wide timing window that causes a rare bug.  To understand the process you need some background in how NFTokens work.

When an NFToken is minted, it may have a transfer fee associated with it.  If that transfer fee is non-zero, then a portion of the funds paid for the NFToken's transfer are syphoned off for the NFT's issuer.  That transfer fee is always paid in the same funds as were used for the transfer.

The `NFTokenCreateOffer` transaction verifies that,

- If the NFToken has a transfer fee and
- The funds for the transfer are an IOU (not XRP) then
- The NFToken issuer must have a trust line for the funds.  

If the issuer does not have the necessary trust line then the `NFTokenCreateOffer` fails.

But here's the timing window.  When the `NFTokenCreateOffer` happens no funds are transferred.  The funds are transferred when the corresponding `NFTokenAcceptOffer` transaction completes.  But `NFTokenAcceptOffer` does not verify the presence of the trust line.

With that background, here are the steps for the bug:

1. Alice creates a trust line for USD.
2. Alice mints an NFToken with a non-zero transfer fee.
3. Becky acquires the NFToken from Alice.
4. Becky creates an offer to sell the NFToken for USD(100).
5. Alice removes her trust line for USD.
6. Carol accepts Becky's offer for the NFToken and pays in USD.
7.  Alice's trust line is recreated and receives the transfer fee in USD.

The bug appears in step 7, where the trust line that Alice deleted in step 5 is recreated.

The fix is simply to put a check in the `NFTokenAcceptOffer` transaction that is similar to the check in `NFTokenCreateOffer`.  But the check is transaction changing, so it must be guarded by an amendment.

#### #4941

This issue describes an even rarer, but related bug.

The checks described in the previous issue involve looking for a trust line connected to the NFToken issuer.  That _almost_ always works.  But there's one situation where it doesn't.  An IOU issuer can always accept any IOU that they issue.  And there is no trust line to represent that capability.  In fact, having a trust line from an account to itself is forbidden.

Here are the steps for the bug:

1. Alice issues USD
2. Alice mints an NFToken with a non-zero transfer fee.
3. Becky acquires the NFToken from Alice.
4. Becky attempts to creates an offer to sell the NFToken for Alice's USD(100).  This attempt fails with `tecNO_LINE`

The bug appears in step 4, where Becky cannot create the offer.

The fix is simply to check for the presence of the trust line _or_ if the IOU's issuer is the same as the NFToken issuer.  But the check is transaction changing, so it must be guarded by an amendment.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (unit tests for these changes were added)

### Consideration

This NFT-related amendment arrives at about the same time as a different NFT-related amendment: https://github.com/XRPLF/rippled/pull/4945

Should these two pull requests be merged into a single amendment?

## Proposed Commit Message
```
Add the fixEnforceNFTokenTrustline amendment:

Fix bugs in interactions between NFTokenOffers and trust lines.

Since the NFTokenAcceptOffer does not check the trust line that
the issuer receives as a transfer fee in the NFTokenAcceptOffer,
if the issuer deletes the trust line after NFTokenCreateOffer,
the trust line is created for the issuer by the
NFTokenAcceptOffer.  That's fixed.

Also if Alice issues an IOU and also mints NFTokens with a
transfer fee, Alice's IOU cannot be used to pay for transfers
of those NFTokens.  That's fixed.

Resolves #4925.
Resolves #4941.
```
