### PR TITLE
chore: change Github Action triggers for build/test jobs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,12 @@
 <!--
 This PR template helps you to write a good pull request description.
 Please feel free to include additional useful information even beyond what is requested below.
+
+If your branch is on a personal fork and has a name that allows it to
+run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
+opening the PR.  This avoids unnecessary redundant test runs. Renaming
+the branch after opening the PR will close the PR.
+https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
 -->
 
 ## High Level Overview of Change

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,5 +1,16 @@
 name: macos
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    # If the branches list is ever changed, be sure to change it on all
+    # build/test jobs (nix, macos, windows)
+    branches:
+      # Always build the package branches
+      - develop
+      - release
+      - master
+      # Branches that opt-in to running
+      - 'ci/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,5 +1,16 @@
 name: nix
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    # If the branches list is ever changed, be sure to change it on all
+    # build/test jobs (nix, macos, windows)
+    branches:
+      # Always build the package branches
+      - develop
+      - release
+      - master
+      # Branches that opt-in to running
+      - 'ci/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,17 @@
 name: windows
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    # If the branches list is ever changed, be sure to change it on all
+    # build/test jobs (nix, macos, windows)
+    branches:
+      # Always build the package branches
+      - develop
+      - release
+      - master
+      # Branches that opt-in to running
+      - 'ci/**'
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:


### PR DESCRIPTION
## High Level Overview of Change

Github Actions for the build/test jobs (`nix.yml`, `mac.yml`, `windows.yml`) will only run on branches that build packages (`develop`, `release`, `master`), and branches with names starting with `ci/`. This is especially targeted toward personal forks where CI runs are set up, but frequently unnecessary, and particularly once a pull request is opened - at that point any runs on the forks are redundant and wasteful.

### Context of Change

This is intended as a compromise between disabling CI jobs on personal forks entirely, and having the jobs run as a free-for-all. Note that it will *not* affect PR jobs at all.

### Type of Change

- [X ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
