### PR TITLE
fix: better error handling in account RPCs

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -1119,7 +1119,7 @@ if (tests)
     #]===============================]
     src/test/rpc/AccountCurrencies_test.cpp
     src/test/rpc/AccountInfo_test.cpp
-    src/test/rpc/AccountLinesRPC_test.cpp
+    src/test/rpc/AccountLines_test.cpp
     src/test/rpc/AccountObjects_test.cpp
     src/test/rpc/AccountOffers_test.cpp
     src/test/rpc/AccountSet_test.cpp

--- a/src/ripple/rpc/handlers/AccountChannels.cpp
+++ b/src/ripple/rpc/handlers/AccountChannels.cpp
@@ -72,7 +72,7 @@ doAccountChannels(RPC::JsonContext& context)
         return RPC::missing_field_error(jss::account);
 
     if (!params[jss::account].isString())
-        return rpcError(rpcINVALID_PARAMS);
+        return RPC::invalid_field_error(jss::account);
 
     std::shared_ptr<ReadView const> ledger;
     auto result = RPC::lookupLedger(ledger, context);

--- a/src/ripple/rpc/handlers/AccountChannels.cpp
+++ b/src/ripple/rpc/handlers/AccountChannels.cpp
@@ -71,6 +71,9 @@ doAccountChannels(RPC::JsonContext& context)
     if (!params.isMember(jss::account))
         return RPC::missing_field_error(jss::account);
 
+    if (!params[jss::account].isString())
+        return rpcError(rpcINVALID_PARAMS);
+
     std::shared_ptr<ReadView const> ledger;
     auto result = RPC::lookupLedger(ledger, context);
     if (!ledger)

--- a/src/ripple/rpc/handlers/AccountCurrenciesHandler.cpp
+++ b/src/ripple/rpc/handlers/AccountCurrenciesHandler.cpp
@@ -40,13 +40,13 @@ doAccountCurrencies(RPC::JsonContext& context)
     if (params.isMember(jss::account))
     {
         if (!params[jss::account].isString())
-            return rpcError(rpcINVALID_PARAMS);
+            return RPC::invalid_field_error(jss::account);
         strIdent = params[jss::account].asString();
     }
     else if (params.isMember(jss::ident))
     {
         if (!params[jss::ident].isString())
-            return rpcError(rpcINVALID_PARAMS);
+            return RPC::invalid_field_error(jss::ident);
         strIdent = params[jss::ident].asString();
     }
 

--- a/src/ripple/rpc/handlers/AccountCurrenciesHandler.cpp
+++ b/src/ripple/rpc/handlers/AccountCurrenciesHandler.cpp
@@ -33,18 +33,28 @@ doAccountCurrencies(RPC::JsonContext& context)
 {
     auto& params = context.params;
 
+    if (!(params.isMember(jss::account) || params.isMember(jss::ident)))
+        return RPC::missing_field_error(jss::account);
+
+    std::string strIdent;
+    if (params.isMember(jss::account))
+    {
+        if (!params[jss::account].isString())
+            return rpcError(rpcINVALID_PARAMS);
+        strIdent = params[jss::account].asString();
+    }
+    else if (params.isMember(jss::ident))
+    {
+        if (!params[jss::ident].isString())
+            return rpcError(rpcINVALID_PARAMS);
+        strIdent = params[jss::ident].asString();
+    }
+
     // Get the current ledger
     std::shared_ptr<ReadView const> ledger;
     auto result = RPC::lookupLedger(ledger, context);
     if (!ledger)
         return result;
-
-    if (!(params.isMember(jss::account) || params.isMember(jss::ident)))
-        return RPC::missing_field_error(jss::account);
-
-    std::string const strIdent(
-        params.isMember(jss::account) ? params[jss::account].asString()
-                                      : params[jss::ident].asString());
 
     // Get info on account.
     auto id = parseBase58<AccountID>(strIdent);

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -23,6 +23,7 @@
 #include <ripple/ledger/ReadView.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/Indexes.h>
+#include <ripple/protocol/RPCErr.h>
 #include <ripple/protocol/UintTypes.h>
 #include <ripple/protocol/jss.h>
 #include <ripple/rpc/Context.h>
@@ -53,9 +54,17 @@ doAccountInfo(RPC::JsonContext& context)
 
     std::string strIdent;
     if (params.isMember(jss::account))
+    {
+        if (!params[jss::account].isString())
+            return rpcError(rpcINVALID_PARAMS);
         strIdent = params[jss::account].asString();
+    }
     else if (params.isMember(jss::ident))
+    {
+        if (!params[jss::ident].isString())
+            return rpcError(rpcINVALID_PARAMS);
         strIdent = params[jss::ident].asString();
+    }
     else
         return RPC::missing_field_error(jss::account);
 

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -56,13 +56,13 @@ doAccountInfo(RPC::JsonContext& context)
     if (params.isMember(jss::account))
     {
         if (!params[jss::account].isString())
-            return rpcError(rpcINVALID_PARAMS);
+            return RPC::invalid_field_error(jss::account);
         strIdent = params[jss::account].asString();
     }
     else if (params.isMember(jss::ident))
     {
         if (!params[jss::ident].isString())
-            return rpcError(rpcINVALID_PARAMS);
+            return RPC::invalid_field_error(jss::ident);
         strIdent = params[jss::ident].asString();
     }
     else

--- a/src/ripple/rpc/handlers/AccountLines.cpp
+++ b/src/ripple/rpc/handlers/AccountLines.cpp
@@ -80,6 +80,9 @@ doAccountLines(RPC::JsonContext& context)
     if (!params.isMember(jss::account))
         return RPC::missing_field_error(jss::account);
 
+    if (!params[jss::account].isString())
+        return rpcError(rpcINVALID_PARAMS);
+
     std::shared_ptr<ReadView const> ledger;
     auto result = RPC::lookupLedger(ledger, context);
     if (!ledger)

--- a/src/ripple/rpc/handlers/AccountLines.cpp
+++ b/src/ripple/rpc/handlers/AccountLines.cpp
@@ -81,7 +81,7 @@ doAccountLines(RPC::JsonContext& context)
         return RPC::missing_field_error(jss::account);
 
     if (!params[jss::account].isString())
-        return rpcError(rpcINVALID_PARAMS);
+        return RPC::invalid_field_error(jss::account);
 
     std::shared_ptr<ReadView const> ledger;
     auto result = RPC::lookupLedger(ledger, context);

--- a/src/ripple/rpc/handlers/AccountObjects.cpp
+++ b/src/ripple/rpc/handlers/AccountObjects.cpp
@@ -55,7 +55,7 @@ doAccountNFTs(RPC::JsonContext& context)
         return RPC::missing_field_error(jss::account);
 
     if (!params[jss::account].isString())
-        return rpcError(rpcINVALID_PARAMS);
+        return RPC::invalid_field_error(jss::account);
 
     auto id = parseBase58<AccountID>(params[jss::account].asString());
     if (!id)
@@ -170,7 +170,7 @@ doAccountObjects(RPC::JsonContext& context)
         return RPC::missing_field_error(jss::account);
 
     if (!params[jss::account].isString())
-        return rpcError(rpcINVALID_PARAMS);
+        return RPC::invalid_field_error(jss::account);
 
     std::shared_ptr<ReadView const> ledger;
     auto result = RPC::lookupLedger(ledger, context);

--- a/src/ripple/rpc/handlers/AccountObjects.cpp
+++ b/src/ripple/rpc/handlers/AccountObjects.cpp
@@ -169,13 +169,14 @@ doAccountObjects(RPC::JsonContext& context)
     if (!params.isMember(jss::account))
         return RPC::missing_field_error(jss::account);
 
+    if (!params[jss::account].isString())
+        return rpcError(rpcINVALID_PARAMS);
+
     std::shared_ptr<ReadView const> ledger;
     auto result = RPC::lookupLedger(ledger, context);
     if (ledger == nullptr)
         return result;
 
-    if (!params[jss::account].isString())
-        return rpcError(rpcINVALID_PARAMS);
     auto const id = parseBase58<AccountID>(params[jss::account].asString());
     if (!id)
     {

--- a/src/ripple/rpc/handlers/AccountObjects.cpp
+++ b/src/ripple/rpc/handlers/AccountObjects.cpp
@@ -54,17 +54,19 @@ doAccountNFTs(RPC::JsonContext& context)
     if (!params.isMember(jss::account))
         return RPC::missing_field_error(jss::account);
 
-    std::shared_ptr<ReadView const> ledger;
-    auto result = RPC::lookupLedger(ledger, context);
-    if (ledger == nullptr)
-        return result;
+    if (!params[jss::account].isString())
+        return rpcError(rpcINVALID_PARAMS);
 
     auto id = parseBase58<AccountID>(params[jss::account].asString());
     if (!id)
     {
-        RPC::inject_error(rpcACT_MALFORMED, result);
-        return result;
+        return rpcError(rpcACT_MALFORMED);
     }
+
+    std::shared_ptr<ReadView const> ledger;
+    auto result = RPC::lookupLedger(ledger, context);
+    if (ledger == nullptr)
+        return result;
     auto const accountID{id.value()};
 
     if (!ledger->exists(keylet::account(accountID)))

--- a/src/ripple/rpc/handlers/AccountObjects.cpp
+++ b/src/ripple/rpc/handlers/AccountObjects.cpp
@@ -172,6 +172,8 @@ doAccountObjects(RPC::JsonContext& context)
     if (ledger == nullptr)
         return result;
 
+    if (!params[jss::account].isString())
+        return rpcError(rpcINVALID_PARAMS);
     auto const id = parseBase58<AccountID>(params[jss::account].asString());
     if (!id)
     {

--- a/src/ripple/rpc/handlers/AccountOffers.cpp
+++ b/src/ripple/rpc/handlers/AccountOffers.cpp
@@ -60,6 +60,9 @@ doAccountOffers(RPC::JsonContext& context)
     if (!params.isMember(jss::account))
         return RPC::missing_field_error(jss::account);
 
+    if (!params[jss::account].isString())
+        return rpcError(rpcINVALID_PARAMS);
+
     std::shared_ptr<ReadView const> ledger;
     auto result = RPC::lookupLedger(ledger, context);
     if (!ledger)

--- a/src/ripple/rpc/handlers/AccountOffers.cpp
+++ b/src/ripple/rpc/handlers/AccountOffers.cpp
@@ -61,7 +61,7 @@ doAccountOffers(RPC::JsonContext& context)
         return RPC::missing_field_error(jss::account);
 
     if (!params[jss::account].isString())
-        return rpcError(rpcINVALID_PARAMS);
+        return RPC::invalid_field_error(jss::account);
 
     std::shared_ptr<ReadView const> ledger;
     auto result = RPC::lookupLedger(ledger, context);

--- a/src/ripple/rpc/handlers/AccountOffers.cpp
+++ b/src/ripple/rpc/handlers/AccountOffers.cpp
@@ -87,7 +87,7 @@ doAccountOffers(RPC::JsonContext& context)
         return *err;
 
     if (limit == 0)
-        return rpcError(rpcINVALID_PARAMS);
+        return RPC::invalid_field_error(jss::limit);
 
     Json::Value& jsonOffers(result[jss::offers] = Json::arrayValue);
     std::vector<std::shared_ptr<SLE const>> offers;
@@ -104,13 +104,13 @@ doAccountOffers(RPC::JsonContext& context)
         std::stringstream marker(params[jss::marker].asString());
         std::string value;
         if (!std::getline(marker, value, ','))
-            return rpcError(rpcINVALID_PARAMS);
+            return RPC::invalid_field_error(jss::marker);
 
         if (!startAfter.parseHex(value))
-            return rpcError(rpcINVALID_PARAMS);
+            return RPC::invalid_field_error(jss::marker);
 
         if (!std::getline(marker, value, ','))
-            return rpcError(rpcINVALID_PARAMS);
+            return RPC::invalid_field_error(jss::marker);
 
         try
         {
@@ -118,7 +118,7 @@ doAccountOffers(RPC::JsonContext& context)
         }
         catch (boost::bad_lexical_cast&)
         {
-            return rpcError(rpcINVALID_PARAMS);
+            return RPC::invalid_field_error(jss::marker);
         }
 
         // We then must check if the object pointed to by the marker is actually

--- a/src/ripple/rpc/handlers/AccountTx.cpp
+++ b/src/ripple/rpc/handlers/AccountTx.cpp
@@ -439,7 +439,7 @@ doAccountTxJson(RPC::JsonContext& context)
     args.forward =
         params.isMember(jss::forward) && params[jss::forward].asBool();
 
-    if (!params.isMember(jss::account))
+    if (!params.isMember(jss::account) || !params[jss::account].isString())
         return rpcError(rpcINVALID_PARAMS);
 
     auto const account =

--- a/src/ripple/rpc/handlers/AccountTx.cpp
+++ b/src/ripple/rpc/handlers/AccountTx.cpp
@@ -439,7 +439,10 @@ doAccountTxJson(RPC::JsonContext& context)
     args.forward =
         params.isMember(jss::forward) && params[jss::forward].asBool();
 
-    if (!params.isMember(jss::account) || !params[jss::account].isString())
+    if (!params.isMember(jss::account))
+        return RPC::missing_field_error(jss::account);
+
+    if (!params[jss::account].isString())
         return rpcError(rpcINVALID_PARAMS);
 
     auto const account =

--- a/src/ripple/rpc/handlers/AccountTx.cpp
+++ b/src/ripple/rpc/handlers/AccountTx.cpp
@@ -426,12 +426,12 @@ doAccountTxJson(RPC::JsonContext& context)
     if (context.apiVersion > 1u && params.isMember(jss::binary) &&
         !params[jss::binary].isBool())
     {
-        return rpcError(rpcINVALID_PARAMS);
+        return RPC::invalid_field_error(jss::binary);
     }
     if (context.apiVersion > 1u && params.isMember(jss::forward) &&
         !params[jss::forward].isBool())
     {
-        return rpcError(rpcINVALID_PARAMS);
+        return RPC::invalid_field_error(jss::forward);
     }
 
     args.limit = params.isMember(jss::limit) ? params[jss::limit].asUInt() : 0;
@@ -443,7 +443,7 @@ doAccountTxJson(RPC::JsonContext& context)
         return RPC::missing_field_error(jss::account);
 
     if (!params[jss::account].isString())
-        return rpcError(rpcINVALID_PARAMS);
+        return RPC::invalid_field_error(jss::account);
 
     auto const account =
         parseBase58<AccountID>(params[jss::account].asString());

--- a/src/ripple/rpc/handlers/NoRippleCheck.cpp
+++ b/src/ripple/rpc/handlers/NoRippleCheck.cpp
@@ -66,6 +66,10 @@ doNoRippleCheck(RPC::JsonContext& context)
 
     if (!params.isMember("role"))
         return RPC::missing_field_error("role");
+
+    if (!params[jss::account].isString())
+        return rpcError(rpcINVALID_PARAMS);
+
     bool roleGateway = false;
     {
         std::string const role = params["role"].asString();

--- a/src/ripple/rpc/handlers/NoRippleCheck.cpp
+++ b/src/ripple/rpc/handlers/NoRippleCheck.cpp
@@ -68,7 +68,7 @@ doNoRippleCheck(RPC::JsonContext& context)
         return RPC::missing_field_error("role");
 
     if (!params[jss::account].isString())
-        return rpcError(rpcINVALID_PARAMS);
+        return RPC::invalid_field_error(jss::account);
 
     bool roleGateway = false;
     {
@@ -94,7 +94,7 @@ doNoRippleCheck(RPC::JsonContext& context)
     if (context.apiVersion > 1u && params.isMember(jss::transactions) &&
         !params[jss::transactions].isBool())
     {
-        return rpcError(rpcINVALID_PARAMS);
+        return RPC::invalid_field_error(jss::transactions);
     }
 
     std::shared_ptr<ReadView const> ledger;

--- a/src/test/app/AccountTxPaging_test.cpp
+++ b/src/test/app/AccountTxPaging_test.cpp
@@ -271,6 +271,6 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(AccountTxPaging, app, ripple);
+BEAST_DEFINE_TESTSUITE(AccountTxPaging, rpc, ripple);
 
 }  // namespace ripple

--- a/src/test/app/AccountTxPaging_test.cpp
+++ b/src/test/app/AccountTxPaging_test.cpp
@@ -271,6 +271,6 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(AccountTxPaging, rpc, ripple);
+BEAST_DEFINE_TESTSUITE(AccountTxPaging, app, ripple);
 
 }  // namespace ripple

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -879,7 +879,7 @@ struct PayChan_test : public beast::unit_test::suite
                 Json::Value params;
                 params[jss::account] = param;
                 auto jrr = env.rpc(
-                    "json", "account_tx", to_string(params))[jss::result];
+                    "json", "account_channels", to_string(params))[jss::result];
                 BEAST_EXPECT(jrr[jss::error] == "invalidParams");
                 BEAST_EXPECT(
                     jrr[jss::error_message] == "Invalid field 'account'.");

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -881,7 +881,8 @@ struct PayChan_test : public beast::unit_test::suite
                 auto jrr = env.rpc(
                     "json", "account_tx", to_string(params))[jss::result];
                 BEAST_EXPECT(jrr[jss::error] == "invalidParams");
-                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+                BEAST_EXPECT(
+                    jrr[jss::error_message] == "Invalid field 'account'.");
             };
 
             testInvalidAccountParam(1);

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -874,6 +874,24 @@ struct PayChan_test : public beast::unit_test::suite
         env(create(alice, bob, channelFunds, settleDelay, pk));
         env.close();
         {
+            // test account non-string
+            auto testInvalidAccountParam = [&](auto const& param) {
+                Json::Value params;
+                params[jss::account] = param;
+                auto jrr = env.rpc(
+                    "json", "account_tx", to_string(params))[jss::result];
+                BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+            };
+
+            testInvalidAccountParam(1);
+            testInvalidAccountParam(1.1);
+            testInvalidAccountParam(true);
+            testInvalidAccountParam(Json::Value(Json::nullValue));
+            testInvalidAccountParam(Json::Value(Json::objectValue));
+            testInvalidAccountParam(Json::Value(Json::arrayValue));
+        }
+        {
             auto const r =
                 env.rpc("account_channels", alice.human(), bob.human());
             BEAST_EXPECT(r[jss::result][jss::channels].size() == 1);

--- a/src/test/rpc/AccountCurrencies_test.cpp
+++ b/src/test/rpc/AccountCurrencies_test.cpp
@@ -80,6 +80,28 @@ class AccountCurrencies_test : public beast::unit_test::suite
         }
 
         {
+            // test ident non-string
+            auto testInvalidIdentParam = [&](auto const& param) {
+                Json::Value params;
+                params[jss::ident] = param;
+                auto jrr = env.rpc(
+                    "json",
+                    "account_currencies",
+                    to_string(params))[jss::result];
+                BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+                BEAST_EXPECT(
+                    jrr[jss::error_message] == "Invalid field 'ident'.");
+            };
+
+            testInvalidIdentParam(1);
+            testInvalidIdentParam(1.1);
+            testInvalidIdentParam(true);
+            testInvalidIdentParam(Json::Value(Json::nullValue));
+            testInvalidIdentParam(Json::Value(Json::objectValue));
+            testInvalidIdentParam(Json::Value(Json::arrayValue));
+        }
+
+        {
             Json::Value params;
             params[jss::account] =
                 "llIIOO";  // these are invalid in bitcoin alphabet

--- a/src/test/rpc/AccountCurrencies_test.cpp
+++ b/src/test/rpc/AccountCurrencies_test.cpp
@@ -39,6 +39,7 @@ class AccountCurrencies_test : public beast::unit_test::suite
 
         {  // invalid ledger (hash)
             Json::Value params;
+            params[jss::account] = Account{"bob"}.human();
             params[jss::ledger_hash] = 1;
             auto const result = env.rpc(
                 "json",
@@ -54,6 +55,27 @@ class AccountCurrencies_test : public beast::unit_test::suite
             BEAST_EXPECT(result[jss::error] == "invalidParams");
             BEAST_EXPECT(
                 result[jss::error_message] == "Missing field 'account'.");
+        }
+
+        {
+            // test account non-string
+            auto testInvalidAccountParam = [&](auto const& param) {
+                Json::Value params;
+                params[jss::account] = param;
+                auto jrr = env.rpc(
+                    "json",
+                    "account_currencies",
+                    to_string(params))[jss::result];
+                BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+            };
+
+            testInvalidAccountParam(1);
+            testInvalidAccountParam(1.1);
+            testInvalidAccountParam(true);
+            testInvalidAccountParam(Json::Value(Json::nullValue));
+            testInvalidAccountParam(Json::Value(Json::objectValue));
+            testInvalidAccountParam(Json::Value(Json::arrayValue));
         }
 
         {
@@ -198,6 +220,6 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(AccountCurrencies, app, ripple);
+BEAST_DEFINE_TESTSUITE(AccountCurrencies, rpc, ripple);
 
 }  // namespace ripple

--- a/src/test/rpc/AccountCurrencies_test.cpp
+++ b/src/test/rpc/AccountCurrencies_test.cpp
@@ -67,7 +67,8 @@ class AccountCurrencies_test : public beast::unit_test::suite
                     "account_currencies",
                     to_string(params))[jss::result];
                 BEAST_EXPECT(jrr[jss::error] == "invalidParams");
-                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+                BEAST_EXPECT(
+                    jrr[jss::error_message] == "Invalid field 'account'.");
             };
 
             testInvalidAccountParam(1);

--- a/src/test/rpc/AccountInfo_test.cpp
+++ b/src/test/rpc/AccountInfo_test.cpp
@@ -98,7 +98,7 @@ public:
             testInvalidAccountParam(Json::Value(Json::arrayValue));
         }
         {
-            // Cannot pass a non-string into the `account` param
+            // Cannot pass a non-string into the `ident` param
 
             auto testInvalidIdentParam = [&](auto const& param) {
                 Json::Value params;

--- a/src/test/rpc/AccountInfo_test.cpp
+++ b/src/test/rpc/AccountInfo_test.cpp
@@ -78,6 +78,44 @@ public:
             BEAST_EXPECT(
                 info[jss::result][jss::error_message] == "Account malformed.");
         }
+        {
+            // Cannot pass a non-string into the `account` param
+
+            auto testInvalidAccountParam = [&](auto const& param) {
+                Json::Value params;
+                params[jss::account] = param;
+                auto jrr = env.rpc(
+                    "json", "account_info", to_string(params))[jss::result];
+                BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+            };
+
+            testInvalidAccountParam(1);
+            testInvalidAccountParam(1.1);
+            testInvalidAccountParam(true);
+            testInvalidAccountParam(Json::Value(Json::nullValue));
+            testInvalidAccountParam(Json::Value(Json::objectValue));
+            testInvalidAccountParam(Json::Value(Json::arrayValue));
+        }
+        {
+            // Cannot pass a non-string into the `account` param
+
+            auto testInvalidIdentParam = [&](auto const& param) {
+                Json::Value params;
+                params[jss::ident] = param;
+                auto jrr = env.rpc(
+                    "json", "account_info", to_string(params))[jss::result];
+                BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+            };
+
+            testInvalidIdentParam(1);
+            testInvalidIdentParam(1.1);
+            testInvalidIdentParam(true);
+            testInvalidIdentParam(Json::Value(Json::nullValue));
+            testInvalidIdentParam(Json::Value(Json::objectValue));
+            testInvalidIdentParam(Json::Value(Json::arrayValue));
+        }
     }
 
     // Test the "signer_lists" argument in account_info.
@@ -652,7 +690,7 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(AccountInfo, app, ripple);
+BEAST_DEFINE_TESTSUITE(AccountInfo, rpc, ripple);
 
 }  // namespace test
 }  // namespace ripple

--- a/src/test/rpc/AccountInfo_test.cpp
+++ b/src/test/rpc/AccountInfo_test.cpp
@@ -87,7 +87,8 @@ public:
                 auto jrr = env.rpc(
                     "json", "account_info", to_string(params))[jss::result];
                 BEAST_EXPECT(jrr[jss::error] == "invalidParams");
-                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+                BEAST_EXPECT(
+                    jrr[jss::error_message] == "Invalid field 'account'.");
             };
 
             testInvalidAccountParam(1);
@@ -106,7 +107,8 @@ public:
                 auto jrr = env.rpc(
                     "json", "account_info", to_string(params))[jss::result];
                 BEAST_EXPECT(jrr[jss::error] == "invalidParams");
-                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+                BEAST_EXPECT(
+                    jrr[jss::error_message] == "Invalid field 'account'.");
             };
 
             testInvalidIdentParam(1);

--- a/src/test/rpc/AccountInfo_test.cpp
+++ b/src/test/rpc/AccountInfo_test.cpp
@@ -36,6 +36,7 @@ public:
     void
     testErrors()
     {
+        testcase("Errors");
         using namespace jtx;
         Env env(*this);
         {
@@ -108,7 +109,7 @@ public:
                     "json", "account_info", to_string(params))[jss::result];
                 BEAST_EXPECT(jrr[jss::error] == "invalidParams");
                 BEAST_EXPECT(
-                    jrr[jss::error_message] == "Invalid field 'account'.");
+                    jrr[jss::error_message] == "Invalid field 'ident'.");
             };
 
             testInvalidIdentParam(1);
@@ -124,6 +125,7 @@ public:
     void
     testSignerLists()
     {
+        testcase("Signer lists");
         using namespace jtx;
         Env env(*this);
         Account const alice{"alice"};
@@ -245,6 +247,7 @@ public:
     void
     testSignerListsApiVersion2()
     {
+        testcase("Signer lists APIv2");
         using namespace jtx;
         Env env{*this};
         Account const alice{"alice"};
@@ -366,6 +369,7 @@ public:
     void
     testSignerListsV2()
     {
+        testcase("Signer lists v2");
         using namespace jtx;
         Env env(*this);
         Account const alice{"alice"};
@@ -555,6 +559,7 @@ public:
     void
     testAccountFlags(FeatureBitset const& features)
     {
+        testcase("Account flags");
         using namespace jtx;
 
         Env env(*this, features);

--- a/src/test/rpc/AccountLines_test.cpp
+++ b/src/test/rpc/AccountLines_test.cpp
@@ -27,7 +27,7 @@ namespace ripple {
 
 namespace RPC {
 
-class AccountLinesRPC_test : public beast::unit_test::suite
+class AccountLines_test : public beast::unit_test::suite
 {
 public:
     void
@@ -54,6 +54,24 @@ public:
             BEAST_EXPECT(
                 lines[jss::result][jss::error_message] ==
                 RPC::make_error(rpcACT_MALFORMED)[jss::error_message]);
+        }
+        {
+            // test account non-string
+            auto testInvalidAccountParam = [&](auto const& param) {
+                Json::Value params;
+                params[jss::account] = param;
+                auto jrr = env.rpc(
+                    "json", "account_lines", to_string(params))[jss::result];
+                BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+            };
+
+            testInvalidAccountParam(1);
+            testInvalidAccountParam(1.1);
+            testInvalidAccountParam(true);
+            testInvalidAccountParam(Json::Value(Json::nullValue));
+            testInvalidAccountParam(Json::Value(Json::objectValue));
+            testInvalidAccountParam(Json::Value(Json::arrayValue));
         }
         Account const alice{"alice"};
         {
@@ -1474,7 +1492,7 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(AccountLinesRPC, app, ripple);
+BEAST_DEFINE_TESTSUITE(AccountLines, rpc, ripple);
 
 }  // namespace RPC
 }  // namespace ripple

--- a/src/test/rpc/AccountLines_test.cpp
+++ b/src/test/rpc/AccountLines_test.cpp
@@ -63,7 +63,8 @@ public:
                 auto jrr = env.rpc(
                     "json", "account_lines", to_string(params))[jss::result];
                 BEAST_EXPECT(jrr[jss::error] == "invalidParams");
-                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+                BEAST_EXPECT(
+                    jrr[jss::error_message] == "Invalid field 'account'.");
             };
 
             testInvalidAccountParam(1);

--- a/src/test/rpc/AccountObjects_test.cpp
+++ b/src/test/rpc/AccountObjects_test.cpp
@@ -1051,12 +1051,41 @@ public:
     }
 
     void
+    testAccountNFTs()
+    {
+        testcase("account_nfts");
+
+        using namespace jtx;
+        Env env(*this);
+
+        // test validation
+        {
+            auto testInvalidAccountParam = [&](auto const& param) {
+                Json::Value params;
+                params[jss::account] = param;
+                auto jrr = env.rpc(
+                    "json", "account_nfts", to_string(params))[jss::result];
+                BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+            };
+
+            testInvalidAccountParam(1);
+            testInvalidAccountParam(1.1);
+            testInvalidAccountParam(true);
+            testInvalidAccountParam(Json::Value(Json::nullValue));
+            testInvalidAccountParam(Json::Value(Json::objectValue));
+            testInvalidAccountParam(Json::Value(Json::arrayValue));
+        }
+    }
+
+    void
     run() override
     {
         testErrors();
         testUnsteppedThenStepped();
         testUnsteppedThenSteppedWithNFTs();
         testObjectTypes();
+        testAccountNFTs();
     }
 };
 

--- a/src/test/rpc/AccountObjects_test.cpp
+++ b/src/test/rpc/AccountObjects_test.cpp
@@ -134,7 +134,8 @@ public:
                 auto jrr = env.rpc(
                     "json", "account_objects", to_string(params))[jss::result];
                 BEAST_EXPECT(jrr[jss::error] == "invalidParams");
-                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+                BEAST_EXPECT(
+                    jrr[jss::error_message] == "Invalid field 'account'.");
             };
 
             testInvalidAccountParam(1);
@@ -1066,7 +1067,8 @@ public:
                 auto jrr = env.rpc(
                     "json", "account_nfts", to_string(params))[jss::result];
                 BEAST_EXPECT(jrr[jss::error] == "invalidParams");
-                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+                BEAST_EXPECT(
+                    jrr[jss::error_message] == "Invalid field 'account'.");
             };
 
             testInvalidAccountParam(1);

--- a/src/test/rpc/AccountObjects_test.cpp
+++ b/src/test/rpc/AccountObjects_test.cpp
@@ -123,8 +123,11 @@ public:
 
         // test error on no account
         {
-            auto resp = env.rpc("json", "account_objects");
-            BEAST_EXPECT(resp[jss::error_message] == "Syntax error.");
+            Json::Value params;
+            auto resp = env.rpc("json", "account_objects", to_string(params));
+            BEAST_EXPECT(
+                resp[jss::result][jss::error_message] ==
+                "Missing field 'account'.");
         }
         // test account non-string
         {

--- a/src/test/rpc/AccountObjects_test.cpp
+++ b/src/test/rpc/AccountObjects_test.cpp
@@ -126,6 +126,24 @@ public:
             auto resp = env.rpc("json", "account_objects");
             BEAST_EXPECT(resp[jss::error_message] == "Syntax error.");
         }
+        // test account non-string
+        {
+            auto testInvalidAccountParam = [&](auto const& param) {
+                Json::Value params;
+                params[jss::account] = param;
+                auto jrr = env.rpc(
+                    "json", "account_objects", to_string(params))[jss::result];
+                BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+            };
+
+            testInvalidAccountParam(1);
+            testInvalidAccountParam(1.1);
+            testInvalidAccountParam(true);
+            testInvalidAccountParam(Json::Value(Json::nullValue));
+            testInvalidAccountParam(Json::Value(Json::objectValue));
+            testInvalidAccountParam(Json::Value(Json::arrayValue));
+        }
         // test error on  malformed account string.
         {
             Json::Value params;
@@ -1042,7 +1060,7 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(AccountObjects, app, ripple);
+BEAST_DEFINE_TESTSUITE(AccountObjects, rpc, ripple);
 
 }  // namespace test
 }  // namespace ripple

--- a/src/test/rpc/AccountOffers_test.cpp
+++ b/src/test/rpc/AccountOffers_test.cpp
@@ -309,7 +309,9 @@ public:
                 jvParams.toStyledString())[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "invalidParams");
             BEAST_EXPECT(jrr[jss::status] == "error");
-            BEAST_EXPECT(jrr[jss::error_message] == "Invalid field 'account'.");
+            BEAST_EXPECTS(
+                jrr[jss::error_message] == "Invalid field 'marker'.",
+                jrr.toStyledString());
         }
 
         {

--- a/src/test/rpc/AccountOffers_test.cpp
+++ b/src/test/rpc/AccountOffers_test.cpp
@@ -246,7 +246,7 @@ public:
                 Json::Value params;
                 params[jss::account] = param;
                 auto jrr = env.rpc(
-                    "json", "account_objects", to_string(params))[jss::result];
+                    "json", "account_offers", to_string(params))[jss::result];
                 BEAST_EXPECT(jrr[jss::error] == "invalidParams");
                 BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
             };

--- a/src/test/rpc/AccountOffers_test.cpp
+++ b/src/test/rpc/AccountOffers_test.cpp
@@ -248,7 +248,8 @@ public:
                 auto jrr = env.rpc(
                     "json", "account_offers", to_string(params))[jss::result];
                 BEAST_EXPECT(jrr[jss::error] == "invalidParams");
-                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+                BEAST_EXPECT(
+                    jrr[jss::error_message] == "Invalid field 'account'.");
             };
 
             testInvalidAccountParam(1);
@@ -308,7 +309,7 @@ public:
                 jvParams.toStyledString())[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "invalidParams");
             BEAST_EXPECT(jrr[jss::status] == "error");
-            BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+            BEAST_EXPECT(jrr[jss::error_message] == "Invalid field 'account'.");
         }
 
         {

--- a/src/test/rpc/AccountOffers_test.cpp
+++ b/src/test/rpc/AccountOffers_test.cpp
@@ -37,6 +37,8 @@ public:
     void
     testNonAdminMinLimit()
     {
+        testcase("Non-Admin Min Limit");
+
         using namespace jtx;
         Env env{*this, envconfig(no_admin)};
         Account const gw("G1");
@@ -81,6 +83,9 @@ public:
     void
     testSequential(bool asAdmin)
     {
+        testcase(
+            std::string("Sequential - ") + (asAdmin ? "admin" : "non-admin"));
+
         using namespace jtx;
         Env env{*this, asAdmin ? envconfig() : envconfig(no_admin)};
         Account const gw("G1");
@@ -215,6 +220,8 @@ public:
     void
     testBadInput()
     {
+        testcase("Bad input");
+
         using namespace jtx;
         Env env(*this);
         Account const gw("G1");
@@ -231,6 +238,25 @@ public:
             BEAST_EXPECT(jrr[jss::error] == "badSyntax");
             BEAST_EXPECT(jrr[jss::status] == "error");
             BEAST_EXPECT(jrr[jss::error_message] == "Syntax error.");
+        }
+
+        {
+            // test account non-string
+            auto testInvalidAccountParam = [&](auto const& param) {
+                Json::Value params;
+                params[jss::account] = param;
+                auto jrr = env.rpc(
+                    "json", "account_objects", to_string(params))[jss::result];
+                BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+            };
+
+            testInvalidAccountParam(1);
+            testInvalidAccountParam(1.1);
+            testInvalidAccountParam(true);
+            testInvalidAccountParam(Json::Value(Json::nullValue));
+            testInvalidAccountParam(Json::Value(Json::objectValue));
+            testInvalidAccountParam(Json::Value(Json::arrayValue));
         }
 
         {
@@ -326,7 +352,7 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(AccountOffers, app, ripple);
+BEAST_DEFINE_TESTSUITE(AccountOffers, rpc, ripple);
 
 }  // namespace test
 }  // namespace ripple

--- a/src/test/rpc/AccountTx_test.cpp
+++ b/src/test/rpc/AccountTx_test.cpp
@@ -109,6 +109,7 @@ class AccountTx_test : public beast::unit_test::suite
     void
     testParameters(unsigned int apiVersion)
     {
+        testcase("Parameters APIv" + std::to_string(apiVersion));
         using namespace test::jtx;
 
         Env env(*this);
@@ -406,6 +407,8 @@ class AccountTx_test : public beast::unit_test::suite
     void
     testContents()
     {
+        testcase("Contents");
+
         // Get results for all transaction types that can be associated
         // with an account.  Start by generating all transaction types.
         using namespace test::jtx;
@@ -618,6 +621,8 @@ class AccountTx_test : public beast::unit_test::suite
     void
     testAccountDelete()
     {
+        testcase("AccountDelete");
+
         // Verify that if an account is resurrected then the account_tx RPC
         // command still recovers all transactions on that account before
         // and after resurrection.
@@ -758,7 +763,7 @@ public:
         testAccountDelete();
     }
 };
-BEAST_DEFINE_TESTSUITE(AccountTx, app, ripple);
+BEAST_DEFINE_TESTSUITE(AccountTx, rpc, ripple);
 
 }  // namespace test
 }  // namespace ripple

--- a/src/test/rpc/AccountTx_test.cpp
+++ b/src/test/rpc/AccountTx_test.cpp
@@ -353,6 +353,24 @@ class AccountTx_test : public beast::unit_test::suite
                     env.rpc("json", "account_tx", to_string(p)),
                     rpcLGR_IDX_MALFORMED));
         }
+        // test account non-string
+        {
+            auto testInvalidAccountParam = [&](auto const& param) {
+                Json::Value params;
+                params[jss::account] = param;
+                auto jrr = env.rpc(
+                    "json", "account_tx", to_string(params))[jss::result];
+                BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+            };
+
+            testInvalidAccountParam(1);
+            testInvalidAccountParam(1.1);
+            testInvalidAccountParam(true);
+            testInvalidAccountParam(Json::Value(Json::nullValue));
+            testInvalidAccountParam(Json::Value(Json::objectValue));
+            testInvalidAccountParam(Json::Value(Json::arrayValue));
+        }
         // test binary and forward for bool/non bool values
         {
             Json::Value p{jParms};

--- a/src/test/rpc/AccountTx_test.cpp
+++ b/src/test/rpc/AccountTx_test.cpp
@@ -362,7 +362,8 @@ class AccountTx_test : public beast::unit_test::suite
                 auto jrr = env.rpc(
                     "json", "account_tx", to_string(params))[jss::result];
                 BEAST_EXPECT(jrr[jss::error] == "invalidParams");
-                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+                BEAST_EXPECT(
+                    jrr[jss::error_message] == "Invalid field 'account'.");
             };
 
             testInvalidAccountParam(1);

--- a/src/test/rpc/NoRippleCheck_test.cpp
+++ b/src/test/rpc/NoRippleCheck_test.cpp
@@ -64,6 +64,26 @@ class NoRippleCheck_test : public beast::unit_test::suite
             BEAST_EXPECT(result[jss::error_message] == "Missing field 'role'.");
         }
 
+        // test account non-string
+        {
+            auto testInvalidAccountParam = [&](auto const& param) {
+                Json::Value params;
+                params[jss::account] = param;
+                params[jss::role] = "user";
+                auto jrr = env.rpc(
+                    "json", "noripple_check", to_string(params))[jss::result];
+                BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+            };
+
+            testInvalidAccountParam(1);
+            testInvalidAccountParam(1.1);
+            testInvalidAccountParam(true);
+            testInvalidAccountParam(Json::Value(Json::nullValue));
+            testInvalidAccountParam(Json::Value(Json::objectValue));
+            testInvalidAccountParam(Json::Value(Json::arrayValue));
+        }
+
         {  // invalid role field
             Json::Value params;
             params[jss::account] = alice.human();
@@ -369,12 +389,12 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(NoRippleCheck, app, ripple);
+BEAST_DEFINE_TESTSUITE(NoRippleCheck, rpc, ripple);
 
 // These tests that deal with limit amounts are slow because of the
 // offer/account setup, so making them manual -- the additional coverage
 // provided by them is minimal
 
-BEAST_DEFINE_TESTSUITE_MANUAL_PRIO(NoRippleCheckLimits, app, ripple, 1);
+BEAST_DEFINE_TESTSUITE_MANUAL_PRIO(NoRippleCheckLimits, rpc, ripple, 1);
 
 }  // namespace ripple

--- a/src/test/rpc/NoRippleCheck_test.cpp
+++ b/src/test/rpc/NoRippleCheck_test.cpp
@@ -73,7 +73,8 @@ class NoRippleCheck_test : public beast::unit_test::suite
                 auto jrr = env.rpc(
                     "json", "noripple_check", to_string(params))[jss::result];
                 BEAST_EXPECT(jrr[jss::error] == "invalidParams");
-                BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
+                BEAST_EXPECT(
+                    jrr[jss::error_message] == "Invalid field 'account'.");
             };
 
             testInvalidAccountParam(1);


### PR DESCRIPTION
## High Level Overview of Change

This PR adds a check for whether the `account` and `ident` params in several account-based RPCs are strings. If not, it returns `invalidParams`. Some error messages are also improved to be more specific.

Note: This PR looks a lot larger than it is; it is really just the same change(s) applied over and over again across several RPCs.

### Context of Change

rippled currently returns `Internal error` in this scenario. 

The error in the logs is `Caught throw: Type is not convertible to string`

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [x] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

This is a bugfix, not a breaking change, but there isn't an option for that.

## Test Plan
Added unit tests that fail before this patch and now pass.

## Future Tasks
Audit other RPCs for this sort of issue.
