### PR TITLE
Add the`fixEmptyDID` amendment

### DIFF
--- a/src/ripple/app/tx/impl/DID.cpp
+++ b/src/ripple/app/tx/impl/DID.cpp
@@ -161,6 +161,13 @@ DIDSet::doApply()
     set(sfURI);
     set(sfDIDDocument);
     set(sfData);
+    if (ctx_.view().rules().enabled(fixEmptyDID) &&
+        !sleDID->isFieldPresent(sfURI) &&
+        !sleDID->isFieldPresent(sfDIDDocument) &&
+        !sleDID->isFieldPresent(sfData))
+    {
+        return tecEMPTY_DID;
+    }
 
     return addSLE(ctx_, sleDID, account_);
 }

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -74,7 +74,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 68;
+static constexpr std::size_t numFeatures = 69;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -355,6 +355,7 @@ extern uint256 const fixFillOrKill;
 extern uint256 const fixNFTokenReserve;
 extern uint256 const fixInnerObjTemplate;
 extern uint256 const featurePriceOracle;
+extern uint256 const fixEmptyDID;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -458,10 +458,11 @@ REGISTER_FEATURE(AMM,                           Supported::yes, VoteBehavior::De
 REGISTER_FEATURE(XChainBridge,                  Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixDisallowIncomingV1,         Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FEATURE(DID,                           Supported::yes, VoteBehavior::DefaultNo);
-REGISTER_FIX(fixFillOrKill,                     Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FIX    (fixFillOrKill,                 Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixNFTokenReserve,             Supported::yes, VoteBehavior::DefaultNo);
-REGISTER_FIX(fixInnerObjTemplate,               Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FIX    (fixInnerObjTemplate,           Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FEATURE(PriceOracle,                   Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FIX    (fixEmptyDID,                   Supported::yes, VoteBehavior::DefaultNo);
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.


### PR DESCRIPTION
## High Level Overview of Change

This PR introduces an amendment that fixes a problem where DIDs can be empty, which shouldn't be able to happen. An empty DID object is equivalent to not having a DID object at all, so there is no need to take up the extra object reserve.

### Context of Change

If a`DIDSet` transaction is sent with one or two of the fields (`DIDDocument`/`Data`/`URI`) as an empty string, when there is no pre-existing DID, the `DID` object is created with empty fields.

Recreation: https://devnet.xrpl.org/transactions/A73FEA27EF6A24438A7E9A3B8192B1C0B430E503A14212933CAFF54C66C51FCD

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [x] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

## Test Plan

A unit test was added that reproduces the issue. The test ensures that behavior remains the same pre-amendment, and is the desired behavior post-amendment.
