### PR TITLE
Fix conan typo:

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -119,7 +119,7 @@ class Xrpl(ConanFile):
         'CMakeLists.txt',
         'Builds/*',
         'bin/getRippledInfo',
-        'cfg/*'
+        'cfg/*',
         'external/*',
         'src/*',
     )


### PR DESCRIPTION
## High Level Overview of Change

Fixed typo in conanfile

### Context of Change

Added missed coma in 'exports_sources'

### Type of Change
- [ x ] Bug fix (non-breaking change which fixes an issue)
