### PR TITLE
[TRIVIAL] Ensure all sorting is ASCII-order consistently across platforms

### DIFF
--- a/Builds/levelization/levelization.sh
+++ b/Builds/levelization/levelization.sh
@@ -13,6 +13,9 @@ then
   git clean -ix
 fi
 
+# Ensure all sorting is ASCII-order consistently across platforms.
+export LANG=C
+
 rm -rfv results
 mkdir results
 includes="$( pwd )/results/rawincludes.txt"


### PR DESCRIPTION
## High Level Overview of Change

This change explicitly specifies `LANG=C` in the levelization script, which causes it to use plain ASCII ordering, and should cause the levelization results to be consistent across environments.

### Context of Change

This is a follow up to the physical redesign PR #4997. The merge / migration instructions in that PR note:

> Check the sort order in Builds/levelization/results/ordering.txt. [...] Different versions of `sort` have been inconsistent on this matter in my experience. [...] 

The cause of this inconsistency is not the version of `sort`, but the language settings of the shell, which varies depending on local configuration.

### Type of Change

- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)

## Before / After

Before:
On some machines, running `./Builds/levelization/levelization.sh` will change the order of the results in `ordering.txt`.

After:
Running that script anywhere will give consistent results. Run against an unmodified `develop` branch, it should result in no changes.
