### PR TITLE
chore: Rename two files from Directory* to Dir*:

### DIFF
--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -19,7 +19,7 @@
 
 #include <test/jtx.h>
 #include <xrpld/app/tx/applySteps.h>
-#include <xrpld/ledger/Directory.h>
+#include <xrpld/ledger/Dir.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/TxFlags.h>

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -18,7 +18,7 @@
 //==============================================================================
 
 #include <test/jtx.h>
-#include <xrpld/ledger/Directory.h>
+#include <xrpld/ledger/Dir.h>
 #include <xrpld/rpc/detail/RPCHelpers.h>
 #include <xrpl/basics/chrono.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/test/ledger/Directory_test.cpp
+++ b/src/test/ledger/Directory_test.cpp
@@ -17,7 +17,6 @@
 
 #include <test/jtx.h>
 #include <xrpld/ledger/BookDirs.h>
-#include <xrpld/ledger/Directory.h>
 #include <xrpld/ledger/Sandbox.h>
 #include <xrpl/basics/random.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/xrpld/app/paths/detail/BookStep.cpp
+++ b/src/xrpld/app/paths/detail/BookStep.cpp
@@ -23,7 +23,6 @@
 #include <xrpld/app/paths/detail/FlatSets.h>
 #include <xrpld/app/paths/detail/Steps.h>
 #include <xrpld/app/tx/detail/OfferStream.h>
-#include <xrpld/ledger/Directory.h>
 #include <xrpld/ledger/PaymentSandbox.h>
 #include <xrpl/basics/IOUAmount.h>
 #include <xrpl/basics/Log.h>

--- a/src/xrpld/app/tx/detail/NFTokenBurn.cpp
+++ b/src/xrpld/app/tx/detail/NFTokenBurn.cpp
@@ -19,7 +19,6 @@
 
 #include <xrpld/app/tx/detail/NFTokenBurn.h>
 #include <xrpld/app/tx/detail/NFTokenUtils.h>
-#include <xrpld/ledger/Directory.h>
 #include <xrpld/ledger/View.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Protocol.h>

--- a/src/xrpld/app/tx/detail/NFTokenUtils.cpp
+++ b/src/xrpld/app/tx/detail/NFTokenUtils.cpp
@@ -18,7 +18,7 @@
 //==============================================================================
 
 #include <xrpld/app/tx/detail/NFTokenUtils.h>
-#include <xrpld/ledger/Directory.h>
+#include <xrpld/ledger/Dir.h>
 #include <xrpld/ledger/View.h>
 #include <xrpl/basics/algorithm.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/xrpld/ledger/Dir.h
+++ b/src/xrpld/ledger/Dir.h
@@ -25,6 +25,18 @@
 
 namespace ripple {
 
+/** A class that simplifies iterating ledger directory pages
+
+    The Dir class provides a forward iterator for walking through
+    the uint256 values contained in ledger directories.
+
+    The Dir class also allows accelerated directory walking by
+    stepping directly from one page to the next using the next_page()
+    member function.
+
+    As of July 2024, the Dir class is only being used with NFTokenOffer
+    directories and for unit tests.
+*/
 class Dir
 {
 private:

--- a/src/xrpld/ledger/detail/Dir.cpp
+++ b/src/xrpld/ledger/detail/Dir.cpp
@@ -17,7 +17,7 @@
 */
 //==============================================================================
 
-#include <xrpld/ledger/Directory.h>
+#include <xrpld/ledger/Dir.h>
 
 namespace ripple {
 


### PR DESCRIPTION
## High Level Overview of Change

The `Dir` class was contained in two files named `Directory.h` and `Directory.cpp`.  The files are renamed `Dir.h` and `Dir.cpp` to reflect the class that they contain.  Additionally:

1. A few unnecessary includes of `Directory.h` have been removed and
2. A little documentation of the `Dir` class has been added.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
- [x] Documentation update
