### PR TITLE
RIPD-1847 fix select query condition

### DIFF
--- a/src/ripple/app/rdb/backend/detail/impl/Node.cpp
+++ b/src/ripple/app/rdb/backend/detail/impl/Node.cpp
@@ -1125,7 +1125,7 @@ accountTxPage(
     {
         sql = boost::str(
             boost::format(
-                prefix + (R"(AccountTransactions.LedgerSeq BETWEEN '%u' AND '%u'
+                prefix + (R"(AccountTransactions.LedgerSeq BETWEEN %u AND %u
              ORDER BY AccountTransactions.LedgerSeq %s,
              AccountTransactions.TxnSeq %s
              LIMIT %u;)")) %
@@ -1148,12 +1148,14 @@ accountTxPage(
             FROM AccountTransactions, Transactions WHERE
             (AccountTransactions.TransID = Transactions.TransID AND
             AccountTransactions.Account = '%s' AND
-            AccountTransactions.LedgerSeq BETWEEN '%u' AND '%u')
-            OR
+            AccountTransactions.LedgerSeq BETWEEN %u AND %u)
+            UNION
+            SELECT AccountTransactions.LedgerSeq,AccountTransactions.TxnSeq,Status,RawTxn,TxnMeta
+            FROM AccountTransactions, Transactions WHERE
             (AccountTransactions.TransID = Transactions.TransID AND
             AccountTransactions.Account = '%s' AND
-            AccountTransactions.LedgerSeq = '%u' AND
-            AccountTransactions.TxnSeq %s '%u')
+            AccountTransactions.LedgerSeq = %u AND
+            AccountTransactions.TxnSeq %s %u)
             ORDER BY AccountTransactions.LedgerSeq %s,
             AccountTransactions.TxnSeq %s
             LIMIT %u;


### PR DESCRIPTION
## High Level Overview of Change

perf: improve `account_tx` SQL query:

The witness server makes heavily use of the `account_tx` RPC command. Perf
testing showed that the SQL query used by `account_tx` became unacceptably slow
when the DB was large and there was a `marker` parameter. The plan for the query
showed only indexed reads. This appears to be an issue with the internal SQLite
optimizer. This patch rewrote the query to use `UNION` instead of `OR` and
significantly improves performance. See RXI-896 and RIPD-1847 for more details.

### Example
was:

```
SELECT AccountTransactions.LedgerSeq,AccountTransactions.TxnSeq,
  Status,RawTxn,TxnMeta
  FROM AccountTransactions, Transactions WHERE
  (AccountTransactions.TransID = Transactions.TransID AND
  AccountTransactions.Account = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh' AND
  AccountTransactions.LedgerSeq BETWEEN '415398' AND '415441')
  OR
  (AccountTransactions.TransID = Transactions.TransID AND
  AccountTransactions.Account = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh' AND
  AccountTransactions.LedgerSeq = '415442' AND
  AccountTransactions.TxnSeq <= '152')
  ORDER BY AccountTransactions.LedgerSeq DESC,
  AccountTransactions.TxnSeq DESC
  LIMIT 400;
```

became:
```
SELECT AccountTransactions.LedgerSeq,AccountTransactions.TxnSeq,Status,RawTxn,TxnMeta
  FROM AccountTransactions, Transactions WHERE
  (AccountTransactions.TransID = Transactions.TransID AND
  AccountTransactions.Account = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh' AND
  AccountTransactions.LedgerSeq BETWEEN 415398 AND 415441)
UNION
SELECT AccountTransactions.LedgerSeq,AccountTransactions.TxnSeq,Status,RawTxn,TxnMeta
  FROM AccountTransactions, Transactions WHERE
  (AccountTransactions.TransID = Transactions.TransID AND
  AccountTransactions.Account = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh' AND
  AccountTransactions.LedgerSeq = 415442 AND
  AccountTransactions.TxnSeq <= 152)
  ORDER BY AccountTransactions.LedgerSeq DESC,
  AccountTransactions.TxnSeq DESC
  LIMIT 400;
```
## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)