### PR TITLE
fix: change error for invalid `feature` param in `feature` RPC

### DIFF
--- a/src/test/rpc/Feature_test.cpp
+++ b/src/test/rpc/Feature_test.cpp
@@ -229,9 +229,28 @@ class Feature_test : public beast::unit_test::suite
         using namespace test::jtx;
         Env env{*this};
 
-        auto jrr = env.rpc("feature", "AllTheThings")[jss::result];
-        BEAST_EXPECT(jrr[jss::error] == "badFeature");
-        BEAST_EXPECT(jrr[jss::error_message] == "Feature unknown or invalid.");
+        auto testInvalidParam = [&](auto const& param) {
+            Json::Value params;
+            params[jss::feature] = param;
+            auto jrr =
+                env.rpc("json", "feature", to_string(params))[jss::result];
+            BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+            BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+        };
+
+        testInvalidParam(1);
+        testInvalidParam(1.1);
+        testInvalidParam(true);
+        testInvalidParam(Json::Value(Json::nullValue));
+        testInvalidParam(Json::Value(Json::objectValue));
+        testInvalidParam(Json::Value(Json::arrayValue));
+
+        {
+            auto jrr = env.rpc("feature", "AllTheThings")[jss::result];
+            BEAST_EXPECT(jrr[jss::error] == "badFeature");
+            BEAST_EXPECT(
+                jrr[jss::error_message] == "Feature unknown or invalid.");
+        }
     }
 
     void

--- a/src/xrpld/rpc/handlers/Feature1.cpp
+++ b/src/xrpld/rpc/handlers/Feature1.cpp
@@ -38,6 +38,15 @@ doFeature(RPC::JsonContext& context)
     if (context.app.config().reporting())
         return rpcError(rpcREPORTING_UNSUPPORTED);
 
+    if (context.params.isMember(jss::feature))
+    {
+        // ensure that the `feature` param is a string
+        if (!context.params[jss::feature].isString())
+        {
+            return rpcError(rpcINVALID_PARAMS);
+        }
+    }
+
     bool const isAdmin = context.role == Role::ADMIN;
     // Get majority amendment status
     majorityAmendments_t majorities;


### PR DESCRIPTION
## High Level Overview of Change

This PR changes the error message for invalid values of `feature` in the `feature` RPC. Now, if a non-string is passed into the function, it will return `invalidParams`, instead of `badFeature` as it did before.

### Context of Change

In rippled 2.2.0, a non-admin version of `feature` was added. This makes the need for proper error handling more important.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### API Impact

- [x] Public API: Breaking change (in general, breaking changes should only impact the next api_version)

While this is technically a breaking change, I consider it more of a bugfix. Only the error message is changing.

## Test Plan

Additional unit tests were added.
