### PR TITLE
chore: Add comments to SignerEntries.h

### DIFF
--- a/src/xrpld/app/tx/detail/SignerEntries.cpp
+++ b/src/xrpld/app/tx/detail/SignerEntries.cpp
@@ -30,7 +30,7 @@ Expected<std::vector<SignerEntries::SignerEntry>, NotTEC>
 SignerEntries::deserialize(
     STObject const& obj,
     beast::Journal journal,
-    std::string const& annotation)
+    std::string_view annotation)
 {
     std::pair<std::vector<SignerEntry>, NotTEC> s;
 

--- a/src/xrpld/app/tx/detail/SignerEntries.h
+++ b/src/xrpld/app/tx/detail/SignerEntries.h
@@ -27,18 +27,27 @@
 #include <xrpl/protocol/STTx.h>              // STTx::maxMultiSigners
 #include <xrpl/protocol/TER.h>               // temMALFORMED
 #include <xrpl/protocol/UintTypes.h>         // AccountID
+
 #include <optional>
+#include <string_view>
 
 namespace ripple {
 
 // Forward declarations
 class STObject;
 
-// Support for SignerEntries that is needed by a few Transactors
+// Support for SignerEntries that is needed by a few Transactors.
+//
+// SignerEntries is represented as a std::vector<SignerEntries::SignerEntry>.
+// There is no direct constructor for SignerEntries.
+//
+//  o A std::vector<SignerEntries::SignerEntry> is a SignerEntries.
+//  o More commonly, SignerEntries are extracted from an STObject by
+//    calling SignerEntries::deserialize().
 class SignerEntries
 {
 public:
-    explicit SignerEntries() = default;
+    explicit SignerEntries() = delete;
 
     struct SignerEntry
     {
@@ -69,11 +78,15 @@ public:
     };
 
     // Deserialize a SignerEntries array from the network or from the ledger.
+    //
+    // obj Contains a SignerEntries field that is an STArray.
+    // journal For reporting error conditions.
+    // annotation Source of SignerEntries, like "ledger" or "transaction".
     static Expected<std::vector<SignerEntry>, NotTEC>
     deserialize(
         STObject const& obj,
         beast::Journal journal,
-        std::string const& annotation);
+        std::string_view annotation);
 };
 
 }  // namespace ripple


### PR DESCRIPTION
## High Level Overview of Change

The `SignerEntries` class was not particularly well documented.  This pull request adds a few comments to that class.  The class might be confusing to some folks without the additional comments.

While I was in there I changed one parameter from `std::string const&` to `std::string_view` which might be a tiny performance boost.  It avoids constructing a `std::string` from a `char const*` at the call sites.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
- [x] Documentation update
