### PR TITLE
Fix crash inside `OverlayImpl` loops over `ids_`

### DIFF
--- a/src/test/overlay/tx_reduce_relay_test.cpp
+++ b/src/test/overlay/tx_reduce_relay_test.cpp
@@ -189,7 +189,10 @@ private:
             consumer,
             std::move(stream_ptr),
             overlay);
+        BEAST_EXPECT(
+            overlay.findPeerByPublicKey(key) == std::shared_ptr<PeerImp>{});
         overlay.add_active(peer);
+        BEAST_EXPECT(overlay.findPeerByPublicKey(key) == peer);
         peers.emplace_back(peer);  // overlay stores week ptr to PeerImp
         lid_ += 2;
         rid_ += 2;

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -1207,14 +1207,14 @@ std::shared_ptr<Peer>
 OverlayImpl::findPeerByPublicKey(PublicKey const& pubKey)
 {
     std::lock_guard lock(mutex_);
-    // NOTE The purpose of p is to delay the destruction of PeerImp
-    std::shared_ptr<PeerImp> p;
-    for (auto [_, w] : ids_)
+    // NOTE The purpose of peer is to delay the destruction of PeerImp
+    std::shared_ptr<PeerImp> peer;
+    for (auto const& e : ids_)
     {
-        if (p = w.lock(); p != nullptr)
+        if (peer = e.second.lock(); peer != nullptr)
         {
-            if (p->getNodePublic() == pubKey)
-                return p;
+            if (peer->getNodePublic() == pubKey)
+                return peer;
         }
     }
     return {};

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -1157,13 +1157,13 @@ OverlayImpl::getActivePeers(
     std::size_t& enabledInSkip) const
 {
     Overlay::PeerSequence ret;
-    std::lock_guard lock(mutex_);
+    std::unique_lock lock(mutex_);
 
     active = ids_.size();
     disabled = enabledInSkip = 0;
     ret.reserve(ids_.size());
 
-    for (auto& [id, w] : ids_)
+    for (auto& [id, w] : copyIds(lock))
     {
         if (auto p = w.lock())
         {
@@ -1204,8 +1204,8 @@ OverlayImpl::findPeerByShortID(Peer::id_t const& id) const
 std::shared_ptr<Peer>
 OverlayImpl::findPeerByPublicKey(PublicKey const& pubKey)
 {
-    std::lock_guard lock(mutex_);
-    for (auto const& e : ids_)
+    std::unique_lock lock(mutex_);
+    for (auto const& e : copyIds(lock))
     {
         if (auto peer = e.second.lock())
         {

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -1163,12 +1163,11 @@ OverlayImpl::getActivePeers(
     disabled = enabledInSkip = 0;
     ret.reserve(ids_.size());
 
-    for (auto i = ids_.begin(); i != ids_.end();)
+    // NOTE The purpose of p is to delay the destruction of PeerImp
+    std::shared_ptr<PeerImp> p;
+    for (auto& [id, w] : ids_)
     {
-        auto w = i->second;
-        auto id = i->first;
-        ++i;  // NOTE: Must increment i before `w.lock()`
-        if (auto p = w.lock())
+        if (p = w.lock(); p != nullptr)
         {
             bool const reduceRelayEnabled = p->txReduceRelayEnabled();
             // tx reduced relay feature disabled
@@ -1208,14 +1207,14 @@ std::shared_ptr<Peer>
 OverlayImpl::findPeerByPublicKey(PublicKey const& pubKey)
 {
     std::lock_guard lock(mutex_);
-    for (auto i = ids_.begin(); i != ids_.end();)
+    // NOTE The purpose of p is to delay the destruction of PeerImp
+    std::shared_ptr<PeerImp> p;
+    for (auto [_, w] : ids_)
     {
-        auto w = i->second;
-        ++i;  // NOTE: Must increment i before `w.lock()`
-        if (auto peer = w.lock())
+        if (p = w.lock(); p != nullptr)
         {
-            if (peer->getNodePublic() == pubKey)
-                return peer;
+            if (p->getNodePublic() == pubKey)
+                return p;
         }
     }
     return {};

--- a/src/xrpld/overlay/detail/OverlayImpl.h
+++ b/src/xrpld/overlay/detail/OverlayImpl.h
@@ -627,6 +627,23 @@ private:
         }
         m_stats.peerDisconnects = getPeerDisconnect();
     }
+
+    // Use this function to replace ids_ in a buggy loop similar to this:
+    //
+    // std::unique_lock lock(mutex_);
+    // for (auto p : ids_)
+    // {
+    //     if (auto p = w.lock())
+    //     {
+    //         // . . .
+    //     } // PeerImp owned by p may be destroyed, invalidating the iterator
+    // }
+    auto
+    copyIds(std::unique_lock<std::recursive_mutex>&) const
+    {
+        return std::vector<decltype(ids_)::value_type>(
+            ids_.begin(), ids_.end());
+    }
 };
 
 }  // namespace ripple

--- a/src/xrpld/overlay/detail/OverlayImpl.h
+++ b/src/xrpld/overlay/detail/OverlayImpl.h
@@ -627,23 +627,6 @@ private:
         }
         m_stats.peerDisconnects = getPeerDisconnect();
     }
-
-    // Use this function to replace ids_ in a buggy loop similar to this:
-    //
-    // std::unique_lock lock(mutex_);
-    // for (auto p : ids_)
-    // {
-    //     if (auto p = w.lock())
-    //     {
-    //         // . . .
-    //     } // PeerImp owned by p may be destroyed, invalidating the iterator
-    // }
-    auto
-    copyIds(std::unique_lock<std::recursive_mutex>&) const
-    {
-        return std::vector<decltype(ids_)::value_type>(
-            ids_.begin(), ids_.end());
-    }
 };
 
 }  // namespace ripple


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Functions `OverlayImpl::getActivePeers` and `OverlayImpl::findPeerByPublicKey` may cause a crash when iterating over `ids_` 

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

Functions `OverlayImpl::getActivePeers` and `OverlayImpl::findPeerByPublicKey` use the following _buggy_ pattern to iterate over `ids_` :

```c++
for (auto& [id, w] : ids_)
{
    if (auto p = w.lock())
    {
        // ...
    } // p destroyed here
}
```

The problem is that, given specific thread scheduling, when `p` is destroyed at a marked location, it might also cause the destruction of the `PeerImp` that it owned since the start of `if (auto p = w.lock())` block. This destruction in turn will call `OverlayImpl::onPeerDeactivate` which will remove the current element from `ids_` collection, hence invalidating the iterator to the removed element. This is all happening while `p` is being destroyed, that is before the `for` at the start of the loop tries to increment the iterator (that just got invalidated) to reach to the next element. Incrementing the invalidated operator is an invalid operation, in practice it will yield bad data, causing a crash.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
