### PR TITLE
Fix workflows

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -13,8 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    container:
-      image: docker://rippleci/rippled-ci-builder:2944b78d22db
+    container: rippleci/rippled-build-ubuntu:aaf5e3e
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,10 +23,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - name: choose Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
       - name: install Conan
         run: brew install conan@1
       - name: install Ninja

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+      - name: choose Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
       - name: install Ninja
         if: matrix.generator == 'Ninja'
         run: brew install ninja

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,18 +24,17 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: install Conan
-        run: brew reinstall conan@1
+        run: |
+          brew install conan@1
+          echo '/opt/homebrew/opt/conan@1/bin' >> $GITHUB_PATH
       - name: install Ninja
         if: matrix.generator == 'Ninja'
         run: brew install ninja
       - name: check environment
         run: |
-          eval $(brew shellenv)
           env | sort
           echo ${PATH} | tr ':' '\n'
           python --version
-          ls -l /opt/homebrew/bin || true
-          ls -l /opt/homebrew/sbin || true
           conan --version
           cmake --version
       - name: configure Conan

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,6 +34,8 @@ jobs:
           env | sort
           echo ${PATH} | tr ':' '\n'
           python --version
+          ls -l /opt/homebrew/bin || true
+          ls -l /opt/homebrew/sbin || true
           conan --version
           cmake --version
       - name: configure Conan

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: install Conan
-        run: brew install conan@1
+        run: brew reinstall conan@1
       - name: install Ninja
         if: matrix.generator == 'Ninja'
         run: brew install ninja

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,7 +39,8 @@ jobs:
           cmake --version
       - name: configure Conan
         run : |
-          conan profile get env.CXXFLAGS default || true
+          conan profile new default --detect
+          conan profile update settings.compiler.cppstd=20 default
           conan profile update 'conf.tools.build:cxxflags+=["-DBOOST_ASIO_DISABLE_CONCEPTS"]' default
       - name: build dependencies
         uses: ./.github/actions/dependencies

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,7 +39,7 @@ jobs:
           cmake --version
       - name: configure Conan
         run : |
-          conan profile new default --detect
+          conan profile new default --detect || true
           conan profile update settings.compiler.cppstd=20 default
           conan profile update 'conf.tools.build:cxxflags+=["-DBOOST_ASIO_DISABLE_CONCEPTS"]' default
       - name: build dependencies

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,6 +30,7 @@ jobs:
         run: brew install ninja
       - name: check environment
         run: |
+          eval $(brew shellenv)
           env | sort
           echo ${PATH} | tr ':' '\n'
           python --version

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+      - name: install Conan
+        run: brew install conan@1
       - name: install Ninja
         if: matrix.generator == 'Ninja'
         run: brew install ninja

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,6 +56,7 @@ jobs:
         shell: bash
         run: |
           conan profile new default --detect
+          conan profile update settings.compiler.cppstd=20 default
           conan profile update settings.compiler.runtime=MT${{ matrix.configuration == 'Debug' && 'd' || '' }} default
       - name: build dependencies
         uses: ./.github/actions/dependencies


### PR DESCRIPTION
We have decided to update the macOS runners, which requires additional configuration. The `doxygen` workflow container needs to be updated to accommodate the latest action versions.