### PR TITLE
Remove flow assert:

### DIFF
--- a/src/ripple/app/paths/impl/StrandFlow.h
+++ b/src/ripple/app/paths/impl/StrandFlow.h
@@ -834,7 +834,13 @@ flow(
     {
         if (actualOut > outReq)
         {
-            assert(0);
+            // Rounding in the payment engine is causing this assert to
+            // sometimes fire with "dust" amounts. This is causing issues when
+            // running debug builds of rippled. While this issue still needs to
+            // be resolved, the assert is causing more harm than good at this
+            // point.
+            // assert(0);
+
             return {tefEXCEPTION, std::move(ofrsToRmOnFail)};
         }
         if (!partialPayment)


### PR DESCRIPTION
Rounding in the payment engine is causing an assert to sometimes fire with "dust" amounts. This is causing issues when running debug builds of rippled. This issue will be addressed, but the assert is no longer serving its purpose.


### Type of Change


- [ x] Bug fix (non-breaking change which fixes an issue)

