### PR TITLE
Proposed 2.2.0-rc2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,15 +197,39 @@ existing maintainer without a vote.
 
 ## Current Maintainers
 
+Maintainers are users with admin access to the repo. Maintainers do not typically approve or deny pull requests.
+
+* [intelliot](https://github.com/intelliot) (Ripple)
 * [JoelKatz](https://github.com/JoelKatz) (Ripple)
-* [manojsdoshi](https://github.com/manojsdoshi) (Ripple)
-* [n3tc4t](https://github.com/n3tc4t) (XRPL Labs)
 * [nixer89](https://github.com/nixer89) (XRP Ledger Foundation)
-* [RichardAH](https://github.com/RichardAH) (XRPL Labs + XRP Ledger Foundation)
-* [seelabs](https://github.com/seelabs) (Ripple)
 * [Silkjaer](https://github.com/Silkjaer) (XRP Ledger Foundation)
 * [WietseWind](https://github.com/WietseWind) (XRPL Labs + XRP Ledger Foundation)
+
+## Current Code Reviewers
+
+Code Reviewers are developers who have the ability to review and approve source code changes.
+
+* [HowardHinnant](https://github.com/HowardHinnant) (Ripple)
+* [scottschurr](https://github.com/scottschurr) (Ripple)
+* [seelabs](https://github.com/seelabs) (Ripple)
 * [Ed Hennis](https://github.com/ximinez) (Ripple)
+* [mvadari](https://github.com/mvadari) (Ripple)
+* [thejohnfreeman](https://github.com/thejohnfreeman) (Ripple)
+* [Bronek](https://github.com/Bronek) (Ripple)
+* [manojsdoshi](https://github.com/manojsdoshi) (Ripple)
+* [godexsoft](https://github.com/godexsoft) (Ripple)
+* [mDuo13](https://github.com/mDuo13) (Ripple)
+* [ckniffen](https://github.com/ckniffen) (Ripple)
+* [arihantkothari](https://github.com/arihantkothari) (Ripple)
+* [pwang200](https://github.com/pwang200) (Ripple)
+* [sophiax851](https://github.com/sophiax851) (Ripple)
+* [shawnxie999](https://github.com/shawnxie999) (Ripple)
+* [gregtatcam](https://github.com/gregtatcam) (Ripple)
+* [mtrippled](https://github.com/mtrippled) (Ripple)
+* [ckeshava](https://github.com/ckeshava) (Ripple)
+* [nbougalis](https://github.com/nbougalis) None
+* [RichardAH](https://github.com/RichardAH) (XRPL Labs + XRP Ledger Foundation)
+* [dangell7](https://github.com/dangell7) (XRPL Labs)
 
 
 [1]: https://docs.github.com/en/get-started/quickstart/contributing-to-projects

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,6 @@ existing maintainer without a vote.
 * [JoelKatz](https://github.com/JoelKatz) (Ripple)
 * [manojsdoshi](https://github.com/manojsdoshi) (Ripple)
 * [n3tc4t](https://github.com/n3tc4t) (XRPL Labs)
-* [Nik Bougalis](https://github.com/nbougalis)
 * [nixer89](https://github.com/nixer89) (XRP Ledger Foundation)
 * [RichardAH](https://github.com/RichardAH) (XRPL Labs + XRP Ledger Foundation)
 * [seelabs](https://github.com/seelabs) (Ripple)

--- a/conanfile.py
+++ b/conanfile.py
@@ -116,7 +116,7 @@ class Xrpl(ConanFile):
             self.requires('rocksdb/6.29.5')
 
     exports_sources = (
-        'CMakeLists.txt', 'Builds/*', 'bin/getRippledInfo', 'src/*', 'cfg/*'
+        'CMakeLists.txt', 'Builds/*', 'bin/getRippledInfo', 'src/*', 'cfg/*', 'external/*'
     )
 
     def layout(self):

--- a/src/ripple/app/misc/AMMHelpers.h
+++ b/src/ripple/app/misc/AMMHelpers.h
@@ -21,7 +21,9 @@
 #define RIPPLE_APP_MISC_AMMHELPERS_H_INCLUDED
 
 #include <ripple/basics/IOUAmount.h>
+#include <ripple/basics/Log.h>
 #include <ripple/basics/Number.h>
+#include <ripple/beast/utility/Journal.h>
 #include <ripple/protocol/AMMCore.h>
 #include <ripple/protocol/AmountConversions.h>
 #include <ripple/protocol/Feature.h>
@@ -34,6 +36,20 @@
 #include <type_traits>
 
 namespace ripple {
+
+namespace detail {
+
+Number
+reduceOffer(auto const& amount)
+{
+    static Number const reducedOfferPct(9999, -4);
+
+    // Make sure the result is always less than amount or zero.
+    NumberRoundModeGuard mg(Number::towards_zero);
+    return amount * reducedOfferPct;
+}
+
+}  // namespace detail
 
 /** Calculate LP Tokens given AMM pool reserves.
  * @param asset1 AMM one side of the pool reserve
@@ -147,12 +163,165 @@ withinRelativeDistance(Amt const& calc, Amt const& req, Number const& dist)
 }
 // clang-format on
 
-/** Finds takerPays (i) and takerGets (o) such that given pool composition
- * poolGets(I) and poolPays(O): (O - o) / (I + i) = quality.
- * Where takerGets is calculated as the swapAssetIn (see below).
- * The above equation produces the quadratic equation:
- * i^2*(1-fee) + i*I*(2-fee) + I^2 - I*O/quality,
- * which is solved for i, and o is found with swapAssetIn().
+/** Solve quadratic equation to find takerGets or takerPays. Round
+ * to minimize the amount in order to maximize the quality.
+ */
+std::optional<Number>
+solveQuadraticEqSmallest(Number const& a, Number const& b, Number const& c);
+
+/** Generate AMM offer starting with takerGets when AMM pool
+ * from the payment perspective is IOU(in)/XRP(out)
+ * Equations:
+ * Spot Price Quality after the offer is consumed:
+ *     Qsp = (O - o) / (I + i)    -- equation (1)
+ *  where O is poolPays, I is poolGets, o is takerGets, i is takerPays
+ * Swap out:
+ *     i = (I * o) / (O - o) * f  -- equation (2)
+ *  where f is (1 - tfee/100000), tfee is in basis points
+ * Effective price targetQuality:
+ *     Qep = o / i                -- equation (3)
+ * There are two scenarios to consider
+ * A) Qsp = Qep. Substitute i in (1) with (2) and solve for o
+ *    and Qsp = targetQuality(Qt):
+ *     o**2 + o * (I * Qt * (1 - 1 / f) - 2 * O) + O**2 - Qt * I * O = 0
+ * B) Qep = Qsp. Substitute i in (3) with (2) and solve for o
+ *    and Qep = targetQuality(Qt):
+ *     o = O - I * Qt / f
+ * Since the scenario is not known a priori, both A and B are solved and
+ * the lowest value of o is takerGets. takerPays is calculated with
+ * swap out eq (2). If o is less or equal to 0 then the offer can't
+ * be generated.
+ */
+template <typename TIn, typename TOut>
+std::optional<TAmounts<TIn, TOut>>
+getAMMOfferStartWithTakerGets(
+    TAmounts<TIn, TOut> const& pool,
+    Quality const& targetQuality,
+    std::uint16_t const& tfee)
+{
+    if (targetQuality.rate() == beast::zero)
+        return std::nullopt;
+
+    NumberRoundModeGuard mg(Number::to_nearest);
+    auto const f = feeMult(tfee);
+    auto const a = 1;
+    auto const b = pool.in * (1 - 1 / f) / targetQuality.rate() - 2 * pool.out;
+    auto const c =
+        pool.out * pool.out - (pool.in * pool.out) / targetQuality.rate();
+
+    auto nTakerGets = solveQuadraticEqSmallest(a, b, c);
+    if (!nTakerGets || *nTakerGets <= 0)
+        return std::nullopt;  // LCOV_EXCL_LINE
+
+    auto const nTakerGetsConstraint =
+        pool.out - pool.in / (targetQuality.rate() * f);
+    if (nTakerGetsConstraint <= 0)
+        return std::nullopt;
+
+    // Select the smallest to maximize the quality
+    if (nTakerGetsConstraint < *nTakerGets)
+        nTakerGets = nTakerGetsConstraint;
+
+    auto getAmounts = [&pool, &tfee](Number const& nTakerGetsProposed) {
+        // Round downward to minimize the offer and to maximize the quality.
+        // This has the most impact when takerGets is XRP.
+        auto const takerGets = toAmount<TOut>(
+            getIssue(pool.out), nTakerGetsProposed, Number::downward);
+        return TAmounts<TIn, TOut>{
+            swapAssetOut(pool, takerGets, tfee), takerGets};
+    };
+
+    // Try to reduce the offer size to improve the quality.
+    // The quality might still not match the targetQuality for a tiny offer.
+    if (auto const amounts = getAmounts(*nTakerGets);
+        Quality{amounts} < targetQuality)
+        return getAmounts(detail::reduceOffer(amounts.out));
+    else
+        return amounts;
+}
+
+/** Generate AMM offer starting with takerPays when AMM pool
+ * from the payment perspective is XRP(in)/IOU(out) or IOU(in)/IOU(out).
+ * Equations:
+ * Spot Price Quality after the offer is consumed:
+ *     Qsp = (O - o) / (I + i)       -- equation (1)
+ *  where O is poolPays, I is poolGets, o is takerGets, i is takerPays
+ * Swap in:
+ *     o = (O * i * f) / (I + i * f) -- equation (2)
+ *  where f is (1 - tfee/100000), tfee is in basis points
+ * Effective price quality:
+ *     Qep = o / i                   -- equation (3)
+ * There are two scenarios to consider
+ * A) Qsp = Qep. Substitute o in (1) with (2) and solve for i
+ *    and Qsp = targetQuality(Qt):
+ *     i**2 * f + i * I * (1 + f) + I**2 - I * O / Qt = 0
+ * B) Qep = Qsp. Substitute i in (3) with (2) and solve for i
+ *    and Qep = targetQuality(Qt):
+ *     i = O / Qt - I / f
+ * Since the scenario is not known a priori, both A and B are solved and
+ * the lowest value of i is takerPays. takerGets is calculated with
+ * swap in eq (2). If i is less or equal to 0 then the offer can't
+ * be generated.
+ */
+template <typename TIn, typename TOut>
+std::optional<TAmounts<TIn, TOut>>
+getAMMOfferStartWithTakerPays(
+    TAmounts<TIn, TOut> const& pool,
+    Quality const& targetQuality,
+    std::uint16_t tfee)
+{
+    if (targetQuality.rate() == beast::zero)
+        return std::nullopt;
+
+    NumberRoundModeGuard mg(Number::to_nearest);
+    auto const f = feeMult(tfee);
+    auto const& a = f;
+    auto const b = pool.in * (1 + f);
+    auto const c =
+        pool.in * pool.in - pool.in * pool.out * targetQuality.rate();
+
+    auto nTakerPays = solveQuadraticEqSmallest(a, b, c);
+    if (!nTakerPays || nTakerPays <= 0)
+        return std::nullopt;  // LCOV_EXCL_LINE
+
+    auto const nTakerPaysConstraint =
+        pool.out * targetQuality.rate() - pool.in / f;
+    if (nTakerPaysConstraint <= 0)
+        return std::nullopt;
+
+    // Select the smallest to maximize the quality
+    if (nTakerPaysConstraint < *nTakerPays)
+        nTakerPays = nTakerPaysConstraint;
+
+    auto getAmounts = [&pool, &tfee](Number const& nTakerPaysProposed) {
+        // Round downward to minimize the offer and to maximize the quality.
+        // This has the most impact when takerPays is XRP.
+        auto const takerPays = toAmount<TIn>(
+            getIssue(pool.in), nTakerPaysProposed, Number::downward);
+        return TAmounts<TIn, TOut>{
+            takerPays, swapAssetIn(pool, takerPays, tfee)};
+    };
+
+    // Try to reduce the offer size to improve the quality.
+    // The quality might still not match the targetQuality for a tiny offer.
+    if (auto const amounts = getAmounts(*nTakerPays);
+        Quality{amounts} < targetQuality)
+        return getAmounts(detail::reduceOffer(amounts.in));
+    else
+        return amounts;
+}
+
+/**   Generate AMM offer so that either updated Spot Price Quality (SPQ)
+ * is equal to LOB quality (in this case AMM offer quality is
+ * better than LOB quality) or AMM offer is equal to LOB quality
+ * (in this case SPQ is better than LOB quality).
+ * Pre-amendment code calculates takerPays first. If takerGets is XRP,
+ * it is rounded down, which results in worse offer quality than
+ * LOB quality, and the offer might fail to generate.
+ * Post-amendment code calculates the XRP offer side first. The result
+ * is rounded down, which makes the offer quality better.
+ *   It might not be possible to match either SPQ or AMM offer to LOB
+ * quality. This generally happens at higher fees.
  * @param pool AMM pool balances
  * @param quality requested quality
  * @param tfee trading fee in basis points
@@ -163,43 +332,111 @@ std::optional<TAmounts<TIn, TOut>>
 changeSpotPriceQuality(
     TAmounts<TIn, TOut> const& pool,
     Quality const& quality,
-    std::uint16_t tfee)
+    std::uint16_t tfee,
+    Rules const& rules,
+    beast::Journal j)
 {
-    auto const f = feeMult(tfee);  // 1 - fee
-    auto const& a = f;
-    auto const b = pool.in * (1 + f);
-    Number const c = pool.in * pool.in - pool.in * pool.out * quality.rate();
-    if (auto const res = b * b - 4 * a * c; res < 0)
-        return std::nullopt;
-    else if (auto const nTakerPaysPropose = (-b + root2(res)) / (2 * a);
-             nTakerPaysPropose > 0)
+    if (!rules.enabled(fixAMMv1_1))
     {
-        auto const nTakerPays = [&]() {
-            // The fee might make the AMM offer quality less than CLOB quality.
-            // Therefore, AMM offer has to satisfy this constraint: o / i >= q.
-            // Substituting o with swapAssetIn() gives:
-            // i <= O / q - I / (1 - fee).
-            auto const nTakerPaysConstraint =
-                pool.out * quality.rate() - pool.in / f;
-            if (nTakerPaysPropose > nTakerPaysConstraint)
-                return nTakerPaysConstraint;
-            return nTakerPaysPropose;
-        }();
-        if (nTakerPays <= 0)
-            return std::nullopt;
-        auto const takerPays = toAmount<TIn>(
-            getIssue(pool.in), nTakerPays, Number::rounding_mode::upward);
-        // should not fail
-        if (auto const amounts =
-                TAmounts<TIn, TOut>{
-                    takerPays, swapAssetIn(pool, takerPays, tfee)};
-            Quality{amounts} < quality &&
-            !withinRelativeDistance(Quality{amounts}, quality, Number(1, -7)))
-            Throw<std::runtime_error>("changeSpotPriceQuality failed");
-        else
-            return amounts;
+        // Finds takerPays (i) and takerGets (o) such that given pool
+        // composition poolGets(I) and poolPays(O): (O - o) / (I + i) = quality.
+        // Where takerGets is calculated as the swapAssetIn (see below).
+        // The above equation produces the quadratic equation:
+        // i^2*(1-fee) + i*I*(2-fee) + I^2 - I*O/quality,
+        // which is solved for i, and o is found with swapAssetIn().
+        auto const f = feeMult(tfee);  // 1 - fee
+        auto const& a = f;
+        auto const b = pool.in * (1 + f);
+        Number const c =
+            pool.in * pool.in - pool.in * pool.out * quality.rate();
+        if (auto const res = b * b - 4 * a * c; res < 0)
+            return std::nullopt;  // LCOV_EXCL_LINE
+        else if (auto const nTakerPaysPropose = (-b + root2(res)) / (2 * a);
+                 nTakerPaysPropose > 0)
+        {
+            auto const nTakerPays = [&]() {
+                // The fee might make the AMM offer quality less than CLOB
+                // quality. Therefore, AMM offer has to satisfy this constraint:
+                // o / i >= q. Substituting o with swapAssetIn() gives: i <= O /
+                // q - I / (1 - fee).
+                auto const nTakerPaysConstraint =
+                    pool.out * quality.rate() - pool.in / f;
+                if (nTakerPaysPropose > nTakerPaysConstraint)
+                    return nTakerPaysConstraint;
+                return nTakerPaysPropose;
+            }();
+            if (nTakerPays <= 0)
+            {
+                JLOG(j.trace())
+                    << "changeSpotPriceQuality calc failed: "
+                    << to_string(pool.in) << " " << to_string(pool.out) << " "
+                    << quality << " " << tfee;
+                return std::nullopt;
+            }
+            auto const takerPays =
+                toAmount<TIn>(getIssue(pool.in), nTakerPays, Number::upward);
+            // should not fail
+            if (auto const amounts =
+                    TAmounts<TIn, TOut>{
+                        takerPays, swapAssetIn(pool, takerPays, tfee)};
+                Quality{amounts} < quality &&
+                !withinRelativeDistance(
+                    Quality{amounts}, quality, Number(1, -7)))
+            {
+                JLOG(j.error())
+                    << "changeSpotPriceQuality failed: " << to_string(pool.in)
+                    << " " << to_string(pool.out) << " "
+                    << " " << quality << " " << tfee << " "
+                    << to_string(amounts.in) << " " << to_string(amounts.out);
+                Throw<std::runtime_error>("changeSpotPriceQuality failed");
+            }
+            else
+            {
+                JLOG(j.trace())
+                    << "changeSpotPriceQuality succeeded: "
+                    << to_string(pool.in) << " " << to_string(pool.out) << " "
+                    << " " << quality << " " << tfee << " "
+                    << to_string(amounts.in) << " " << to_string(amounts.out);
+                return amounts;
+            }
+        }
+        JLOG(j.trace()) << "changeSpotPriceQuality calc failed: "
+                        << to_string(pool.in) << " " << to_string(pool.out)
+                        << " " << quality << " " << tfee;
+        return std::nullopt;
     }
-    return std::nullopt;
+
+    // Generate the offer starting with XRP side. Return seated offer amounts
+    // if the offer can be generated, otherwise nullopt.
+    auto const amounts = [&]() {
+        if (isXRP(getIssue(pool.out)))
+            return getAMMOfferStartWithTakerGets(pool, quality, tfee);
+        return getAMMOfferStartWithTakerPays(pool, quality, tfee);
+    }();
+    if (!amounts)
+    {
+        JLOG(j.trace()) << "changeSpotPrice calc failed: " << to_string(pool.in)
+                        << " " << to_string(pool.out) << " " << quality << " "
+                        << tfee << std::endl;
+        return std::nullopt;
+    }
+
+    if (Quality{*amounts} < quality)
+    {
+        JLOG(j.error()) << "changeSpotPriceQuality failed: "
+                        << to_string(pool.in) << " " << to_string(pool.out)
+                        << " " << quality << " " << tfee << " "
+                        << to_string(amounts->in) << " "
+                        << to_string(amounts->out);
+        return std::nullopt;
+    }
+
+    JLOG(j.trace()) << "changeSpotPriceQuality succeeded: "
+                    << to_string(pool.in) << " " << to_string(pool.out) << " "
+                    << " " << quality << " " << tfee << " "
+                    << to_string(amounts->in) << " " << to_string(amounts->out);
+
+    return amounts;
 }
 
 /** AMM pool invariant - the product (A * B) after swap in/out has to remain
@@ -231,7 +468,7 @@ swapAssetIn(
     std::uint16_t tfee)
 {
     if (auto const& rules = getCurrentTransactionRules();
-        rules && rules->enabled(fixAMMRounding))
+        rules && rules->enabled(fixAMMv1_1))
     {
         // set rounding to always favor the amm. Clip to zero.
         // calculate:
@@ -275,8 +512,7 @@ swapAssetIn(
         if (swapOut.signum() < 0)
             return toAmount<TOut>(getIssue(pool.out), 0);
 
-        return toAmount<TOut>(
-            getIssue(pool.out), swapOut, Number::rounding_mode::downward);
+        return toAmount<TOut>(getIssue(pool.out), swapOut, Number::downward);
     }
     else
     {
@@ -284,7 +520,7 @@ swapAssetIn(
             getIssue(pool.out),
             pool.out -
                 (pool.in * pool.out) / (pool.in + assetIn * feeMult(tfee)),
-            Number::rounding_mode::downward);
+            Number::downward);
     }
 }
 
@@ -305,7 +541,7 @@ swapAssetOut(
     std::uint16_t tfee)
 {
     if (auto const& rules = getCurrentTransactionRules();
-        rules && rules->enabled(fixAMMRounding))
+        rules && rules->enabled(fixAMMv1_1))
     {
         // set rounding to always favor the amm. Clip to zero.
         // calculate:
@@ -349,8 +585,7 @@ swapAssetOut(
         if (swapIn.signum() < 0)
             return toAmount<TIn>(getIssue(pool.in), 0);
 
-        return toAmount<TIn>(
-            getIssue(pool.in), swapIn, Number::rounding_mode::upward);
+        return toAmount<TIn>(getIssue(pool.in), swapIn, Number::upward);
     }
     else
     {
@@ -358,7 +593,7 @@ swapAssetOut(
             getIssue(pool.in),
             ((pool.in * pool.out) / (pool.out - assetOut) - pool.in) /
                 feeMult(tfee),
-            Number::rounding_mode::upward);
+            Number::upward);
     }
 }
 

--- a/src/ripple/app/misc/AMMUtils.h
+++ b/src/ripple/app/misc/AMMUtils.h
@@ -113,6 +113,16 @@ initializeFeeAuctionVote(
     Issue const& lptIssue,
     std::uint16_t tfee);
 
+/** Return true if the Liquidity Provider is the only AMM provider, false
+ * otherwise. Return tecINTERNAL if encountered an unexpected condition,
+ * for instance Liquidity Provider has more than one LPToken trustline.
+ */
+Expected<bool, TER>
+isOnlyLiquidityProvider(
+    ReadView const& view,
+    Issue const& ammIssue,
+    AccountID const& lpAccount);
+
 }  // namespace ripple
 
 #endif  // RIPPLE_APP_MISC_AMMUTILS_H_INLCUDED

--- a/src/ripple/app/misc/impl/AMMHelpers.cpp
+++ b/src/ripple/app/misc/impl/AMMHelpers.cpp
@@ -167,7 +167,7 @@ adjustAmountsByLPTokens(
     {
         bool const ammRoundingEnabled = [&]() {
             if (auto const& rules = getCurrentTransactionRules();
-                rules && rules->enabled(fixAMMRounding))
+                rules && rules->enabled(fixAMMv1_1))
                 return true;
             return false;
         }();

--- a/src/ripple/app/misc/impl/AMMHelpers.cpp
+++ b/src/ripple/app/misc/impl/AMMHelpers.cpp
@@ -203,4 +203,19 @@ solveQuadraticEq(Number const& a, Number const& b, Number const& c)
     return (-b + root2(b * b - 4 * a * c)) / (2 * a);
 }
 
+// Minimize takerGets or takerPays
+std::optional<Number>
+solveQuadraticEqSmallest(Number const& a, Number const& b, Number const& c)
+{
+    auto const d = b * b - 4 * a * c;
+    if (d < 0)
+        return std::nullopt;
+    // use numerically stable citardauq formula for quadratic equation solution
+    // https://people.csail.mit.edu/bkph/articles/Quadratics.pdf
+    if (b > 0)
+        return (2 * c) / (-b - root2(d));
+    else
+        return (2 * c) / (-b + root2(d));
+}
+
 }  // namespace ripple

--- a/src/ripple/app/paths/impl/AMMLiquidity.cpp
+++ b/src/ripple/app/paths/impl/AMMLiquidity.cpp
@@ -205,8 +205,8 @@ AMMLiquidity<TIn, TOut>::getOffer(
                 return maxOffer(balances, view.rules());
             }
             else if (
-                auto const amounts =
-                    changeSpotPriceQuality(balances, *clobQuality, tradingFee_))
+                auto const amounts = changeSpotPriceQuality(
+                    balances, *clobQuality, tradingFee_, view.rules(), j_))
             {
                 return AMMOffer<TIn, TOut>(
                     *this, *amounts, balances, Quality{*amounts});
@@ -239,7 +239,12 @@ AMMLiquidity<TIn, TOut>::getOffer(
             return offer;
         }
 
-        JLOG(j_.error()) << "AMMLiquidity::getOffer, failed";
+        JLOG(j_.error()) << "AMMLiquidity::getOffer, failed "
+                         << ammContext_.multiPath() << " "
+                         << ammContext_.curIters() << " "
+                         << (clobQuality ? clobQuality->rate() : STAmount{})
+                         << " " << to_string(balances.in) << " "
+                         << to_string(balances.out);
     }
 
     return std::nullopt;

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -297,6 +297,14 @@ public:
         return true;
     }
 
+    // A payment doesn't use quality threshold (limitQuality)
+    // since the strand's quality doesn't directly relate to the step's quality.
+    std::optional<Quality>
+    qualityThreshold(Quality const& lobQuality) const
+    {
+        return lobQuality;
+    }
+
     // For a payment ofrInRate is always the same as trIn.
     std::uint32_t
     getOfrInRate(Step const*, AccountID const&, std::uint32_t trIn) const
@@ -448,6 +456,25 @@ public:
     checkQualityThreshold(Quality const& quality) const
     {
         return !defaultPath_ || quality >= qualityThreshold_;
+    }
+
+    // Return quality threshold or nullopt to use when generating AMM offer.
+    // AMM synthetic offer is generated to match LOB offer quality.
+    // If LOB tip offer quality is less than qualityThreshold
+    // then generated AMM offer quality is also less than qualityThreshold and
+    // the offer is not crossed even though AMM might generate a better quality
+    // offer. To address this, if qualityThreshold is greater than lobQuality
+    // then don't use quality to generate the AMM offer. The limit out value
+    // generates the maximum AMM offer in this case, which matches
+    // the quality threshold. This only applies to single path scenario.
+    // Multi-path AMM offers work the same as LOB offers.
+    std::optional<Quality>
+    qualityThreshold(Quality const& lobQuality) const
+    {
+        if (this->ammLiquidity_ && !this->ammLiquidity_->multiPath() &&
+            qualityThreshold_ > lobQuality)
+            return std::nullopt;
+        return lobQuality;
     }
 
     // For offer crossing don't pay the transfer fee if alice is paying alice.
@@ -758,8 +785,16 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
     };
 
     // At any payment engine iteration, AMM offer can only be consumed once.
-    auto tryAMM = [&](std::optional<Quality> const& quality) -> bool {
-        auto ammOffer = getAMMOffer(sb, quality);
+    auto tryAMM = [&](std::optional<Quality> const& lobQuality) -> bool {
+        // If offer crossing then use either LOB quality or nullopt
+        // to prevent AMM being blocked by a lower quality LOB.
+        auto const qualityThreshold = [&]() -> std::optional<Quality> {
+            if (sb.rules().enabled(fixAMMv1_1) && lobQuality)
+                return static_cast<TDerived const*>(this)->qualityThreshold(
+                    *lobQuality);
+            return lobQuality;
+        }();
+        auto ammOffer = getAMMOffer(sb, qualityThreshold);
         return !ammOffer || execOffer(*ammOffer);
     };
 
@@ -776,7 +811,7 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
     }
     else
     {
-        // Might have AMM offer if there is no CLOB offers.
+        // Might have AMM offer if there are no LOB offers.
         tryAMM(std::nullopt);
     }
 
@@ -851,17 +886,37 @@ BookStep<TIn, TOut, TDerived>::tip(ReadView const& view) const
     // This can be simplified (and sped up) if directories are never empty.
     Sandbox sb(&view, tapNONE);
     BookTip bt(sb, book_);
-    auto const clobQuality =
+    auto const lobQuality =
         bt.step(j_) ? std::optional<Quality>(bt.quality()) : std::nullopt;
-    // Don't pass in clobQuality. For one-path it returns the offer as
-    // the pool balances and the resulting quality is Spot Price Quality.
-    // For multi-path it returns the actual offer.
-    // AMM quality is better or no CLOB offer
-    if (auto const ammOffer = getAMMOffer(view, std::nullopt); ammOffer &&
-        ((clobQuality && ammOffer->quality() > clobQuality) || !clobQuality))
+    // Multi-path offer generates an offer with the quality
+    // calculated from the offer size and the quality is constant in this case.
+    // Single path offer quality changes with the offer size. Spot price quality
+    // (SPQ) can't be used in this case as the upper bound quality because
+    // even if SPQ quality is better than LOB quality, it might not be possible
+    // to generate AMM offer at or better quality than LOB quality. Another
+    // factor to consider is limit quality on offer crossing. If LOB quality
+    // is greater than limit quality then use LOB quality when generating AMM
+    // offer, otherwise don't use quality threshold when generating AMM offer.
+    // AMM or LOB offer, whether multi-path or single path then can be selected
+    // based on the best offer quality. Using the quality to generate AMM offer
+    // in this case also prevents the payment engine from going into multiple
+    // iterations to cross a LOB offer. This happens when AMM changes
+    // the out amount at the start of iteration to match the limitQuality
+    // on offer crossing but AMM can't generate the offer at this quality,
+    // as the result a LOB offer is partially crossed, and it might take a few
+    // iterations to fully cross the offer.
+    auto const qualityThreshold = [&]() -> std::optional<Quality> {
+        if (view.rules().enabled(fixAMMv1_1) && lobQuality)
+            return static_cast<TDerived const*>(this)->qualityThreshold(
+                *lobQuality);
+        return std::nullopt;
+    }();
+    // AMM quality is better or no LOB offer
+    if (auto const ammOffer = getAMMOffer(view, qualityThreshold); ammOffer &&
+        ((lobQuality && ammOffer->quality() > lobQuality) || !lobQuality))
         return ammOffer;
-    // CLOB quality is better or nullopt
-    return clobQuality;
+    // LOB quality is better or nullopt
+    return lobQuality;
 }
 
 template <class TIn, class TOut, class TDerived>

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -532,7 +532,7 @@ public:
         // Single path AMM offer has to factor in the transfer in rate
         // when calculating the upper bound quality and the quality function
         // because single path AMM's offer quality is not constant.
-        if (!rules.enabled(fixAMMRounding))
+        if (!rules.enabled(fixAMMv1_1))
             return ofrQ;
         else if (
             offerType == OfferType::CLOB ||

--- a/src/ripple/app/paths/impl/StrandFlow.h
+++ b/src/ripple/app/paths/impl/StrandFlow.h
@@ -834,7 +834,13 @@ flow(
     {
         if (actualOut > outReq)
         {
-            assert(0);
+            // Rounding in the payment engine is causing this assert to
+            // sometimes fire with "dust" amounts. This is causing issues when
+            // running debug builds of rippled. While this issue still needs to
+            // be resolved, the assert is causing more harm than good at this
+            // point.
+            // assert(0);
+
             return {tefEXCEPTION, std::move(ofrsToRmOnFail)};
         }
         if (!partialPayment)

--- a/src/ripple/app/tx/impl/AMMCreate.cpp
+++ b/src/ripple/app/tx/impl/AMMCreate.cpp
@@ -252,8 +252,8 @@ applyCreate(
             : 1};
     sleAMMRoot->setFieldU32(sfSequence, seqno);
     // Ignore reserves requirement, disable the master key, allow default
-    // rippling (AMM LPToken can be used as a token in another AMM, which must
-    // support payments and offer crossing), and enable deposit authorization to
+    // rippling (AMM LPToken can be used in payments and offer crossing but
+    // not as a token in another AMM), and enable deposit authorization to
     // prevent payments into AMM.
     // Note, that the trustlines created by AMM have 0 credit limit.
     // This prevents shifting the balance between accounts via AMM,

--- a/src/ripple/app/tx/impl/DeleteOracle.cpp
+++ b/src/ripple/app/tx/impl/DeleteOracle.cpp
@@ -48,7 +48,7 @@ TER
 DeleteOracle::preclaim(PreclaimContext const& ctx)
 {
     if (!ctx.view.exists(keylet::account(ctx.tx.getAccountID(sfAccount))))
-        return terNO_ACCOUNT;
+        return terNO_ACCOUNT;  // LCOV_EXCL_LINE
 
     if (auto const sle = ctx.view.read(keylet::oracle(
             ctx.tx.getAccountID(sfAccount), ctx.tx[sfOracleDocumentID]));
@@ -60,8 +60,10 @@ DeleteOracle::preclaim(PreclaimContext const& ctx)
     else if (ctx.tx.getAccountID(sfAccount) != sle->getAccountID(sfOwner))
     {
         // this can't happen because of the above check
+        // LCOV_EXCL_START
         JLOG(ctx.j.debug()) << "Oracle Delete: invalid account.";
         return tecINTERNAL;
+        // LCOV_EXCL_STOP
     }
     return tesSUCCESS;
 }
@@ -74,18 +76,20 @@ DeleteOracle::deleteOracle(
     beast::Journal j)
 {
     if (!sle)
-        return tesSUCCESS;
+        return tecINTERNAL;  // LCOV_EXCL_LINE
 
     if (!view.dirRemove(
             keylet::ownerDir(account), (*sle)[sfOwnerNode], sle->key(), true))
     {
+        // LCOV_EXCL_START
         JLOG(j.fatal()) << "Unable to delete Oracle from owner.";
         return tefBAD_LEDGER;
+        // LCOV_EXCL_STOP
     }
 
     auto const sleOwner = view.peek(keylet::account(account));
     if (!sleOwner)
-        return tecINTERNAL;
+        return tecINTERNAL;  // LCOV_EXCL_LINE
 
     auto const count =
         sle->getFieldArray(sfPriceDataSeries).size() > 5 ? -2 : -1;
@@ -104,7 +108,7 @@ DeleteOracle::doApply()
             keylet::oracle(account_, ctx_.tx[sfOracleDocumentID])))
         return deleteOracle(ctx_.view(), sle, account_, j_);
 
-    return tecINTERNAL;
+    return tecINTERNAL;  // LCOV_EXCL_LINE
 }
 
 }  // namespace ripple

--- a/src/ripple/app/tx/impl/SetOracle.cpp
+++ b/src/ripple/app/tx/impl/SetOracle.cpp
@@ -74,7 +74,7 @@ SetOracle::preclaim(PreclaimContext const& ctx)
     auto const sleSetter =
         ctx.view.read(keylet::account(ctx.tx.getAccountID(sfAccount)));
     if (!sleSetter)
-        return terNO_ACCOUNT;
+        return terNO_ACCOUNT;  // LCOV_EXCL_LINE
 
     // lastUpdateTime must be within maxLastUpdateTimeDelta seconds
     // of the last closed ledger
@@ -88,8 +88,7 @@ SetOracle::preclaim(PreclaimContext const& ctx)
     std::size_t const lastUpdateTimeEpoch =
         lastUpdateTime - epoch_offset.count();
     if (closeTime < maxLastUpdateTimeDelta)
-        Throw<std::runtime_error>(
-            "Oracle: close time is less than maxLastUpdateTimeDelta");
+        return tecINTERNAL;  // LCOV_EXCL_LINE
     if (lastUpdateTimeEpoch < (closeTime - maxLastUpdateTimeDelta) ||
         lastUpdateTimeEpoch > (closeTime + maxLastUpdateTimeDelta))
         return tecINVALID_UPDATE_TIME;
@@ -194,7 +193,7 @@ adjustOwnerCount(ApplyContext& ctx, int count)
         return true;
     }
 
-    return false;
+    return false;  // LCOV_EXCL_LINE
 }
 
 static void
@@ -274,7 +273,7 @@ SetOracle::doApply()
         auto const newCount = pairs.size() > 5 ? 2 : 1;
         auto const adjust = newCount - oldCount;
         if (adjust != 0 && !adjustOwnerCount(ctx_, adjust))
-            return tefINTERNAL;
+            return tefINTERNAL;  // LCOV_EXCL_LINE
 
         ctx_.view().update(sle);
     }
@@ -295,13 +294,13 @@ SetOracle::doApply()
         auto page = ctx_.view().dirInsert(
             keylet::ownerDir(account_), sle->key(), describeOwnerDir(account_));
         if (!page)
-            return tecDIR_FULL;
+            return tecDIR_FULL;  // LCOV_EXCL_LINE
 
         (*sle)[sfOwnerNode] = *page;
 
         auto const count = series.size() > 5 ? 2 : 1;
         if (!adjustOwnerCount(ctx_, count))
-            return tefINTERNAL;
+            return tefINTERNAL;  // LCOV_EXCL_LINE
 
         ctx_.view().insert(sle);
     }

--- a/src/ripple/basics/Number.h
+++ b/src/ripple/basics/Number.h
@@ -387,6 +387,26 @@ public:
     operator=(saveNumberRoundMode const&) = delete;
 };
 
+// saveNumberRoundMode doesn't do quite enough for us.  What we want is a
+// Number::RoundModeGuard that sets the new mode and restores the old mode
+// when it leaves scope.  Since Number doesn't have that facility, we'll
+// build it here.
+class NumberRoundModeGuard
+{
+    saveNumberRoundMode saved_;
+
+public:
+    explicit NumberRoundModeGuard(Number::rounding_mode mode) noexcept
+        : saved_{Number::setround(mode)}
+    {
+    }
+
+    NumberRoundModeGuard(NumberRoundModeGuard const&) = delete;
+
+    NumberRoundModeGuard&
+    operator=(NumberRoundModeGuard const&) = delete;
+};
+
 }  // namespace ripple
 
 #endif  // RIPPLE_BASICS_NUMBER_H_INCLUDED

--- a/src/ripple/conditions/impl/utils.h
+++ b/src/ripple/conditions/impl/utils.h
@@ -20,6 +20,8 @@
 #ifndef RIPPLE_CONDITIONS_UTILS_H
 #define RIPPLE_CONDITIONS_UTILS_H
 
+#include <ripple/basics/Buffer.h>
+#include <ripple/basics/Slice.h>
 #include <ripple/basics/strHex.h>
 #include <ripple/conditions/impl/error.h>
 #include <boost/dynamic_bitset.hpp>

--- a/src/ripple/consensus/LedgerTrie.h
+++ b/src/ripple/consensus/LedgerTrie.h
@@ -23,6 +23,7 @@
 #include <ripple/basics/ToString.h>
 #include <ripple/json/json_value.h>
 #include <algorithm>
+#include <iomanip>
 #include <memory>
 #include <optional>
 #include <sstream>

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -1147,7 +1147,7 @@ accountSend(
     beast::Journal j,
     WaiveTransferFee waiveFee)
 {
-    if (view.rules().enabled(fixAMMRounding))
+    if (view.rules().enabled(fixAMMv1_1))
     {
         if (saAmount < beast::zero)
         {

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -359,7 +359,7 @@ extern uint256 const featurePriceOracle;
 extern uint256 const fixEmptyDID;
 extern uint256 const fixXChainRewardRounding;
 extern uint256 const fixPreviousTxnID;
-extern uint256 const fixAMMRounding;
+extern uint256 const fixAMMv1_1;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.2.0-rc1"
+char const* const versionString = "2.2.0-rc2"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -466,7 +466,7 @@ REGISTER_FEATURE(PriceOracle,                   Supported::yes, VoteBehavior::De
 REGISTER_FIX    (fixEmptyDID,                   Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixXChainRewardRounding,       Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixPreviousTxnID,              Supported::yes, VoteBehavior::DefaultNo);
-REGISTER_FIX    (fixAMMv1_1,                Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FIX    (fixAMMv1_1,                    Supported::yes, VoteBehavior::DefaultNo);
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -466,7 +466,7 @@ REGISTER_FEATURE(PriceOracle,                   Supported::yes, VoteBehavior::De
 REGISTER_FIX    (fixEmptyDID,                   Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixXChainRewardRounding,       Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixPreviousTxnID,              Supported::yes, VoteBehavior::DefaultNo);
-REGISTER_FIX    (fixAMMRounding,                Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FIX    (fixAMMv1_1,                Supported::yes, VoteBehavior::DefaultNo);
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -1367,26 +1367,6 @@ canonicalizeRoundStrict(
 
 namespace {
 
-// saveNumberRoundMode doesn't do quite enough for us.  What we want is a
-// Number::RoundModeGuard that sets the new mode and restores the old mode
-// when it leaves scope.  Since Number doesn't have that facility, we'll
-// build it here.
-class NumberRoundModeGuard
-{
-    saveNumberRoundMode saved_;
-
-public:
-    explicit NumberRoundModeGuard(Number::rounding_mode mode) noexcept
-        : saved_{Number::setround(mode)}
-    {
-    }
-
-    NumberRoundModeGuard(NumberRoundModeGuard const&) = delete;
-
-    NumberRoundModeGuard&
-    operator=(NumberRoundModeGuard const&) = delete;
-};
-
 // We need a class that has an interface similar to NumberRoundModeGuard
 // but does nothing.
 class DontAffectNumberRoundMode

--- a/src/ripple/rpc/handlers/LedgerEntry.cpp
+++ b/src/ripple/rpc/handlers/LedgerEntry.cpp
@@ -624,7 +624,7 @@ doLedgerEntry(RPC::JsonContext& context)
                 auto const& oracle = context.params[jss::oracle];
                 auto const documentID = [&]() -> std::optional<std::uint32_t> {
                     auto const& id = oracle[jss::oracle_document_id];
-                    if (id.isConvertibleTo(Json::ValueType::uintValue))
+                    if (id.isUInt() || (id.isInt() && id.asInt() >= 0))
                         return std::make_optional(id.asUInt());
                     else if (id.isString())
                     {

--- a/src/test/app/AMMCalc_test.cpp
+++ b/src/test/app/AMMCalc_test.cpp
@@ -413,13 +413,18 @@ class AMMCalc_test : public beast::unit_test::suite
             //     10 is AMM trading fee
             else if (*p == "changespq")
             {
+                Env env(*this);
                 if (auto const pool = getAmounts(++p))
                 {
                     if (auto const offer = getAmounts(p))
                     {
                         auto const fee = getFee(p);
                         if (auto const ammOffer = changeSpotPriceQuality(
-                                pool->first, Quality{offer->first}, fee);
+                                pool->first,
+                                Quality{offer->first},
+                                fee,
+                                env.current()->rules(),
+                                beast::Journal(beast::Journal::getNullSink()));
                             ammOffer)
                             std::cout
                                 << "amm offer: " << toString(ammOffer->in)

--- a/src/test/app/AMMExtended_test.cpp
+++ b/src/test/app/AMMExtended_test.cpp
@@ -233,7 +233,7 @@ private:
                 {{XRP(10'100), USD(10'000)}},
                 0,
                 std::nullopt,
-                tweakedFeatures);
+                {tweakedFeatures});
 
             // Immediate or Cancel - cross as much as possible
             // and add nothing on the books.
@@ -257,7 +257,7 @@ private:
                 {{XRP(10'100), USD(10'000)}},
                 0,
                 std::nullopt,
-                tweakedFeatures);
+                {tweakedFeatures});
 
             // tfPassive -- place the offer without crossing it.
             testAMM(
@@ -274,7 +274,7 @@ private:
                 {{XRP(10'100), USD(10'000)}},
                 0,
                 std::nullopt,
-                tweakedFeatures);
+                {tweakedFeatures});
 
             // tfPassive -- cross only offers of better quality.
             testAMM(
@@ -296,7 +296,7 @@ private:
                 {{XRP(11'000), USD(9'000)}},
                 0,
                 std::nullopt,
-                tweakedFeatures);
+                {tweakedFeatures});
         }
     }
 
@@ -430,7 +430,7 @@ private:
             {{XRP(10'000), USD(10'000)}},
             0,
             std::nullopt,
-            features);
+            {features});
     }
 
     void
@@ -453,7 +453,7 @@ private:
             {{XRP(10'000), USD(10'100)}},
             0,
             std::nullopt,
-            features);
+            {features});
     }
 
     void
@@ -477,7 +477,7 @@ private:
             {{XRP(10'100), USD(10'000)}},
             0,
             std::nullopt,
-            features);
+            {features});
     }
 
     void
@@ -643,7 +643,7 @@ private:
             {{XRP(9'900), USD(10'100)}},
             0,
             std::nullopt,
-            features);
+            {features});
     }
 
     void
@@ -952,7 +952,7 @@ private:
             {{XRP(10'000), USD(10'100)}},
             0,
             std::nullopt,
-            features);
+            {features});
 
         // Reverse the order, so the offer in the books is to sell XRP
         // in return for USD.
@@ -973,7 +973,7 @@ private:
             {{XRP(10'100), USD(10'000)}},
             0,
             std::nullopt,
-            features);
+            {features});
 
         {
             // Bridged crossing.

--- a/src/test/csf/Histogram.h
+++ b/src/test/csf/Histogram.h
@@ -20,7 +20,9 @@
 #define RIPPLE_TEST_CSF_HISTOGRAM_H_INCLUDED
 
 #include <algorithm>
+#include <cassert>
 #include <chrono>
+#include <cmath>
 #include <map>
 
 namespace ripple {

--- a/src/test/csf/Tx.h
+++ b/src/test/csf/Tx.h
@@ -24,6 +24,7 @@
 #include <boost/iterator/function_output_iterator.hpp>
 #include <map>
 #include <ostream>
+#include <sstream>
 #include <string>
 #include <type_traits>
 

--- a/src/test/jtx/AMMTest.h
+++ b/src/test/jtx/AMMTest.h
@@ -84,7 +84,7 @@ protected:
         std::optional<std::pair<STAmount, STAmount>> const& pool = std::nullopt,
         std::uint16_t tfee = 0,
         std::optional<jtx::ter> const& ter = std::nullopt,
-        std::optional<FeatureBitset> const& features = std::nullopt);
+        std::vector<FeatureBitset> const& features = {supported_amendments()});
 };
 
 class AMMTest : public jtx::AMMTestBase

--- a/src/test/jtx/JTx.h
+++ b/src/test/jtx/JTx.h
@@ -21,6 +21,7 @@
 #define RIPPLE_TEST_JTX_JTX_H_INCLUDED
 
 #include <ripple/json/json_value.h>
+#include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/STTx.h>
 #include <ripple/protocol/TER.h>
 #include <test/jtx/basic_prop.h>

--- a/src/test/jtx/impl/AMMTest.cpp
+++ b/src/test/jtx/impl/AMMTest.cpp
@@ -103,44 +103,45 @@ AMMTestBase::testAMM(
     std::optional<std::pair<STAmount, STAmount>> const& pool,
     std::uint16_t tfee,
     std::optional<jtx::ter> const& ter,
-    std::optional<FeatureBitset> const& features)
+    std::vector<FeatureBitset> const& vfeatures)
 {
     using namespace jtx;
-    auto env = [&]() {
-        if (features)
-            return Env{*this, *features};
-        return Env{*this};
-    }();
 
-    auto const [asset1, asset2] =
-        pool ? *pool : std::make_pair(XRP(10000), USD(10000));
-    auto tofund = [&](STAmount const& a) -> STAmount {
-        if (a.native())
-        {
-            auto const defXRP = XRP(30000);
-            if (a <= defXRP)
-                return defXRP;
-            return a + XRP(1000);
-        }
-        auto const defIOU = STAmount{a.issue(), 30000};
-        if (a <= defIOU)
-            return defIOU;
-        return a + STAmount{a.issue(), 1000};
-    };
-    auto const toFund1 = tofund(asset1);
-    auto const toFund2 = tofund(asset2);
-    BEAST_EXPECT(asset1 <= toFund1 && asset2 <= toFund2);
+    for (auto const& features : vfeatures)
+    {
+        Env env{*this, features};
 
-    if (!asset1.native() && !asset2.native())
-        fund(env, gw, {alice, carol}, {toFund1, toFund2}, Fund::All);
-    else if (asset1.native())
-        fund(env, gw, {alice, carol}, toFund1, {toFund2}, Fund::All);
-    else if (asset2.native())
-        fund(env, gw, {alice, carol}, toFund2, {toFund1}, Fund::All);
+        auto const [asset1, asset2] =
+            pool ? *pool : std::make_pair(XRP(10000), USD(10000));
+        auto tofund = [&](STAmount const& a) -> STAmount {
+            if (a.native())
+            {
+                auto const defXRP = XRP(30000);
+                if (a <= defXRP)
+                    return defXRP;
+                return a + XRP(1000);
+            }
+            auto const defIOU = STAmount{a.issue(), 30000};
+            if (a <= defIOU)
+                return defIOU;
+            return a + STAmount{a.issue(), 1000};
+        };
+        auto const toFund1 = tofund(asset1);
+        auto const toFund2 = tofund(asset2);
+        BEAST_EXPECT(asset1 <= toFund1 && asset2 <= toFund2);
 
-    AMM ammAlice(env, alice, asset1, asset2, false, tfee);
-    BEAST_EXPECT(ammAlice.expectBalances(asset1, asset2, ammAlice.tokens()));
-    cb(ammAlice, env);
+        if (!asset1.native() && !asset2.native())
+            fund(env, gw, {alice, carol}, {toFund1, toFund2}, Fund::All);
+        else if (asset1.native())
+            fund(env, gw, {alice, carol}, toFund1, {toFund2}, Fund::All);
+        else if (asset2.native())
+            fund(env, gw, {alice, carol}, toFund2, {toFund1}, Fund::All);
+
+        AMM ammAlice(env, alice, asset1, asset2, false, tfee);
+        BEAST_EXPECT(
+            ammAlice.expectBalances(asset1, asset2, ammAlice.tokens()));
+        cb(ammAlice, env);
+    }
 }
 
 XRPAmount

--- a/src/test/jtx/impl/AMMTest.cpp
+++ b/src/test/jtx/impl/AMMTest.cpp
@@ -137,10 +137,15 @@ AMMTestBase::testAMM(
         else if (asset2.native())
             fund(env, gw, {alice, carol}, toFund2, {toFund1}, Fund::All);
 
-        AMM ammAlice(env, alice, asset1, asset2, false, tfee);
-        BEAST_EXPECT(
-            ammAlice.expectBalances(asset1, asset2, ammAlice.tokens()));
-        cb(ammAlice, env);
+        AMM ammAlice(
+            env,
+            alice,
+            asset1,
+            asset2,
+            CreateArg{.log = false, .tfee = tfee, .err = ter});
+        if (BEAST_EXPECT(
+                ammAlice.expectBalances(asset1, asset2, ammAlice.tokens())))
+            cb(ammAlice, env);
     }
 }
 

--- a/src/test/rpc/GRPCTestClientBase.h
+++ b/src/test/rpc/GRPCTestClientBase.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLED_GRPCTESTCLIENTBASE_H
 #define RIPPLED_GRPCTESTCLIENTBASE_H
 
+#include <grpcpp/grpcpp.h>
 #include <org/xrpl/rpc/v1/xrp_ledger.grpc.pb.h>
 #include <test/jtx/envconfig.h>
 

--- a/src/test/rpc/GetAggregatePrice_test.cpp
+++ b/src/test/rpc/GetAggregatePrice_test.cpp
@@ -35,10 +35,9 @@ public:
     {
         testcase("Errors");
         using namespace jtx;
-        using Oracles = std::vector<std::pair<Account, std::uint32_t>>;
         Account const owner{"owner"};
         Account const some{"some"};
-        static Oracles oracles = {{owner, 1}};
+        static OraclesData oracles = {{owner, 1}};
 
         {
             Env env(*this);
@@ -55,6 +54,32 @@ public:
                 ret[jss::error_message].asString() ==
                 "Missing field 'quote_asset'.");
 
+            // invalid base_asset, quote_asset
+            std::vector<AnyValue> invalidAsset = {
+                NoneTag,
+                1,
+                -1,
+                1.2,
+                "",
+                "invalid",
+                "a",
+                "ab",
+                "A",
+                "AB",
+                "ABCD",
+                "010101",
+                "012345678901234567890123456789012345678",
+                "012345678901234567890123456789012345678G"};
+            for (auto const& v : invalidAsset)
+            {
+                ret = Oracle::aggregatePrice(env, "USD", v, oracles);
+                BEAST_EXPECT(ret[jss::error].asString() == "invalidParams");
+                ret = Oracle::aggregatePrice(env, v, "USD", oracles);
+                BEAST_EXPECT(ret[jss::error].asString() == "invalidParams");
+                ret = Oracle::aggregatePrice(env, v, v, oracles);
+                BEAST_EXPECT(ret[jss::error].asString() == "invalidParams");
+            }
+
             // missing oracles array
             ret = Oracle::aggregatePrice(env, "XRP", "USD");
             BEAST_EXPECT(
@@ -62,16 +87,39 @@ public:
                 "Missing field 'oracles'.");
 
             // empty oracles array
-            ret = Oracle::aggregatePrice(env, "XRP", "USD", Oracles{});
+            ret = Oracle::aggregatePrice(env, "XRP", "USD", OraclesData{});
             BEAST_EXPECT(ret[jss::error].asString() == "oracleMalformed");
 
+            // no token pairs found
+            ret = Oracle::aggregatePrice(env, "YAN", "USD", oracles);
+            BEAST_EXPECT(ret[jss::error].asString() == "objectNotFound");
+
             // invalid oracle document id
+            // id doesn't exist
             ret = Oracle::aggregatePrice(env, "XRP", "USD", {{{owner, 2}}});
             BEAST_EXPECT(ret[jss::error].asString() == "objectNotFound");
+            // invalid values
+            std::vector<AnyValue> invalidDocument = {
+                NoneTag, 1.2, -1, "", "none", "1.2"};
+            for (auto const& v : invalidDocument)
+            {
+                ret = Oracle::aggregatePrice(env, "XRP", "USD", {{{owner, v}}});
+                Json::Value jv;
+                toJson(jv, v);
+                BEAST_EXPECT(ret[jss::error].asString() == "invalidParams");
+            }
+            // missing document id
+            ret = Oracle::aggregatePrice(
+                env, "XRP", "USD", {{{owner, std::nullopt}}});
+            BEAST_EXPECT(ret[jss::error].asString() == "oracleMalformed");
 
             // invalid owner
             ret = Oracle::aggregatePrice(env, "XRP", "USD", {{{some, 1}}});
             BEAST_EXPECT(ret[jss::error].asString() == "objectNotFound");
+            // missing account
+            ret = Oracle::aggregatePrice(
+                env, "XRP", "USD", {{{std::nullopt, 1}}});
+            BEAST_EXPECT(ret[jss::error].asString() == "oracleMalformed");
 
             // oracles have wrong asset pair
             env.fund(XRP(1'000), owner);
@@ -82,18 +130,35 @@ public:
             BEAST_EXPECT(ret[jss::error].asString() == "objectNotFound");
 
             // invalid trim value
-            ret = Oracle::aggregatePrice(
-                env, "XRP", "USD", {{{owner, oracle.documentID()}}}, 0);
-            BEAST_EXPECT(ret[jss::error].asString() == "invalidParams");
-            ret = Oracle::aggregatePrice(
-                env, "XRP", "USD", {{{owner, oracle.documentID()}}}, 26);
-            BEAST_EXPECT(ret[jss::error].asString() == "invalidParams");
+            std::vector<AnyValue> invalidTrim = {
+                NoneTag, 0, 26, -1, 1.2, "", "none", "1.2"};
+            for (auto const& v : invalidTrim)
+            {
+                ret = Oracle::aggregatePrice(
+                    env, "XRP", "USD", {{{owner, oracle.documentID()}}}, v);
+                BEAST_EXPECT(ret[jss::error].asString() == "invalidParams");
+            }
+
+            // invalid time threshold value
+            std::vector<AnyValue> invalidTime = {
+                NoneTag, -1, 1.2, "", "none", "1.2"};
+            for (auto const& v : invalidTime)
+            {
+                ret = Oracle::aggregatePrice(
+                    env,
+                    "XRP",
+                    "USD",
+                    {{{owner, oracle.documentID()}}},
+                    std::nullopt,
+                    v);
+                BEAST_EXPECT(ret[jss::error].asString() == "invalidParams");
+            }
         }
 
         // too many oracles
         {
             Env env(*this);
-            std::vector<std::pair<Account, std::uint32_t>> oracles;
+            OraclesData oracles;
             for (int i = 0; i < 201; ++i)
             {
                 Account const owner(std::to_string(i));
@@ -132,7 +197,7 @@ public:
         // or time threshold
         {
             Env env(*this);
-            std::vector<std::pair<Account, std::uint32_t>> oracles;
+            OraclesData oracles;
             prep(env, oracles);
             // entire and trimmed stats
             auto ret = Oracle::aggregatePrice(env, "XRP", "USD", oracles);
@@ -148,7 +213,7 @@ public:
         // Aggregate data set includes all price oracle instances
         {
             Env env(*this);
-            std::vector<std::pair<Account, std::uint32_t>> oracles;
+            OraclesData oracles;
             prep(env, oracles);
             // entire and trimmed stats
             auto ret =
@@ -171,14 +236,14 @@ public:
         // updated ledgers
         {
             Env env(*this);
-            std::vector<std::pair<Account, std::uint32_t>> oracles;
+            OraclesData oracles;
             prep(env, oracles);
             for (int i = 0; i < 3; ++i)
             {
                 Oracle oracle(
                     env,
                     {.owner = oracles[i].first,
-                     .documentID = oracles[i].second},
+                     .documentID = asUInt(*oracles[i].second)},
                     false);
                 // push XRP/USD by more than three ledgers, so this price
                 // oracle is not included in the dataset
@@ -191,7 +256,7 @@ public:
                 Oracle oracle(
                     env,
                     {.owner = oracles[i].first,
-                     .documentID = oracles[i].second},
+                     .documentID = asUInt(*oracles[i].second)},
                     false);
                 // push XRP/USD by two ledgers, so this price
                 // is included in the dataset
@@ -201,7 +266,7 @@ public:
 
             // entire and trimmed stats
             auto ret =
-                Oracle::aggregatePrice(env, "XRP", "USD", oracles, 20, 200);
+                Oracle::aggregatePrice(env, "XRP", "USD", oracles, 20, "200");
             BEAST_EXPECT(ret[jss::entire_set][jss::mean] == "74.6");
             BEAST_EXPECT(ret[jss::entire_set][jss::size].asUInt() == 7);
             BEAST_EXPECT(
@@ -219,14 +284,14 @@ public:
         // Reduced data set because of the time threshold
         {
             Env env(*this);
-            std::vector<std::pair<Account, std::uint32_t>> oracles;
+            OraclesData oracles;
             prep(env, oracles);
             for (int i = 0; i < oracles.size(); ++i)
             {
                 Oracle oracle(
                     env,
                     {.owner = oracles[i].first,
-                     .documentID = oracles[i].second},
+                     .documentID = asUInt(*oracles[i].second)},
                     false);
                 // push XRP/USD by two ledgers, so this price
                 // is included in the dataset

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -26,6 +26,7 @@
 #include <ripple/protocol/STXChainBridge.h>
 #include <ripple/protocol/jss.h>
 #include <test/jtx.h>
+#include <test/jtx/Oracle.h>
 #include <test/jtx/attester.h>
 #include <test/jtx/multisign.h>
 #include <test/jtx/xchain_bridge.h>
@@ -2279,6 +2280,87 @@ class LedgerRPC_test : public beast::unit_test::suite
         }
     }
 
+    void
+    testInvalidOracleLedgerEntry()
+    {
+        testcase("Invalid Oracle Ledger Entry");
+        using namespace ripple::test::jtx;
+        using namespace ripple::test::jtx::oracle;
+
+        Env env(*this);
+        Account const owner("owner");
+        env.fund(XRP(1'000), owner);
+        Oracle oracle(env, {.owner = owner});
+
+        // Malformed document id
+        auto res = Oracle::ledgerEntry(env, owner, NoneTag);
+        BEAST_EXPECT(res[jss::error].asString() == "invalidParams");
+        std::vector<AnyValue> invalid = {-1, 1.2, "", "Invalid"};
+        for (auto const& v : invalid)
+        {
+            auto const res = Oracle::ledgerEntry(env, owner, v);
+            BEAST_EXPECT(res[jss::error].asString() == "malformedDocumentID");
+        }
+        // Missing document id
+        res = Oracle::ledgerEntry(env, owner, std::nullopt);
+        BEAST_EXPECT(res[jss::error].asString() == "malformedRequest");
+
+        // Missing account
+        res = Oracle::ledgerEntry(env, std::nullopt, 1);
+        BEAST_EXPECT(res[jss::error].asString() == "malformedRequest");
+
+        // Malformed account
+        std::string malfAccount = to_string(owner.id());
+        malfAccount.replace(10, 1, 1, '!');
+        res = Oracle::ledgerEntry(env, malfAccount, 1);
+        BEAST_EXPECT(res[jss::error].asString() == "malformedAddress");
+    }
+
+    void
+    testOracleLedgerEntry()
+    {
+        testcase("Oracle Ledger Entry");
+        using namespace ripple::test::jtx;
+        using namespace ripple::test::jtx::oracle;
+
+        Env env(*this);
+        std::vector<AccountID> accounts;
+        std::vector<std::uint32_t> oracles;
+        for (int i = 0; i < 10; ++i)
+        {
+            Account const owner(std::string("owner") + std::to_string(i));
+            env.fund(XRP(1'000), owner);
+            // different accounts can have the same asset pair
+            Oracle oracle(env, {.owner = owner, .documentID = i});
+            accounts.push_back(owner.id());
+            oracles.push_back(oracle.documentID());
+            // same account can have different asset pair
+            Oracle oracle1(env, {.owner = owner, .documentID = i + 10});
+            accounts.push_back(owner.id());
+            oracles.push_back(oracle1.documentID());
+        }
+        for (int i = 0; i < accounts.size(); ++i)
+        {
+            auto const jv = [&]() {
+                // document id is uint32
+                if (i % 2)
+                    return Oracle::ledgerEntry(env, accounts[i], oracles[i]);
+                // document id is string
+                return Oracle::ledgerEntry(
+                    env, accounts[i], std::to_string(oracles[i]));
+            }();
+            try
+            {
+                BEAST_EXPECT(
+                    jv[jss::node][jss::Owner] == to_string(accounts[i]));
+            }
+            catch (...)
+            {
+                fail();
+            }
+        }
+    }
+
 public:
     void
     run() override
@@ -2304,6 +2386,8 @@ public:
         testQueue();
         testLedgerAccountsOption();
         testLedgerEntryDID();
+        testInvalidOracleLedgerEntry();
+        testOracleLedgerEntry();
 
         forAllApiVersions(std::bind_front(
             &LedgerRPC_test::testLedgerEntryInvalidParams, this));


### PR DESCRIPTION
## High Level Overview of Change

This is a release candidate for the 2.2.0 release.

Highlights:
- #5016
- #5013

The base branch is `release`. [All releases (including betas)](https://github.com/XRPLF/rippled/blob/develop/CONTRIBUTING.md#before-you-start) go in `release`. This PR will be merged with `--ff-only` (not squashed or rebased, and not using the GitHub UI) to both `release` and `develop`.

### Context of Change

This introduces
- the `fixAMMv1_1` amendment which fixes several issues with the AMM including: low quality lob offers blocking AMM offers, fixing how transfer fees are handled with the AMM, fixing an issue with an internal function that adjust amounts by lp tokens, and fixing an issue when the lp token balance of the last liquidity provider does not match the LPTokenBalance (due to floating point issues).
- Fixes to the price oracle where some input parameters were not properly validated.
- Misc fixes for conan, missing include files, and updating the CONTRIBUTING file.

It also introduces the first step in a physical code reorganization, unit test utilities to test RPC calls, and a global `Rules` object for transaction processing.

### Type of Change

- [x] Release

### API Impact

No API impact.
