### PR TITLE
[TRIVIAL] Fix NuDB build error

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -98,6 +98,12 @@ Update the compiler settings:
    conan profile update settings.compiler.cppstd=20 default
    ```
 
+Configure Conan to use recipe revisions:
+
+   ```
+   conan config set general.revisions_enabled=1
+   ```
+
 **Linux** developers will commonly have a default Conan [profile][] that compiles
 with GCC and links with libstdc++.
 If you are linking with libstdc++ (see profile setting `compiler.libcxx`),
@@ -185,6 +191,17 @@ It patches their CMake to correctly import its dependencies.
    conan export external/soci soci/4.0.3@
    # Conan 2.x
    conan export --version 4.0.3 external/soci
+   ```
+
+Export our [Conan recipe for NuDB](./external/nudb).
+It fixes some source files to add missing `#include`s.
+
+
+   ```
+   # Conan 1.x
+   conan export external/nudb nudb/2.0.8@
+   # Conan 2.x
+   conan export --version 2.0.8 external/nudb
    ```
 
 ### Build and Test

--- a/BUILD.md
+++ b/BUILD.md
@@ -98,7 +98,7 @@ Update the compiler settings:
    conan profile update settings.compiler.cppstd=20 default
    ```
 
-Configure Conan to use recipe revisions:
+Configure Conan (1.x only) to use recipe revisions:
 
    ```
    conan config set general.revisions_enabled=1

--- a/external/nudb/conandata.yml
+++ b/external/nudb/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "2.0.8":
+    url: "https://github.com/CPPAlliance/NuDB/archive/2.0.8.tar.gz"
+    sha256: "9b71903d8ba111cd893ab064b9a8b6ac4124ed8bd6b4f67250205bc43c7f13a8"
+patches:
+  "2.0.8":
+    - patch_file: "patches/2.0.8-0001-add-include-stdexcept-for-msvc.patch"
+      patch_description: "Fix build for MSVC by including stdexcept"
+      patch_type: "portability"
+      patch_source: "https://github.com/cppalliance/NuDB/pull/100/files"

--- a/external/nudb/conanfile.py
+++ b/external/nudb/conanfile.py
@@ -1,0 +1,72 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=1.52.0"
+
+
+class NudbConan(ConanFile):
+    name = "nudb"
+    description = "A fast key/value insert-only database for SSD drives in C++11"
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/CPPAlliance/NuDB"
+    topics = ("header-only", "KVS", "insert-only")
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 11
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("boost/1.83.0")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        apply_conandata_patches(self)
+
+    def package(self):
+        copy(self, "LICENSE*",
+             dst=os.path.join(self.package_folder, "licenses"),
+             src=self.source_folder)
+        copy(self, "*",
+             dst=os.path.join(self.package_folder, "include"),
+             src=os.path.join(self.source_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        self.cpp_info.set_property("cmake_target_name", "NuDB")
+        self.cpp_info.set_property("cmake_target_aliases", ["NuDB::nudb"])
+        self.cpp_info.set_property("cmake_find_mode", "both")
+
+        self.cpp_info.components["core"].set_property("cmake_target_name", "nudb")
+        self.cpp_info.components["core"].names["cmake_find_package"] = "nudb"
+        self.cpp_info.components["core"].names["cmake_find_package_multi"] = "nudb"
+        self.cpp_info.components["core"].requires = ["boost::thread", "boost::system"]
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.names["cmake_find_package"] = "NuDB"
+        self.cpp_info.names["cmake_find_package_multi"] = "NuDB"

--- a/external/nudb/patches/2.0.8-0001-add-include-stdexcept-for-msvc.patch
+++ b/external/nudb/patches/2.0.8-0001-add-include-stdexcept-for-msvc.patch
@@ -1,0 +1,24 @@
+diff --git a/include/nudb/detail/stream.hpp b/include/nudb/detail/stream.hpp
+index 6c07bf1..e0ce8ed 100644
+--- a/include/nudb/detail/stream.hpp
++++ b/include/nudb/detail/stream.hpp
+@@ -14,6 +14,7 @@
+ #include <cstdint>
+ #include <cstring>
+ #include <memory>
++#include <stdexcept>
+ 
+ namespace nudb {
+ namespace detail {
+diff --git a/include/nudb/impl/context.ipp b/include/nudb/impl/context.ipp
+index beb7058..ffde0b3 100644
+--- a/include/nudb/impl/context.ipp
++++ b/include/nudb/impl/context.ipp
+@@ -9,6 +9,7 @@
+ #define NUDB_IMPL_CONTEXT_IPP
+ 
+ #include <nudb/detail/store_base.hpp>
++#include <stdexcept>
+ 
+ namespace nudb {
+ 

--- a/src/xrpld/nodestore/detail/varint.h
+++ b/src/xrpld/nodestore/detail/varint.h
@@ -20,12 +20,6 @@
 #ifndef BEAST_NUDB_VARINT_H_INCLUDED
 #define BEAST_NUDB_VARINT_H_INCLUDED
 
-/*
- * Without this header, nudb/detail/stream.hpp fails to build on Windows. Until
- * this is fixed, include it here.
- */
-#include <stdexcept>
-
 #include <cstdint>
 #include <nudb/detail/stream.hpp>
 #include <type_traits>

--- a/src/xrpld/nodestore/detail/varint.h
+++ b/src/xrpld/nodestore/detail/varint.h
@@ -20,6 +20,12 @@
 #ifndef BEAST_NUDB_VARINT_H_INCLUDED
 #define BEAST_NUDB_VARINT_H_INCLUDED
 
+/*
+ * Without this header, nudb/detail/stream.hpp fails to build on Windows. Until
+ * this is fixed, include it here.
+ */
+#include <stdexcept>
+
 #include <cstdint>
 #include <nudb/detail/stream.hpp>
 #include <type_traits>


### PR DESCRIPTION
## High Level Overview of Change

Fix a build error that seems to be limited to non-unity builds on Windows (Visual Studio) due to a missing `#include` in NuDB.

### Context of Change

I think the reordering of `#includes` in the physical redesign PR (#4997) removed a silent dependency from one of the headers in NuDB. The dependency version of NuDB didn't change, as far as I can tell. CI didn't catch the issue because the Windows build uses unity to save time.

The error is:
```
C:\Users\passp\.conan\data\nudb\2.0.8\_\_\package\5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9\include\nudb/detail/stream.hpp(64,20): error C2039: 'logic_error': is not a member of 'std' [C:\Dev\rippled\upstream\build\cmake\msvc19.OFF\rippled.vcxproj]
```
`std::logic_error` requires `<stdexcept>`, but `nudb/detail/stream.hpp` does not include it.

My assumption is some other header that had previously been ordered before `stream.hpp` and included `<stdexcept>` is now ordered after `stream.hpp`. I don't think it's worth figuring out which file it is, because it's obviously a problem with NuDB.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Build

## Future Tasks

See also: https://github.com/cppalliance/NuDB/pull/100