### PR TITLE
Fix gcc-14 build

### DIFF
--- a/src/ripple/app/rdb/impl/Download.cpp
+++ b/src/ripple/app/rdb/impl/Download.cpp
@@ -20,6 +20,8 @@
 #include <ripple/app/rdb/Download.h>
 #include <soci/sqlite3/soci-sqlite3.h>
 
+#include <fstream>
+
 namespace ripple {
 
 std::pair<std::unique_ptr<DatabaseCon>, std::optional<std::uint64_t>>

--- a/src/ripple/basics/impl/FileUtilities.cpp
+++ b/src/ripple/basics/impl/FileUtilities.cpp
@@ -19,6 +19,8 @@
 
 #include <ripple/basics/FileUtilities.h>
 
+#include <fstream>
+
 namespace ripple {
 
 std::string
@@ -41,7 +43,7 @@ getFileContents(
         return {};
     }
 
-    ifstream fileStream(fullPath, std::ios::in);
+    std::ifstream fileStream(fullPath, std::ios::in);
 
     if (!fileStream)
     {
@@ -71,7 +73,7 @@ writeFileContents(
     using namespace boost::filesystem;
     using namespace boost::system::errc;
 
-    ofstream fileStream(destPath, std::ios::out | std::ios::trunc);
+    std::ofstream fileStream(destPath, std::ios::out | std::ios::trunc);
 
     if (!fileStream)
     {

--- a/src/ripple/net/impl/DatabaseBody.ipp
+++ b/src/ripple/net/impl/DatabaseBody.ipp
@@ -19,6 +19,8 @@
 
 #include <ripple/app/rdb/Download.h>
 
+#include <fstream>
+
 namespace ripple {
 
 inline void

--- a/src/ripple/nodestore/impl/DatabaseShardImp.cpp
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.cpp
@@ -40,6 +40,8 @@
 #include <sys/statvfs.h>
 #endif
 
+#include <fstream>
+
 namespace ripple {
 
 namespace NodeStore {

--- a/src/test/unit_test/FileDirGuard.h
+++ b/src/test/unit_test/FileDirGuard.h
@@ -21,8 +21,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #define TEST_UNIT_TEST_DIRGUARD_H
 
 #include <ripple/basics/contract.h>
+
 #include <boost/filesystem.hpp>
 #include <test/jtx/TestSuite.h>
+
+#include <fstream>
 
 namespace ripple {
 namespace test {


### PR DESCRIPTION
## High Level Overview of Change

Fix fstream usage to be compatible with gcc-14

### Context of Change

gcc-14  require explicit definition of the fstream classes

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### API Impact

none
