### PR TITLE
[TRIVIAL] fix: Remove redundant STAmount conversion in test

### DIFF
--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -127,7 +127,7 @@ private:
             STIssue(sfAsset, STAmount(XRP(2'000)).issue()));
         BEAST_EXPECT(
             STIssue(sfAsset, STAmount(XRP(2'000)).issue()) !=
-            STIssue(sfAsset, STAmount({USD(2'000)}).issue()));
+            STIssue(sfAsset, STAmount(USD(2'000)).issue()));
     }
 
     void


### PR DESCRIPTION
Does what it says on the tin.