### PR TITLE
Fix offer crossing with transfer fee over AMM and other fixes

### DIFF
--- a/src/ripple/app/misc/AMMUtils.h
+++ b/src/ripple/app/misc/AMMUtils.h
@@ -113,6 +113,16 @@ initializeFeeAuctionVote(
     Issue const& lptIssue,
     std::uint16_t tfee);
 
+/** Return true if the Liquidity Provider is the only AMM provider, false
+ * otherwise. Return tecINTERNAL if encountered an unexpected condition,
+ * for instance Liquidity Provider has more than one LPToken trustline.
+ */
+Expected<bool, TER>
+isOnlyLiquidityProvider(
+    ReadView const& view,
+    Issue const& ammIssue,
+    AccountID const& lpAccount);
+
 }  // namespace ripple
 
 #endif  // RIPPLE_APP_MISC_AMMUTILS_H_INLCUDED

--- a/src/ripple/app/misc/impl/AMMHelpers.cpp
+++ b/src/ripple/app/misc/impl/AMMHelpers.cpp
@@ -167,7 +167,7 @@ adjustAmountsByLPTokens(
     {
         bool const ammRoundingEnabled = [&]() {
             if (auto const& rules = getCurrentTransactionRules();
-                rules && rules->enabled(fixAMMRounding))
+                rules && rules->enabled(fixAMMv1_1))
                 return true;
             return false;
         }();

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -532,7 +532,7 @@ public:
         // Single path AMM offer has to factor in the transfer in rate
         // when calculating the upper bound quality and the quality function
         // because single path AMM's offer quality is not constant.
-        if (!rules.enabled(fixAMMRounding))
+        if (!rules.enabled(fixAMMv1_1))
             return ofrQ;
         else if (
             offerType == OfferType::CLOB ||

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -466,7 +466,7 @@ REGISTER_FEATURE(PriceOracle,                   Supported::yes, VoteBehavior::De
 REGISTER_FIX    (fixEmptyDID,                   Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixXChainRewardRounding,       Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixPreviousTxnID,              Supported::yes, VoteBehavior::DefaultNo);
-REGISTER_FIX    (fixAMMv1_1,                Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FIX    (fixAMMv1_1,                    Supported::yes, VoteBehavior::DefaultNo);
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.

--- a/src/test/app/AMMExtended_test.cpp
+++ b/src/test/app/AMMExtended_test.cpp
@@ -233,7 +233,7 @@ private:
                 {{XRP(10'100), USD(10'000)}},
                 0,
                 std::nullopt,
-                tweakedFeatures);
+                {tweakedFeatures});
 
             // Immediate or Cancel - cross as much as possible
             // and add nothing on the books.
@@ -257,7 +257,7 @@ private:
                 {{XRP(10'100), USD(10'000)}},
                 0,
                 std::nullopt,
-                tweakedFeatures);
+                {tweakedFeatures});
 
             // tfPassive -- place the offer without crossing it.
             testAMM(
@@ -274,7 +274,7 @@ private:
                 {{XRP(10'100), USD(10'000)}},
                 0,
                 std::nullopt,
-                tweakedFeatures);
+                {tweakedFeatures});
 
             // tfPassive -- cross only offers of better quality.
             testAMM(
@@ -296,7 +296,7 @@ private:
                 {{XRP(11'000), USD(9'000)}},
                 0,
                 std::nullopt,
-                tweakedFeatures);
+                {tweakedFeatures});
         }
     }
 
@@ -430,7 +430,7 @@ private:
             {{XRP(10'000), USD(10'000)}},
             0,
             std::nullopt,
-            features);
+            {features});
     }
 
     void
@@ -453,7 +453,7 @@ private:
             {{XRP(10'000), USD(10'100)}},
             0,
             std::nullopt,
-            features);
+            {features});
     }
 
     void
@@ -477,7 +477,7 @@ private:
             {{XRP(10'100), USD(10'000)}},
             0,
             std::nullopt,
-            features);
+            {features});
     }
 
     void
@@ -643,7 +643,7 @@ private:
             {{XRP(9'900), USD(10'100)}},
             0,
             std::nullopt,
-            features);
+            {features});
     }
 
     void
@@ -952,7 +952,7 @@ private:
             {{XRP(10'000), USD(10'100)}},
             0,
             std::nullopt,
-            features);
+            {features});
 
         // Reverse the order, so the offer in the books is to sell XRP
         // in return for USD.
@@ -973,7 +973,7 @@ private:
             {{XRP(10'100), USD(10'000)}},
             0,
             std::nullopt,
-            features);
+            {features});
 
         {
             // Bridged crossing.

--- a/src/test/jtx/AMMTest.h
+++ b/src/test/jtx/AMMTest.h
@@ -84,7 +84,7 @@ protected:
         std::optional<std::pair<STAmount, STAmount>> const& pool = std::nullopt,
         std::uint16_t tfee = 0,
         std::optional<jtx::ter> const& ter = std::nullopt,
-        std::optional<FeatureBitset> const& features = std::nullopt);
+        std::vector<FeatureBitset> const& features = {supported_amendments()});
 };
 
 class AMMTest : public jtx::AMMTestBase

--- a/src/test/jtx/impl/AMMTest.cpp
+++ b/src/test/jtx/impl/AMMTest.cpp
@@ -103,44 +103,45 @@ AMMTestBase::testAMM(
     std::optional<std::pair<STAmount, STAmount>> const& pool,
     std::uint16_t tfee,
     std::optional<jtx::ter> const& ter,
-    std::optional<FeatureBitset> const& features)
+    std::vector<FeatureBitset> const& vfeatures)
 {
     using namespace jtx;
-    auto env = [&]() {
-        if (features)
-            return Env{*this, *features};
-        return Env{*this};
-    }();
 
-    auto const [asset1, asset2] =
-        pool ? *pool : std::make_pair(XRP(10000), USD(10000));
-    auto tofund = [&](STAmount const& a) -> STAmount {
-        if (a.native())
-        {
-            auto const defXRP = XRP(30000);
-            if (a <= defXRP)
-                return defXRP;
-            return a + XRP(1000);
-        }
-        auto const defIOU = STAmount{a.issue(), 30000};
-        if (a <= defIOU)
-            return defIOU;
-        return a + STAmount{a.issue(), 1000};
-    };
-    auto const toFund1 = tofund(asset1);
-    auto const toFund2 = tofund(asset2);
-    BEAST_EXPECT(asset1 <= toFund1 && asset2 <= toFund2);
+    for (auto const& features : vfeatures)
+    {
+        Env env{*this, features};
 
-    if (!asset1.native() && !asset2.native())
-        fund(env, gw, {alice, carol}, {toFund1, toFund2}, Fund::All);
-    else if (asset1.native())
-        fund(env, gw, {alice, carol}, toFund1, {toFund2}, Fund::All);
-    else if (asset2.native())
-        fund(env, gw, {alice, carol}, toFund2, {toFund1}, Fund::All);
+        auto const [asset1, asset2] =
+            pool ? *pool : std::make_pair(XRP(10000), USD(10000));
+        auto tofund = [&](STAmount const& a) -> STAmount {
+            if (a.native())
+            {
+                auto const defXRP = XRP(30000);
+                if (a <= defXRP)
+                    return defXRP;
+                return a + XRP(1000);
+            }
+            auto const defIOU = STAmount{a.issue(), 30000};
+            if (a <= defIOU)
+                return defIOU;
+            return a + STAmount{a.issue(), 1000};
+        };
+        auto const toFund1 = tofund(asset1);
+        auto const toFund2 = tofund(asset2);
+        BEAST_EXPECT(asset1 <= toFund1 && asset2 <= toFund2);
 
-    AMM ammAlice(env, alice, asset1, asset2, false, tfee);
-    BEAST_EXPECT(ammAlice.expectBalances(asset1, asset2, ammAlice.tokens()));
-    cb(ammAlice, env);
+        if (!asset1.native() && !asset2.native())
+            fund(env, gw, {alice, carol}, {toFund1, toFund2}, Fund::All);
+        else if (asset1.native())
+            fund(env, gw, {alice, carol}, toFund1, {toFund2}, Fund::All);
+        else if (asset2.native())
+            fund(env, gw, {alice, carol}, toFund2, {toFund1}, Fund::All);
+
+        AMM ammAlice(env, alice, asset1, asset2, false, tfee);
+        BEAST_EXPECT(
+            ammAlice.expectBalances(asset1, asset2, ammAlice.tokens()));
+        cb(ammAlice, env);
+    }
 }
 
 XRPAmount

--- a/src/test/jtx/impl/AMMTest.cpp
+++ b/src/test/jtx/impl/AMMTest.cpp
@@ -137,10 +137,15 @@ AMMTestBase::testAMM(
         else if (asset2.native())
             fund(env, gw, {alice, carol}, toFund2, {toFund1}, Fund::All);
 
-        AMM ammAlice(env, alice, asset1, asset2, false, tfee);
-        BEAST_EXPECT(
-            ammAlice.expectBalances(asset1, asset2, ammAlice.tokens()));
-        cb(ammAlice, env);
+        AMM ammAlice(
+            env,
+            alice,
+            asset1,
+            asset2,
+            CreateArg{.log = false, .tfee = tfee, .err = ter});
+        if (BEAST_EXPECT(
+                ammAlice.expectBalances(asset1, asset2, ammAlice.tokens())))
+            cb(ammAlice, env);
     }
 }
 


### PR DESCRIPTION
## High Level Overview of Change

This PR addresses three issues:
- Offer crossing with the transfer fee via AMM 
- LPToken adjustment to factor in the LPTokenBalance rounding
- Possible conflict between Liquidity Provider trustline LPToken balance
   and LPTokenBalance when last Liquidity Provider withdraws all tokens

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [x] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

## Before / After

1. `qualityUpperBound()` and `QualityFunction` calculation doesn't factor in the transfer fee on offer crossing.
    This is correct behavior when crossing an account offer. Single-path with AMM limits the `out` value based 
    on the limitQuality. If the transfer fee is not factored in then the out value is going to be such that
    the generated AMM offer quality matches the limitQuality.  But the effective quality is smaller because 
    `takerPays` amount factors in the transfer fee when the strand's quality is calculated. The fix factors in
    the transfer fee when the quality is adjusted for the fees on offer crossing.
2. `adjustAmountsByLPTokens()` function is not returning adjusted tokens and amounts in some cases.
    The fix returns the adjusted LPToken and adjusted amounts.
3.  Liquidity Provider's (LP) LPToken trustline balances might not add up to the total LPTokenBalance due to the rounding. 
     This results in a dust amount left in the balances on the last LP withdrawal or the withdrawal transaction failing. The fix
     sets the LPTokenBalance to the trustline balance if LP is the only remaining LP on withdrawal transaction.

## Test Plan

Updated AMM_test and AMMExtended unit-tests.
