### PR TITLE
Proposed 2.2.0-rc3

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -154,6 +154,7 @@ class Xrpl(ConanFile):
         libxrpl = self.cpp_info.components['libxrpl']
         libxrpl.libs = [
             'xrpl_core',
+            'xrpl.libpb',
             'ed25519',
             'secp256k1',
         ]

--- a/src/ripple/app/tx/impl/SetOracle.cpp
+++ b/src/ripple/app/tx/impl/SetOracle.cpp
@@ -23,7 +23,6 @@
 #include <ripple/ledger/View.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/InnerObjectFormats.h>
-#include <ripple/protocol/Rules.h>
 #include <ripple/protocol/TxFlags.h>
 #include <ripple/protocol/digest.h>
 
@@ -97,10 +96,10 @@ SetOracle::preclaim(PreclaimContext const& ctx)
         ctx.tx.getAccountID(sfAccount), ctx.tx[sfOracleDocumentID]));
 
     // token pairs to add/update
-    hash_set<std::pair<Currency, Currency>> pairs;
+    std::set<std::pair<Currency, Currency>> pairs;
     // token pairs to delete. if a token pair doesn't include
     // the price then this pair should be deleted from the object.
-    hash_set<std::pair<Currency, Currency>> pairsDel;
+    std::set<std::pair<Currency, Currency>> pairsDel;
     for (auto const& entry : ctx.tx.getFieldArray(sfPriceDataSeries))
     {
         if (entry[sfBaseAsset] == entry[sfQuoteAsset])
@@ -216,7 +215,7 @@ SetOracle::doApply()
         // the token pair that doesn't have their price updated will not
         // include neither price nor scale in the updated PriceDataSeries
 
-        hash_map<std::pair<Currency, Currency>, STObject> pairs;
+        std::map<std::pair<Currency, Currency>, STObject> pairs;
         // collect current token pairs
         for (auto const& entry : sle->getFieldArray(sfPriceDataSeries))
         {

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.2.0-rc2"
+char const* const versionString = "2.2.0-rc3"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)


### PR DESCRIPTION
## High Level Overview of Change

This is a release candidate for the 2.2.0 release.

Highlights:
- #5021
- #5022

The base branch is `release`. [All releases (including betas)](https://github.com/XRPLF/rippled/blob/develop/CONTRIBUTING.md#before-you-start) go in `release`. This PR will be merged with `--ff-only` (not squashed or rebased, and not using the GitHub UI) to both `release` and `develop`.

### Context of Change

This introduces
- Fixes to the price oracle where servers could disagree about the order of price data series (due to servers having different implementations of a hash table).

### Type of Change

- [x] Release

### API Impact

No API impact.
