### PR TITLE
Add the fixAMMOfferRounding amendment

### DIFF
--- a/src/ripple/app/misc/AMMHelpers.h
+++ b/src/ripple/app/misc/AMMHelpers.h
@@ -216,8 +216,8 @@ getAMMOfferStartWithTakerGets(
         nTakerGets = nTakerGetsConstraint;
 
     auto getAmounts = [&](Number const& nTakerGets) {
-      // Round downward to minimize the offer and to maximize the quality.
-      // This has the most impact when takerGets is XRP.
+        // Round downward to minimize the offer and to maximize the quality.
+        // This has the most impact when takerGets is XRP.
         auto const takerGets = toAmount<TOut>(
             getIssue(pool.out), nTakerGets, Number::rounding_mode::downward);
         return TAmounts<TIn, TOut>{

--- a/src/ripple/app/misc/AMMHelpers.h
+++ b/src/ripple/app/misc/AMMHelpers.h
@@ -211,7 +211,7 @@ getAMMOfferStartWithTakerGets(
 
     auto nTakerGets = solveQuadraticEqSmallest(a, b, c);
     if (!nTakerGets || *nTakerGets <= 0)
-        return std::nullopt;
+        return std::nullopt;  // LCOV_EXCL_LINE
 
     auto const nTakerGetsConstraint =
         pool.out - pool.in / (targetQuality.rate() * f);
@@ -282,7 +282,7 @@ getAMMOfferStartWithTakerPays(
 
     auto nTakerPays = solveQuadraticEqSmallest(a, b, c);
     if (!nTakerPays || nTakerPays <= 0)
-        return std::nullopt;
+        return std::nullopt;  // LCOV_EXCL_LINE
 
     auto const nTakerPaysConstraint =
         pool.out * targetQuality.rate() - pool.in / f;
@@ -350,7 +350,7 @@ changeSpotPriceQuality(
         Number const c =
             pool.in * pool.in - pool.in * pool.out * quality.rate();
         if (auto const res = b * b - 4 * a * c; res < 0)
-            return std::nullopt;
+            return std::nullopt;  // LCOV_EXCL_LINE
         else if (auto const nTakerPaysPropose = (-b + root2(res)) / (2 * a);
                  nTakerPaysPropose > 0)
         {

--- a/src/ripple/app/misc/AMMHelpers.h
+++ b/src/ripple/app/misc/AMMHelpers.h
@@ -222,11 +222,11 @@ getAMMOfferStartWithTakerGets(
     if (nTakerGetsConstraint < *nTakerGets)
         nTakerGets = nTakerGetsConstraint;
 
-    auto getAmounts = [&pool, &tfee](Number const& nTakerGets_) {
+    auto getAmounts = [&pool, &tfee](Number const& nTakerGetsProposed) {
         // Round downward to minimize the offer and to maximize the quality.
         // This has the most impact when takerGets is XRP.
-        auto const takerGets =
-            toAmount<TOut>(getIssue(pool.out), nTakerGets_, Number::downward);
+        auto const takerGets = toAmount<TOut>(
+            getIssue(pool.out), nTakerGetsProposed, Number::downward);
         return TAmounts<TIn, TOut>{
             swapAssetOut(pool, takerGets, tfee), takerGets};
     };
@@ -293,11 +293,11 @@ getAMMOfferStartWithTakerPays(
     if (nTakerPaysConstraint < *nTakerPays)
         nTakerPays = nTakerPaysConstraint;
 
-    auto getAmounts = [&pool, &tfee](Number const& nTakerPays_) {
+    auto getAmounts = [&pool, &tfee](Number const& nTakerPaysProposed) {
         // Round downward to minimize the offer and to maximize the quality.
         // This has the most impact when takerPays is XRP.
-        auto const takerPays =
-            toAmount<TIn>(getIssue(pool.in), nTakerPays_, Number::downward);
+        auto const takerPays = toAmount<TIn>(
+            getIssue(pool.in), nTakerPaysProposed, Number::downward);
         return TAmounts<TIn, TOut>{
             takerPays, swapAssetIn(pool, takerPays, tfee)};
     };

--- a/src/ripple/app/misc/impl/AMMHelpers.cpp
+++ b/src/ripple/app/misc/impl/AMMHelpers.cpp
@@ -203,4 +203,52 @@ solveQuadraticEq(Number const& a, Number const& b, Number const& c)
     return (-b + root2(b * b - 4 * a * c)) / (2 * a);
 }
 
+// Minimize takerGets or takerPays
+std::optional<Number>
+solveQuadraticEqSmallest(Number const& a, Number const& b, Number const& c)
+{
+    // calculate:
+    // d = b * b - 4 * a * c
+    // (-b + root2(d)) / (2 * a)
+    // minimize:
+    // (-b + root2(d)) / (2 * a)
+    // (-b + root2(d))
+    // root2(d)
+    // d
+    // b * b
+    // maximize:
+    // 4 * a * c
+    // (2 * a)
+    if (b > 0)
+    {
+        auto const d = downward()((downward()(b * b) - upward()(4 * a * c)));
+        if (d < 0)
+            return std::nullopt;
+        return downward()(
+            downward()(-b + downward()(root2(d))) / upward()(2 * a));
+    }
+    else
+    {
+        // calculate:
+        // d = b * b - 4 * a * c
+        // (-b - root2(d)) / (2 * a)
+        // minimize:
+        // (-b - root2(d)) / (2 * a)
+        // (-b - root2(d))
+        // maximize:
+        // root2(d)
+        // d
+        // b * b
+        // minimize:
+        // 4 * a * c
+        // maximize:
+        // (2 * a)
+        auto const d = upward()((upward()(b * b) - downward()(4 * a * c)));
+        if (d < 0)
+            return std::nullopt;
+        return downward()(
+            downward()(-b - upward()(root2(d))) / upward()(2 * a));
+    }
+}
+
 }  // namespace ripple

--- a/src/ripple/app/misc/impl/AMMHelpers.cpp
+++ b/src/ripple/app/misc/impl/AMMHelpers.cpp
@@ -207,48 +207,15 @@ solveQuadraticEq(Number const& a, Number const& b, Number const& c)
 std::optional<Number>
 solveQuadraticEqSmallest(Number const& a, Number const& b, Number const& c)
 {
-    // calculate:
-    // d = b * b - 4 * a * c
-    // (-b + root2(d)) / (2 * a)
-    // minimize:
-    // (-b + root2(d)) / (2 * a)
-    // (-b + root2(d))
-    // root2(d)
-    // d
-    // b * b
-    // maximize:
-    // 4 * a * c
-    // (2 * a)
+    auto const d = b * b - 4 * a * c;
+    if (d < 0)
+        return std::nullopt;
+    // use numerically stable citardauq formula for quadratic equation solution
+    // https://people.csail.mit.edu/bkph/articles/Quadratics.pdf
     if (b > 0)
-    {
-        auto const d = downward()((downward()(b * b) - upward()(4 * a * c)));
-        if (d < 0)
-            return std::nullopt;
-        return downward()(
-            downward()(-b + downward()(root2(d))) / upward()(2 * a));
-    }
+        return (2 * c) / (-b - root2(d));
     else
-    {
-        // calculate:
-        // d = b * b - 4 * a * c
-        // (-b - root2(d)) / (2 * a)
-        // minimize:
-        // (-b - root2(d)) / (2 * a)
-        // (-b - root2(d))
-        // maximize:
-        // root2(d)
-        // d
-        // b * b
-        // minimize:
-        // 4 * a * c
-        // maximize:
-        // (2 * a)
-        auto const d = upward()((upward()(b * b) - downward()(4 * a * c)));
-        if (d < 0)
-            return std::nullopt;
-        return downward()(
-            downward()(-b - upward()(root2(d))) / upward()(2 * a));
-    }
+        return (2 * c) / (-b + root2(d));
 }
 
 }  // namespace ripple

--- a/src/ripple/app/paths/impl/AMMLiquidity.cpp
+++ b/src/ripple/app/paths/impl/AMMLiquidity.cpp
@@ -205,8 +205,8 @@ AMMLiquidity<TIn, TOut>::getOffer(
                 return maxOffer(balances, view.rules());
             }
             else if (
-                auto const amounts =
-                    changeSpotPriceQuality(balances, *clobQuality, tradingFee_))
+                auto const amounts = changeSpotPriceQuality(
+                    balances, *clobQuality, tradingFee_, view.rules(), j_))
             {
                 return AMMOffer<TIn, TOut>(
                     *this, *amounts, balances, Quality{*amounts});
@@ -239,7 +239,12 @@ AMMLiquidity<TIn, TOut>::getOffer(
             return offer;
         }
 
-        JLOG(j_.error()) << "AMMLiquidity::getOffer, failed";
+        JLOG(j_.error()) << "AMMLiquidity::getOffer, failed "
+                         << ammContext_.multiPath() << " "
+                         << ammContext_.curIters() << " "
+                         << (clobQuality ? clobQuality->rate() : STAmount{})
+                         << " " << to_string(balances.in) << " "
+                         << to_string(balances.out);
     }
 
     return std::nullopt;

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -298,6 +298,7 @@ public:
     }
 
     // A payment doesn't use max quality threshold (limitQuality)
+    // since the strand's quality doesn't directly relate to the step's quality.
     Quality const&
     maxQualityThreshold(Quality const& lobQuality) const
     {
@@ -808,7 +809,7 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
     }
     else
     {
-        // Might have AMM offer if there is no CLOB offers.
+        // Might have AMM offer if there are no LOB offers.
         tryAMM(std::nullopt);
     }
 

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -786,7 +786,7 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
         // limit quality to prevent AMM being blocked by a lower quality
         // LOB.
         auto const bestQuality = [&]() -> std::optional<Quality> {
-            if (sb.rules().enabled(fixAMMRounding) && lobQuality)
+            if (sb.rules().enabled(fixAMMv1_1) && lobQuality)
                 return static_cast<TDerived const*>(this)->maxQualityThreshold(
                     *lobQuality);
             return lobQuality;
@@ -903,7 +903,7 @@ BookStep<TIn, TOut, TDerived>::tip(ReadView const& view) const
     // is partially crossed, and it might take a few iterations to fully cross
     // the offer.
     auto const targetQuality = [&]() -> std::optional<Quality> {
-        if (view.rules().enabled(fixAMMRounding) && lobQuality)
+        if (view.rules().enabled(fixAMMv1_1) && lobQuality)
             return static_cast<TDerived const*>(this)->maxQualityThreshold(
                 *lobQuality);
         return std::nullopt;

--- a/src/ripple/app/tx/impl/AMMCreate.cpp
+++ b/src/ripple/app/tx/impl/AMMCreate.cpp
@@ -252,8 +252,8 @@ applyCreate(
             : 1};
     sleAMMRoot->setFieldU32(sfSequence, seqno);
     // Ignore reserves requirement, disable the master key, allow default
-    // rippling (AMM LPToken can be used as a token in another AMM, which must
-    // support payments and offer crossing), and enable deposit authorization to
+    // rippling (AMM LPToken can be used in payments and offer crossing but
+    // not as a token in another AMM), and enable deposit authorization to
     // prevent payments into AMM.
     // Note, that the trustlines created by AMM have 0 credit limit.
     // This prevents shifting the balance between accounts via AMM,

--- a/src/ripple/basics/Number.h
+++ b/src/ripple/basics/Number.h
@@ -387,6 +387,71 @@ public:
     operator=(saveNumberRoundMode const&) = delete;
 };
 
+// Functors to facilitate intermediate steps rounding mode
+// in complex arithmetic expressions.
+// Class constructor saves the current rounding mode,
+// sets the requested rounding mode, and is called before
+// the arithmetic expression is evaluated. The rounding mode
+// state is restored in the functor call, which sets the outer
+// functor rounding mode or the initial mode. For instance, if
+// the following expression has to be minimized:
+// (a * b) / (c - d) then the functors are called as follows:
+// downard()(downward()(a * b) / upward()(c - d))
+// the call sequence is as follows:
+// set downward; set downward; num = a * b; restore downward; return n;
+// set upward; den = c - d; restore downward; return den; r = num / den;
+// restore to_nearest; return r;
+
+class upward
+{
+private:
+    Number::rounding_mode mode_;
+
+public:
+    upward() : mode_(Number::getround())
+    {
+        Number::setround(Number::rounding_mode::upward);
+    }
+    ~upward() = default;
+    upward(upward const&) = delete;
+    upward(upward const&&) = delete;
+    upward&
+    operator=(upward const&) = delete;
+    upward&
+    operator=(upward const&&) = delete;
+    Number const&
+    operator()(Number const& n)
+    {
+        Number::setround(mode_);
+        return n;
+    }
+};
+
+class downward
+{
+private:
+    Number::rounding_mode mode_;
+
+public:
+    downward() : mode_(Number::getround())
+    {
+        Number::setround(Number::rounding_mode::downward);
+    }
+    ~downward() = default;
+    downward(downward const&) = delete;
+    downward(downward const&&) = delete;
+    downward&
+    operator=(downward const&) = delete;
+    downward&
+    operator=(downward const&&) = delete;
+    Number const&
+    operator()(Number const& n)
+    {
+        Number::setround(mode_);
+        return n;
+    }
+};
+
 }  // namespace ripple
 
 #endif  // RIPPLE_BASICS_NUMBER_H_INCLUDED

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -1147,7 +1147,7 @@ accountSend(
     beast::Journal j,
     WaiveTransferFee waiveFee)
 {
-    if (view.rules().enabled(fixAMMRounding))
+    if (view.rules().enabled(fixAMMv1_1))
     {
         if (saAmount < beast::zero)
         {

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -359,7 +359,7 @@ extern uint256 const featurePriceOracle;
 extern uint256 const fixEmptyDID;
 extern uint256 const fixXChainRewardRounding;
 extern uint256 const fixPreviousTxnID;
-extern uint256 const fixAMMRounding;
+extern uint256 const fixAMMv1_1;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -466,7 +466,7 @@ REGISTER_FEATURE(PriceOracle,                   Supported::yes, VoteBehavior::De
 REGISTER_FIX    (fixEmptyDID,                   Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixXChainRewardRounding,       Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixPreviousTxnID,              Supported::yes, VoteBehavior::DefaultNo);
-REGISTER_FIX    (fixAMMRounding,                Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FIX    (fixAMMv1_1,                Supported::yes, VoteBehavior::DefaultNo);
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -1367,26 +1367,6 @@ canonicalizeRoundStrict(
 
 namespace {
 
-// saveNumberRoundMode doesn't do quite enough for us.  What we want is a
-// Number::RoundModeGuard that sets the new mode and restores the old mode
-// when it leaves scope.  Since Number doesn't have that facility, we'll
-// build it here.
-class NumberRoundModeGuard
-{
-    saveNumberRoundMode saved_;
-
-public:
-    explicit NumberRoundModeGuard(Number::rounding_mode mode) noexcept
-        : saved_{Number::setround(mode)}
-    {
-    }
-
-    NumberRoundModeGuard(NumberRoundModeGuard const&) = delete;
-
-    NumberRoundModeGuard&
-    operator=(NumberRoundModeGuard const&) = delete;
-};
-
 // We need a class that has an interface similar to NumberRoundModeGuard
 // but does nothing.
 class DontAffectNumberRoundMode

--- a/src/test/app/AMMCalc_test.cpp
+++ b/src/test/app/AMMCalc_test.cpp
@@ -413,13 +413,18 @@ class AMMCalc_test : public beast::unit_test::suite
             //     10 is AMM trading fee
             else if (*p == "changespq")
             {
+                Env env(*this);
                 if (auto const pool = getAmounts(++p))
                 {
                     if (auto const offer = getAmounts(p))
                     {
                         auto const fee = getFee(p);
                         if (auto const ammOffer = changeSpotPriceQuality(
-                                pool->first, Quality{offer->first}, fee);
+                                pool->first,
+                                Quality{offer->first},
+                                fee,
+                                env.current()->rules(),
+                                beast::Journal(beast::Journal::getNullSink()));
                             ammOffer)
                             std::cout
                                 << "amm offer: " << toString(ammOffer->in)

--- a/src/test/app/AMMExtended_test.cpp
+++ b/src/test/app/AMMExtended_test.cpp
@@ -94,7 +94,7 @@ private:
             sendmax(BTC(1'000)),
             txflags(tfPartialPayment));
 
-        if (!features[fixAMMRounding])
+        if (!features[fixAMMv1_1])
         {
             BEAST_EXPECT(ammCarol.expectBalances(
                 STAmount{BTC, UINT64_C(1'001'000000374812), -12},
@@ -720,7 +720,7 @@ private:
         auto const jrr = env.rpc("json", "submit", to_string(payment));
         BEAST_EXPECT(jrr[jss::result][jss::status] == "success");
         BEAST_EXPECT(jrr[jss::result][jss::engine_result] == "tesSUCCESS");
-        if (!features[fixAMMRounding])
+        if (!features[fixAMMv1_1])
         {
             BEAST_EXPECT(ammAlice.expectBalances(
                 STAmount(XTS, UINT64_C(101'010101010101), -12),
@@ -1291,7 +1291,7 @@ private:
         env(offer(cam, B_BUX(30), A_BUX(30)));
 
         // AMM is consumed up to the first cam Offer quality
-        if (!features[fixAMMRounding])
+        if (!features[fixAMMv1_1])
         {
             BEAST_EXPECT(ammCarol.expectBalances(
                 STAmount{A_BUX, UINT64_C(309'3541659651605), -13},
@@ -1308,16 +1308,16 @@ private:
         else
         {
             BEAST_EXPECT(ammCarol.expectBalances(
-                STAmount{A_BUX, UINT64_C(309'3541659651602), -13},
-                STAmount{B_BUX, UINT64_C(320'021550998442), -12},
+                STAmount{A_BUX, UINT64_C(309'3541659651604), -13},
+                STAmount{B_BUX, UINT64_C(320'0215509984419), -13},
                 ammCarol.tokens()));
             BEAST_EXPECT(expectOffers(
                 env,
                 cam,
                 1,
                 {{Amounts{
-                    STAmount{B_BUX, UINT64_C(20'021550998442), -12},
-                    STAmount{A_BUX, UINT64_C(20'021550998442), -12}}}}));
+                    STAmount{B_BUX, UINT64_C(20'0215509984419), -13},
+                    STAmount{A_BUX, UINT64_C(20'0215509984419), -13}}}}));
         }
     }
 
@@ -1444,7 +1444,7 @@ private:
         using namespace jtx;
         FeatureBitset const all{supported_amendments()};
         testRmFundedOffer(all);
-        testRmFundedOffer(all - fixAMMRounding);
+        testRmFundedOffer(all - fixAMMv1_1);
         testEnforceNoRipple(all);
         testFillModes(all);
         testOfferCrossWithXRP(all);
@@ -1458,7 +1458,7 @@ private:
         testOfferCreateThenCross(all);
         testSellFlagExceedLimit(all);
         testGatewayCrossCurrency(all);
-        testGatewayCrossCurrency(all - fixAMMRounding);
+        testGatewayCrossCurrency(all - fixAMMv1_1);
         // testPartialCross
         // testXRPDirectCross
         // testDirectCross
@@ -1470,7 +1470,7 @@ private:
         testBadPathAssert(all);
         testSellFlagBasic(all);
         testDirectToDirectPath(all);
-        testDirectToDirectPath(all - fixAMMRounding);
+        testDirectToDirectPath(all - fixAMMv1_1);
         // testSelfCrossLowQualityOffer
         // testOfferInScaling
         // testOfferInScalingWithXferRate
@@ -2335,7 +2335,7 @@ private:
                 txflags(tfNoRippleDirect | tfPartialPayment | tfLimitQuality));
             env.close();
 
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 // alice buys 77.2727USD with 75.5555GBP and pays 25% tr fee
                 // on 75.5555GBP
@@ -2382,7 +2382,7 @@ private:
             env(offer(alice, EUR(100), USD(100)));
             env.close();
 
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 // 95.2380USD is swapped in for 100EUR
                 BEAST_EXPECT(amm.expectBalances(
@@ -2435,7 +2435,7 @@ private:
             env(pay(gw, dan, USD(1'000)));
             AMM ammDan(env, dan, USD(1'000), EUR(1'050));
 
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 // alice -> bob -> gw -> carol. $50 should have transfer fee;
                 // $10, no fee
@@ -2504,7 +2504,7 @@ private:
             // alice buys 107.1428USD with 120GBP and pays 25% tr fee on 120GBP
             // 1,000 - 120*1.25 = 850GBP
             BEAST_EXPECT(expectLine(env, alice, GBP(850)));
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 // 120GBP is swapped in for 107.1428USD
                 BEAST_EXPECT(amm.expectBalances(
@@ -2593,7 +2593,7 @@ private:
             env.close();
 
             BEAST_EXPECT(expectLine(env, alice, GBP(850)));
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 // alice buys 107.1428EUR with 120GBP and pays 25% tr fee on
                 // 120GBP 1,000 - 120*1.25 = 850GBP 120GBP is swapped in for
@@ -2710,7 +2710,7 @@ private:
                 txflags(tfNoRippleDirect | tfPartialPayment | tfLimitQuality));
             env.close();
 
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 // alice buys 28.125USD with 24GBP and pays 25% tr fee
                 // on 24GBP
@@ -2767,7 +2767,7 @@ private:
                 txflags(tfNoRippleDirect | tfPartialPayment | tfLimitQuality));
             env.close();
 
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 // alice buys 70.4210EUR with 70.4210GBP via the offer
                 // and pays 25% tr fee on 70.4210GBP
@@ -2859,7 +2859,7 @@ private:
                 txflags(tfNoRippleDirect | tfPartialPayment | tfLimitQuality));
             env.close();
 
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 // alice buys 53.3322EUR with 56.3368GBP via the amm
                 // and pays 25% tr fee on 56.3368GBP
@@ -2937,7 +2937,7 @@ private:
                 txflags(tfNoRippleDirect | tfPartialPayment | tfLimitQuality));
             env.close();
 
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 // alice buys 53.3322EUR with 107.5308GBP
                 // 25% on 86.0246GBP is paid in tr fee
@@ -3008,7 +3008,7 @@ private:
                 txflags(tfNoRippleDirect | tfPartialPayment | tfLimitQuality));
             env.close();
 
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 // 108.1481GBP is swapped in for 97.5935EUR
                 BEAST_EXPECT(amm1.expectBalances(
@@ -3181,7 +3181,7 @@ private:
         // Alice offers to buy 1000 XRP for 1000 USD. She takes Bob's first
         // offer, removes 999 more as unfunded, then hits the step limit.
         env(offer(alice, USD(1'000), XRP(1'000)));
-        if (!features[fixAMMRounding])
+        if (!features[fixAMMv1_1])
             env.require(balance(
                 alice, STAmount{USD, UINT64_C(2'050126257867561), -15}));
         else
@@ -3292,7 +3292,7 @@ private:
             env(offer(bob, XRP(100), USD(100)));
             env(offer(bob, XRP(1'000), USD(100)));
             AMM ammDan(env, dan, XRP(1'000), USD(1'100));
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 env(pay(alice, carol, USD(10'000)),
                     paths(XRP),
@@ -4102,9 +4102,9 @@ private:
         testBookStep(all);
         testBookStep(all | ownerPaysFee);
         testTransferRate(all | ownerPaysFee);
-        testTransferRate((all - fixAMMRounding) | ownerPaysFee);
+        testTransferRate((all - fixAMMv1_1) | ownerPaysFee);
         testTransferRateNoOwnerFee(all);
-        testTransferRateNoOwnerFee(all - fixAMMRounding);
+        testTransferRateNoOwnerFee(all - fixAMMv1_1);
         testLimitQuality();
         testXRPPathLoop();
     }
@@ -4115,7 +4115,7 @@ private:
         using namespace jtx;
         FeatureBitset const all{supported_amendments()};
         testStepLimit(all);
-        testStepLimit(all - fixAMMRounding);
+        testStepLimit(all - fixAMMv1_1);
     }
 
     void
@@ -4124,7 +4124,7 @@ private:
         using namespace jtx;
         FeatureBitset const all{supported_amendments()};
         test_convert_all_of_an_asset(all);
-        test_convert_all_of_an_asset(all - fixAMMRounding);
+        test_convert_all_of_an_asset(all - fixAMMv1_1);
     }
 
     void

--- a/src/test/app/AMMExtended_test.cpp
+++ b/src/test/app/AMMExtended_test.cpp
@@ -1459,11 +1459,7 @@ private:
         testSellFlagExceedLimit(all);
         testGatewayCrossCurrency(all);
         testGatewayCrossCurrency(all - fixAMMv1_1);
-        // testPartialCross
-        // testXRPDirectCross
-        // testDirectCross
         testBridgedCross(all);
-        // testSellOffer
         testSellWithFillOrKill(all);
         testTransferRateOffer(all);
         testSelfIssueOffer(all);
@@ -1471,16 +1467,8 @@ private:
         testSellFlagBasic(all);
         testDirectToDirectPath(all);
         testDirectToDirectPath(all - fixAMMv1_1);
-        // testSelfCrossLowQualityOffer
-        // testOfferInScaling
-        // testOfferInScalingWithXferRate
-        // testOfferThresholdWithReducedFunds
-        // testTinyOffer
-        // testSelfPayXferFeeOffer
-        // testSelfPayXferFeeOffer
         testRequireAuth(all);
         testMissingAuth(all);
-        // testRCSmoketest
     }
 
     void

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -37,6 +37,8 @@
 #include <utility>
 #include <vector>
 
+#include <boost/regex.hpp>
+
 namespace ripple {
 namespace test {
 
@@ -4060,17 +4062,36 @@ private:
             env(offer(bob, XRP(100), USD(100.001)));
             AMM ammAlice(env, alice, XRP(10'000), USD(10'100));
             env(offer(carol, USD(100), XRP(100)));
-            BEAST_EXPECT(ammAlice.expectBalances(
-                XRPAmount{10'049'825'373},
-                STAmount{USD, UINT64_C(10'049'92586949302), -11},
-                ammAlice.tokens()));
-            BEAST_EXPECT(expectOffers(
-                env,
-                bob,
-                1,
-                {{{XRPAmount{50'074'629},
-                   STAmount{USD, UINT64_C(50'07513050698), -11}}}}));
-            BEAST_EXPECT(expectLine(env, carol, USD(30'100)));
+            if (!features[fixAMMRounding])
+            {
+                BEAST_EXPECT(ammAlice.expectBalances(
+                    XRPAmount{10'049'825'373},
+                    STAmount{USD, UINT64_C(10'049'92586949302), -11},
+                    ammAlice.tokens()));
+                BEAST_EXPECT(expectOffers(
+                    env,
+                    bob,
+                    1,
+                    {{{XRPAmount{50'074'629},
+                       STAmount{USD, UINT64_C(50'07513050698), -11}}}}));
+            }
+            else
+            {
+                BEAST_EXPECT(ammAlice.expectBalances(
+                    XRPAmount{10'049'825'372},
+                    STAmount{USD, UINT64_C(10'049'92587049303), -11},
+                    ammAlice.tokens()));
+                BEAST_EXPECT(expectOffers(
+                    env,
+                    bob,
+                    1,
+                    {{{XRPAmount{50'152'992},
+                       STAmount{USD, UINT64_C(50'15374745888576), -14}}}}));
+                BEAST_EXPECT(expectLine(
+                    env,
+                    carol,
+                    STAmount{USD, UINT64_C(30'099'92138204985), -11}));
+            }
         }
 
         // Individually frozen account
@@ -4352,7 +4373,7 @@ private:
                     env(offer(
                             LP1,
                             XRPAmount{18'095'132},
-                            STAmount{TST, UINT64_C(1'68737984885387), -14}),
+                            STAmount{TST, UINT64_C(1'68737976189735), -14}),
                         txflags(tfPassive));
             },
             [&](Env& env) {
@@ -4677,10 +4698,10 @@ private:
                 BEAST_EXPECT(expectLine(
                     env,
                     bob,
-                    STAmount{EUR, UINT64_C(1'989'987453007616), -12}));
+                    STAmount{EUR, UINT64_C(1'989'987468671679), -12}));
                 BEAST_EXPECT(ammAlice.expectBalances(
                     USD(1'000),
-                    STAmount{EUR, UINT64_C(1'005'012546992384), -12},
+                    STAmount{EUR, UINT64_C(1'005'012531328321), -12},
                     ammAlice.tokens()));
             }
             BEAST_EXPECT(expectOffers(env, carol, 0));
@@ -5196,31 +5217,65 @@ private:
                     {
                         if (rates.first == 1.5)
                         {
-                            BEAST_EXPECT(expectOffers(
-                                env,
-                                ed,
-                                1,
-                                {{Amounts{
-                                    STAmount{
-                                        ETH, UINT64_C(378'6327949540823), -13},
-                                    STAmount{
-                                        USD,
-                                        UINT64_C(283'9745962155617),
-                                        -13}}}}));
+                            if (!features[fixAMMRounding])
+                                BEAST_EXPECT(expectOffers(
+                                    env,
+                                    ed,
+                                    1,
+                                    {{Amounts{
+                                        STAmount{
+                                            ETH,
+                                            UINT64_C(378'6327949540823),
+                                            -13},
+                                        STAmount{
+                                            USD,
+                                            UINT64_C(283'9745962155617),
+                                            -13}}}}));
+                            else
+                                BEAST_EXPECT(expectOffers(
+                                    env,
+                                    ed,
+                                    1,
+                                    {{Amounts{
+                                        STAmount{
+                                            ETH,
+                                            UINT64_C(378'6327949540813),
+                                            -13},
+                                        STAmount{
+                                            USD,
+                                            UINT64_C(283'974596215561),
+                                            -12}}}}));
                         }
                         else
                         {
-                            BEAST_EXPECT(expectOffers(
-                                env,
-                                ed,
-                                1,
-                                {{Amounts{
-                                    STAmount{
-                                        ETH, UINT64_C(325'299461620749), -12},
-                                    STAmount{
-                                        USD,
-                                        UINT64_C(243'9745962155617),
-                                        -13}}}}));
+                            if (!features[fixAMMRounding])
+                                BEAST_EXPECT(expectOffers(
+                                    env,
+                                    ed,
+                                    1,
+                                    {{Amounts{
+                                        STAmount{
+                                            ETH,
+                                            UINT64_C(325'299461620749),
+                                            -12},
+                                        STAmount{
+                                            USD,
+                                            UINT64_C(243'9745962155617),
+                                            -13}}}}));
+                            else
+                                BEAST_EXPECT(expectOffers(
+                                    env,
+                                    ed,
+                                    1,
+                                    {{Amounts{
+                                        STAmount{
+                                            ETH,
+                                            UINT64_C(325'299461620748),
+                                            -12},
+                                        STAmount{
+                                            USD,
+                                            UINT64_C(243'974596215561),
+                                            -12}}}}));
                         }
                     }
                     else if (i == 2)
@@ -5292,29 +5347,71 @@ private:
                 {
                     if (rates.first == 1.5)
                     {
-                        BEAST_EXPECT(expectOffers(
-                            env, ed, 1, {{Amounts{ETH(400), USD(250)}}}));
-                        BEAST_EXPECT(expectOffers(
-                            env,
-                            alice,
-                            1,
-                            {{Amounts{
-                                STAmount{USD, UINT64_C(40'5694150420947), -13},
-                                STAmount{ETH, UINT64_C(64'91106406735152), -14},
-                            }}}));
+                        if (!features[fixAMMRounding])
+                        {
+                            BEAST_EXPECT(expectOffers(
+                                env, ed, 1, {{Amounts{ETH(400), USD(250)}}}));
+                            BEAST_EXPECT(expectOffers(
+                                env,
+                                alice,
+                                1,
+                                {{Amounts{
+                                    STAmount{
+                                        USD, UINT64_C(40'5694150420947), -13},
+                                    STAmount{
+                                        ETH, UINT64_C(64'91106406735152), -14},
+                                }}}));
+                        }
+                        else
+                        {
+                            // Ed offer is partially crossed.
+                            // The updated rounding makes limitQuality
+                            // work if both amendments are enabled
+                            BEAST_EXPECT(expectOffers(
+                                env,
+                                ed,
+                                1,
+                                {{Amounts{
+                                    STAmount{
+                                        ETH, UINT64_C(335'0889359326475), -13},
+                                    STAmount{
+                                        USD, UINT64_C(209'4305849579047), -13},
+                                }}}));
+                            BEAST_EXPECT(expectOffers(env, alice, 0));
+                        }
                     }
                     else
                     {
-                        // Ed offer is partially crossed.
-                        BEAST_EXPECT(expectOffers(
-                            env,
-                            ed,
-                            1,
-                            {{Amounts{
-                                STAmount{ETH, UINT64_C(335'0889359326485), -13},
-                                STAmount{USD, UINT64_C(209'4305849579053), -13},
-                            }}}));
-                        BEAST_EXPECT(expectOffers(env, alice, 0));
+                        if (!features[fixAMMRounding])
+                        {
+                            // Ed offer is partially crossed.
+                            BEAST_EXPECT(expectOffers(
+                                env,
+                                ed,
+                                1,
+                                {{Amounts{
+                                    STAmount{
+                                        ETH, UINT64_C(335'0889359326485), -13},
+                                    STAmount{
+                                        USD, UINT64_C(209'4305849579053), -13},
+                                }}}));
+                            BEAST_EXPECT(expectOffers(env, alice, 0));
+                        }
+                        else
+                        {
+                            // Ed offer is partially crossed.
+                            BEAST_EXPECT(expectOffers(
+                                env,
+                                ed,
+                                1,
+                                {{Amounts{
+                                    STAmount{
+                                        ETH, UINT64_C(335'0889359326475), -13},
+                                    STAmount{
+                                        USD, UINT64_C(209'4305849579047), -13},
+                                }}}));
+                            BEAST_EXPECT(expectOffers(env, alice, 0));
+                        }
                     }
                 }
             }
@@ -5555,6 +5652,149 @@ private:
             tesSUCCESS,
             9,
             false);
+    }
+
+    void
+    testFixAMMOfferRounding(FeatureBitset features)
+    {
+        testcase("Fix AMM Offer Rounding");
+        using namespace jtx;
+
+        enum class Status {
+            FailedShouldSucceed,  // Failed in pre-fix due to rounding,
+                                  //   should succeed after fix
+            SucceededShouldFail,  // Succeeded in pre-fix, should fail after fix
+                                  //   due to small quality difference
+            FailedShouldFail,     // Failed in pre-fix due to rounding,
+                               //   should fail after fix due to small quality
+                               //   difference
+            Fail,    // Both fail because the quality can't be matched
+            Succeed  // succeed in both
+        };
+        // clang-format off
+        std::vector<std::tuple<std::string, std::string, Quality, std::uint16_t, Status>> tests = {
+            {"0.001519763260828713", "1558701", Quality{5414253689393440221}, 1000, Status::FailedShouldSucceed},
+            {"0.01099814367603737", "1892611", Quality{5482264816516900274}, 1000, Status::FailedShouldSucceed},
+            {"0.78", "796599", Quality{5630392334958379008}, 1000, Status::FailedShouldSucceed},
+            {"105439.2955578965", "49398693", Quality{5910869983721805038}, 400, Status::FailedShouldSucceed},
+            {"105870.7966405942", "49198160", Quality{5910886636672739152}, 400, Status::FailedShouldSucceed},
+            {"12408293.23445213", "4340810521", Quality{5911611095910090752}, 997, Status::FailedShouldSucceed},
+            {"12417257.02139501", "4337708190", Quality{5911618893549287514}, 997, Status::FailedShouldSucceed},
+            {"12421193.02929446", "4336257104", Quality{5911617164910090752}, 997, Status::FailedShouldSucceed},
+            {"12430504.11172408", "4332652733", Quality{5911624840510090752}, 997, Status::FailedShouldSucceed},
+            {"12448020.44860317", "4327094808", Quality{5911630793102002342}, 997, Status::FailedShouldSucceed},
+            {"12459400.62586608", "4323181824", Quality{5911636760796038120}, 997, Status::FailedShouldSucceed},
+            {"12484012.69745274", "4314743527", Quality{5911645806886990752}, 997, Status::FailedShouldSucceed},
+            {"1892611", "0.01099814367603737", Quality{6703103457950430139}, 1000, Status::FailedShouldSucceed},
+            {"423028.8508101858", "3392804520", Quality{5837920340654162816}, 600, Status::FailedShouldSucceed},
+            {"44565388.41001027", "73890647", Quality{6058976634606450001}, 1000, Status::FailedShouldSucceed},
+            {"66831.68494832662", "16", Quality{6346111134641742975}, 0, Status::FailedShouldSucceed},
+            {"675.9287302203422", "1242632304", Quality{5625960929244093294}, 300, Status::FailedShouldSucceed},
+            {"7047.112186735699", "1649845866", Quality{5696855348026306945}, 504, Status::FailedShouldSucceed},
+            {"7050.618862421691", "1649021148", Quality{5696851051486606944}, 504, Status::FailedShouldSucceed},
+            {"7067.580774394729", "1645091721", Quality{5696869936556306944}, 504, Status::FailedShouldSucceed},
+            {"840236.4402981238", "47419053", Quality{5982561601648018688}, 499, Status::FailedShouldSucceed},
+            {"771493171", "1.243473020567508", Quality{6707566798038544272}, 100, Status::SucceededShouldFail}, // e-8
+            {"69864389131", "287631.4543025075", Quality{6487623473313516078}, 451, Status::SucceededShouldFail}, // e-27
+            {"4328342973", "12453825.99247381", Quality{6272522264364865181}, 997, Status::Succeed},
+            {"32347017", "7003.93031579449", Quality{6347261126087916670}, 1000, Status::Succeed},
+            {"61697206161", "36631.4583206413", Quality{6558965195382476659}, 500, Status::Succeed},
+            {"1654524979", "7028.659825511603", Quality{6487551345110052981}, 504, Status::Succeed},
+            {"88621.22277293179", "5128418948", Quality{5766347291552869205}, 380, Status::Succeed},
+            {"1892611", "0.01099814367603737", Quality{6703102780512015436}, 1000, Status::Succeed},
+            {"4542.639373338766", "24554809", Quality{5838994982188783710}, 0, Status::Succeed},
+            {"61729242395", "36612.54235922302", Quality{6558965195382476659}, 500, Status::Succeed},
+            {"5132932546", "88542.99750172683", Quality{6419203342950054537}, 380, Status::Succeed},
+            {"61728936416", "36612.72293260183", Quality{6558965195382476659}, 500, Status::Succeed},
+            {"78929964.1549083", "1506494795", Quality{5986890029845558688}, 589, Status::Succeed},
+            {"10096561906", "44727.72453735605", Quality{6487455290284644551}, 250, Status::Succeed},
+            {"61726973824", "36613.8812028485", Quality{6558965195382476659}, 500, Status::Succeed},
+            {"88542.99750172683", "5132932546", Quality{5766340625287267809}, 380, Status::Succeed},
+            {"5092.219565514988", "8768257694", Quality{5626349534958379008}, 503, Status::Succeed},
+            {"3984444708", "2346.961925837792", Quality{6558965195382476659}, 856, Status::Succeed},
+            {"1819778294", "8305.084302902864", Quality{6487429398998540860}, 415, Status::Succeed},
+            {"6970462.633911943", "57359281", Quality{6054087899185946624}, 850, Status::Succeed},
+            {"6867833.409998674", "58209141", Quality{6054087899185946624}, 850, Status::Succeed},
+            {"61729180252", "36612.5790328038", Quality{6558965195382476659}, 500, Status::Succeed},
+            {"3983448845", "2347.543644281467", Quality{6558965195382476659}, 856, Status::Succeed},
+            {"12620994.47870887", "4268375883", Quality{5911709456684429178}, 997, Status::FailedShouldFail},
+            {"69864389131", "87631.4543025075", Quality{6487623473313516078}, 451, Status::Fail},
+            {"161188552", "111348916.0485442", Quality{6126343493209354960}, 951, Status::Fail},
+            {"8786728329", "5082.14702870352", Quality{6558975057426432945}, 503, Status::Fail},
+            {"16029697.27716903", "52533753764", Quality{5839722566538405334}, 300, Status::Fail},
+            {"69083040327", "287653.0870710118", Quality{6487593878219547209}, 451, Status::Fail},
+            {"69149412262", "287378.2320466131", Quality{6487598429267708125}, 451, Status::Fail},
+            {"7085.712662020652", "1641678041", Quality{5696878928996306944}, 504, Status::Fail},
+            {"4287933408", "12647119.31273569", Quality{6272434379517829568}, 997, Status::Fail},
+            {"2589759", "1437955820.851155", Quality{5910540710926591876}, 1000, Status::Fail},
+            {"22071", "581.0131445589597", Quality{6200752082570952858}, 1000, Status::Fail},
+            {"5133.191072353023", "8698642336", Quality{5626404736812508230}, 503, Status::Fail},
+            {"797.6336019392708", "16033", Quality{5985755421420704201}, 1000, Status::Fail},
+            {"10068383848", "44859.76447997668", Quality{6487429644904978750}, 250, Status::Fail},
+            {"2904.871634067977", "86342169", Quality{5768003800713897969}, 1000, Status::Fail},
+            {"52569881886", "16018714.05521815", Quality{6344359875332611941}, 300, Status::Fail},
+            {"1648082737", "7058.314768411529", Quality{6487526401072963590}, 504, Status::Fail},
+            {"13000417.60326603", "226998641", Quality{5986520833276606518}, 1000, Status::Fail},
+            {"5006103033", "4291143.17799397", Quality{6342238275317971011}, 1000, Status::Fail}
+        };
+        // clang-format on
+
+        boost::regex rx("^\\d+$");
+        boost::smatch match;
+        // tests that succeed should have the same amounts pre-fix and post-fix
+        std::vector<std::pair<STAmount, STAmount>> successAmounts;
+        Env env(*this, features);
+        for (auto const& t : tests)
+        {
+            auto getPool = [&](std::string const& v, bool isXRP) {
+                if (isXRP)
+                    return amountFromString(xrpIssue(), v);
+                return amountFromString(noIssue(), v);
+            };
+            auto const& quality = std::get<Quality>(t);
+            auto const tfee = std::get<std::uint16_t>(t);
+            auto const status = std::get<Status>(t);
+            auto const poolInIsXRP =
+                boost::regex_search(std::get<0>(t), match, rx);
+            auto const poolOutIsXRP =
+                boost::regex_search(std::get<1>(t), match, rx);
+            assert(!(poolInIsXRP && poolOutIsXRP));
+            auto const poolIn = getPool(std::get<0>(t), poolInIsXRP);
+            auto const poolOut = getPool(std::get<1>(t), poolOutIsXRP);
+            try
+            {
+                auto const amounts = changeSpotPriceQuality(
+                    Amounts{poolIn, poolOut},
+                    quality,
+                    tfee,
+                    env.current()->rules(),
+                    env.journal);
+                if (amounts)
+                {
+                    BEAST_EXPECT(
+                        status == Status::Succeed ||
+                        (features[fixAMMRounding] &&
+                         status == Status::FailedShouldSucceed) ||
+                        (!features[fixAMMRounding] &&
+                         status == Status::SucceededShouldFail));
+                }
+                else
+                    BEAST_EXPECT(
+                        status == Status::Fail ||
+                        (features[fixAMMRounding] &&
+                         (status == Status::SucceededShouldFail ||
+                          status == Status::FailedShouldFail)));
+            }
+            catch (std::runtime_error const& e)
+            {
+                BEAST_EXPECT(
+                    !strcmp(e.what(), "changeSpotPriceQuality failed"));
+                BEAST_EXPECT(
+                    !features[fixAMMRounding] &&
+                    (status == Status::FailedShouldSucceed ||
+                     status == Status::FailedShouldFail));
+            }
+        }
     }
 
     void
@@ -6017,6 +6257,8 @@ private:
         testFixOverflowOffer(all);
         testFixOverflowOffer(all - fixAMMRounding);
         testSwapRounding();
+        testFixAMMOfferRounding(all);
+        testFixAMMOfferRounding(all - fixAMMRounding);
     }
 };
 

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -5652,9 +5652,9 @@ private:
     }
 
     void
-    testFixAMMOfferRounding(FeatureBitset features)
+    testFixChangeSpotPriceQuality(FeatureBitset features)
     {
-        testcase("Fix AMM Offer Rounding");
+        testcase("Fix changeSpotPriceQuality");
         using namespace jtx;
 
         enum class Status {
@@ -5662,70 +5662,76 @@ private:
                                          // error allowance, succeed post-fix
                                          // because of offer resizing
             FailShouldSucceed,           // Fail in pre-fix due to rounding,
-                                         // succeed after fix because of XRP is
+                                         // succeed after fix because of XRP
                                          // side is generated first
             SucceedShouldFail,           // Succeed in pre-fix, fail after fix
                                          // due to small quality difference
             Fail,    // Both fail because the quality can't be matched
             Succeed  // Both succeed
         };
+        using enum Status;
+        auto const xrpIouAmounts10_100 =
+            TAmounts{XRPAmount{10}, IOUAmount{100}};
+        auto const iouXrpAmounts10_100 =
+            TAmounts{IOUAmount{10}, XRPAmount{100}};
         // clang-format off
         std::vector<std::tuple<std::string, std::string, Quality, std::uint16_t, Status>> tests = {
-            {"0.001519763260828713", "1558701", Quality{5414253689393440221}, 1000, Status::FailShouldSucceed},
-            {"0.01099814367603737", "1892611", Quality{5482264816516900274}, 1000, Status::FailShouldSucceed},
-            {"0.78", "796599", Quality{5630392334958379008}, 1000, Status::FailShouldSucceed},
-            {"105439.2955578965", "49398693", Quality{5910869983721805038}, 400, Status::FailShouldSucceed},
-            {"12408293.23445213", "4340810521", Quality{5911611095910090752}, 997, Status::FailShouldSucceed},
-            {"1892611", "0.01099814367603737", Quality{6703103457950430139}, 1000, Status::FailShouldSucceed},
-            {"423028.8508101858", "3392804520", Quality{5837920340654162816}, 600, Status::FailShouldSucceed},
-            {"44565388.41001027", "73890647", Quality{6058976634606450001}, 1000, Status::FailShouldSucceed},
-            {"66831.68494832662", "16", Quality{6346111134641742975}, 0, Status::FailShouldSucceed},
-            {"675.9287302203422", "1242632304", Quality{5625960929244093294}, 300, Status::FailShouldSucceed},
-            {"7047.112186735699", "1649845866", Quality{5696855348026306945}, 504, Status::FailShouldSucceed},
-            {"840236.4402981238", "47419053", Quality{5982561601648018688}, 499, Status::FailShouldSucceed},
-            {"992715.618909774", "189445631733", Quality{5697835648288106944}, 815, Status::SucceedShouldSucceedResize},
-            {"504636667521", "185545883.9506651", Quality{6343802275337659280}, 503, Status::SucceedShouldSucceedResize},
-            {"992706.7218636649", "189447316000", Quality{5697835648288106944}, 797, Status::SucceedShouldSucceedResize},
-            {"1.068737911388205", "127860278877", Quality{5268604356368739396}, 293, Status::SucceedShouldSucceedResize},
-            {"17932506.56880419", "189308.6043676173", Quality{6206460598195440068}, 311, Status::SucceedShouldSucceedResize},
-            {"1.066379294658174", "128042251493", Quality{5268559341368739328}, 270, Status::SucceedShouldSucceedResize},
-            {"350131413924", "1576879.110907892", Quality{6487411636539049449}, 650, Status::Fail},
-            {"422093460", "2.731797662057464", Quality{6702911108534394924}, 1000, Status::Fail},
-            {"76128132223", "367172.7148422662", Quality{6487263463413514240}, 548, Status::Fail},
-            {"132701839250", "280703770.7695443", Quality{6273750681188885075}, 562, Status::Fail},
-            {"994165.7604612011", "189551302411", Quality{5697835592690668727}, 815, Status::Fail},
-            {"45053.33303227917", "86612695359", Quality{5625695218943638190}, 500, Status::Fail},
-            {"199649.077043865", "14017933007", Quality{5766034667318524880}, 324, Status::Fail},
-            {"27751824831.70903", "78896950", Quality{6272538159621630432}, 500, Status::Fail},
-            {"225.3731275781907", "156431793648", Quality{5477818047604078924}, 989, Status::Fail},
-            {"199649.077043865", "14017933007", Quality{5766036094462806309}, 324, Status::Fail},
-            {"3.590272027140361", "20677643641", Quality{5406056147042156356}, 808, Status::Fail},
-            {"1.070884664490231", "127604712776", Quality{5268620608623825741}, 293, Status::Fail},
-            {"3272.448829820197", "6275124076", Quality{5625710328924117902}, 81, Status::Fail},
-            {"0.009059512633902926", "7994028", Quality{5477511954775533172}, 1000, Status::Fail},
-            {"1", "1.0", Quality{0}, 100, Status::Fail},
-            {"1.0", "1", Quality{0}, 100, Status::Fail},
-            {"10", "10.0", Quality{TAmounts{XRPAmount{10}, IOUAmount{100}}}, 100, Status::Fail},
-            {"10.0", "10", Quality{TAmounts{IOUAmount{10}, XRPAmount{100}}}, 100, Status::Fail},
-            {"69864389131", "287631.4543025075", Quality{6487623473313516078}, 451, Status::Succeed},
-            {"4328342973", "12453825.99247381", Quality{6272522264364865181}, 997, Status::Succeed},
-            {"32347017", "7003.93031579449", Quality{6347261126087916670}, 1000, Status::Succeed},
-            {"61697206161", "36631.4583206413", Quality{6558965195382476659}, 500, Status::Succeed},
-            {"1654524979", "7028.659825511603", Quality{6487551345110052981}, 504, Status::Succeed},
-            {"88621.22277293179", "5128418948", Quality{5766347291552869205}, 380, Status::Succeed},
-            {"1892611", "0.01099814367603737", Quality{6703102780512015436}, 1000, Status::Succeed},
-            {"4542.639373338766", "24554809", Quality{5838994982188783710}, 0, Status::Succeed},
-            {"5132932546", "88542.99750172683", Quality{6419203342950054537}, 380, Status::Succeed},
-            {"78929964.1549083", "1506494795", Quality{5986890029845558688}, 589, Status::Succeed},
-            {"10096561906", "44727.72453735605", Quality{6487455290284644551}, 250, Status::Succeed},
-            {"5092.219565514988", "8768257694", Quality{5626349534958379008}, 503, Status::Succeed},
-            {"1819778294", "8305.084302902864", Quality{6487429398998540860}, 415, Status::Succeed},
-            {"6970462.633911943", "57359281", Quality{6054087899185946624}, 850, Status::Succeed},
-            {"3983448845", "2347.543644281467", Quality{6558965195382476659}, 856, Status::Succeed},
+            //Pool In              ,  Pool Out,             Quality                     , Fee,  Status
+            {"0.001519763260828713", "1558701",             Quality{5414253689393440221}, 1000, FailShouldSucceed},
+            {"0.01099814367603737",  "1892611",             Quality{5482264816516900274}, 1000, FailShouldSucceed},
+            {"0.78",                 "796599",              Quality{5630392334958379008}, 1000, FailShouldSucceed},
+            {"105439.2955578965",    "49398693",            Quality{5910869983721805038},  400, FailShouldSucceed},
+            {"12408293.23445213",    "4340810521",          Quality{5911611095910090752},  997, FailShouldSucceed},
+            {"1892611",              "0.01099814367603737", Quality{6703103457950430139}, 1000, FailShouldSucceed},
+            {"423028.8508101858",    "3392804520",          Quality{5837920340654162816},  600, FailShouldSucceed},
+            {"44565388.41001027",    "73890647",            Quality{6058976634606450001}, 1000, FailShouldSucceed},
+            {"66831.68494832662",    "16",                  Quality{6346111134641742975},    0, FailShouldSucceed},
+            {"675.9287302203422",    "1242632304",          Quality{5625960929244093294},  300, FailShouldSucceed},
+            {"7047.112186735699",    "1649845866",          Quality{5696855348026306945},  504, FailShouldSucceed},
+            {"840236.4402981238",    "47419053",            Quality{5982561601648018688},  499, FailShouldSucceed},
+            {"992715.618909774",     "189445631733",        Quality{5697835648288106944},  815, SucceedShouldSucceedResize},
+            {"504636667521",         "185545883.9506651",   Quality{6343802275337659280},  503, SucceedShouldSucceedResize},
+            {"992706.7218636649",    "189447316000",        Quality{5697835648288106944},  797, SucceedShouldSucceedResize},
+            {"1.068737911388205",    "127860278877",        Quality{5268604356368739396},  293, SucceedShouldSucceedResize},
+            {"17932506.56880419",    "189308.6043676173",   Quality{6206460598195440068},  311, SucceedShouldSucceedResize},
+            {"1.066379294658174",    "128042251493",        Quality{5268559341368739328},  270, SucceedShouldSucceedResize},
+            {"350131413924",         "1576879.110907892",   Quality{6487411636539049449},  650, Fail},
+            {"422093460",            "2.731797662057464",   Quality{6702911108534394924}, 1000, Fail},
+            {"76128132223",          "367172.7148422662",   Quality{6487263463413514240},  548, Fail},
+            {"132701839250",         "280703770.7695443",   Quality{6273750681188885075},  562, Fail},
+            {"994165.7604612011",    "189551302411",        Quality{5697835592690668727},  815, Fail},
+            {"45053.33303227917",    "86612695359",         Quality{5625695218943638190},  500, Fail},
+            {"199649.077043865",     "14017933007",         Quality{5766034667318524880},  324, Fail},
+            {"27751824831.70903",    "78896950",            Quality{6272538159621630432},  500, Fail},
+            {"225.3731275781907",    "156431793648",        Quality{5477818047604078924},  989, Fail},
+            {"199649.077043865",     "14017933007",         Quality{5766036094462806309},  324, Fail},
+            {"3.590272027140361",    "20677643641",         Quality{5406056147042156356},  808, Fail},
+            {"1.070884664490231",    "127604712776",        Quality{5268620608623825741},  293, Fail},
+            {"3272.448829820197",    "6275124076",          Quality{5625710328924117902},   81, Fail},
+            {"0.009059512633902926", "7994028",             Quality{5477511954775533172}, 1000, Fail},
+            {"1",                    "1.0",                 Quality{0},                    100, Fail},
+            {"1.0",                  "1",                   Quality{0},                    100, Fail},
+            {"10",                   "10.0",                Quality{xrpIouAmounts10_100},  100, Fail},
+            {"10.0",                 "10",                  Quality{iouXrpAmounts10_100},  100, Fail},
+            {"69864389131",          "287631.4543025075",   Quality{6487623473313516078},  451, Succeed},
+            {"4328342973",           "12453825.99247381",   Quality{6272522264364865181},  997, Succeed},
+            {"32347017",             "7003.93031579449",    Quality{6347261126087916670}, 1000, Succeed},
+            {"61697206161",          "36631.4583206413",    Quality{6558965195382476659},  500, Succeed},
+            {"1654524979",           "7028.659825511603",   Quality{6487551345110052981},  504, Succeed},
+            {"88621.22277293179",    "5128418948",          Quality{5766347291552869205},  380, Succeed},
+            {"1892611",              "0.01099814367603737", Quality{6703102780512015436}, 1000, Succeed},
+            {"4542.639373338766",    "24554809",            Quality{5838994982188783710},    0, Succeed},
+            {"5132932546",           "88542.99750172683",   Quality{6419203342950054537},  380, Succeed},
+            {"78929964.1549083",     "1506494795",          Quality{5986890029845558688},  589, Succeed},
+            {"10096561906",          "44727.72453735605",   Quality{6487455290284644551},  250, Succeed},
+            {"5092.219565514988",    "8768257694",          Quality{5626349534958379008},  503, Succeed},
+            {"1819778294",           "8305.084302902864",   Quality{6487429398998540860},  415, Succeed},
+            {"6970462.633911943",    "57359281",            Quality{6054087899185946624},  850, Succeed},
+            {"3983448845",           "2347.543644281467",   Quality{6558965195382476659},  856, Succeed},
             // This is a tiny offer 12drops/19321952e-15 it succeeds pre-amendment because of the error allowance.
             // Post amendment it is resized to 11drops/17711789e-15 but the quality is still less than
             // the target quality and the offer fails.
-            {"771493171", "1.243473020567508", Quality{6707566798038544272}, 100, Status::SucceedShouldFail},
+            {"771493171",            "1.243473020567508",   Quality{6707566798038544272},  100, SucceedShouldFail},
         };
         // clang-format on
 
@@ -5763,14 +5769,14 @@ private:
                     env.journal);
                 if (amounts)
                 {
-                    if (status == Status::SucceedShouldSucceedResize)
+                    if (status == SucceedShouldSucceedResize)
                     {
                         if (!features[fixAMMv1_1])
                             BEAST_EXPECT(Quality{*amounts} < quality);
                         else
                             BEAST_EXPECT(Quality{*amounts} >= quality);
                     }
-                    else if (status == Status::Succeed)
+                    else if (status == Succeed)
                     {
                         if (!features[fixAMMv1_1])
                             BEAST_EXPECT(
@@ -5780,13 +5786,13 @@ private:
                         else
                             BEAST_EXPECT(Quality{*amounts} >= quality);
                     }
-                    else if (status == Status::FailShouldSucceed)
+                    else if (status == FailShouldSucceed)
                     {
                         BEAST_EXPECT(
                             features[fixAMMv1_1] &&
                             Quality{*amounts} >= quality);
                     }
-                    else if (status == Status::SucceedShouldFail)
+                    else if (status == SucceedShouldFail)
                     {
                         BEAST_EXPECT(
                             !features[fixAMMv1_1] &&
@@ -5801,7 +5807,7 @@ private:
                     // be matched. Verify by generating a tiny offer, which
                     // doesn't match the quality. Exclude zero quality since
                     // no offer is generated in this case.
-                    if (status == Status::Fail && quality != Quality{0})
+                    if (status == Fail && quality != Quality{0})
                     {
                         auto tinyOffer = [&]() {
                             if (isXRP(poolIn))
@@ -5833,11 +5839,11 @@ private:
                         }();
                         BEAST_EXPECT(Quality(tinyOffer) < quality);
                     }
-                    else if (status == Status::FailShouldSucceed)
+                    else if (status == FailShouldSucceed)
                     {
                         BEAST_EXPECT(!features[fixAMMv1_1]);
                     }
-                    else if (status == Status::SucceedShouldFail)
+                    else if (status == SucceedShouldFail)
                     {
                         BEAST_EXPECT(features[fixAMMv1_1]);
                     }
@@ -5848,8 +5854,7 @@ private:
                 BEAST_EXPECT(
                     !strcmp(e.what(), "changeSpotPriceQuality failed"));
                 BEAST_EXPECT(
-                    !features[fixAMMv1_1] &&
-                    status == Status::FailShouldSucceed);
+                    !features[fixAMMv1_1] && status == FailShouldSucceed);
             }
         }
 
@@ -6446,8 +6451,8 @@ private:
         testFixOverflowOffer(all);
         testFixOverflowOffer(all - fixAMMv1_1);
         testSwapRounding();
-        testFixAMMOfferRounding(all);
-        testFixAMMOfferRounding(all - fixAMMv1_1);
+        testFixChangeSpotPriceQuality(all);
+        testFixChangeSpotPriceQuality(all - fixAMMv1_1);
         testFixAMMOfferBlockedByLOB(all);
         testFixAMMOfferBlockedByLOB(all - fixAMMv1_1);
     }

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -2957,7 +2957,7 @@ private:
                 // alice pays ~1.011USD in fees, which is ~10 times more
                 // than carol's fee
                 // 100.099431529USD swapped in for 100XRP
-                if (!features[fixAMMRounding])
+                if (!features[fixAMMv1_1])
                 {
                     BEAST_EXPECT(ammAlice.expectBalances(
                         XRPAmount{13'000'000'668},
@@ -2986,7 +2986,7 @@ private:
                 }
                 // carol pays ~9.94USD in fees, which is ~10 times more in
                 // trading fees vs discounted fee.
-                if (!features[fixAMMRounding])
+                if (!features[fixAMMv1_1])
                 {
                     BEAST_EXPECT(
                         env.balance(carol, USD) ==
@@ -3011,7 +3011,7 @@ private:
                 // carol pays ~1.008XRP in trading fee, which is
                 // ~10 times more than the discounted fee.
                 // 99.815876XRP is swapped in for 100USD
-                if (!features[fixAMMRounding])
+                if (!features[fixAMMv1_1])
                 {
                     BEAST_EXPECT(ammAlice.expectBalances(
                         XRPAmount(13'100'824'790),
@@ -3113,7 +3113,7 @@ private:
                 IOUAmount{1'004'487'562112089, -9}));
             // Bob pays the full fee ~0.1USD
             env(pay(bob, alice, XRP(10)), path(~XRP), sendmax(USD(11)));
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 BEAST_EXPECT(amm.expectBalances(
                     XRPAmount{1'000'010'011},
@@ -3522,7 +3522,7 @@ private:
                 XRPAmount(10'030'082'730),
                 STAmount(EUR, UINT64_C(9'970'007498125468), -12),
                 ammEUR_XRP.tokens()));
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 BEAST_EXPECT(ammUSD_EUR.expectBalances(
                     STAmount(USD, UINT64_C(9'970'097277662122), -12),
@@ -3623,7 +3623,7 @@ private:
                     sendmax(XRP(200)),
                     txflags(tfPartialPayment));
                 env.close();
-                if (!features[fixAMMRounding])
+                if (!features[fixAMMv1_1])
                 {
                     BEAST_EXPECT(ammAlice.expectBalances(
                         XRP(10'100), USD(10'000), ammAlice.tokens()));
@@ -3835,7 +3835,7 @@ private:
                 path(~USD),
                 path(~ETH, ~EUR, ~USD),
                 sendmax(XRP(200)));
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 // XRP-ETH-EUR-USD
                 // This path provides ~26.06USD/26.2XRP
@@ -3916,7 +3916,7 @@ private:
                 path(~EUR, ~BTC, ~USD),
                 path(~ETH, ~EUR, ~BTC, ~USD),
                 sendmax(XRP(200)));
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 // XRP-EUR-BTC-USD path provides ~17.8USD/~18.7XRP
                 // XRP-ETH-EUR-BTC-USD path provides ~82.2USD/82.4XRP
@@ -3983,7 +3983,7 @@ private:
                     path(~XRP, ~USD),
                     sendmax(EUR(400)),
                     txflags(tfPartialPayment | tfNoRippleDirect));
-                if (!features[fixAMMRounding])
+                if (!features[fixAMMv1_1])
                 {
                     // Carol gets ~29.91USD because of the AMM offers limit
                     BEAST_EXPECT(ammAlice.expectBalances(
@@ -4030,7 +4030,7 @@ private:
                     txflags(tfPartialPayment | tfNoRippleDirect));
                 BEAST_EXPECT(ammAlice.expectBalances(
                     XRPAmount{10'101'010'102}, USD(9'900), ammAlice.tokens()));
-                if (!features[fixAMMRounding])
+                if (!features[fixAMMv1_1])
                 {
                     // Carol gets ~100USD
                     BEAST_EXPECT(expectLine(
@@ -4062,7 +4062,7 @@ private:
             env(offer(bob, XRP(100), USD(100.001)));
             AMM ammAlice(env, alice, XRP(10'000), USD(10'100));
             env(offer(carol, USD(100), XRP(100)));
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 BEAST_EXPECT(ammAlice.expectBalances(
                     XRPAmount{10'049'825'373},
@@ -4360,7 +4360,7 @@ private:
         // Execute with CLOB offer
         prep(
             [&](Env& env) {
-                if (!features[fixAMMRounding])
+                if (!features[fixAMMv1_1])
                     env(offer(
                             LP1,
                             XRPAmount{18'095'133},
@@ -4602,7 +4602,7 @@ private:
                     {{Amounts{
                         STAmount{EUR, UINT64_C(5'025125628140703), -15},
                         STAmount{USD, UINT64_C(5'025125628140703), -15}}}}));
-                if (!features[fixAMMRounding])
+                if (!features[fixAMMv1_1])
                 {
                     BEAST_EXPECT(ammAlice.expectBalances(
                         STAmount{USD, UINT64_C(1'004'974874371859), -12},
@@ -4642,7 +4642,7 @@ private:
                 sendmax(EUR(15)),
                 txflags(tfNoRippleDirect));
             BEAST_EXPECT(expectLine(env, ed, USD(2'010)));
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 BEAST_EXPECT(expectLine(env, bob, EUR(1'990)));
                 BEAST_EXPECT(ammAlice.expectBalances(
@@ -4679,7 +4679,7 @@ private:
                 sendmax(EUR(15)),
                 txflags(tfNoRippleDirect));
             BEAST_EXPECT(expectLine(env, ed, USD(2'010)));
-            if (!features[fixAMMRounding])
+            if (!features[fixAMMv1_1])
             {
                 BEAST_EXPECT(expectLine(
                     env,
@@ -4695,10 +4695,10 @@ private:
                 BEAST_EXPECT(expectLine(
                     env,
                     bob,
-                    STAmount{EUR, UINT64_C(1'989'987468671679), -12}));
+                    STAmount{EUR, UINT64_C(1'989'987453007628), -12}));
                 BEAST_EXPECT(ammAlice.expectBalances(
                     USD(1'000),
-                    STAmount{EUR, UINT64_C(1'005'012531328321), -12},
+                    STAmount{EUR, UINT64_C(1'005'012546992372), -12},
                     ammAlice.tokens()));
             }
             BEAST_EXPECT(expectOffers(env, carol, 0));
@@ -5210,11 +5210,11 @@ private:
                         BEAST_EXPECT(!amm->expectBalances(
                             USD(1'000), ETH(1'000), amm->tokens()));
                     }
-                    if (i == 2 && !features[fixAMMRounding])
+                    if (i == 2 && !features[fixAMMv1_1])
                     {
                         if (rates.first == 1.5)
                         {
-                            if (!features[fixAMMRounding])
+                            if (!features[fixAMMv1_1])
                                 BEAST_EXPECT(expectOffers(
                                     env,
                                     ed,
@@ -5245,7 +5245,7 @@ private:
                         }
                         else
                         {
-                            if (!features[fixAMMRounding])
+                            if (!features[fixAMMv1_1])
                                 BEAST_EXPECT(expectOffers(
                                     env,
                                     ed,
@@ -5344,7 +5344,7 @@ private:
                 {
                     if (rates.first == 1.5)
                     {
-                        if (!features[fixAMMRounding])
+                        if (!features[fixAMMv1_1])
                         {
                             BEAST_EXPECT(expectOffers(
                                 env, ed, 1, {{Amounts{ETH(400), USD(250)}}}));
@@ -5379,7 +5379,7 @@ private:
                     }
                     else
                     {
-                        if (!features[fixAMMRounding])
+                        if (!features[fixAMMv1_1])
                         {
                             // Ed offer is partially crossed.
                             BEAST_EXPECT(expectOffers(
@@ -5455,7 +5455,7 @@ private:
 
                     BEAST_EXPECT(expectLine(env, bob, USD(2'100)));
 
-                    if (i == 2 && !features[fixAMMRounding])
+                    if (i == 2 && !features[fixAMMv1_1])
                     {
                         if (rates.first == 1.5)
                         {
@@ -5658,41 +5658,52 @@ private:
         using namespace jtx;
 
         enum class Status {
-            FailedShouldSucceed,  // Failed in pre-fix due to rounding,
-                                  //   should succeed after fix
-            SucceededShouldFail,  // Succeeded in pre-fix, should fail after fix
-                                  //   due to small quality difference
-            FailedShouldFail,     // Failed in pre-fix due to rounding,
-                               //   should fail after fix due to small quality
-                               //   difference
+            SucceedShouldSucceedResize,  // Succeed in pre-fix because
+                                         // error allowance, succeed post-fix
+                                         // because of offer resizing
+            FailShouldSucceed,           // Fail in pre-fix due to rounding,
+                                         // succeed after fix because of XRP is
+                                         // side is generated first
+            SucceedShouldFail,           // Succeed in pre-fix, fail after fix
+                                         // due to small quality difference
             Fail,    // Both fail because the quality can't be matched
-            Succeed  // succeed in both
+            Succeed  // Both succeed
         };
         // clang-format off
         std::vector<std::tuple<std::string, std::string, Quality, std::uint16_t, Status>> tests = {
-            {"0.001519763260828713", "1558701", Quality{5414253689393440221}, 1000, Status::FailedShouldSucceed},
-            {"0.01099814367603737", "1892611", Quality{5482264816516900274}, 1000, Status::FailedShouldSucceed},
-            {"0.78", "796599", Quality{5630392334958379008}, 1000, Status::FailedShouldSucceed},
-            {"105439.2955578965", "49398693", Quality{5910869983721805038}, 400, Status::FailedShouldSucceed},
-            {"105870.7966405942", "49198160", Quality{5910886636672739152}, 400, Status::FailedShouldSucceed},
-            {"12408293.23445213", "4340810521", Quality{5911611095910090752}, 997, Status::FailedShouldSucceed},
-            {"12417257.02139501", "4337708190", Quality{5911618893549287514}, 997, Status::FailedShouldSucceed},
-            {"12421193.02929446", "4336257104", Quality{5911617164910090752}, 997, Status::FailedShouldSucceed},
-            {"12430504.11172408", "4332652733", Quality{5911624840510090752}, 997, Status::FailedShouldSucceed},
-            {"12448020.44860317", "4327094808", Quality{5911630793102002342}, 997, Status::FailedShouldSucceed},
-            {"12459400.62586608", "4323181824", Quality{5911636760796038120}, 997, Status::FailedShouldSucceed},
-            {"12484012.69745274", "4314743527", Quality{5911645806886990752}, 997, Status::FailedShouldSucceed},
-            {"1892611", "0.01099814367603737", Quality{6703103457950430139}, 1000, Status::FailedShouldSucceed},
-            {"423028.8508101858", "3392804520", Quality{5837920340654162816}, 600, Status::FailedShouldSucceed},
-            {"44565388.41001027", "73890647", Quality{6058976634606450001}, 1000, Status::FailedShouldSucceed},
-            {"66831.68494832662", "16", Quality{6346111134641742975}, 0, Status::FailedShouldSucceed},
-            {"675.9287302203422", "1242632304", Quality{5625960929244093294}, 300, Status::FailedShouldSucceed},
-            {"7047.112186735699", "1649845866", Quality{5696855348026306945}, 504, Status::FailedShouldSucceed},
-            {"7050.618862421691", "1649021148", Quality{5696851051486606944}, 504, Status::FailedShouldSucceed},
-            {"7067.580774394729", "1645091721", Quality{5696869936556306944}, 504, Status::FailedShouldSucceed},
-            {"840236.4402981238", "47419053", Quality{5982561601648018688}, 499, Status::FailedShouldSucceed},
-            {"771493171", "1.243473020567508", Quality{6707566798038544272}, 100, Status::SucceededShouldFail}, // e-8
-            {"69864389131", "287631.4543025075", Quality{6487623473313516078}, 451, Status::SucceededShouldFail}, // e-27
+            {"0.001519763260828713", "1558701", Quality{5414253689393440221}, 1000, Status::FailShouldSucceed},
+            {"0.01099814367603737", "1892611", Quality{5482264816516900274}, 1000, Status::FailShouldSucceed},
+            {"0.78", "796599", Quality{5630392334958379008}, 1000, Status::FailShouldSucceed},
+            {"105439.2955578965", "49398693", Quality{5910869983721805038}, 400, Status::FailShouldSucceed},
+            {"12408293.23445213", "4340810521", Quality{5911611095910090752}, 997, Status::FailShouldSucceed},
+            {"1892611", "0.01099814367603737", Quality{6703103457950430139}, 1000, Status::FailShouldSucceed},
+            {"423028.8508101858", "3392804520", Quality{5837920340654162816}, 600, Status::FailShouldSucceed},
+            {"44565388.41001027", "73890647", Quality{6058976634606450001}, 1000, Status::FailShouldSucceed},
+            {"66831.68494832662", "16", Quality{6346111134641742975}, 0, Status::FailShouldSucceed},
+            {"675.9287302203422", "1242632304", Quality{5625960929244093294}, 300, Status::FailShouldSucceed},
+            {"7047.112186735699", "1649845866", Quality{5696855348026306945}, 504, Status::FailShouldSucceed},
+            {"840236.4402981238", "47419053", Quality{5982561601648018688}, 499, Status::FailShouldSucceed},
+            {"992715.618909774", "189445631733", Quality{5697835648288106944}, 815, Status::SucceedShouldSucceedResize},
+            {"504636667521", "185545883.9506651", Quality{6343802275337659280}, 503, Status::SucceedShouldSucceedResize},
+            {"992706.7218636649", "189447316000", Quality{5697835648288106944}, 797, Status::SucceedShouldSucceedResize},
+            {"1.068737911388205", "127860278877", Quality{5268604356368739396}, 293, Status::SucceedShouldSucceedResize},
+            {"17932506.56880419", "189308.6043676173", Quality{6206460598195440068}, 311, Status::SucceedShouldSucceedResize},
+            {"1.066379294658174", "128042251493", Quality{5268559341368739328}, 270, Status::SucceedShouldSucceedResize},
+            {"350131413924", "1576879.110907892", Quality{6487411636539049449}, 650, Status::Fail},
+            {"422093460", "2.731797662057464", Quality{6702911108534394924}, 1000, Status::Fail},
+            {"76128132223", "367172.7148422662", Quality{6487263463413514240}, 548, Status::Fail},
+            {"132701839250", "280703770.7695443", Quality{6273750681188885075}, 562, Status::Fail},
+            {"994165.7604612011", "189551302411", Quality{5697835592690668727}, 815, Status::Fail},
+            {"45053.33303227917", "86612695359", Quality{5625695218943638190}, 500, Status::Fail},
+            {"199649.077043865", "14017933007", Quality{5766034667318524880}, 324, Status::Fail},
+            {"27751824831.70903", "78896950", Quality{6272538159621630432}, 500, Status::Fail},
+            {"225.3731275781907", "156431793648", Quality{5477818047604078924}, 989, Status::Fail},
+            {"199649.077043865", "14017933007", Quality{5766036094462806309}, 324, Status::Fail},
+            {"3.590272027140361", "20677643641", Quality{5406056147042156356}, 808, Status::Fail},
+            {"1.070884664490231", "127604712776", Quality{5268620608623825741}, 293, Status::Fail},
+            {"3272.448829820197", "6275124076", Quality{5625710328924117902}, 81, Status::Fail},
+            {"0.009059512633902926", "7994028", Quality{5477511954775533172}, 1000, Status::Fail},
+            {"69864389131", "287631.4543025075", Quality{6487623473313516078}, 451, Status::Succeed},
             {"4328342973", "12453825.99247381", Quality{6272522264364865181}, 997, Status::Succeed},
             {"32347017", "7003.93031579449", Quality{6347261126087916670}, 1000, Status::Succeed},
             {"61697206161", "36631.4583206413", Quality{6558965195382476659}, 500, Status::Succeed},
@@ -5700,39 +5711,17 @@ private:
             {"88621.22277293179", "5128418948", Quality{5766347291552869205}, 380, Status::Succeed},
             {"1892611", "0.01099814367603737", Quality{6703102780512015436}, 1000, Status::Succeed},
             {"4542.639373338766", "24554809", Quality{5838994982188783710}, 0, Status::Succeed},
-            {"61729242395", "36612.54235922302", Quality{6558965195382476659}, 500, Status::Succeed},
             {"5132932546", "88542.99750172683", Quality{6419203342950054537}, 380, Status::Succeed},
-            {"61728936416", "36612.72293260183", Quality{6558965195382476659}, 500, Status::Succeed},
             {"78929964.1549083", "1506494795", Quality{5986890029845558688}, 589, Status::Succeed},
             {"10096561906", "44727.72453735605", Quality{6487455290284644551}, 250, Status::Succeed},
-            {"61726973824", "36613.8812028485", Quality{6558965195382476659}, 500, Status::Succeed},
-            {"88542.99750172683", "5132932546", Quality{5766340625287267809}, 380, Status::Succeed},
             {"5092.219565514988", "8768257694", Quality{5626349534958379008}, 503, Status::Succeed},
-            {"3984444708", "2346.961925837792", Quality{6558965195382476659}, 856, Status::Succeed},
             {"1819778294", "8305.084302902864", Quality{6487429398998540860}, 415, Status::Succeed},
             {"6970462.633911943", "57359281", Quality{6054087899185946624}, 850, Status::Succeed},
-            {"6867833.409998674", "58209141", Quality{6054087899185946624}, 850, Status::Succeed},
-            {"61729180252", "36612.5790328038", Quality{6558965195382476659}, 500, Status::Succeed},
             {"3983448845", "2347.543644281467", Quality{6558965195382476659}, 856, Status::Succeed},
-            {"12620994.47870887", "4268375883", Quality{5911709456684429178}, 997, Status::FailedShouldFail},
-            {"69864389131", "87631.4543025075", Quality{6487623473313516078}, 451, Status::Fail},
-            {"161188552", "111348916.0485442", Quality{6126343493209354960}, 951, Status::Fail},
-            {"8786728329", "5082.14702870352", Quality{6558975057426432945}, 503, Status::Fail},
-            {"16029697.27716903", "52533753764", Quality{5839722566538405334}, 300, Status::Fail},
-            {"69083040327", "287653.0870710118", Quality{6487593878219547209}, 451, Status::Fail},
-            {"69149412262", "287378.2320466131", Quality{6487598429267708125}, 451, Status::Fail},
-            {"7085.712662020652", "1641678041", Quality{5696878928996306944}, 504, Status::Fail},
-            {"4287933408", "12647119.31273569", Quality{6272434379517829568}, 997, Status::Fail},
-            {"2589759", "1437955820.851155", Quality{5910540710926591876}, 1000, Status::Fail},
-            {"22071", "581.0131445589597", Quality{6200752082570952858}, 1000, Status::Fail},
-            {"5133.191072353023", "8698642336", Quality{5626404736812508230}, 503, Status::Fail},
-            {"797.6336019392708", "16033", Quality{5985755421420704201}, 1000, Status::Fail},
-            {"10068383848", "44859.76447997668", Quality{6487429644904978750}, 250, Status::Fail},
-            {"2904.871634067977", "86342169", Quality{5768003800713897969}, 1000, Status::Fail},
-            {"52569881886", "16018714.05521815", Quality{6344359875332611941}, 300, Status::Fail},
-            {"1648082737", "7058.314768411529", Quality{6487526401072963590}, 504, Status::Fail},
-            {"13000417.60326603", "226998641", Quality{5986520833276606518}, 1000, Status::Fail},
-            {"5006103033", "4291143.17799397", Quality{6342238275317971011}, 1000, Status::Fail}
+            // This is a tiny offer 12drops/19321952e-15 it succeeds pre-amendment because of the error allowance.
+            // Post amendment it is resized to 11drops/17711789e-15 but the quality is still less than
+            // the target quality and the offer fails.
+            {"771493171", "1.243473020567508", Quality{6707566798038544272}, 100, Status::SucceedShouldFail},
         };
         // clang-format on
 
@@ -5741,6 +5730,8 @@ private:
         // tests that succeed should have the same amounts pre-fix and post-fix
         std::vector<std::pair<STAmount, STAmount>> successAmounts;
         Env env(*this, features);
+        auto rules = env.current()->rules();
+        CurrentTransactionRulesGuard rg(rules);
         for (auto const& t : tests)
         {
             auto getPool = [&](std::string const& v, bool isXRP) {
@@ -5768,28 +5759,92 @@ private:
                     env.journal);
                 if (amounts)
                 {
-                    BEAST_EXPECT(
-                        status == Status::Succeed ||
-                        (features[fixAMMRounding] &&
-                         status == Status::FailedShouldSucceed) ||
-                        (!features[fixAMMRounding] &&
-                         status == Status::SucceededShouldFail));
+                    if (status == Status::SucceedShouldSucceedResize)
+                    {
+                        if (!features[fixAMMv1_1])
+                            BEAST_EXPECT(Quality{*amounts} < quality);
+                        else
+                            BEAST_EXPECT(Quality{*amounts} >= quality);
+                    }
+                    else if (status == Status::Succeed)
+                    {
+                        if (!features[fixAMMv1_1])
+                            BEAST_EXPECT(
+                                Quality{*amounts} >= quality ||
+                                withinRelativeDistance(
+                                    Quality{*amounts}, quality, Number{1, -7}));
+                        else
+                            BEAST_EXPECT(Quality{*amounts} >= quality);
+                    }
+                    else if (status == Status::FailShouldSucceed)
+                    {
+                        BEAST_EXPECT(
+                            features[fixAMMv1_1] &&
+                            Quality{*amounts} >= quality);
+                    }
+                    else if (status == Status::SucceedShouldFail)
+                    {
+                        BEAST_EXPECT(
+                            !features[fixAMMv1_1] &&
+                            Quality{*amounts} < quality &&
+                            withinRelativeDistance(
+                                Quality{*amounts}, quality, Number{1, -7}));
+                    }
                 }
                 else
-                    BEAST_EXPECT(
-                        status == Status::Fail ||
-                        (features[fixAMMRounding] &&
-                         (status == Status::SucceededShouldFail ||
-                          status == Status::FailedShouldFail)));
+                {
+                    // Fails pre- and post-amendment because the quality can't
+                    // be matched. Verify by generating a tiny offer, which
+                    // doesn't match the quality.
+                    if (status == Status::Fail)
+                    {
+                        auto tinyOffer = [&]() {
+                            if (isXRP(poolIn))
+                            {
+                                auto const takerPays = STAmount{xrpIssue(), 1};
+                                return Amounts{
+                                    takerPays,
+                                    swapAssetIn(
+                                        Amounts{poolIn, poolOut},
+                                        takerPays,
+                                        tfee)};
+                            }
+                            else if (isXRP(poolOut))
+                            {
+                                auto const takerGets = STAmount{xrpIssue(), 1};
+                                return Amounts{
+                                    swapAssetOut(
+                                        Amounts{poolIn, poolOut},
+                                        takerGets,
+                                        tfee),
+                                    takerGets};
+                            }
+                            auto const takerPays = toAmount<STAmount>(
+                                getIssue(poolIn), Number{1, -10} * poolIn);
+                            return Amounts{
+                                takerPays,
+                                swapAssetIn(
+                                    Amounts{poolIn, poolOut}, takerPays, tfee)};
+                        }();
+                        BEAST_EXPECT(Quality(tinyOffer) < quality);
+                    }
+                    else if (status == Status::FailShouldSucceed)
+                    {
+                        BEAST_EXPECT(!features[fixAMMv1_1]);
+                    }
+                    else if (status == Status::SucceedShouldFail)
+                    {
+                        BEAST_EXPECT(features[fixAMMv1_1]);
+                    }
+                }
             }
             catch (std::runtime_error const& e)
             {
                 BEAST_EXPECT(
                     !strcmp(e.what(), "changeSpotPriceQuality failed"));
                 BEAST_EXPECT(
-                    !features[fixAMMRounding] &&
-                    (status == Status::FailedShouldSucceed ||
-                     status == Status::FailedShouldFail));
+                    !features[fixAMMv1_1] &&
+                    status == Status::FailShouldSucceed);
             }
         }
     }
@@ -6132,18 +6187,14 @@ private:
                     txflags(tfPartialPayment));
                 env.close();
 
-                auto const failUsdGH = features[fixAMMRounding]
-                    ? input.failUsdGHr
-                    : input.failUsdGH;
-                auto const failUsdBIT = features[fixAMMRounding]
-                    ? input.failUsdBITr
-                    : input.failUsdBIT;
-                auto const goodUsdGH = features[fixAMMRounding]
-                    ? input.goodUsdGHr
-                    : input.goodUsdGH;
-                auto const goodUsdBIT = features[fixAMMRounding]
-                    ? input.goodUsdBITr
-                    : input.goodUsdBIT;
+                auto const failUsdGH =
+                    features[fixAMMv1_1] ? input.failUsdGHr : input.failUsdGH;
+                auto const failUsdBIT =
+                    features[fixAMMv1_1] ? input.failUsdBITr : input.failUsdBIT;
+                auto const goodUsdGH =
+                    features[fixAMMv1_1] ? input.goodUsdGHr : input.goodUsdGH;
+                auto const goodUsdBIT =
+                    features[fixAMMv1_1] ? input.goodUsdBITr : input.goodUsdBIT;
                 if (!features[fixAMMOverflowOffer])
                 {
                     BEAST_EXPECT(amm.expectBalances(
@@ -6214,7 +6265,7 @@ private:
             {{xrpPool, iouPool}},
             889,
             std::nullopt,
-            {jtx::supported_amendments() | fixAMMRounding});
+            {jtx::supported_amendments() | fixAMMv1_1});
     }
 
     void
@@ -6237,7 +6288,7 @@ private:
         env(offer(carol, USD(0.49), XRP(1)));
         env.close();
 
-        if (!features[fixAMMRounding])
+        if (!features[fixAMMv1_1])
         {
             BEAST_EXPECT(
                 amm.expectBalances(XRP(200'000), USD(100'000), amm.tokens()));
@@ -6272,33 +6323,33 @@ private:
         testFeeVote();
         testInvalidBid();
         testBid(all);
-        testBid(all - fixAMMRounding);
+        testBid(all - fixAMMv1_1);
         testInvalidAMMPayment();
         testBasicPaymentEngine(all);
-        testBasicPaymentEngine(all - fixAMMRounding);
+        testBasicPaymentEngine(all - fixAMMv1_1);
         testAMMTokens();
         testAmendment();
         testFlags();
         testRippling();
         testAMMAndCLOB(all);
-        testAMMAndCLOB(all - fixAMMRounding);
+        testAMMAndCLOB(all - fixAMMv1_1);
         testTradingFee(all);
-        testTradingFee(all - fixAMMRounding);
+        testTradingFee(all - fixAMMv1_1);
         testAdjustedTokens();
         testAutoDelete();
         testClawback();
         testAMMID();
         testSelection(all);
-        testSelection(all - fixAMMRounding);
+        testSelection(all - fixAMMv1_1);
         testFixDefaultInnerObj();
         testMalformed();
         testFixOverflowOffer(all);
-        testFixOverflowOffer(all - fixAMMRounding);
+        testFixOverflowOffer(all - fixAMMv1_1);
         testSwapRounding();
         testFixAMMOfferRounding(all);
-        testFixAMMOfferRounding(all - fixAMMRounding);
+        testFixAMMOfferRounding(all - fixAMMv1_1);
         testFixAMMOfferBlockedByLOB(all);
-        testFixAMMOfferBlockedByLOB(all - fixAMMRounding);
+        testFixAMMOfferBlockedByLOB(all - fixAMMv1_1);
     }
 };
 

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -5799,8 +5799,9 @@ private:
                 {
                     // Fails pre- and post-amendment because the quality can't
                     // be matched. Verify by generating a tiny offer, which
-                    // doesn't match the quality.
-                    if (status == Status::Fail)
+                    // doesn't match the quality. Exclude zero quality since
+                    // no offer is generated in this case.
+                    if (status == Status::Fail && quality != Quality{0})
                     {
                         auto tinyOffer = [&]() {
                             if (isXRP(poolIn))

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -5703,6 +5703,10 @@ private:
             {"1.070884664490231", "127604712776", Quality{5268620608623825741}, 293, Status::Fail},
             {"3272.448829820197", "6275124076", Quality{5625710328924117902}, 81, Status::Fail},
             {"0.009059512633902926", "7994028", Quality{5477511954775533172}, 1000, Status::Fail},
+            {"1", "1.0", Quality{0}, 100, Status::Fail},
+            {"1.0", "1", Quality{0}, 100, Status::Fail},
+            {"10", "10.0", Quality{TAmounts{XRPAmount{10}, IOUAmount{100}}}, 100, Status::Fail},
+            {"10.0", "10", Quality{TAmounts{IOUAmount{10}, XRPAmount{100}}}, 100, Status::Fail},
             {"69864389131", "287631.4543025075", Quality{6487623473313516078}, 451, Status::Succeed},
             {"4328342973", "12453825.99247381", Quality{6272522264364865181}, 997, Status::Succeed},
             {"32347017", "7003.93031579449", Quality{6347261126087916670}, 1000, Status::Succeed},
@@ -5846,6 +5850,14 @@ private:
                     !features[fixAMMv1_1] &&
                     status == Status::FailShouldSucceed);
             }
+        }
+
+        // Test negative discriminant
+        {
+            // b**2 - 4 * a * c -> 1 * 1 - 4 * 1 * 1 = -3
+            auto const res =
+                solveQuadraticEqSmallest(Number{1}, Number{1}, Number{1});
+            BEAST_EXPECT(!res.has_value());
         }
     }
 


### PR DESCRIPTION
## High Level Overview of Change

Introduces `fixAMMOfferRounding` amendment to improve quality of the generated AMM offer for a single path payment when one side of the offer is XRP and there is a Limit Order Book (LOB) offer for the same asset pair on the DEX.

### Context of Change

A single-path AMM offer with account offer on DEX, is always generated
starting with the takerPays first, which is rounded up, and then
the takerGets, which is rounded down. This rounding ensures that the pool's
product invariant is maintained. However, when one of the offer's side
is XRP, this rounding can result in the AMM offer having a lower
quality, potentially causing offer generation to fail if the quality
is lower than the account's offer quality.
    
To address this issue, the proposed fix adjusts the offer generation process
to start with the XRP side first and always rounds it down. This results
in a smaller offer size, improving the offer's quality.
This change still ensures the product invariant, as the other generated
side is the exact result of the swap-in or swap-out equations.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [x] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact


- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)


## Test Plan

A unit-test `testFixAMMOfferRounding()` is added to AMM_test to verify this amendment
