### PR TITLE
XLS-70d Credentials

### DIFF
--- a/include/xrpl/protocol/ErrorCodes.h
+++ b/include/xrpl/protocol/ErrorCodes.h
@@ -148,7 +148,10 @@ enum error_code_i {
     // Oracle
     rpcORACLE_MALFORMED = 94,
 
-    rpcLAST = rpcORACLE_MALFORMED  // rpcLAST should always equal the last code.
+    // deposit_authorized + credentials
+    rpcBAD_CREDENTIALS = 95,
+
+    rpcLAST = rpcBAD_CREDENTIALS  // rpcLAST should always equal the last code.
 };
 
 /** Codes returned in the `warnings` array of certain RPC commands.

--- a/include/xrpl/protocol/Feature.h
+++ b/include/xrpl/protocol/Feature.h
@@ -80,7 +80,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 82;
+static constexpr std::size_t numFeatures = 83;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated

--- a/include/xrpl/protocol/HashPrefix.h
+++ b/include/xrpl/protocol/HashPrefix.h
@@ -84,6 +84,9 @@ enum class HashPrefix : std::uint32_t {
 
     /** Payment Channel Claim */
     paymentChannelClaim = detail::make_hash_prefix('C', 'L', 'M'),
+
+    /** Credentials signature */
+    credential = detail::make_hash_prefix('C', 'R', 'D'),
 };
 
 template <class Hasher>

--- a/include/xrpl/protocol/Indexes.h
+++ b/include/xrpl/protocol/Indexes.h
@@ -30,6 +30,7 @@
 #include <xrpl/protocol/Serializer.h>
 #include <xrpl/protocol/UintTypes.h>
 #include <xrpl/protocol/jss.h>
+
 #include <cstdint>
 
 namespace ripple {
@@ -189,6 +190,9 @@ check(uint256 const& key) noexcept
 Keylet
 depositPreauth(AccountID const& owner, AccountID const& preauthorized) noexcept;
 
+Keylet
+depositPreauth(AccountID const& owner, STArray const& authCreds) noexcept;
+
 inline Keylet
 depositPreauth(uint256 const& key) noexcept
 {
@@ -286,6 +290,18 @@ did(AccountID const& account) noexcept;
 
 Keylet
 oracle(AccountID const& account, std::uint32_t const& documentID) noexcept;
+
+Keylet
+credential(
+    AccountID const& subject,
+    AccountID const& issuer,
+    Slice const& credType) noexcept;
+
+inline Keylet
+credential(uint256 const& key) noexcept
+{
+    return {ltCREDENTIAL, key};
+}
 
 Keylet
 mptIssuance(std::uint32_t seq, AccountID const& issuer) noexcept;

--- a/include/xrpl/protocol/Indexes.h
+++ b/include/xrpl/protocol/Indexes.h
@@ -191,7 +191,9 @@ Keylet
 depositPreauth(AccountID const& owner, AccountID const& preauthorized) noexcept;
 
 Keylet
-depositPreauth(AccountID const& owner, STArray const& authCreds) noexcept;
+depositPreauth(
+    AccountID const& owner,
+    std::set<std::pair<AccountID, Slice>> const& authCreds) noexcept;
 
 inline Keylet
 depositPreauth(uint256 const& key) noexcept

--- a/include/xrpl/protocol/LedgerFormats.h
+++ b/include/xrpl/protocol/LedgerFormats.h
@@ -186,6 +186,9 @@ enum LedgerSpecificFlags {
 
     // ltMPTOKEN
     lsfMPTAuthorized = 0x00000002,
+
+    // ltCREDENTIAL
+    lsfAccepted = 0x00010000,
 };
 
 //------------------------------------------------------------------------------

--- a/include/xrpl/protocol/Protocol.h
+++ b/include/xrpl/protocol/Protocol.h
@@ -48,6 +48,9 @@ std::size_t constexpr unfundedOfferRemoveLimit = 1000;
 /** The maximum number of expired offers to delete at once */
 std::size_t constexpr expiredOfferRemoveLimit = 256;
 
+/** The maximum number of credentials can be passed in array */
+std::size_t constexpr credentialsArrayMaxSize = 8;
+
 /** The maximum number of metadata entries allowed in one transaction */
 std::size_t constexpr oversizeMetaDataCap = 5200;
 
@@ -94,6 +97,12 @@ std::size_t constexpr maxDIDAttestationLength = 256;
 
 /** The maximum length of a domain */
 std::size_t constexpr maxDomainLength = 256;
+
+/** The maximum length of a URI inside a Credential */
+std::size_t constexpr maxCredentialURILength = 256;
+
+/** The maximum length of a CredentialType inside a Credential */
+std::size_t constexpr maxCredentialTypeLength = 64;
 
 /** The maximum length of MPTokenMetadata */
 std::size_t constexpr maxMPTokenMetadataLength = 1024;

--- a/include/xrpl/protocol/Protocol.h
+++ b/include/xrpl/protocol/Protocol.h
@@ -48,9 +48,6 @@ std::size_t constexpr unfundedOfferRemoveLimit = 1000;
 /** The maximum number of expired offers to delete at once */
 std::size_t constexpr expiredOfferRemoveLimit = 256;
 
-/** The maximum number of credentials can be passed in array */
-std::size_t constexpr credentialsArrayMaxSize = 8;
-
 /** The maximum number of metadata entries allowed in one transaction */
 std::size_t constexpr oversizeMetaDataCap = 5200;
 
@@ -103,6 +100,9 @@ std::size_t constexpr maxCredentialURILength = 256;
 
 /** The maximum length of a CredentialType inside a Credential */
 std::size_t constexpr maxCredentialTypeLength = 64;
+
+/** The maximum number of credentials can be passed in array */
+std::size_t constexpr maxCredentialsArraySize = 8;
 
 /** The maximum length of MPTokenMetadata */
 std::size_t constexpr maxMPTokenMetadataLength = 1024;

--- a/include/xrpl/protocol/TER.h
+++ b/include/xrpl/protocol/TER.h
@@ -343,6 +343,7 @@ enum TECcodes : TERUnderlyingType {
     tecARRAY_EMPTY = 190,
     tecARRAY_TOO_LARGE = 191,
     tecLOCKED = 192,
+    tecBAD_CREDENTIALS = 193,
 };
 
 //------------------------------------------------------------------------------

--- a/include/xrpl/protocol/UintTypes.h
+++ b/include/xrpl/protocol/UintTypes.h
@@ -134,6 +134,12 @@ struct hash<ripple::Directory> : ripple::Directory::hasher
     explicit hash() = default;
 };
 
+template <>
+struct hash<ripple::uint256> : ripple::uint256::hasher
+{
+    explicit hash() = default;
+};
+
 }  // namespace std
 
 #endif

--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -29,6 +29,8 @@
 // If you add an amendment here, then do not forget to increment `numFeatures`
 // in include/xrpl/protocol/Feature.h.
 
+XRPL_FEATURE(Credentials,                Supported::yes, VoteBehavior::DefaultNo)
+XRPL_FEATURE(AMMClawback,                Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (AMMv1_2,                    Supported::yes, VoteBehavior::DefaultNo)
 // InvariantsV1_1 will be changes to Supported::yes when all the
 // invariants expected to be included under it are complete.
@@ -96,8 +98,7 @@ XRPL_FIX    (1513,                       Supported::yes, VoteBehavior::DefaultYe
 XRPL_FEATURE(FlowCross,                  Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FEATURE(Flow,                       Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FEATURE(OwnerPaysFee,               Supported::no,  VoteBehavior::DefaultNo)
-XRPL_FEATURE(AMMClawback,                Supported::yes,  VoteBehavior::DefaultYes)
-XRPL_FEATURE(Credentials,                Supported::yes, VoteBehavior::DefaultNo)
+
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.

--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -97,6 +97,7 @@ XRPL_FEATURE(FlowCross,                  Supported::yes, VoteBehavior::DefaultYe
 XRPL_FEATURE(Flow,                       Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FEATURE(OwnerPaysFee,               Supported::no,  VoteBehavior::DefaultNo)
 XRPL_FEATURE(AMMClawback,                Supported::yes,  VoteBehavior::DefaultYes)
+XRPL_FEATURE(Credentials,                Supported::yes, VoteBehavior::DefaultNo)
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.

--- a/include/xrpl/protocol/detail/ledger_entries.macro
+++ b/include/xrpl/protocol/detail/ledger_entries.macro
@@ -245,10 +245,11 @@ LEDGER_ENTRY(ltOFFER, 0x006f, Offer, ({
  */
 LEDGER_ENTRY(ltDEPOSIT_PREAUTH, 0x0070, DepositPreauth, ({
     {sfAccount,              soeREQUIRED},
-    {sfAuthorize,            soeREQUIRED},
+    {sfAuthorize,            soeOPTIONAL},
     {sfOwnerNode,            soeREQUIRED},
     {sfPreviousTxnID,        soeREQUIRED},
     {sfPreviousTxnLgrSeq,    soeREQUIRED},
+    {sfAuthorizeCredentials, soeOPTIONAL},
 }))
 
 /** A claim id for a cross chain transaction.
@@ -419,4 +420,19 @@ LEDGER_ENTRY(ltMPTOKEN, 0x007f, MPToken, ({
     {sfOwnerNode,                soeREQUIRED},
     {sfPreviousTxnID,            soeREQUIRED},
     {sfPreviousTxnLgrSeq,        soeREQUIRED},
+}))
+
+/** A ledger object which tracks Credential
+    \sa keylet::credential
+ */
+LEDGER_ENTRY(ltCREDENTIAL, 0x0081, Credential, ({
+    {sfSubject,              soeREQUIRED},
+    {sfIssuer,               soeREQUIRED},
+    {sfCredentialType,       soeREQUIRED},
+    {sfExpiration,           soeOPTIONAL},
+    {sfURI,                  soeOPTIONAL},
+    {sfIssuerNode,           soeREQUIRED},
+    {sfSubjectNode,          soeREQUIRED},
+    {sfPreviousTxnID,        soeREQUIRED},
+    {sfPreviousTxnLgrSeq,    soeREQUIRED},
 }))

--- a/include/xrpl/protocol/detail/sfields.macro
+++ b/include/xrpl/protocol/detail/sfields.macro
@@ -140,6 +140,8 @@ TYPED_SFIELD(sfAssetPrice,               UINT64,    23)
 TYPED_SFIELD(sfMaximumAmount,            UINT64,    24, SField::sMD_BaseTen|SField::sMD_Default)
 TYPED_SFIELD(sfOutstandingAmount,        UINT64,    25, SField::sMD_BaseTen|SField::sMD_Default)
 TYPED_SFIELD(sfMPTAmount,                UINT64,    26, SField::sMD_BaseTen|SField::sMD_Default)
+TYPED_SFIELD(sfIssuerNode,               UINT64,    27)
+TYPED_SFIELD(sfSubjectNode,              UINT64,    28)
 
 // 128-bit
 TYPED_SFIELD(sfEmailHash,                UINT128,    1)
@@ -258,6 +260,7 @@ TYPED_SFIELD(sfData,                     VL,        27)
 TYPED_SFIELD(sfAssetClass,               VL,        28)
 TYPED_SFIELD(sfProvider,                 VL,        29)
 TYPED_SFIELD(sfMPTokenMetadata,          VL,        30)
+TYPED_SFIELD(sfCredentialType,           VL,        31)
 
 // account (common)
 TYPED_SFIELD(sfAccount,                  ACCOUNT,    1)
@@ -280,12 +283,14 @@ TYPED_SFIELD(sfAttestationSignerAccount, ACCOUNT,   20)
 TYPED_SFIELD(sfAttestationRewardAccount, ACCOUNT,   21)
 TYPED_SFIELD(sfLockingChainDoor,         ACCOUNT,   22)
 TYPED_SFIELD(sfIssuingChainDoor,         ACCOUNT,   23)
+TYPED_SFIELD(sfSubject,                  ACCOUNT,   24)
 
 // vector of 256-bit
 TYPED_SFIELD(sfIndexes,                  VECTOR256,  1, SField::sMD_Never)
 TYPED_SFIELD(sfHashes,                   VECTOR256,  2)
 TYPED_SFIELD(sfAmendments,               VECTOR256,  3)
 TYPED_SFIELD(sfNFTokenOffers,            VECTOR256,  4)
+TYPED_SFIELD(sfCredentialIDs,            VECTOR256,  5)
 
 // path set
 UNTYPED_SFIELD(sfPaths,                  PATHSET,    1)
@@ -337,6 +342,7 @@ UNTYPED_SFIELD(sfXChainCreateAccountProofSig, OBJECT, 29)
 UNTYPED_SFIELD(sfXChainClaimAttestationCollectionElement, OBJECT, 30)
 UNTYPED_SFIELD(sfXChainCreateAccountAttestationCollectionElement, OBJECT, 31)
 UNTYPED_SFIELD(sfPriceData,              OBJECT,    32)
+UNTYPED_SFIELD(sfCredential,             OBJECT,    33)
 
 // array of objects (common)
 // ARRAY/1 is reserved for end of array
@@ -364,3 +370,5 @@ UNTYPED_SFIELD(sfXChainCreateAccountAttestations, ARRAY, 22)
 //                                                  23 unused
 UNTYPED_SFIELD(sfPriceDataSeries,        ARRAY,     24)
 UNTYPED_SFIELD(sfAuthAccounts,           ARRAY,     25)
+UNTYPED_SFIELD(sfAuthorizeCredentials,   ARRAY,     26)
+UNTYPED_SFIELD(sfUnauthorizeCredentials, ARRAY,     27)

--- a/include/xrpl/protocol/detail/transactions.macro
+++ b/include/xrpl/protocol/detail/transactions.macro
@@ -37,6 +37,7 @@ TRANSACTION(ttPAYMENT, 0, Payment, ({
     {sfInvoiceID, soeOPTIONAL},
     {sfDestinationTag, soeOPTIONAL},
     {sfDeliverMin, soeOPTIONAL, soeMPTSupported},
+    {sfCredentialIDs, soeOPTIONAL},
 }))
 
 /** This transaction type creates an escrow object. */
@@ -55,6 +56,7 @@ TRANSACTION(ttESCROW_FINISH, 2, EscrowFinish, ({
     {sfOfferSequence, soeREQUIRED},
     {sfFulfillment, soeOPTIONAL},
     {sfCondition, soeOPTIONAL},
+    {sfCredentialIDs, soeOPTIONAL},
 }))
 
 
@@ -139,6 +141,7 @@ TRANSACTION(ttPAYCHAN_CLAIM, 15, PaymentChannelClaim, ({
     {sfBalance, soeOPTIONAL},
     {sfSignature, soeOPTIONAL},
     {sfPublicKey, soeOPTIONAL},
+    {sfCredentialIDs, soeOPTIONAL},
 }))
 
 /** This transaction type creates a new check. */
@@ -166,6 +169,8 @@ TRANSACTION(ttCHECK_CANCEL, 18, CheckCancel, ({
 TRANSACTION(ttDEPOSIT_PREAUTH, 19, DepositPreauth, ({
     {sfAuthorize, soeOPTIONAL},
     {sfUnauthorize, soeOPTIONAL},
+    {sfAuthorizeCredentials, soeOPTIONAL},
+    {sfUnauthorizeCredentials, soeOPTIONAL},
 }))
 
 /** This transaction type modifies a trustline between two accounts. */
@@ -179,6 +184,7 @@ TRANSACTION(ttTRUST_SET, 20, TrustSet, ({
 TRANSACTION(ttACCOUNT_DELETE, 21, AccountDelete, ({
     {sfDestination, soeREQUIRED},
     {sfDestinationTag, soeOPTIONAL},
+    {sfCredentialIDs, soeOPTIONAL},
 }))
 
 // 22 reserved
@@ -420,6 +426,28 @@ TRANSACTION(ttMPTOKEN_AUTHORIZE, 57, MPTokenAuthorize, ({
     {sfHolder, soeOPTIONAL},
 }))
 
+/** This transaction type create an Credential instance */
+TRANSACTION(ttCREDENTIAL_CREATE, 58, CredentialCreate, ({
+    {sfSubject, soeREQUIRED},
+    {sfCredentialType, soeREQUIRED},
+    {sfExpiration, soeOPTIONAL},
+    {sfURI, soeOPTIONAL},
+}))
+
+/** This transaction type accept an Credential object */
+TRANSACTION(ttCREDENTIAL_ACCEPT, 59, CredentialAccept, ({
+    {sfIssuer, soeREQUIRED},
+    {sfCredentialType, soeREQUIRED},
+}))
+
+/** This transaction type delete an Credential object */
+TRANSACTION(ttCREDENTIAL_DELETE, 60, CredentialDelete, ({
+    {sfSubject, soeOPTIONAL},
+    {sfIssuer, soeOPTIONAL},
+    {sfCredentialType, soeREQUIRED},
+}))
+
+
 /** This system-generated transaction type is used to update the status of the various amendments.
 
     For details, see: https://xrpl.org/amendments.html
@@ -455,3 +483,4 @@ TRANSACTION(ttUNL_MODIFY, 102, UNLModify, ({
     {sfLedgerSequence, soeREQUIRED},
     {sfUNLModifyValidator, soeREQUIRED},
 }))
+

--- a/include/xrpl/protocol/jss.h
+++ b/include/xrpl/protocol/jss.h
@@ -63,6 +63,7 @@ JSS(BidMin);               // in: AMM Bid
 JSS(Bridge);               // ledger type.
 JSS(Check);                // ledger type.
 JSS(ClearFlag);            // field.
+JSS(Credential);           // ledger type.
 JSS(DID);                  // ledger type.
 JSS(DeliverMax);           // out: alias to Amount
 JSS(DeliverMin);           // in: TransactionSign
@@ -75,6 +76,7 @@ JSS(FeeSettings);          // ledger type.
 JSS(Flags);                // in/out: TransactionSign; field.
 JSS(Holder);               // field.
 JSS(Invalid);              //
+JSS(Issuer);               // in: Credential transactions
 JSS(LastLedgerSequence);   // in: TransactionSign; field
 JSS(LastUpdateTime);       // field.
 JSS(LedgerHashes);         // ledger type.
@@ -107,6 +109,7 @@ JSS(Sequence);                           // in/out: TransactionSign; field.
 JSS(SetFlag);                            // field.
 JSS(SignerList);                         // ledger type.
 JSS(SigningPubKey);                      // field.
+JSS(Subject);                            // in: Credential transactions
 JSS(TakerGets);                          // field.
 JSS(TakerPays);                          // field.
 JSS(Ticket);                             // ledger type.
@@ -165,6 +168,7 @@ JSS(attestations);
 JSS(attestation_reward_account);
 JSS(auction_slot);            // out: amm_info
 JSS(authorized);              // out: AccountLines
+JSS(authorize_credentials);   // in: ledger_entry DepositPreauth
 JSS(auth_accounts);           // out: amm_info
 JSS(auth_change);             // out: AccountInfo
 JSS(auth_change_queued);      // out: AccountInfo
@@ -228,6 +232,9 @@ JSS(converge_time_s);         // out: NetworkOPs
 JSS(cookie);                  // out: NetworkOPs
 JSS(count);                   // in: AccountTx*, ValidatorList
 JSS(counters);                // in/out: retrieve counters
+JSS(credential);              // in: LedgerEntry Credential
+JSS(credentials);             // in: deposit_authorized
+JSS(credential_type);         // in: LedgerEntry DepositPreauth
 JSS(ctid);                    // in/out: Tx RPC
 JSS(currency_a);              // out: BookChanges
 JSS(currency_b);              // out: BookChanges
@@ -614,6 +621,7 @@ JSS(streams);                 // in: Subscribe, Unsubscribe
 JSS(strict);                  // in: AccountCurrencies, AccountInfo
 JSS(sub_index);               // in: LedgerEntry
 JSS(subcommand);              // in: PathFind
+JSS(subject);                 // in: LedgerEntry Credential
 JSS(success);                 // rpc
 JSS(supported);               // out: AmendmentTableImpl
 JSS(sync_mode);               // in: Submit

--- a/include/xrpl/protocol/jss.h
+++ b/include/xrpl/protocol/jss.h
@@ -168,7 +168,7 @@ JSS(attestations);
 JSS(attestation_reward_account);
 JSS(auction_slot);            // out: amm_info
 JSS(authorized);              // out: AccountLines
-JSS(authorize_credentials);   // in: ledger_entry DepositPreauth
+JSS(authorized_credentials);   // in: ledger_entry DepositPreauth
 JSS(auth_accounts);           // out: amm_info
 JSS(auth_change);             // out: AccountInfo
 JSS(auth_change_queued);      // out: AccountInfo

--- a/src/libxrpl/protocol/ErrorCodes.cpp
+++ b/src/libxrpl/protocol/ErrorCodes.cpp
@@ -108,7 +108,8 @@ constexpr static ErrorInfo unorderedErrorInfos[]{
     {rpcTOO_BUSY,               "tooBusy",              "The server is too busy to help you now.", 503},
     {rpcTXN_NOT_FOUND,          "txnNotFound",          "Transaction not found.", 404},
     {rpcUNKNOWN_COMMAND,        "unknownCmd",           "Unknown method.", 405},
-    {rpcORACLE_MALFORMED,       "oracleMalformed",      "Oracle request is malformed.", 400}};
+    {rpcORACLE_MALFORMED,       "oracleMalformed",      "Oracle request is malformed.", 400},
+    {rpcBAD_CREDENTIALS,        "badCredentials",       "Credentials do not exist, are not accepted, or have expired.", 400}};
 // clang-format on
 
 // Sort and validate unorderedErrorInfos at compile time.  Should be

--- a/src/libxrpl/protocol/Indexes.cpp
+++ b/src/libxrpl/protocol/Indexes.cpp
@@ -315,6 +315,7 @@ depositPreauth(AccountID const& owner, AccountID const& preauthorized) noexcept
         indexHash(LedgerNameSpace::DEPOSIT_PREAUTH, owner, preauthorized)};
 }
 
+// Credentials should be sorted here, use credentials::makeSorted
 Keylet
 depositPreauth(
     AccountID const& owner,

--- a/src/libxrpl/protocol/Indexes.cpp
+++ b/src/libxrpl/protocol/Indexes.cpp
@@ -20,6 +20,7 @@
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/SField.h>
+#include <xrpl/protocol/STArray.h>
 #include <xrpl/protocol/STXChainBridge.h>
 #include <xrpl/protocol/SeqProxy.h>
 #include <xrpl/protocol/digest.h>
@@ -63,6 +64,7 @@ enum class LedgerNameSpace : std::uint16_t {
     XRP_PAYMENT_CHANNEL = 'x',
     CHECK = 'C',
     DEPOSIT_PREAUTH = 'p',
+    DEPOSIT_PREAUTH_CREDENTIALS = 'P',
     NEGATIVE_UNL = 'N',
     NFTOKEN_OFFER = 'q',
     NFTOKEN_BUY_OFFERS = 'h',
@@ -75,6 +77,7 @@ enum class LedgerNameSpace : std::uint16_t {
     ORACLE = 'R',
     MPTOKEN_ISSUANCE = '~',
     MPTOKEN = 't',
+    CREDENTIAL = 'D',
 
     // No longer used or supported. Left here to reserve the space
     // to avoid accidental reuse.
@@ -313,6 +316,26 @@ depositPreauth(AccountID const& owner, AccountID const& preauthorized) noexcept
         indexHash(LedgerNameSpace::DEPOSIT_PREAUTH, owner, preauthorized)};
 }
 
+Keylet
+depositPreauth(AccountID const& owner, STArray const& authCreds) noexcept
+{
+    std::vector<uint256> hashes;
+    hashes.reserve(authCreds.size());
+    for (auto const& o : authCreds)
+    {
+        hashes.push_back(sha512Half(
+            o.getAccountID(sfIssuer), o.getFieldVL(sfCredentialType)));
+    }
+
+    // eleminate duplicates
+    std::sort(hashes.begin(), hashes.end());
+    hashes.erase(std::unique(hashes.begin(), hashes.end()), hashes.end());
+
+    return {
+        ltDEPOSIT_PREAUTH,
+        indexHash(LedgerNameSpace::DEPOSIT_PREAUTH_CREDENTIALS, owner, hashes)};
+}
+
 //------------------------------------------------------------------------------
 
 Keylet
@@ -489,6 +512,18 @@ mptoken(uint256 const& issuanceKey, AccountID const& holder) noexcept
     return {
         ltMPTOKEN, indexHash(LedgerNameSpace::MPTOKEN, issuanceKey, holder)};
 }
+
+Keylet
+credential(
+    AccountID const& subject,
+    AccountID const& issuer,
+    Slice const& credType) noexcept
+{
+    return {
+        ltCREDENTIAL,
+        indexHash(LedgerNameSpace::CREDENTIAL, subject, issuer, credType)};
+}
+
 }  // namespace keylet
 
 }  // namespace ripple

--- a/src/libxrpl/protocol/Indexes.cpp
+++ b/src/libxrpl/protocol/Indexes.cpp
@@ -20,7 +20,6 @@
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/SField.h>
-#include <xrpl/protocol/STArray.h>
 #include <xrpl/protocol/STXChainBridge.h>
 #include <xrpl/protocol/SeqProxy.h>
 #include <xrpl/protocol/digest.h>
@@ -317,19 +316,14 @@ depositPreauth(AccountID const& owner, AccountID const& preauthorized) noexcept
 }
 
 Keylet
-depositPreauth(AccountID const& owner, STArray const& authCreds) noexcept
+depositPreauth(
+    AccountID const& owner,
+    std::set<std::pair<AccountID, Slice>> const& authCreds) noexcept
 {
     std::vector<uint256> hashes;
     hashes.reserve(authCreds.size());
     for (auto const& o : authCreds)
-    {
-        hashes.push_back(sha512Half(
-            o.getAccountID(sfIssuer), o.getFieldVL(sfCredentialType)));
-    }
-
-    // eleminate duplicates
-    std::sort(hashes.begin(), hashes.end());
-    hashes.erase(std::unique(hashes.begin(), hashes.end()), hashes.end());
+        hashes.emplace_back(sha512Half(o.first, o.second));
 
     return {
         ltDEPOSIT_PREAUTH,

--- a/src/libxrpl/protocol/InnerObjectFormats.cpp
+++ b/src/libxrpl/protocol/InnerObjectFormats.cpp
@@ -147,6 +147,13 @@ InnerObjectFormats::InnerObjectFormats()
             {sfAssetPrice, soeOPTIONAL},
             {sfScale, soeDEFAULT},
         });
+
+    add(sfCredential.jsonName.c_str(),
+        sfCredential.getCode(),
+        {
+            {sfIssuer, soeREQUIRED},
+            {sfCredentialType, soeREQUIRED},
+        });
 }
 
 InnerObjectFormats const&

--- a/src/libxrpl/protocol/TER.cpp
+++ b/src/libxrpl/protocol/TER.cpp
@@ -116,6 +116,7 @@ transResults()
         MAKE_ERROR(tecARRAY_EMPTY,                   "Array is empty."),
         MAKE_ERROR(tecARRAY_TOO_LARGE,               "Array is too large."),
         MAKE_ERROR(tecLOCKED,                        "Fund is locked."),
+        MAKE_ERROR(tecBAD_CREDENTIALS,               "Bad credentials."),
 
         MAKE_ERROR(tefALREADY,                     "The exact transaction was already in this ledger."),
         MAKE_ERROR(tefBAD_ADD_AUTH,                "Not authorized to add account."),

--- a/src/test/app/AccountDelete_test.cpp
+++ b/src/test/app/AccountDelete_test.cpp
@@ -1164,25 +1164,18 @@ public:
 
             auto const acctDelFee{drops(env.current()->fees().increment)};
 
-            // becky can't delete account as DepositPreauth object doesn't
-            // exists
-            env(acctdelete(becky, alice),
-                credentials::ids(
-                    {"098B7F1B146470A1C5084DC7832C04A72939E3EBC58E68AB8B579BA07"
-                     "2B0CECB"}),
-                fee(acctDelFee),
-                ter(tecNO_PERMISSION));
-            env.close();
+            std::string const credIdx =
+                "098B7F1B146470A1C5084DC7832C04A72939E3EBC58E68AB8B579BA072B0CE"
+                "CB";
 
-            // but can delete with old DepositPreauth
+            // and can't delete even with old DepositPreauth
             env(deposit::auth(alice, becky));
             env.close();
 
             env(acctdelete(becky, alice),
-                credentials::ids(
-                    {"098B7F1B146470A1C5084DC7832C04A72939E3EBC58E68AB8B579BA07"
-                     "2B0CECB"}),
-                fee(acctDelFee));
+                credentials::ids({credIdx}),
+                fee(acctDelFee),
+                ter(temDISABLED));
             env.close();
         }
     }

--- a/src/test/app/AccountDelete_test.cpp
+++ b/src/test/app/AccountDelete_test.cpp
@@ -1060,7 +1060,11 @@ public:
                 env.close();
 
                 auto jv = credentials::create(john, carol, credType);
-                uint32_t const t = env.now().time_since_epoch().count() + 20;
+                uint32_t const t = env.current()
+                                       ->info()
+                                       .parentCloseTime.time_since_epoch()
+                                       .count() +
+                    20;
                 jv[sfExpiration.jsonName] = t;
                 env(jv);
                 env.close();

--- a/src/test/app/AccountDelete_test.cpp
+++ b/src/test/app/AccountDelete_test.cpp
@@ -1070,7 +1070,7 @@ public:
                         env, eaton, carol, credType)[jss::result][jss::index]
                         .asString();
 
-                // fred make preauthorization through autorized account
+                // fred make preauthorization through authorized account
                 env(fset(fred, asfDepositAuth));
                 env.close();
                 env(deposit::auth(fred, eaton));

--- a/src/test/app/AccountDelete_test.cpp
+++ b/src/test/app/AccountDelete_test.cpp
@@ -1119,13 +1119,25 @@ public:
 
             auto const acctDelFee{drops(env.current()->fees().increment)};
 
-            // becky can't delete account as feature disabled
+            // becky can't delete account as DepositPreauth object doesn't
+            // exists
             env(acctdelete(becky, alice),
                 credentials::ids(
                     {"098B7F1B146470A1C5084DC7832C04A72939E3EBC58E68AB8B579BA07"
                      "2B0CECB"}),
                 fee(acctDelFee),
-                ter(temDISABLED));
+                ter(tecNO_PERMISSION));
+            env.close();
+
+            // but can delete with old DepositPreauth
+            env(deposit::auth(alice, becky));
+            env.close();
+
+            env(acctdelete(becky, alice),
+                credentials::ids(
+                    {"098B7F1B146470A1C5084DC7832C04A72939E3EBC58E68AB8B579BA07"
+                     "2B0CECB"}),
+                fee(acctDelFee));
             env.close();
         }
     }

--- a/src/test/app/AccountDelete_test.cpp
+++ b/src/test/app/AccountDelete_test.cpp
@@ -913,6 +913,301 @@ public:
     }
 
     void
+    testDestinationDepositAuthCredentials()
+    {
+        {
+            testcase(
+                "Destination Constraints with DepositAuth and Credentials");
+
+            using namespace test::jtx;
+
+            Account const alice{"alice"};
+            Account const becky{"becky"};
+            Account const carol{"carol"};
+            Account const daria{"daria"};
+
+            const char credType[] = "abcd";
+
+            Env env{*this};
+            env.fund(XRP(100000), alice, becky, carol, daria);
+            env.close();
+
+            // carol issue credentials for becky
+            env(credentials::create(becky, carol, credType));
+            env.close();
+
+            // get credentials index
+            auto const jv =
+                credentials::ledgerEntry(env, becky, carol, credType);
+            std::string const credIdx = jv[jss::result][jss::index].asString();
+
+            // Close enough ledgers to be able to delete becky's account.
+            incLgrSeqForAccDel(env, becky);
+
+            auto const acctDelFee{drops(env.current()->fees().increment)};
+
+            // becky use credentials but they aren't accepted
+            env(acctdelete(becky, alice),
+                credentials::ids({credIdx}),
+                fee(acctDelFee),
+                ter(tecBAD_CREDENTIALS));
+            env.close();
+
+            {
+                // alice sets the lsfDepositAuth flag on her account.  This
+                // should prevent becky from deleting her account while using
+                // alice as the destination.
+                env(fset(alice, asfDepositAuth));
+                env.close();
+            }
+
+            // Fail, credentials still not accepted
+            env(acctdelete(becky, alice),
+                credentials::ids({credIdx}),
+                fee(acctDelFee),
+                ter(tecBAD_CREDENTIALS));
+            env.close();
+
+            // becky accept the credentials
+            env(credentials::accept(becky, carol, credType));
+            env.close();
+
+            // Fail, credentials doesn’t belong to carol
+            env(acctdelete(carol, alice),
+                credentials::ids({credIdx}),
+                fee(acctDelFee),
+                ter(tecBAD_CREDENTIALS));
+
+            // Fail, no depositPreauth for provided credentials
+            env(acctdelete(becky, alice),
+                credentials::ids({credIdx}),
+                fee(acctDelFee),
+                ter(tecNO_PERMISSION));
+            env.close();
+
+            // alice create DepositPreauth Object
+            env(deposit::authCredentials(alice, {{carol, credType}}));
+            env.close();
+
+            // becky attempts to delete her account, but alice won't take her
+            // XRP, so the delete is blocked.
+            env(acctdelete(becky, alice),
+                fee(acctDelFee),
+                ter(tecNO_PERMISSION));
+
+            // becky use empty credentials and can't delete account
+            env(acctdelete(becky, alice),
+                fee(acctDelFee),
+                credentials::ids({}),
+                ter(temMALFORMED));
+
+            // becky use bad credentials and can't delete account
+            env(acctdelete(becky, alice),
+                credentials::ids(
+                    {"48004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6E"
+                     "A288BE4"}),
+                fee(acctDelFee),
+                ter(tecBAD_CREDENTIALS));
+            env.close();
+
+            // becky use credentials and can delete account
+            env(acctdelete(becky, alice),
+                credentials::ids({credIdx}),
+                fee(acctDelFee));
+            env.close();
+
+            // carol issue credentials for daria
+            env(credentials::create(daria, carol, credType));
+            env.close();
+            env(credentials::accept(daria, carol, credType));
+            env.close();
+            std::string const credDaria =
+                credentials::ledgerEntry(
+                    env, daria, carol, credType)[jss::result][jss::index]
+                    .asString();
+
+            // daria use valide credentials, which aren't required and can
+            // delete account
+            env(acctdelete(daria, carol),
+                credentials::ids({credDaria}),
+                fee(acctDelFee));
+            env.close();
+
+            // check that credential object deleted too
+            auto const jNoCred =
+                credentials::ledgerEntry(env, becky, carol, credType);
+
+            BEAST_EXPECT(
+                jNoCred.isObject() && jNoCred.isMember(jss::result) &&
+                jNoCred[jss::result].isMember(jss::error) &&
+                jNoCred[jss::result][jss::error] == "entryNotFound");
+
+            {
+                Account const john{"john"};
+
+                env.fund(XRP(100000), john);
+                env.close();
+
+                auto jv = credentials::create(john, carol, credType);
+                uint32_t const t = env.now().time_since_epoch().count() + 20;
+                jv[sfExpiration.jsonName] = t;
+                env(jv);
+                env.close();
+                env(credentials::accept(john, carol, credType));
+                env.close();
+                jv = credentials::ledgerEntry(env, john, carol, credType);
+                std::string const credIdx =
+                    jv[jss::result][jss::index].asString();
+
+                incLgrSeqForAccDel(env, john);
+
+                // credentials are expired
+                // john use credentials but can't delete account
+                env(acctdelete(john, alice),
+                    credentials::ids({credIdx}),
+                    fee(acctDelFee),
+                    ter(tecEXPIRED));
+                env.close();
+
+                {
+                    // check that credential object deleted
+                    auto jv =
+                        credentials::ledgerEntry(env, john, carol, credType);
+                    BEAST_EXPECT(
+                        jv.isObject() && jv.isMember(jss::result) &&
+                        jv[jss::result].isMember(jss::error) &&
+                        jv[jss::result][jss::error] == "entryNotFound");
+                }
+            }
+        }
+
+        {
+            testcase("Credentials feature disabled");
+            using namespace test::jtx;
+
+            Account const alice{"alice"};
+            Account const becky{"becky"};
+            Account const carol{"carol"};
+
+            Env env{*this, supported_amendments() - featureCredentials};
+            env.fund(XRP(100000), alice, becky, carol);
+            env.close();
+
+            // alice sets the lsfDepositAuth flag on her account.  This should
+            // prevent becky from deleting her account while using alice as the
+            // destination.
+            env(fset(alice, asfDepositAuth));
+            env.close();
+
+            // Close enough ledgers to be able to delete becky's account.
+            incLgrSeqForAccDel(env, becky);
+
+            auto const acctDelFee{drops(env.current()->fees().increment)};
+
+            // becky can't delete account as feature disabled
+            env(acctdelete(becky, alice),
+                credentials::ids(
+                    {"098B7F1B146470A1C5084DC7832C04A72939E3EBC58E68AB8B579BA07"
+                     "2B0CECB"}),
+                fee(acctDelFee),
+                ter(temDISABLED));
+            env.close();
+        }
+    }
+
+    void
+    testDeleteCredentialsOwner()
+    {
+        {
+            testcase("Deleting Issuer deletes issued credentials");
+
+            using namespace test::jtx;
+
+            Account const alice{"alice"};
+            Account const becky{"becky"};
+            Account const carol{"carol"};
+
+            const char credType[] = "abcd";
+
+            Env env{*this};
+            env.fund(XRP(100000), alice, becky, carol);
+            env.close();
+
+            // carol issue credentials for becky
+            env(credentials::create(becky, carol, credType));
+            env.close();
+            env(credentials::accept(becky, carol, credType));
+            env.close();
+
+            // get credentials index
+            auto const jv =
+                credentials::ledgerEntry(env, becky, carol, credType);
+            std::string const credIdx = jv[jss::result][jss::index].asString();
+
+            // Close enough ledgers to be able to delete carol's account.
+            incLgrSeqForAccDel(env, carol);
+
+            auto const acctDelFee{drops(env.current()->fees().increment)};
+            env(acctdelete(carol, alice), fee(acctDelFee));
+            env.close();
+
+            {  // check that credential object deleted too
+                BEAST_EXPECT(!env.le(credIdx));
+                auto const jv =
+                    credentials::ledgerEntry(env, becky, carol, credType);
+                BEAST_EXPECT(
+                    jv.isObject() && jv.isMember(jss::result) &&
+                    jv[jss::result].isMember(jss::error) &&
+                    jv[jss::result][jss::error] == "entryNotFound");
+            }
+        }
+
+        {
+            testcase("Deleting Subject deletes issued credentials");
+
+            using namespace test::jtx;
+
+            Account const alice{"alice"};
+            Account const becky{"becky"};
+            Account const carol{"carol"};
+
+            const char credType[] = "abcd";
+
+            Env env{*this};
+            env.fund(XRP(100000), alice, becky, carol);
+            env.close();
+
+            // carol issue credentials for becky
+            env(credentials::create(becky, carol, credType));
+            env.close();
+            env(credentials::accept(becky, carol, credType));
+            env.close();
+
+            // get credentials index
+            auto const jv =
+                credentials::ledgerEntry(env, becky, carol, credType);
+            std::string const credIdx = jv[jss::result][jss::index].asString();
+
+            // Close enough ledgers to be able to delete carol's account.
+            incLgrSeqForAccDel(env, becky);
+
+            auto const acctDelFee{drops(env.current()->fees().increment)};
+            env(acctdelete(becky, alice), fee(acctDelFee));
+            env.close();
+
+            {  // check that credential object deleted too
+                BEAST_EXPECT(!env.le(credIdx));
+                auto const jv =
+                    credentials::ledgerEntry(env, becky, carol, credType);
+                BEAST_EXPECT(
+                    jv.isObject() && jv.isMember(jss::result) &&
+                    jv[jss::result].isMember(jss::error) &&
+                    jv[jss::result][jss::error] == "entryNotFound");
+            }
+        }
+    }
+
+    void
     run() override
     {
         testBasics();
@@ -925,6 +1220,8 @@ public:
         testBalanceTooSmallForFee();
         testWithTickets();
         testDest();
+        testDestinationDepositAuthCredentials();
+        testDeleteCredentialsOwner();
     }
 };
 

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -108,16 +108,6 @@ class Check_test : public beast::unit_test::suite
         return result;
     }
 
-    // Helper function that returns the owner count on an account.
-    static std::uint32_t
-    ownerCount(test::jtx::Env const& env, test::jtx::Account const& account)
-    {
-        std::uint32_t ret{0};
-        if (auto const sleAccount = env.le(account))
-            ret = sleAccount->getFieldU32(sfOwnerCount);
-        return ret;
-    }
-
     // Helper function that verifies the expected DeliveredAmount is present.
     //
     // NOTE: the function _infers_ the transaction to operate on by calling

--- a/src/test/app/Clawback_test.cpp
+++ b/src/test/app/Clawback_test.cpp
@@ -37,16 +37,6 @@ class Clawback_test : public beast::unit_test::suite
         return boost::lexical_cast<std::string>(t);
     }
 
-    // Helper function that returns the owner count of an account root.
-    static std::uint32_t
-    ownerCount(test::jtx::Env const& env, test::jtx::Account const& acct)
-    {
-        std::uint32_t ret{0};
-        if (auto const sleAcct = env.le(acct))
-            ret = sleAcct->at(sfOwnerCount);
-        return ret;
-    }
-
     // Helper function that returns the number of tickets held by an account.
     static std::uint32_t
     ticketCount(test::jtx::Env const& env, test::jtx::Account const& acct)

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -1,0 +1,856 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2024 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <test/jtx.h>
+#include <xrpld/app/misc/CredentialHelpers.h>
+#include <xrpld/ledger/ApplyViewImpl.h>
+#include <xrpl/basics/strHex.h>
+#include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/Indexes.h>
+#include <xrpl/protocol/Protocol.h>
+#include <xrpl/protocol/TxFlags.h>
+#include <xrpl/protocol/jss.h>
+
+#include <iostream>
+#include <string_view>
+
+namespace ripple {
+namespace test {
+
+static inline bool
+checkVL(
+    std::shared_ptr<SLE const> const& sle,
+    SField const& field,
+    std::string const& expected)
+{
+    return strHex(expected) == strHex(sle->getFieldVL(field));
+}
+
+static inline Keylet
+credentialKeylet(
+    test::jtx::Account const& subject,
+    test::jtx::Account const& issuer,
+    std::string_view credType)
+{
+    return keylet::credential(
+        subject.id(), issuer.id(), Slice(credType.data(), credType.size()));
+}
+
+struct Credentials_test : public beast::unit_test::suite
+{
+    void
+    testSuccessful(FeatureBitset features)
+    {
+        using namespace test::jtx;
+
+        const char credType[] = "abcde";
+        const char uri[] = "uri";
+
+        Account const issuer{"issuer"};
+        Account const subject{"subject"};
+        Account const other{"other"};
+
+        Env env{*this, features};
+
+        {
+            testcase("Create for subject.");
+
+            auto const credKey = credentialKeylet(subject, issuer, credType);
+
+            env.fund(XRP(5000), subject, issuer, other);
+            env.close();
+
+            // Test Create credentials
+            env(credentials::create(subject, issuer, credType),
+                credentials::uri(uri));
+            env.close();
+            {
+                auto const sleCred = env.le(credKey);
+                BEAST_EXPECT(static_cast<bool>(sleCred));
+                if (!sleCred)
+                    return;
+
+                BEAST_EXPECT(sleCred->getAccountID(sfSubject) == subject.id());
+                BEAST_EXPECT(sleCred->getAccountID(sfIssuer) == issuer.id());
+                BEAST_EXPECT(!sleCred->getFieldU32(sfFlags));
+                BEAST_EXPECT(ownerCount(env, issuer) == 1);
+                BEAST_EXPECT(!ownerCount(env, subject));
+                BEAST_EXPECT(checkVL(sleCred, sfCredentialType, credType));
+                BEAST_EXPECT(checkVL(sleCred, sfURI, uri));
+                auto const jle =
+                    credentials::ledgerEntry(env, subject, issuer, credType);
+                BEAST_EXPECT(
+                    jle.isObject() && jle.isMember(jss::result) &&
+                    !jle[jss::result].isMember(jss::error) &&
+                    jle[jss::result].isMember(jss::node) &&
+                    jle[jss::result][jss::node].isMember("LedgerEntryType") &&
+                    jle[jss::result][jss::node]["LedgerEntryType"] ==
+                        jss::Credential);
+            }
+
+            env(credentials::accept(subject, issuer, credType));
+            env.close();
+            {
+                // check switching owner of the credentials from issuer to
+                // subject
+                auto const sleCred = env.le(credKey);
+                BEAST_EXPECT(static_cast<bool>(sleCred));
+                if (!sleCred)
+                    return;
+
+                BEAST_EXPECT(sleCred->getAccountID(sfSubject) == subject.id());
+                BEAST_EXPECT(sleCred->getAccountID(sfIssuer) == issuer.id());
+                BEAST_EXPECT(!ownerCount(env, issuer));
+                BEAST_EXPECT(ownerCount(env, subject) == 1);
+                BEAST_EXPECT(checkVL(sleCred, sfCredentialType, credType));
+                BEAST_EXPECT(checkVL(sleCred, sfURI, uri));
+                BEAST_EXPECT(sleCred->getFieldU32(sfFlags) == lsfAccepted);
+            }
+
+            env(credentials::deleteCred(subject, subject, issuer, credType));
+            env.close();
+            {
+                BEAST_EXPECT(!env.le(credKey));
+                BEAST_EXPECT(!ownerCount(env, issuer));
+                BEAST_EXPECT(!ownerCount(env, subject));
+
+                // check no credential exists anymore
+                auto const jle =
+                    credentials::ledgerEntry(env, subject, issuer, credType);
+                BEAST_EXPECT(
+                    jle.isObject() && jle.isMember(jss::result) &&
+                    jle[jss::result].isMember(jss::error) &&
+                    jle[jss::result][jss::error] == "entryNotFound");
+            }
+        }
+
+        {
+            testcase("Create for themself.");
+
+            auto const credKey = credentialKeylet(issuer, issuer, credType);
+
+            env(credentials::create(issuer, issuer, credType),
+                credentials::uri(uri));
+            env.close();
+            {
+                auto const sleCred = env.le(credKey);
+                BEAST_EXPECT(static_cast<bool>(sleCred));
+                if (!sleCred)
+                    return;
+
+                BEAST_EXPECT(sleCred->getAccountID(sfSubject) == issuer.id());
+                BEAST_EXPECT(sleCred->getAccountID(sfIssuer) == issuer.id());
+                BEAST_EXPECT((sleCred->getFieldU32(sfFlags) & lsfAccepted));
+                BEAST_EXPECT(
+                    sleCred->getFieldU64(sfIssuerNode) ==
+                    sleCred->getFieldU64(sfSubjectNode));
+                BEAST_EXPECT(ownerCount(env, issuer) == 1);
+                BEAST_EXPECT(checkVL(sleCred, sfCredentialType, credType));
+                BEAST_EXPECT(checkVL(sleCred, sfURI, uri));
+                auto const jle =
+                    credentials::ledgerEntry(env, issuer, issuer, credType);
+                BEAST_EXPECT(
+                    jle.isObject() && jle.isMember(jss::result) &&
+                    !jle[jss::result].isMember(jss::error) &&
+                    jle[jss::result].isMember(jss::node) &&
+                    jle[jss::result][jss::node].isMember("LedgerEntryType") &&
+                    jle[jss::result][jss::node]["LedgerEntryType"] ==
+                        jss::Credential);
+            }
+
+            env(credentials::deleteCred(issuer, issuer, issuer, credType));
+            env.close();
+            {
+                BEAST_EXPECT(!env.le(credKey));
+                BEAST_EXPECT(!ownerCount(env, issuer));
+
+                // check no credential exists anymore
+                auto const jle =
+                    credentials::ledgerEntry(env, issuer, issuer, credType);
+                BEAST_EXPECT(
+                    jle.isObject() && jle.isMember(jss::result) &&
+                    jle[jss::result].isMember(jss::error) &&
+                    jle[jss::result][jss::error] == "entryNotFound");
+            }
+        }
+    }
+
+    void
+    testCredentialsDelete(FeatureBitset features)
+    {
+        using namespace test::jtx;
+
+        const char credType[] = "abcde";
+
+        Account const issuer{"issuer"};
+        Account const subject{"subject"};
+        Account const other{"other"};
+
+        Env env{*this, features};
+
+        // fund subject and issuer
+        env.fund(XRP(5000), issuer, subject, other);
+        env.close();
+
+        {
+            testcase("Delete issuer before accept");
+
+            auto const credKey = credentialKeylet(subject, issuer, credType);
+            env(credentials::create(subject, issuer, credType));
+            env.close();
+
+            // delete issuer
+            {
+                int const delta = env.seq(issuer) + 255;
+                for (int i = 0; i < delta; ++i)
+                    env.close();
+                auto const acctDelFee{drops(env.current()->fees().increment)};
+                env(acctdelete(issuer, other), fee(acctDelFee));
+                env.close();
+            }
+
+            // check credentials deleted too
+            {
+                BEAST_EXPECT(!env.le(credKey));
+                BEAST_EXPECT(!ownerCount(env, subject));
+
+                // check no credential exists anymore
+                auto const jle =
+                    credentials::ledgerEntry(env, subject, issuer, credType);
+                BEAST_EXPECT(
+                    jle.isObject() && jle.isMember(jss::result) &&
+                    jle[jss::result].isMember(jss::error) &&
+                    jle[jss::result][jss::error] == "entryNotFound");
+            }
+
+            // resurrection
+            env.fund(XRP(5000), issuer);
+            env.close();
+        }
+
+        {
+            testcase("Delete issuer after accept");
+
+            auto const credKey = credentialKeylet(subject, issuer, credType);
+            env(credentials::create(subject, issuer, credType));
+            env.close();
+            env(credentials::accept(subject, issuer, credType));
+            env.close();
+
+            // delete issuer
+            {
+                int const delta = env.seq(issuer) + 255;
+                for (int i = 0; i < delta; ++i)
+                    env.close();
+                auto const acctDelFee{drops(env.current()->fees().increment)};
+                env(acctdelete(issuer, other), fee(acctDelFee));
+                env.close();
+            }
+
+            // check credentials deleted too
+            {
+                BEAST_EXPECT(!env.le(credKey));
+                BEAST_EXPECT(!ownerCount(env, subject));
+
+                // check no credential exists anymore
+                auto const jle =
+                    credentials::ledgerEntry(env, subject, issuer, credType);
+                BEAST_EXPECT(
+                    jle.isObject() && jle.isMember(jss::result) &&
+                    jle[jss::result].isMember(jss::error) &&
+                    jle[jss::result][jss::error] == "entryNotFound");
+            }
+
+            // resurrection
+            env.fund(XRP(5000), issuer);
+            env.close();
+        }
+
+        {
+            testcase("Delete subject before accept ");
+
+            auto const credKey = credentialKeylet(subject, issuer, credType);
+            env(credentials::create(subject, issuer, credType));
+            env.close();
+
+            // delete subject
+            {
+                int const delta = env.seq(subject) + 255;
+                for (int i = 0; i < delta; ++i)
+                    env.close();
+                auto const acctDelFee{drops(env.current()->fees().increment)};
+                env(acctdelete(subject, other), fee(acctDelFee));
+                env.close();
+            }
+
+            // check credentials deleted too
+            {
+                BEAST_EXPECT(!env.le(credKey));
+                BEAST_EXPECT(!ownerCount(env, issuer));
+
+                // check no credential exists anymore
+                auto const jle =
+                    credentials::ledgerEntry(env, subject, issuer, credType);
+                BEAST_EXPECT(
+                    jle.isObject() && jle.isMember(jss::result) &&
+                    jle[jss::result].isMember(jss::error) &&
+                    jle[jss::result][jss::error] == "entryNotFound");
+            }
+
+            // resurrection
+            env.fund(XRP(5000), subject);
+            env.close();
+        }
+
+        {
+            testcase("Delete subject after accept ");
+
+            auto const credKey = credentialKeylet(subject, issuer, credType);
+            env(credentials::create(subject, issuer, credType));
+            env.close();
+            env(credentials::accept(subject, issuer, credType));
+            env.close();
+
+            // delete subject
+            {
+                int const delta = env.seq(subject) + 255;
+                for (int i = 0; i < delta; ++i)
+                    env.close();
+                auto const acctDelFee{drops(env.current()->fees().increment)};
+                env(acctdelete(subject, other), fee(acctDelFee));
+                env.close();
+            }
+
+            // check credentials deleted too
+            {
+                BEAST_EXPECT(!env.le(credKey));
+                BEAST_EXPECT(!ownerCount(env, issuer));
+
+                // check no credential exists anymore
+                auto const jle =
+                    credentials::ledgerEntry(env, subject, issuer, credType);
+                BEAST_EXPECT(
+                    jle.isObject() && jle.isMember(jss::result) &&
+                    jle[jss::result].isMember(jss::error) &&
+                    jle[jss::result][jss::error] == "entryNotFound");
+            }
+
+            // resurrection
+            env.fund(XRP(5000), subject);
+            env.close();
+        }
+
+        {
+            testcase("Delete by other");
+
+            auto const credKey = credentialKeylet(subject, issuer, credType);
+            auto jv = credentials::create(subject, issuer, credType);
+            uint32_t const t = env.now().time_since_epoch().count();
+            jv[sfExpiration.jsonName] = t + 20;
+            env(jv);
+
+            // time advance
+            env.close();
+            env.close();
+            env.close();
+
+            // Other account delete credentials
+            env(credentials::deleteCred(other, subject, issuer, credType));
+            env.close();
+
+            // check credentials object
+            {
+                BEAST_EXPECT(!env.le(credKey));
+                BEAST_EXPECT(!ownerCount(env, issuer));
+                BEAST_EXPECT(!ownerCount(env, subject));
+
+                // check no credential exists anymore
+                auto const jle =
+                    credentials::ledgerEntry(env, subject, issuer, credType);
+                BEAST_EXPECT(
+                    jle.isObject() && jle.isMember(jss::result) &&
+                    jle[jss::result].isMember(jss::error) &&
+                    jle[jss::result][jss::error] == "entryNotFound");
+            }
+        }
+
+        {
+            testcase("Delete by subject");
+
+            env(credentials::create(subject, issuer, credType));
+            env.close();
+
+            // Subject can delete
+            env(credentials::deleteCred(subject, subject, issuer, credType));
+            env.close();
+            {
+                auto const credKey =
+                    credentialKeylet(subject, issuer, credType);
+                BEAST_EXPECT(!env.le(credKey));
+                BEAST_EXPECT(!ownerCount(env, subject));
+                BEAST_EXPECT(!ownerCount(env, issuer));
+                auto const jle =
+                    credentials::ledgerEntry(env, subject, issuer, credType);
+                BEAST_EXPECT(
+                    jle.isObject() && jle.isMember(jss::result) &&
+                    jle[jss::result].isMember(jss::error) &&
+                    jle[jss::result][jss::error] == "entryNotFound");
+            }
+        }
+
+        {
+            testcase("Delete  by issuer");
+            env(credentials::create(subject, issuer, credType));
+            env.close();
+
+            env(credentials::deleteCred(issuer, subject, issuer, credType));
+            env.close();
+            {
+                auto const credKey =
+                    credentialKeylet(subject, issuer, credType);
+                BEAST_EXPECT(!env.le(credKey));
+                BEAST_EXPECT(!ownerCount(env, subject));
+                BEAST_EXPECT(!ownerCount(env, issuer));
+                auto const jle =
+                    credentials::ledgerEntry(env, subject, issuer, credType);
+                BEAST_EXPECT(
+                    jle.isObject() && jle.isMember(jss::result) &&
+                    jle[jss::result].isMember(jss::error) &&
+                    jle[jss::result][jss::error] == "entryNotFound");
+            }
+        }
+    }
+
+    void
+    testCreateFailed(FeatureBitset features)
+    {
+        using namespace test::jtx;
+
+        const char credType[] = "abcde";
+
+        Account const issuer{"issuer"};
+        Account const subject{"subject"};
+
+        {
+            using namespace jtx;
+            Env env{*this, features};
+
+            env.fund(XRP(5000), subject, issuer);
+            env.close();
+
+            {
+                testcase("Credentials fail, no subject param.");
+                auto jv = credentials::create(subject, issuer, credType);
+                jv.removeMember(jss::Subject);
+                env(jv, ter(temMALFORMED));
+            }
+
+            {
+                auto jv = credentials::create(subject, issuer, credType);
+                jv[jss::Subject] = to_string(xrpAccount());
+                env(jv, ter(temMALFORMED));
+            }
+
+            {
+                testcase("Credentials fail, no credentialType param.");
+                auto jv = credentials::create(subject, issuer, credType);
+                jv.removeMember(sfCredentialType.jsonName);
+                env(jv, ter(temMALFORMED));
+            }
+
+            {
+                testcase("Credentials fail, empty credentialType param.");
+                auto jv = credentials::create(subject, issuer, "");
+                env(jv, ter(temMALFORMED));
+            }
+
+            {
+                testcase(
+                    "Credentials fail, credentialType length > "
+                    "maxCredentialTypeLength.");
+                constexpr std::string_view longCredType =
+                    "abcdefghijklmnopqrstuvwxyz01234567890qwertyuiop[]"
+                    "asdfghjkl;'zxcvbnm8237tr28weufwldebvfv8734t07p   "
+                    "9hfup;wDJFBVSD8f72  "
+                    "pfhiusdovnbs;"
+                    "djvbldafghwpEFHdjfaidfgio84763tfysgdvhjasbd "
+                    "vujhgWQIE7F6WEUYFGWUKEYFVQW87FGWOEFWEFUYWVEF8723GFWEFB"
+                    "WULE"
+                    "fv28o37gfwEFB3872TFO8GSDSDVD";
+                static_assert(longCredType.size() > maxCredentialTypeLength);
+                auto jv = credentials::create(subject, issuer, longCredType);
+                env(jv, ter(temMALFORMED));
+            }
+
+            {
+                testcase("Credentials fail, URI length > 256.");
+                constexpr std::string_view longURI =
+                    "abcdefghijklmnopqrstuvwxyz01234567890qwertyuiop[]"
+                    "asdfghjkl;'zxcvbnm8237tr28weufwldebvfv8734t07p   "
+                    "9hfup;wDJFBVSD8f72  "
+                    "pfhiusdovnbs;"
+                    "djvbldafghwpEFHdjfaidfgio84763tfysgdvhjasbd "
+                    "vujhgWQIE7F6WEUYFGWUKEYFVQW87FGWOEFWEFUYWVEF8723GFWEFB"
+                    "WULE"
+                    "fv28o37gfwEFB3872TFO8GSDSDVD";
+                static_assert(longURI.size() > maxCredentialURILength);
+                env(credentials::create(subject, issuer, credType),
+                    credentials::uri(longURI),
+                    ter(temMALFORMED));
+            }
+
+            {
+                testcase("Credentials fail, URI empty.");
+                env(credentials::create(subject, issuer, credType),
+                    credentials::uri(""),
+                    ter(temMALFORMED));
+            }
+
+            {
+                testcase("Credentials fail, expiration in the past.");
+                auto jv = credentials::create(subject, issuer, credType);
+                // current time in ripple epoch - 1s
+                uint32_t const t = env.now().time_since_epoch().count() - 1;
+                jv[sfExpiration.jsonName] = t;
+                env(jv, ter(tecEXPIRED));
+            }
+
+            {
+                testcase("Credentials fail, invalid fee.");
+
+                auto jv = credentials::create(subject, issuer, credType);
+                jv[jss::Fee] = -1;
+                env(jv, ter(temBAD_FEE));
+            }
+
+            {
+                testcase("Credentials fail, duplicate.");
+                auto const jv = credentials::create(subject, issuer, credType);
+                env(jv);
+                env.close();
+                env(jv, ter(tecDUPLICATE));
+                env.close();
+            }
+        }
+
+        {
+            using namespace jtx;
+            Env env{*this, features};
+
+            env.fund(XRP(5000), issuer);
+            env.close();
+
+            {
+                testcase("Credentials fail, subject doesn't exist.");
+                auto const jv = credentials::create(subject, issuer, credType);
+                env(jv, ter(tecNO_TARGET));
+            }
+        }
+
+        {
+            using namespace jtx;
+            Env env{*this, features};
+
+            auto const reserve = drops(env.current()->fees().accountReserve(0));
+            env.fund(reserve, subject, issuer);
+            env.close();
+
+            testcase("Credentials fail, not enough reserve.");
+            {
+                auto const jv = credentials::create(subject, issuer, credType);
+                env(jv, ter(tecINSUFFICIENT_RESERVE));
+                env.close();
+            }
+        }
+    }
+
+    void
+    testAcceptFailed(FeatureBitset features)
+    {
+        using namespace jtx;
+
+        const char credType[] = "abcde";
+        Account const issuer{"issuer"};
+        Account const subject{"subject"};
+        Account const other{"other"};
+
+        {
+            Env env{*this, features};
+
+            env.fund(XRP(5000), subject, issuer);
+
+            {
+                testcase("CredentialsAccept fail, Credential doesn't exist.");
+                env(credentials::accept(subject, issuer, credType),
+                    ter(tecNO_ENTRY));
+                env.close();
+            }
+
+            {
+                testcase("CredentialsAccept fail, invalid Issuer account.");
+                auto jv = credentials::accept(subject, issuer, credType);
+                jv[jss::Issuer] = to_string(xrpAccount());
+                env(jv, ter(temINVALID_ACCOUNT_ID));
+                env.close();
+            }
+        }
+
+        {
+            Env env{*this, features};
+
+            env.fund(drops(env.current()->fees().accountReserve(1)), issuer);
+            env.fund(drops(env.current()->fees().accountReserve(0)), subject);
+            env.close();
+
+            {
+                testcase("CredentialsAccept fail, not enough reserve.");
+                env(credentials::create(subject, issuer, credType));
+                env.close();
+
+                env(credentials::accept(subject, issuer, credType),
+                    ter(tecINSUFFICIENT_RESERVE));
+                env.close();
+            }
+        }
+
+        {
+            using namespace jtx;
+            Env env{*this, features};
+
+            env.fund(XRP(5000), subject, issuer);
+            env.close();
+
+            {
+                env(credentials::create(subject, issuer, credType));
+                env.close();
+
+                testcase("CredentialsAccept fail, invalid fee.");
+                auto jv = credentials::accept(subject, issuer, credType);
+                jv[jss::Fee] = -1;
+                env(jv, ter(temBAD_FEE));
+
+                testcase("CredentialsAccept fail, lsfAccepted already set.");
+                env(credentials::accept(subject, issuer, credType));
+                env.close();
+                env(credentials::accept(subject, issuer, credType),
+                    ter(tecDUPLICATE));
+                env.close();
+            }
+
+            {
+                const char credType2[] = "efghi";
+
+                testcase("CredentialsAccept fail, expired credentials.");
+                auto jv = credentials::create(subject, issuer, credType2);
+                uint32_t const t = env.now().time_since_epoch().count();
+                jv[sfExpiration.jsonName] = t;
+                env(jv);
+                env.close();
+
+                // credentials are expired now
+                env(credentials::accept(subject, issuer, credType2),
+                    ter(tecEXPIRED));
+                env.close();
+
+                // check that expired credentials were deleted
+                auto const jDelCred =
+                    credentials::ledgerEntry(env, subject, issuer, credType2);
+                BEAST_EXPECT(
+                    jDelCred.isObject() && jDelCred.isMember(jss::result) &&
+                    jDelCred[jss::result].isMember(jss::error) &&
+                    jDelCred[jss::result][jss::error] == "entryNotFound");
+            }
+        }
+
+        {
+            using namespace jtx;
+            Env env{*this, features};
+
+            env.fund(XRP(5000), issuer, subject, other);
+            env.close();
+
+            {
+                testcase("CredentialsAccept fail, issuer doesn't exist.");
+                auto jv = credentials::create(subject, issuer, credType);
+                env(jv);
+                env.close();
+
+                // delete issuer
+                int const delta = env.seq(issuer) + 255;
+                for (int i = 0; i < delta; ++i)
+                    env.close();
+                auto const acctDelFee{drops(env.current()->fees().increment)};
+                env(acctdelete(issuer, other), fee(acctDelFee));
+
+                // can't accept - no issuer account
+                jv = credentials::accept(subject, issuer, credType);
+                env(jv, ter(tecNO_ISSUER));
+                env.close();
+            }
+        }
+    }
+
+    void
+    testDeleteFailed(FeatureBitset features)
+    {
+        using namespace test::jtx;
+
+        const char credType[] = "abcde";
+        Account const issuer{"issuer"};
+        Account const subject{"subject"};
+        Account const other{"other"};
+
+        {
+            using namespace jtx;
+            Env env{*this, features};
+
+            env.fund(XRP(5000), subject, issuer, other);
+            env.close();
+
+            {
+                testcase("CredentialsDelete fail, no Credentials.");
+                env(credentials::deleteCred(subject, subject, issuer, credType),
+                    ter(tecNO_ENTRY));
+                env.close();
+            }
+
+            {
+                testcase("CredentialsDelete fail, invalid Subject account.");
+                auto jv =
+                    credentials::deleteCred(subject, subject, issuer, credType);
+                jv[jss::Subject] = to_string(xrpAccount());
+                env(jv, ter(temINVALID_ACCOUNT_ID));
+                env.close();
+            }
+
+            {
+                testcase("CredentialsDelete fail, invalid Issuer account.");
+                auto jv =
+                    credentials::deleteCred(subject, subject, issuer, credType);
+                jv[jss::Issuer] = to_string(xrpAccount());
+                env(jv, ter(temINVALID_ACCOUNT_ID));
+                env.close();
+            }
+
+            {
+                const char credType2[] = "fghij";
+
+                env(credentials::create(subject, issuer, credType2));
+                env.close();
+
+                // Other account can't delete credentials without expiration
+                env(credentials::deleteCred(other, subject, issuer, credType2),
+                    ter(tecNO_PERMISSION));
+                env.close();
+            }
+
+            {
+                testcase("CredentialsDelete fail, time not expired yet.");
+
+                auto jv = credentials::create(subject, issuer, credType);
+                // current time in ripple epoch + 1000s
+                uint32_t const t = env.now().time_since_epoch().count() + 1000;
+                jv[sfExpiration.jsonName] = t;
+                env(jv);
+                env.close();
+
+                // Other account can't delete credentials that not expired
+                env(credentials::deleteCred(other, subject, issuer, credType),
+                    ter(tecNO_PERMISSION));
+                env.close();
+            }
+
+            {
+                testcase("CredentialsDelete fail, no Issuer and Subject.");
+
+                auto jv =
+                    credentials::deleteCred(subject, subject, issuer, credType);
+                jv.removeMember(jss::Subject);
+                jv.removeMember(jss::Issuer);
+                env(jv, ter(temMALFORMED));
+                env.close();
+            }
+
+            {
+                testcase("CredentialsDelete fail, invalid fee.");
+
+                auto jv =
+                    credentials::deleteCred(subject, subject, issuer, credType);
+                jv[jss::Fee] = -1;
+                env(jv, ter(temBAD_FEE));
+                env.close();
+            }
+
+            {
+                testcase("deleteSLE fail, bad SLE.");
+                auto view = std::make_shared<ApplyViewImpl>(
+                    env.current().get(), ApplyFlags::tapNONE);
+                auto ter =
+                    ripple::credentials::deleteSLE(*view, {}, env.journal);
+                BEAST_EXPECT(ter == tecNO_ENTRY);
+            }
+        }
+    }
+
+    void
+    testFeatureFailed(FeatureBitset features)
+    {
+        using namespace test::jtx;
+
+        const char credType[] = "abcde";
+        Account const issuer{"issuer"};
+        Account const subject{"subject"};
+
+        {
+            using namespace jtx;
+            Env env{*this, features};
+
+            env.fund(XRP(5000), subject, issuer);
+            env.close();
+
+            {
+                testcase("Credentials fail, Feature is not enabled.");
+                env(credentials::create(subject, issuer, credType),
+                    ter(temDISABLED));
+                env(credentials::accept(subject, issuer, credType),
+                    ter(temDISABLED));
+                env(credentials::deleteCred(subject, subject, issuer, credType),
+                    ter(temDISABLED));
+            }
+        }
+    }
+
+    void
+    run() override
+    {
+        using namespace test::jtx;
+        FeatureBitset const all{supported_amendments()};
+        testSuccessful(all);
+        testCredentialsDelete(all);
+        testCreateFailed(all);
+        testAcceptFailed(all);
+        testDeleteFailed(all);
+        testFeatureFailed(all - featureCredentials);
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(Credentials, app, ripple);
+
+}  // namespace test
+}  // namespace ripple

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -361,7 +361,10 @@ struct Credentials_test : public beast::unit_test::suite
 
             auto const credKey = credentialKeylet(subject, issuer, credType);
             auto jv = credentials::create(subject, issuer, credType);
-            uint32_t const t = env.now().time_since_epoch().count();
+            uint32_t const t = env.current()
+                                   ->info()
+                                   .parentCloseTime.time_since_epoch()
+                                   .count();
             jv[sfExpiration.jsonName] = t + 20;
             env(jv);
 
@@ -520,7 +523,11 @@ struct Credentials_test : public beast::unit_test::suite
                 testcase("Credentials fail, expiration in the past.");
                 auto jv = credentials::create(subject, issuer, credType);
                 // current time in ripple epoch - 1s
-                uint32_t const t = env.now().time_since_epoch().count() - 1;
+                uint32_t const t = env.current()
+                                       ->info()
+                                       .parentCloseTime.time_since_epoch()
+                                       .count() -
+                    1;
                 jv[sfExpiration.jsonName] = t;
                 env(jv, ter(tecEXPIRED));
             }
@@ -652,7 +659,10 @@ struct Credentials_test : public beast::unit_test::suite
 
                 testcase("CredentialsAccept fail, expired credentials.");
                 auto jv = credentials::create(subject, issuer, credType2);
-                uint32_t const t = env.now().time_since_epoch().count();
+                uint32_t const t = env.current()
+                                       ->info()
+                                       .parentCloseTime.time_since_epoch()
+                                       .count();
                 jv[sfExpiration.jsonName] = t;
                 env(jv);
                 env.close();
@@ -759,7 +769,11 @@ struct Credentials_test : public beast::unit_test::suite
 
                 auto jv = credentials::create(subject, issuer, credType);
                 // current time in ripple epoch + 1000s
-                uint32_t const t = env.now().time_since_epoch().count() + 1000;
+                uint32_t const t = env.current()
+                                       ->info()
+                                       .parentCloseTime.time_since_epoch()
+                                       .count() +
+                    1000;
                 jv[sfExpiration.jsonName] = t;
                 env(jv);
                 env.close();

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -486,13 +486,7 @@ struct Credentials_test : public beast::unit_test::suite
                     "maxCredentialTypeLength.");
                 constexpr std::string_view longCredType =
                     "abcdefghijklmnopqrstuvwxyz01234567890qwertyuiop[]"
-                    "asdfghjkl;'zxcvbnm8237tr28weufwldebvfv8734t07p   "
-                    "9hfup;wDJFBVSD8f72  "
-                    "pfhiusdovnbs;"
-                    "djvbldafghwpEFHdjfaidfgio84763tfysgdvhjasbd "
-                    "vujhgWQIE7F6WEUYFGWUKEYFVQW87FGWOEFWEFUYWVEF8723GFWEFB"
-                    "WULE"
-                    "fv28o37gfwEFB3872TFO8GSDSDVD";
+                    "asdfghjkl;'zxcvbnm8237tr28weufwldebvfv8734t07p";
                 static_assert(longCredType.size() > maxCredentialTypeLength);
                 auto jv = credentials::create(subject, issuer, longCredType);
                 env(jv, ter(temMALFORMED));

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -430,7 +430,7 @@ struct Credentials_test : public beast::unit_test::suite
         }
 
         {
-            testcase("Delete  by issuer");
+            testcase("Delete by issuer");
             env(credentials::create(subject, issuer, credType));
             env.close();
 

--- a/src/test/app/DID_test.cpp
+++ b/src/test/app/DID_test.cpp
@@ -30,16 +30,6 @@
 namespace ripple {
 namespace test {
 
-// Helper function that returns the owner count of an account root.
-static std::uint32_t
-ownerCount(test::jtx::Env const& env, test::jtx::Account const& acct)
-{
-    std::uint32_t ret{0};
-    if (auto const sleAcct = env.le(acct))
-        ret = sleAcct->at(sfOwnerCount);
-    return ret;
-}
-
 bool
 checkVL(Slice const& result, std::string expected)
 {

--- a/src/test/app/DepositAuth_test.cpp
+++ b/src/test/app/DepositAuth_test.cpp
@@ -1032,6 +1032,20 @@ struct DepositPreauth_test : public beast::unit_test::suite
             }
 
             {
+                // both included [Unauthorize, UnauthorizeCredentials]
+                auto jv = deposit::unauthCredentials(bob, {{issuer, credType}});
+                jv[sfUnauthorize.jsonName] = issuer.human();
+                env(jv, ter(temMALFORMED));
+            }
+
+            {
+                // both included [Authorize, UnauthorizeCredentials]
+                auto jv = deposit::unauthCredentials(bob, {{issuer, credType}});
+                jv[sfAuthorize.jsonName] = issuer.human();
+                env(jv, ter(temMALFORMED));
+            }
+
+            {
                 // AuthorizeCredentials is empty
                 auto jv = deposit::authCredentials(bob, {});
                 env(jv, ter(temMALFORMED));
@@ -1086,7 +1100,7 @@ struct DepositPreauth_test : public beast::unit_test::suite
             }
 
             {
-                // not enough resevre
+                // not enough reserve
                 Account const john{"john"};
                 env.fund(env.current()->fees().accountReserve(0), john);
                 auto jv = deposit::authCredentials(john, {{issuer, credType}});
@@ -1114,7 +1128,7 @@ struct DepositPreauth_test : public beast::unit_test::suite
                     jDP[jss::result][jss::node]["LedgerEntryType"] ==
                         jss::DepositPreauth);
 
-                // CHeck object fields
+                // Check object fields
                 BEAST_EXPECT(
                     jDP[jss::result][jss::node][jss::Account] == bob.human());
                 auto const& credentials(
@@ -1149,7 +1163,7 @@ struct DepositPreauth_test : public beast::unit_test::suite
     }
 
     void
-    testExpCreds()
+    testExpiredCreds()
     {
         using namespace jtx;
         const char credType[] = "abcde";
@@ -1229,7 +1243,7 @@ struct DepositPreauth_test : public beast::unit_test::suite
                 env.close();
                 env.close();
 
-                // credentails are expired
+                // credentials are expired
                 env(pay(gw, bob, USD(150)),
                     credentials::ids({credIdx}),
                     ter(tecEXPIRED));
@@ -1329,7 +1343,7 @@ struct DepositPreauth_test : public beast::unit_test::suite
         testPayment(supported);
         testCredentialsPayment();
         testCredentialsCreation();
-        testExpCreds();
+        testExpiredCreds();
     }
 };
 

--- a/src/test/app/DepositAuth_test.cpp
+++ b/src/test/app/DepositAuth_test.cpp
@@ -667,9 +667,10 @@ struct DepositPreauth_test : public beast::unit_test::suite
                 TER const expectCredentials(
                     supportsCredentials ? TER(tesSUCCESS) : TER(temDISABLED));
                 TER const expectPayment(
-                    !supportsCredentials || !supportsPreauth
-                        ? TER(tecNO_PERMISSION)
-                        : TER(tesSUCCESS));
+                    !supportsCredentials
+                        ? TER(temDISABLED)
+                        : (!supportsPreauth ? TER(tecNO_PERMISSION)
+                                            : TER(tesSUCCESS)));
                 TER const expectDP(
                     !supportsPreauth
                         ? TER(temDISABLED)
@@ -839,16 +840,15 @@ struct DepositPreauth_test : public beast::unit_test::suite
             // But can create old DepositPreauth
             env(deposit::auth(bob, alice));
             env.close();
-            // And alice can pay without credentials
-            env(pay(alice, bob, XRP(10)));
-            env.close();
 
-            // And alice can pay with any credentials, as they aren't checked if
-            // amendement is not enabled
+            // And alice can't pay with any credentials, amendement is not
+            // enabled
             std::string const invalidIdx =
                 "0E0B04ED60588A758B67E21FBBE95AC5A63598BA951761DC0EC9C08D7E"
                 "01E034";
-            env(pay(alice, bob, XRP(10)), credentials::ids({invalidIdx}));
+            env(pay(alice, bob, XRP(10)),
+                credentials::ids({invalidIdx}),
+                ter(temDISABLED));
             env.close();
         }
 

--- a/src/test/app/DepositAuth_test.cpp
+++ b/src/test/app/DepositAuth_test.cpp
@@ -392,9 +392,9 @@ ledgerEntryDepositPreauth(
     Json::Value jvParams;
     jvParams[jss::ledger_index] = jss::validated;
     jvParams[jss::deposit_preauth][jss::owner] = acc.human();
-    jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+    jvParams[jss::deposit_preauth][jss::authorized_credentials] =
         Json::arrayValue;
-    auto& arr(jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+    auto& arr(jvParams[jss::deposit_preauth][jss::authorized_credentials]);
     for (auto const& o : auth)
     {
         arr.append(o.toLEJson());

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -1509,6 +1509,148 @@ struct Escrow_test : public beast::unit_test::suite
     }
 
     void
+    testCredentials()
+    {
+        testcase("Test with credentials");
+
+        using namespace jtx;
+        using namespace std::chrono;
+
+        Account const alice{"alice"};
+        Account const bob{"bob"};
+        Account const carol{"carol"};
+        Account const dillon{"dillon "};
+        Account const zelda{"zelda"};
+
+        const char credType[] = "abcde";
+
+        {
+            // Credentials amendment not enabled
+            Env env(*this, supported_amendments() - featureCredentials);
+            env.fund(XRP(5000), alice, bob);
+            env.close();
+
+            auto const seq = env.seq(alice);
+            env(escrow(alice, bob, XRP(1000)), finish_time(env.now() + 1s));
+            env.close();
+            std::string const credIdx =
+                "48004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
+                "E4";
+            env(finish(bob, alice, seq),
+                credentials::ids({credIdx}),
+                ter(temDISABLED));
+        }
+
+        {
+            Env env(*this);
+
+            env.fund(XRP(5000), alice, bob, carol, dillon, zelda);
+            env.close();
+
+            env(credentials::create(carol, zelda, credType));
+            env.close();
+            auto const jv =
+                credentials::ledgerEntry(env, carol, zelda, credType);
+            std::string const credIdx = jv[jss::result][jss::index].asString();
+
+            auto const seq = env.seq(alice);
+            env(escrow(alice, bob, XRP(1000)), finish_time(env.now() + 50s));
+            env.close();
+
+            // Bob require preauthorization
+            env(fset(bob, asfDepositAuth));
+            env.close();
+
+            // Fail, credentials not accepted
+            env(finish(carol, alice, seq),
+                credentials::ids({credIdx}),
+                ter(tecBAD_CREDENTIALS));
+
+            env.close();
+
+            env(credentials::accept(carol, zelda, credType));
+            env.close();
+
+            // Fail, credentials doesn’t belong to root account
+            env(finish(dillon, alice, seq),
+                credentials::ids({credIdx}),
+                ter(tecBAD_CREDENTIALS));
+
+            // Fail, no depositPreauth
+            env(finish(carol, alice, seq),
+                credentials::ids({credIdx}),
+                ter(tecNO_PERMISSION));
+
+            env(deposit::authCredentials(bob, {{zelda, credType}}));
+            env.close();
+
+            // Success
+            env.close();
+            env(finish(carol, alice, seq), credentials::ids({credIdx}));
+            env.close();
+        }
+
+        {
+            testcase("Escrow with credentials without depositPreauth");
+            using namespace std::chrono;
+
+            Env env(*this);
+
+            env.fund(XRP(5000), alice, bob, carol, dillon, zelda);
+            env.close();
+
+            env(credentials::create(carol, zelda, credType));
+            env.close();
+            env(credentials::accept(carol, zelda, credType));
+            env.close();
+            auto const jv =
+                credentials::ledgerEntry(env, carol, zelda, credType);
+            std::string const credIdx = jv[jss::result][jss::index].asString();
+
+            auto const seq = env.seq(alice);
+            env(escrow(alice, bob, XRP(1000)), finish_time(env.now() + 50s));
+            // time advance
+            env.close();
+            env.close();
+            env.close();
+            env.close();
+            env.close();
+            env.close();
+
+            // Succeed, Bob doesn't require preauthorization
+            env(finish(carol, alice, seq), credentials::ids({credIdx}));
+            env.close();
+
+            {
+                const char credType2[] = "fghijk";
+
+                env(credentials::create(bob, zelda, credType2));
+                env.close();
+                env(credentials::accept(bob, zelda, credType2));
+                env.close();
+                auto const credIdxBob =
+                    credentials::ledgerEntry(
+                        env, bob, zelda, credType2)[jss::result][jss::index]
+                        .asString();
+
+                auto const seq = env.seq(alice);
+                env(escrow(alice, bob, XRP(1000)), finish_time(env.now() + 1s));
+                env.close();
+
+                // Bob require preauthorization
+                env(fset(bob, asfDepositAuth));
+                env.close();
+                env(deposit::authCredentials(bob, {{zelda, credType}}));
+                env.close();
+
+                // Use any valid credentials if account == dst
+                env(finish(bob, alice, seq), credentials::ids({credIdxBob}));
+                env.close();
+            }
+        }
+    }
+
+    void
     run() override
     {
         testEnablement();
@@ -1522,6 +1664,7 @@ struct Escrow_test : public beast::unit_test::suite
         testMetaAndOwnership();
         testConsequences();
         testEscrowWithTickets();
+        testCredentials();
     }
 };
 

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -1533,12 +1533,17 @@ struct Escrow_test : public beast::unit_test::suite
             auto const seq = env.seq(alice);
             env(escrow(alice, bob, XRP(1000)), finish_time(env.now() + 1s));
             env.close();
+
+            // can finish with old DepositPreauth
+            env(fset(bob, asfDepositAuth));
+            env.close();
+            env(deposit::auth(bob, alice));
+            env.close();
+
             std::string const credIdx =
                 "48004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
                 "E4";
-            env(finish(bob, alice, seq),
-                credentials::ids({credIdx}),
-                ter(temDISABLED));
+            env(finish(bob, alice, seq), credentials::ids({credIdx}));
         }
 
         {

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -1534,7 +1534,6 @@ struct Escrow_test : public beast::unit_test::suite
             env(escrow(alice, bob, XRP(1000)), finish_time(env.now() + 1s));
             env.close();
 
-            // can finish with old DepositPreauth
             env(fset(bob, asfDepositAuth));
             env.close();
             env(deposit::auth(bob, alice));
@@ -1543,7 +1542,9 @@ struct Escrow_test : public beast::unit_test::suite
             std::string const credIdx =
                 "48004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
                 "E4";
-            env(finish(bob, alice, seq), credentials::ids({credIdx}));
+            env(finish(bob, alice, seq),
+                credentials::ids({credIdx}),
+                ter(temDISABLED));
         }
 
         {

--- a/src/test/app/FixNFTokenPageLinks_test.cpp
+++ b/src/test/app/FixNFTokenPageLinks_test.cpp
@@ -27,16 +27,6 @@ namespace ripple {
 
 class FixNFTokenPageLinks_test : public beast::unit_test::suite
 {
-    // Helper function that returns the owner count of an account root.
-    static std::uint32_t
-    ownerCount(test::jtx::Env const& env, test::jtx::Account const& acct)
-    {
-        std::uint32_t ret{0};
-        if (auto const sleAcct = env.le(acct))
-            ret = sleAcct->at(sfOwnerCount);
-        return ret;
-    }
-
     // Helper function that returns the number of nfts owned by an account.
     static std::uint32_t
     nftCount(test::jtx::Env& env, test::jtx::Account const& acct)

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -1432,8 +1432,8 @@ class MPToken_test : public beast::unit_test::suite
             env(fset(bob, asfDepositAuth));
             env.close();
 
-            // alice try to send 100 MPT to bob, authorization is not checked
-            mptAlice.pay(alice, bob, 100);
+            // alice try to send 100 MPT to bob, not authorized
+            mptAlice.pay(alice, bob, 100, tecNO_PERMISSION);
             env.close();
 
             // alice try to send 100 MPT to bob with credentials, amendment
@@ -1445,7 +1445,7 @@ class MPToken_test : public beast::unit_test::suite
             env(deposit::auth(bob, alice));
             env.close();
 
-            // alice sends 100 MPT to bob, authorization is not checked
+            // alice sends 100 MPT to bob
             mptAlice.pay(alice, bob, 100);
             env.close();
 
@@ -1457,8 +1457,8 @@ class MPToken_test : public beast::unit_test::suite
             env(deposit::unauth(bob, alice));
             env.close();
 
-            // alice try to send 100 MPT to bob, authorization is not checked
-            mptAlice.pay(alice, bob, 100);
+            // alice try to send 100 MPT to bob
+            mptAlice.pay(alice, bob, 100, tecNO_PERMISSION);
             env.close();
 
             // alice sends 100 MPT to bob with credentials, amendment disabled

--- a/src/test/app/NFTokenBurn_test.cpp
+++ b/src/test/app/NFTokenBurn_test.cpp
@@ -28,16 +28,6 @@ namespace ripple {
 
 class NFTokenBurnBaseUtil_test : public beast::unit_test::suite
 {
-    // Helper function that returns the owner count of an account root.
-    static std::uint32_t
-    ownerCount(test::jtx::Env const& env, test::jtx::Account const& acct)
-    {
-        std::uint32_t ret{0};
-        if (auto const sleAcct = env.le(acct))
-            ret = sleAcct->at(sfOwnerCount);
-        return ret;
-    }
-
     // Helper function that returns the number of nfts owned by an account.
     static std::uint32_t
     nftCount(test::jtx::Env& env, test::jtx::Account const& acct)

--- a/src/test/app/NFToken_test.cpp
+++ b/src/test/app/NFToken_test.cpp
@@ -31,16 +31,6 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
 {
     FeatureBitset const disallowIncoming{featureDisallowIncoming};
 
-    // Helper function that returns the owner count of an account root.
-    static std::uint32_t
-    ownerCount(test::jtx::Env const& env, test::jtx::Account const& acct)
-    {
-        std::uint32_t ret{0};
-        if (auto const sleAcct = env.le(acct))
-            ret = sleAcct->at(sfOwnerCount);
-        return ret;
-    }
-
     // Helper function that returns the number of NFTs minted by an issuer.
     static std::uint32_t
     mintedCount(test::jtx::Env const& env, test::jtx::Account const& issuer)
@@ -3948,7 +3938,7 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
                     for (Account const& acct : accounts)
                     {
                         if (std::uint32_t ownerCount =
-                                this->ownerCount(env, acct);
+                                test::jtx::ownerCount(env, acct);
                             ownerCount != 1)
                         {
                             std::stringstream ss;

--- a/src/test/app/Oracle_test.cpp
+++ b/src/test/app/Oracle_test.cpp
@@ -28,16 +28,6 @@ namespace oracle {
 struct Oracle_test : public beast::unit_test::suite
 {
 private:
-    // Helper function that returns the owner count of an account root.
-    static std::uint32_t
-    ownerCount(jtx::Env const& env, jtx::Account const& acct)
-    {
-        std::uint32_t ret{0};
-        if (auto const sleAcct = env.le(acct))
-            ret = sleAcct->at(sfOwnerCount);
-        return ret;
-    }
-
     void
     testInvalidSet()
     {

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -833,6 +833,180 @@ struct PayChan_test : public beast::unit_test::suite
     }
 
     void
+    testDepositAuthCreds()
+    {
+        testcase("Deposit Authorization with Credentials");
+        using namespace jtx;
+        using namespace std::literals::chrono_literals;
+
+        const char credType[] = "abcde";
+
+        Account const alice("alice");
+        Account const bob("bob");
+        Account const carol("carol");
+        Account const dillon("dillon");
+        Account const zelda("zelda");
+
+        {
+            Env env{*this};
+            env.fund(XRP(10000), alice, bob, carol, dillon, zelda);
+
+            auto const pk = alice.pk();
+            auto const settleDelay = 100s;
+            auto const chan = channel(alice, bob, env.seq(alice));
+            env(create(alice, bob, XRP(1000), settleDelay, pk));
+            env.close();
+
+            // alice add funds to the channel
+            env(fund(alice, chan, XRP(1000)));
+            env.close();
+
+            std::string const credBadIdx =
+                "D007AE4B6E1274B4AF872588267B810C2F82716726351D1C7D38D3E5499FC6"
+                "E1";
+
+            auto const delta = XRP(500).value();
+
+            {  // create credentials
+                auto jv = credentials::create(alice, carol, credType);
+                uint32_t const t = env.now().time_since_epoch().count() + 100;
+                jv[sfExpiration.jsonName] = t;
+                env(jv);
+                env.close();
+            }
+
+            auto const jv =
+                credentials::ledgerEntry(env, alice, carol, credType);
+            std::string const credIdx = jv[jss::result][jss::index].asString();
+
+            // Bob require preauthorization
+            env(fset(bob, asfDepositAuth));
+            env.close();
+
+            // Fail, credentials doesn’t belong to root account
+            env(claim(dillon, chan, delta, delta),
+                credentials::ids({credIdx}),
+                ter(tecBAD_CREDENTIALS));
+
+            // Fail, credentials not accepted
+            env(claim(alice, chan, delta, delta),
+                credentials::ids({credIdx}),
+                ter(tecBAD_CREDENTIALS));
+            env.close();
+
+            env(credentials::accept(alice, carol, credType));
+            env.close();
+
+            // Fail, no depositPreauth object
+            env(claim(alice, chan, delta, delta),
+                credentials::ids({credIdx}),
+                ter(tecNO_PERMISSION));
+            env.close();
+
+            // Setup deposit authorization
+            env(deposit::authCredentials(bob, {{carol, credType}}));
+            env.close();
+
+            // Fails because bob's lsfDepositAuth flag is set.
+            env(claim(alice, chan, delta, delta), ter(tecNO_PERMISSION));
+
+            // Fail, bad credentials index.
+            env(claim(alice, chan, delta, delta),
+                credentials::ids({credBadIdx}),
+                ter(tecBAD_CREDENTIALS));
+
+            // Fail, empty credentials
+            env(claim(alice, chan, delta, delta),
+                credentials::ids({}),
+                ter(temMALFORMED));
+
+            {
+                // claim fails cause of expired credentials
+
+                // Every cycle +10sec.
+                for (int i = 0; i < 10; ++i)
+                    env.close();
+
+                env(claim(alice, chan, delta, delta),
+                    credentials::ids({credIdx}),
+                    ter(tecEXPIRED));
+                env.close();
+            }
+
+            {  // create credentials once more
+                env(credentials::create(alice, carol, credType));
+                env.close();
+                env(credentials::accept(alice, carol, credType));
+                env.close();
+
+                auto const jv =
+                    credentials::ledgerEntry(env, alice, carol, credType);
+                std::string const credIdx =
+                    jv[jss::result][jss::index].asString();
+
+                // Success
+                env(claim(alice, chan, delta, delta),
+                    credentials::ids({credIdx}));
+            }
+        }
+
+        {
+            Env env{*this};
+            env.fund(XRP(10000), alice, bob, carol, dillon, zelda);
+
+            auto const pk = alice.pk();
+            auto const settleDelay = 100s;
+            auto const chan = channel(alice, bob, env.seq(alice));
+            env(create(alice, bob, XRP(1000), settleDelay, pk));
+            env.close();
+
+            // alice add funds to the channel
+            env(fund(alice, chan, XRP(1000)));
+            env.close();
+
+            auto const delta = XRP(500).value();
+
+            {  // create credentials
+                env(credentials::create(alice, carol, credType));
+                env.close();
+                env(credentials::accept(alice, carol, credType));
+                env.close();
+            }
+
+            auto const jv =
+                credentials::ledgerEntry(env, alice, carol, credType);
+            std::string const credIdx = jv[jss::result][jss::index].asString();
+
+            // Succeed, lsfDepositAuth is not set
+            env(claim(alice, chan, delta, delta), credentials::ids({credIdx}));
+            env.close();
+        }
+
+        {
+            // Credentials amendment not enabled
+            Env env(*this, supported_amendments() - featureCredentials);
+            env.fund(XRP(5000), "alice", "bob");
+            env.close();
+
+            auto const pk = alice.pk();
+            auto const settleDelay = 100s;
+            auto const chan = channel(alice, bob, env.seq(alice));
+            env(create(alice, bob, XRP(1000), settleDelay, pk));
+            env.close();
+
+            env(fund(alice, chan, XRP(1000)));
+            env.close();
+            std::string const credIdx =
+                "48004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
+                "E4";
+            // Fails because rule not enabled.
+            env(claim(alice, chan, XRP(500).value(), XRP(500).value()),
+                credentials::ids({credIdx}),
+                ter(temDISABLED));
+        }
+    }
+
+    void
     testMultiple(FeatureBitset features)
     {
         // auth amount defaults to balance if not present
@@ -2116,6 +2290,7 @@ public:
         FeatureBitset const all{supported_amendments()};
         testWithFeats(all - disallowIncoming);
         testWithFeats(all);
+        testDepositAuthCreds();
     }
 };
 

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -1003,10 +1003,15 @@ struct PayChan_test : public beast::unit_test::suite
             std::string const credIdx =
                 "48004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
                 "E4";
-            // Fails because rule not enabled.
+
+            // can claim with old DepositPreauth
+            env(fset(bob, asfDepositAuth));
+            env.close();
+            env(deposit::auth(bob, alice));
+            env.close();
+
             env(claim(alice, chan, XRP(500).value(), XRP(500).value()),
-                credentials::ids({credIdx}),
-                ter(temDISABLED));
+                credentials::ids({credIdx}));
         }
     }
 

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -1004,14 +1004,15 @@ struct PayChan_test : public beast::unit_test::suite
                 "48004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
                 "E4";
 
-            // can claim with old DepositPreauth
+            // can't claim with old DepositPreauth because rule is not enabled.
             env(fset(bob, asfDepositAuth));
             env.close();
             env(deposit::auth(bob, alice));
             env.close();
 
             env(claim(alice, chan, XRP(500).value(), XRP(500).value()),
-                credentials::ids({credIdx}));
+                credentials::ids({credIdx}),
+                ter(temDISABLED));
         }
     }
 

--- a/src/test/jtx.h
+++ b/src/test/jtx.h
@@ -32,6 +32,7 @@
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>
 #include <test/jtx/check.h>
+#include <test/jtx/credentials.h>
 #include <test/jtx/delivermin.h>
 #include <test/jtx/deposit.h>
 #include <test/jtx/did.h>

--- a/src/test/jtx/TestHelpers.h
+++ b/src/test/jtx/TestHelpers.h
@@ -96,6 +96,10 @@ getAccountLines(Env& env, AccountID const& acctId, IOU... ious)
 [[nodiscard]] bool
 checkArraySize(Json::Value const& val, unsigned int size);
 
+// Helper function that returns the owner count on an account.
+std::uint32_t
+ownerCount(test::jtx::Env const& env, test::jtx::Account const& account);
+
 /* Path finding */
 /******************************************************************************/
 void

--- a/src/test/jtx/credentials.h
+++ b/src/test/jtx/credentials.h
@@ -1,0 +1,104 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2024 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include <test/jtx/Account.h>
+#include <test/jtx/Env.h>
+#include <test/jtx/owners.h>
+
+namespace ripple {
+namespace test {
+namespace jtx {
+
+namespace credentials {
+
+// Sets the optional URI.
+class uri
+{
+private:
+    std::string const uri_;
+
+public:
+    explicit uri(std::string_view u) : uri_(strHex(u))
+    {
+    }
+
+    void
+    operator()(jtx::Env&, jtx::JTx& jtx) const
+    {
+        jtx.jv[sfURI.jsonName] = uri_;
+    }
+};
+
+// Set credentialsIDs array
+class ids
+{
+private:
+    std::vector<std::string> const credentials_;
+
+public:
+    explicit ids(std::vector<std::string> const& creds) : credentials_(creds)
+    {
+    }
+
+    void
+    operator()(jtx::Env&, jtx::JTx& jtx) const
+    {
+        auto& arr(jtx.jv[sfCredentialIDs.jsonName] = Json::arrayValue);
+        for (auto const& hash : credentials_)
+            arr.append(hash);
+    }
+};
+
+Json::Value
+create(
+    jtx::Account const& subject,
+    jtx::Account const& issuer,
+    std::string_view credType);
+
+Json::Value
+accept(
+    jtx::Account const& subject,
+    jtx::Account const& issuer,
+    std::string_view credType);
+
+Json::Value
+deleteCred(
+    jtx::Account const& acc,
+    jtx::Account const& subject,
+    jtx::Account const& issuer,
+    std::string_view credType);
+
+Json::Value
+ledgerEntry(
+    jtx::Env& env,
+    jtx::Account const& subject,
+    jtx::Account const& issuer,
+    std::string_view credType);
+
+Json::Value
+ledgerEntry(jtx::Env& env, std::string const& credIdx);
+
+}  // namespace credentials
+
+}  // namespace jtx
+
+}  // namespace test
+}  // namespace ripple

--- a/src/test/jtx/deposit.h
+++ b/src/test/jtx/deposit.h
@@ -38,6 +38,41 @@ auth(Account const& account, Account const& auth);
 Json::Value
 unauth(Account const& account, Account const& unauth);
 
+struct AuthorizeCredentials
+{
+    jtx::Account issuer;
+    std::string credType;
+
+    Json::Value
+    toJson() const
+    {
+        Json::Value jv;
+        jv[jss::Issuer] = issuer.human();
+        jv[sfCredentialType.jsonName] = strHex(credType);
+        return jv;
+    }
+
+    // "ledger_entry" uses a different naming convention
+    Json::Value
+    toLEJson() const
+    {
+        Json::Value jv;
+        jv[jss::issuer] = issuer.human();
+        jv[jss::credential_type] = strHex(credType);
+        return jv;
+    }
+};
+
+Json::Value
+authCredentials(
+    jtx::Account const& account,
+    std::vector<AuthorizeCredentials> const& auth);
+
+Json::Value
+unauthCredentials(
+    jtx::Account const& account,
+    std::vector<AuthorizeCredentials> const& auth);
+
 }  // namespace deposit
 
 }  // namespace jtx

--- a/src/test/jtx/impl/TestHelpers.cpp
+++ b/src/test/jtx/impl/TestHelpers.cpp
@@ -50,6 +50,15 @@ checkArraySize(Json::Value const& val, unsigned int size)
     return val.isArray() && val.size() == size;
 }
 
+std::uint32_t
+ownerCount(Env const& env, Account const& account)
+{
+    std::uint32_t ret{0};
+    if (auto const sleAccount = env.le(account))
+        ret = sleAccount->getFieldU32(sfOwnerCount);
+    return ret;
+}
+
 /* Path finding */
 /******************************************************************************/
 void

--- a/src/test/jtx/impl/credentials.cpp
+++ b/src/test/jtx/impl/credentials.cpp
@@ -1,0 +1,110 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2024 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <test/jtx/credentials.h>
+#include <xrpl/protocol/TxFlags.h>
+#include <xrpl/protocol/jss.h>
+
+namespace ripple {
+namespace test {
+namespace jtx {
+
+namespace credentials {
+
+Json::Value
+create(
+    jtx::Account const& subject,
+    jtx::Account const& issuer,
+    std::string_view credType)
+{
+    Json::Value jv;
+    jv[jss::TransactionType] = jss::CredentialCreate;
+
+    jv[jss::Account] = issuer.human();
+    jv[jss::Subject] = subject.human();
+
+    jv[jss::Flags] = tfUniversal;
+    jv[sfCredentialType.jsonName] = strHex(credType);
+
+    return jv;
+}
+
+Json::Value
+accept(
+    jtx::Account const& subject,
+    jtx::Account const& issuer,
+    std::string_view credType)
+{
+    Json::Value jv;
+    jv[jss::TransactionType] = jss::CredentialAccept;
+    jv[jss::Account] = subject.human();
+    jv[jss::Issuer] = issuer.human();
+    jv[sfCredentialType.jsonName] = strHex(credType);
+    jv[jss::Flags] = tfUniversal;
+
+    return jv;
+}
+
+Json::Value
+deleteCred(
+    jtx::Account const& acc,
+    jtx::Account const& subject,
+    jtx::Account const& issuer,
+    std::string_view credType)
+{
+    Json::Value jv;
+    jv[jss::TransactionType] = jss::CredentialDelete;
+    jv[jss::Account] = acc.human();
+    jv[jss::Subject] = subject.human();
+    jv[jss::Issuer] = issuer.human();
+    jv[sfCredentialType.jsonName] = strHex(credType);
+    jv[jss::Flags] = tfUniversal;
+    return jv;
+}
+
+Json::Value
+ledgerEntry(
+    jtx::Env& env,
+    jtx::Account const& subject,
+    jtx::Account const& issuer,
+    std::string_view credType)
+{
+    Json::Value jvParams;
+    jvParams[jss::ledger_index] = jss::validated;
+    jvParams[jss::credential][jss::subject] = subject.human();
+    jvParams[jss::credential][jss::issuer] = issuer.human();
+    jvParams[jss::credential][jss::credential_type] = strHex(credType);
+    return env.rpc("json", "ledger_entry", to_string(jvParams));
+}
+
+Json::Value
+ledgerEntry(jtx::Env& env, std::string const& credIdx)
+{
+    Json::Value jvParams;
+    jvParams[jss::ledger_index] = jss::validated;
+    jvParams[jss::credential] = credIdx;
+    return env.rpc("json", "ledger_entry", to_string(jvParams));
+}
+
+}  // namespace credentials
+
+}  // namespace jtx
+
+}  // namespace test
+}  // namespace ripple

--- a/src/test/jtx/impl/deposit.cpp
+++ b/src/test/jtx/impl/deposit.cpp
@@ -48,6 +48,46 @@ unauth(jtx::Account const& account, jtx::Account const& unauth)
     return jv;
 }
 
+// Add DepositPreauth.
+Json::Value
+authCredentials(
+    jtx::Account const& account,
+    std::vector<AuthorizeCredentials> const& auth)
+{
+    Json::Value jv;
+    jv[sfAccount.jsonName] = account.human();
+    jv[sfAuthorizeCredentials.jsonName] = Json::arrayValue;
+    auto& arr(jv[sfAuthorizeCredentials.jsonName]);
+    for (auto const& o : auth)
+    {
+        Json::Value j2;
+        j2[jss::Credential] = o.toJson();
+        arr.append(std::move(j2));
+    }
+    jv[sfTransactionType.jsonName] = jss::DepositPreauth;
+    return jv;
+}
+
+// Remove DepositPreauth.
+Json::Value
+unauthCredentials(
+    jtx::Account const& account,
+    std::vector<AuthorizeCredentials> const& auth)
+{
+    Json::Value jv;
+    jv[sfAccount.jsonName] = account.human();
+    jv[sfUnauthorizeCredentials.jsonName] = Json::arrayValue;
+    auto& arr(jv[sfUnauthorizeCredentials.jsonName]);
+    for (auto const& o : auth)
+    {
+        Json::Value j2;
+        j2[jss::Credential] = o.toJson();
+        arr.append(std::move(j2));
+    }
+    jv[sfTransactionType.jsonName] = jss::DepositPreauth;
+    return jv;
+}
+
 }  // namespace deposit
 
 }  // namespace jtx

--- a/src/test/jtx/impl/mpt.cpp
+++ b/src/test/jtx/impl/mpt.cpp
@@ -301,14 +301,23 @@ MPTTester::pay(
     Account const& src,
     Account const& dest,
     std::int64_t amount,
-    std::optional<TER> err)
+    std::optional<TER> err,
+    std::optional<std::vector<std::string>> credentials)
 {
     if (!id_)
         Throw<std::runtime_error>("MPT has not been created");
     auto const srcAmt = getBalance(src);
     auto const destAmt = getBalance(dest);
     auto const outstnAmt = getBalance(issuer_);
-    env_(jtx::pay(src, dest, mpt(amount)), ter(err.value_or(tesSUCCESS)));
+
+    if (credentials)
+        env_(
+            jtx::pay(src, dest, mpt(amount)),
+            ter(err.value_or(tesSUCCESS)),
+            credentials::ids(*credentials));
+    else
+        env_(jtx::pay(src, dest, mpt(amount)), ter(err.value_or(tesSUCCESS)));
+
     if (env_.ter() != tesSUCCESS)
         amount = 0;
     if (close_)

--- a/src/test/jtx/mpt.h
+++ b/src/test/jtx/mpt.h
@@ -186,7 +186,8 @@ public:
     pay(Account const& src,
         Account const& dest,
         std::int64_t amount,
-        std::optional<TER> err = std::nullopt);
+        std::optional<TER> err = std::nullopt,
+        std::optional<std::vector<std::string>> credentials = std::nullopt);
 
     void
     claw(

--- a/src/test/rpc/DepositAuthorized_test.cpp
+++ b/src/test/rpc/DepositAuthorized_test.cpp
@@ -398,6 +398,51 @@ public:
         env.close();
 
         {
+            testcase("deposit_authorized with duplicates in credentials");
+            auto const jv = env.rpc(
+                "json",
+                "deposit_authorized",
+                depositAuthArgs(alice, becky, "validated", {credIdx, credIdx})
+                    .toStyledString());
+            auto const& result{jv[jss::result]};
+            BEAST_EXPECT(result[jss::status] == jss::error);
+            BEAST_EXPECT(result[jss::error_code] == rpcBAD_CREDENTIALS);
+        }
+
+        {
+            static const std::vector<std::string> credIds = {
+                "18004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
+                "E4",
+                "28004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
+                "E4",
+                "38004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
+                "E4",
+                "48004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
+                "E4",
+                "58004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
+                "E4",
+                "68004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
+                "E4",
+                "78004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
+                "E4",
+                "88004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
+                "E4",
+                "98004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
+                "E4"};
+            assert(credIds.size() > maxCredentialsArraySize);
+
+            testcase("deposit_authorized too long credentials");
+            auto const jv = env.rpc(
+                "json",
+                "deposit_authorized",
+                depositAuthArgs(alice, becky, "validated", credIds)
+                    .toStyledString());
+            auto const& result{jv[jss::result]};
+            BEAST_EXPECT(result[jss::status] == jss::error);
+            BEAST_EXPECT(result[jss::error_code] == rpcINVALID_PARAMS);
+        }
+
+        {
             testcase("deposit_authorized with credentials");
             auto const jv = env.rpc(
                 "json",

--- a/src/test/rpc/DepositAuthorized_test.cpp
+++ b/src/test/rpc/DepositAuthorized_test.cpp
@@ -31,13 +31,22 @@ public:
     depositAuthArgs(
         jtx::Account const& source,
         jtx::Account const& dest,
-        std::string const& ledger = "")
+        std::string const& ledger = "",
+        std::vector<std::string> const& credentials = {})
     {
         Json::Value args{Json::objectValue};
         args[jss::source_account] = source.human();
         args[jss::destination_account] = dest.human();
         if (!ledger.empty())
             args[jss::ledger_index] = ledger;
+
+        if (!credentials.empty())
+        {
+            auto& arr(args[jss::credentials] = Json::arrayValue);
+            for (auto const& s : credentials)
+                arr.append(s);
+        }
+
         return args;
     }
 
@@ -277,10 +286,200 @@ public:
     }
 
     void
+    testCredentials()
+    {
+        using namespace jtx;
+
+        const char credType[] = "abcde";
+
+        Account const alice{"alice"};
+        Account const becky{"becky"};
+        Account const carol{"carol"};
+
+        Env env(*this);
+        env.fund(XRP(1000), alice, becky, carol);
+        env.close();
+
+        // carol recognize becky
+        env(credentials::create(alice, carol, credType));
+        env.close();
+        // retrieve the index of the credentials
+        auto const jv = credentials::ledgerEntry(env, alice, carol, credType);
+        std::string const credIdx = jv[jss::result][jss::index].asString();
+
+        // becky sets the DepositAuth flag in the current ledger.
+        env(fset(becky, asfDepositAuth));
+        env.close();
+
+        // becky authorize any account recognized by carol to make a payment
+        env(deposit::authCredentials(becky, {{carol, credType}}));
+        env.close();
+
+        {
+            testcase(
+                "deposit_authorized with credentials failed: empty array.");
+
+            auto args = depositAuthArgs(alice, becky, "validated");
+            args[jss::credentials] = Json::arrayValue;
+
+            auto const jv =
+                env.rpc("json", "deposit_authorized", args.toStyledString());
+            auto const& result{jv[jss::result]};
+            BEAST_EXPECT(result.isMember(jss::error));
+        }
+
+        {
+            testcase(
+                "deposit_authorized with credentials failed: not a string "
+                "credentials");
+
+            auto args = depositAuthArgs(alice, becky, "validated");
+            args[jss::credentials] = Json::arrayValue;
+            args[jss::credentials].append(1);
+            args[jss::credentials].append(3);
+
+            auto const jv =
+                env.rpc("json", "deposit_authorized", args.toStyledString());
+            auto const& result{jv[jss::result]};
+            BEAST_EXPECT(result.isMember(jss::error));
+        }
+
+        {
+            testcase(
+                "deposit_authorized with credentials failed: not a hex string "
+                "credentials");
+
+            auto args = depositAuthArgs(alice, becky, "validated");
+            args[jss::credentials] = Json::arrayValue;
+            args[jss::credentials].append("hello world");
+
+            auto const jv =
+                env.rpc("json", "deposit_authorized", args.toStyledString());
+            auto const& result{jv[jss::result]};
+            BEAST_EXPECT(result.isMember(jss::error));
+        }
+
+        {
+            testcase(
+                "deposit_authorized with credentials failed: not a credential "
+                "index");
+
+            auto args = depositAuthArgs(
+                alice,
+                becky,
+                "validated",
+                {"0127AB8B4B29CCDBB61AA51C0799A8A6BB80B86A9899807C11ED576AF8516"
+                 "473"});
+
+            auto const jv =
+                env.rpc("json", "deposit_authorized", args.toStyledString());
+
+            auto const& result{jv[jss::result]};
+            BEAST_EXPECT(result[jss::status] == jss::error);
+            BEAST_EXPECT(result[jss::error_code] == rpcBAD_CREDENTIALS);
+        }
+
+        {
+            testcase(
+                "deposit_authorized with credentials not authorized: "
+                "credential not accepted");
+            auto const jv = env.rpc(
+                "json",
+                "deposit_authorized",
+                depositAuthArgs(alice, becky, "validated", {credIdx})
+                    .toStyledString());
+            auto const& result{jv[jss::result]};
+            BEAST_EXPECT(result[jss::status] == jss::error);
+            BEAST_EXPECT(result[jss::error_code] == rpcBAD_CREDENTIALS);
+        }
+
+        // alice accept credentials
+        env(credentials::accept(alice, carol, credType));
+        env.close();
+
+        {
+            testcase("deposit_authorized with credentials");
+            auto const jv = env.rpc(
+                "json",
+                "deposit_authorized",
+                depositAuthArgs(alice, becky, "validated", {credIdx})
+                    .toStyledString());
+            auto const& result{jv[jss::result]};
+            BEAST_EXPECT(result[jss::status] == jss::success);
+            BEAST_EXPECT(result[jss::deposit_authorized] == true);
+        }
+
+        {
+            testcase("deposit_authorized  account without preauth");
+            auto const jv = env.rpc(
+                "json",
+                "deposit_authorized",
+                depositAuthArgs(becky, alice, "validated", {credIdx})
+                    .toStyledString());
+            auto const& result{jv[jss::result]};
+            BEAST_EXPECT(result[jss::status] == jss::success);
+            BEAST_EXPECT(result[jss::deposit_authorized] == true);
+        }
+
+        {
+            testcase("deposit_authorized with expired credentials");
+
+            // check expired credentials
+            const char credType2[] = "fghijk";
+            std::uint32_t const x = env.now().time_since_epoch().count() + 40;
+
+            // create credentials with expire time 1s
+            auto jv = credentials::create(alice, carol, credType2);
+            jv[sfExpiration.jsonName] = x;
+            env(jv);
+            env.close();
+            env(credentials::accept(alice, carol, credType2));
+            env.close();
+            jv = credentials::ledgerEntry(env, alice, carol, credType2);
+            std::string const credIdx2 = jv[jss::result][jss::index].asString();
+
+            // becky sets the DepositAuth flag in the current ledger.
+            env(fset(becky, asfDepositAuth));
+            env.close();
+
+            // becky authorize any account recognized by carol to make a payment
+            env(deposit::authCredentials(becky, {{carol, credType2}}));
+            env.close();
+
+            {
+                // this should be fine
+                jv = env.rpc(
+                    "json",
+                    "deposit_authorized",
+                    depositAuthArgs(alice, becky, "validated", {credIdx2})
+                        .toStyledString());
+                auto const& result{jv[jss::result]};
+                BEAST_EXPECT(result[jss::status] == jss::success);
+                BEAST_EXPECT(result[jss::deposit_authorized] == true);
+            }
+
+            env.close();  // increase timer by 10s
+            {
+                // now credentials expired
+                jv = env.rpc(
+                    "json",
+                    "deposit_authorized",
+                    depositAuthArgs(alice, becky, "validated", {credIdx2})
+                        .toStyledString());
+
+                auto const& result{jv[jss::result]};
+                BEAST_EXPECT(result[jss::status] == jss::error);
+                BEAST_EXPECT(result[jss::error_code] == rpcBAD_CREDENTIALS);
+            }
+        }
+    }
+
+    void
     run() override
     {
         testValid();
         testErrors();
+        testCredentials();
     }
 };
 

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -812,10 +812,55 @@ class LedgerRPC_test : public beast::unit_test::suite
         }
 
         {
-            // Fail, no subject
+            // Fail, invalid credentials type
+            Json::Value jv;
+            jv[jss::ledger_index] = jss::validated;
+            jv[jss::credential][jss::subject] = alice.human();
+            jv[jss::credential][jss::issuer] = issuer.human();
+            jv[jss::credential][jss::credential_type] = 42;
+            auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Fail, empty subject
             Json::Value jv;
             jv[jss::ledger_index] = jss::validated;
             jv[jss::credential][jss::subject] = "";
+            jv[jss::credential][jss::issuer] = issuer.human();
+            jv[jss::credential][jss::credential_type] =
+                strHex(std::string_view(credType));
+            auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Fail, empty issuer
+            Json::Value jv;
+            jv[jss::ledger_index] = jss::validated;
+            jv[jss::credential][jss::subject] = alice.human();
+            jv[jss::credential][jss::issuer] = "";
+            jv[jss::credential][jss::credential_type] =
+                strHex(std::string_view(credType));
+            auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Fail, empty credentials type
+            Json::Value jv;
+            jv[jss::ledger_index] = jss::validated;
+            jv[jss::credential][jss::subject] = alice.human();
+            jv[jss::credential][jss::issuer] = issuer.human();
+            jv[jss::credential][jss::credential_type] = "";
+            auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Fail, no subject
+            Json::Value jv;
+            jv[jss::ledger_index] = jss::validated;
             jv[jss::credential][jss::issuer] = issuer.human();
             jv[jss::credential][jss::credential_type] =
                 strHex(std::string_view(credType));
@@ -828,7 +873,6 @@ class LedgerRPC_test : public beast::unit_test::suite
             Json::Value jv;
             jv[jss::ledger_index] = jss::validated;
             jv[jss::credential][jss::subject] = alice.human();
-            jv[jss::credential][jss::issuer] = "";
             jv[jss::credential][jss::credential_type] =
                 strHex(std::string_view(credType));
             auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
@@ -841,7 +885,41 @@ class LedgerRPC_test : public beast::unit_test::suite
             jv[jss::ledger_index] = jss::validated;
             jv[jss::credential][jss::subject] = alice.human();
             jv[jss::credential][jss::issuer] = issuer.human();
-            jv[jss::credential][jss::credential_type] = "";
+            auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Fail, not AccountID subject
+            Json::Value jv;
+            jv[jss::ledger_index] = jss::validated;
+            jv[jss::credential][jss::subject] = "wehsdbvasbdfvj";
+            jv[jss::credential][jss::issuer] = issuer.human();
+            jv[jss::credential][jss::credential_type] =
+                strHex(std::string_view(credType));
+            auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Fail, not AccountID issuer
+            Json::Value jv;
+            jv[jss::ledger_index] = jss::validated;
+            jv[jss::credential][jss::subject] = alice.human();
+            jv[jss::credential][jss::issuer] = "c4p93ugndfbsiu";
+            jv[jss::credential][jss::credential_type] =
+                strHex(std::string_view(credType));
+            auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Fail, credentials type isn't hex encoded
+            Json::Value jv;
+            jv[jss::ledger_index] = jss::validated;
+            jv[jss::credential][jss::subject] = alice.human();
+            jv[jss::credential][jss::issuer] = issuer.human();
+            jv[jss::credential][jss::credential_type] = "12KK";
             auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
             checkErrorValue(jrr[jss::result], "malformedRequest", "");
         }
@@ -857,7 +935,6 @@ class LedgerRPC_test : public beast::unit_test::suite
         Env env{*this};
         Account const alice{"alice"};
         Account const becky{"becky"};
-        Account const issuer{"issuer"};
 
         env.fund(XRP(10000), alice, becky);
         env.close();

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -1126,7 +1126,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             auto const jrr =
                 env.rpc("json", "ledger_entry", to_string(jvParams));
             checkErrorValue(
-                jrr[jss::result], "malformedAuthorizeCredentials", "");
+                jrr[jss::result], "malformedAuthorizedCredentials", "");
         }
 
         {
@@ -1148,7 +1148,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             auto const jrr =
                 env.rpc("json", "ledger_entry", to_string(jvParams));
             checkErrorValue(
-                jrr[jss::result], "malformedAuthorizeCredentials", "");
+                jrr[jss::result], "malformedAuthorizedCredentials", "");
         }
 
         {
@@ -1170,7 +1170,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             auto const jrr =
                 env.rpc("json", "ledger_entry", to_string(jvParams));
             checkErrorValue(
-                jrr[jss::result], "malformedAuthorizeCredentials", "");
+                jrr[jss::result], "malformedAuthorizedCredentials", "");
         }
 
         {
@@ -1218,7 +1218,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             auto const jrr =
                 env.rpc("json", "ledger_entry", to_string(jvParams));
             checkErrorValue(
-                jrr[jss::result], "malformedAuthorizeCredentials", "");
+                jrr[jss::result], "malformedAuthorizedCredentials", "");
         }
 
         {
@@ -1260,7 +1260,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             auto const jrr =
                 env.rpc("json", "ledger_entry", to_string(jvParams));
             checkErrorValue(
-                jrr[jss::result], "malformedAuthorizeCredentials", "");
+                jrr[jss::result], "malformedAuthorizedCredentials", "");
         }
 
         {
@@ -1282,7 +1282,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             auto const jrr =
                 env.rpc("json", "ledger_entry", to_string(jvParams));
             checkErrorValue(
-                jrr[jss::result], "malformedAuthorizeCredentials", "");
+                jrr[jss::result], "malformedAuthorizedCredentials", "");
         }
 
         {
@@ -1304,7 +1304,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             auto const jrr =
                 env.rpc("json", "ledger_entry", to_string(jvParams));
             checkErrorValue(
-                jrr[jss::result], "malformedAuthorizeCredentials", "");
+                jrr[jss::result], "malformedAuthorizedCredentials", "");
         }
 
         {

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -728,6 +728,126 @@ class LedgerRPC_test : public beast::unit_test::suite
     }
 
     void
+    testLedgerEntryCredentials()
+    {
+        testcase("ledger_entry credentials");
+
+        using namespace test::jtx;
+
+        Env env(*this);
+        Account const issuer{"issuer"};
+        Account const alice{"alice"};
+        Account const bob{"bob"};
+        const char credType[] = "abcde";
+
+        env.fund(XRP(5000), issuer, alice, bob);
+        env.close();
+
+        // Setup credentials with DepositAuth object for Alice and Bob
+        env(credentials::create(alice, issuer, credType));
+        env.close();
+
+        {
+            // Succeed
+            auto jv = credentials::ledgerEntry(env, alice, issuer, credType);
+            BEAST_EXPECT(
+                jv.isObject() && jv.isMember(jss::result) &&
+                !jv[jss::result].isMember(jss::error) &&
+                jv[jss::result].isMember(jss::node) &&
+                jv[jss::result][jss::node].isMember(
+                    sfLedgerEntryType.jsonName) &&
+                jv[jss::result][jss::node][sfLedgerEntryType.jsonName] ==
+                    jss::Credential);
+
+            std::string const credIdx = jv[jss::result][jss::index].asString();
+
+            jv = credentials::ledgerEntry(env, credIdx);
+            BEAST_EXPECT(
+                jv.isObject() && jv.isMember(jss::result) &&
+                !jv[jss::result].isMember(jss::error) &&
+                jv[jss::result].isMember(jss::node) &&
+                jv[jss::result][jss::node].isMember(
+                    sfLedgerEntryType.jsonName) &&
+                jv[jss::result][jss::node][sfLedgerEntryType.jsonName] ==
+                    jss::Credential);
+        }
+
+        {
+            // Fail, index not a hash
+            auto const jv = credentials::ledgerEntry(env, "");
+            checkErrorValue(jv[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Fail, credential doesn't exist
+            auto const jv = credentials::ledgerEntry(
+                env,
+                "48004829F915654A81B11C4AB8218D96FED67F209B58328A72314FB6EA288B"
+                "E4");
+            checkErrorValue(jv[jss::result], "entryNotFound", "");
+        }
+
+        {
+            // Fail, invalid subject
+            Json::Value jv;
+            jv[jss::ledger_index] = jss::validated;
+            jv[jss::credential][jss::subject] = 42;
+            jv[jss::credential][jss::issuer] = issuer.human();
+            jv[jss::credential][jss::credential_type] =
+                strHex(std::string_view(credType));
+            auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Fail, invalid issuer
+            Json::Value jv;
+            jv[jss::ledger_index] = jss::validated;
+            jv[jss::credential][jss::subject] = alice.human();
+            jv[jss::credential][jss::issuer] = 42;
+            jv[jss::credential][jss::credential_type] =
+                strHex(std::string_view(credType));
+            auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Fail, no subject
+            Json::Value jv;
+            jv[jss::ledger_index] = jss::validated;
+            jv[jss::credential][jss::subject] = "";
+            jv[jss::credential][jss::issuer] = issuer.human();
+            jv[jss::credential][jss::credential_type] =
+                strHex(std::string_view(credType));
+            auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Fail, no issuer
+            Json::Value jv;
+            jv[jss::ledger_index] = jss::validated;
+            jv[jss::credential][jss::subject] = alice.human();
+            jv[jss::credential][jss::issuer] = "";
+            jv[jss::credential][jss::credential_type] =
+                strHex(std::string_view(credType));
+            auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Fail, no credentials type
+            Json::Value jv;
+            jv[jss::ledger_index] = jss::validated;
+            jv[jss::credential][jss::subject] = alice.human();
+            jv[jss::credential][jss::issuer] = issuer.human();
+            jv[jss::credential][jss::credential_type] = "";
+            auto const jrr = env.rpc("json", "ledger_entry", to_string(jv));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+    }
+
+    void
     testLedgerEntryDepositPreauth()
     {
         testcase("ledger_entry Deposit Preauth");
@@ -737,6 +857,7 @@ class LedgerRPC_test : public beast::unit_test::suite
         Env env{*this};
         Account const alice{"alice"};
         Account const becky{"becky"};
+        Account const issuer{"issuer"};
 
         env.fund(XRP(10000), alice, becky);
         env.close();
@@ -855,6 +976,262 @@ class LedgerRPC_test : public beast::unit_test::suite
             Json::Value const jrr = env.rpc(
                 "json", "ledger_entry", to_string(jvParams))[jss::result];
             checkErrorValue(jrr, "malformedAuthorized", "");
+        }
+    }
+
+    void
+    testLedgerEntryDepositPreauthCred()
+    {
+        testcase("ledger_entry Deposit Preauth with credentials");
+
+        using namespace test::jtx;
+
+        Env env(*this);
+        Account const issuer{"issuer"};
+        Account const alice{"alice"};
+        Account const bob{"bob"};
+        const char credType[] = "abcde";
+
+        env.fund(XRP(5000), issuer, alice, bob);
+        env.close();
+
+        {
+            // Setup Bob with DepositAuth
+            env(fset(bob, asfDepositAuth), fee(drops(10)));
+            env.close();
+            env(deposit::authCredentials(bob, {{issuer, credType}}));
+            env.close();
+        }
+
+        {
+            // Succeed
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = jss::validated;
+            jvParams[jss::deposit_preauth][jss::owner] = bob.human();
+
+            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+                Json::arrayValue;
+            auto& arr(
+                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+
+            Json::Value jo;
+            jo[jss::issuer] = issuer.human();
+            jo[jss::credential_type] = strHex(std::string_view(credType));
+            arr.append(std::move(jo));
+            auto const jrr =
+                env.rpc("json", "ledger_entry", to_string(jvParams));
+
+            BEAST_EXPECT(
+                jrr.isObject() && jrr.isMember(jss::result) &&
+                !jrr[jss::result].isMember(jss::error) &&
+                jrr[jss::result].isMember(jss::node) &&
+                jrr[jss::result][jss::node].isMember(
+                    sfLedgerEntryType.jsonName) &&
+                jrr[jss::result][jss::node][sfLedgerEntryType.jsonName] ==
+                    jss::DepositPreauth);
+        }
+
+        {
+            // Failed, invalid account
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = jss::validated;
+            jvParams[jss::deposit_preauth][jss::owner] = bob.human();
+
+            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+                Json::arrayValue;
+            auto& arr(
+                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+
+            Json::Value jo;
+            jo[jss::issuer] = to_string(xrpAccount());
+            jo[jss::credential_type] = strHex(std::string_view(credType));
+            arr.append(std::move(jo));
+            auto const jrr =
+                env.rpc("json", "ledger_entry", to_string(jvParams));
+            checkErrorValue(
+                jrr[jss::result], "malformedAuthorizeCredentials", "");
+        }
+
+        {
+            // Failed, invalid credential_type
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = jss::validated;
+            jvParams[jss::deposit_preauth][jss::owner] = bob.human();
+
+            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+                Json::arrayValue;
+            auto& arr(
+                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+
+            Json::Value jo;
+            jo[jss::issuer] = issuer.human();
+            jo[jss::credential_type] = "";
+            arr.append(std::move(jo));
+
+            auto const jrr =
+                env.rpc("json", "ledger_entry", to_string(jvParams));
+            checkErrorValue(
+                jrr[jss::result], "malformedAuthorizeCredentials", "");
+        }
+
+        {
+            // Failed, authorized and authorize_credentials both present
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = jss::validated;
+            jvParams[jss::deposit_preauth][jss::owner] = bob.human();
+            jvParams[jss::deposit_preauth][jss::authorized] = alice.human();
+
+            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+                Json::arrayValue;
+            auto& arr(
+                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+
+            Json::Value jo;
+            jo[jss::issuer] = issuer.human();
+            jo[jss::credential_type] = strHex(std::string_view(credType));
+            arr.append(std::move(jo));
+
+            auto const jrr =
+                env.rpc("json", "ledger_entry", to_string(jvParams));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Failed, authorize_credentials is not an array
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = jss::validated;
+            jvParams[jss::deposit_preauth][jss::owner] = bob.human();
+            jvParams[jss::deposit_preauth][jss::authorize_credentials] = 42;
+
+            auto const jrr =
+                env.rpc("json", "ledger_entry", to_string(jvParams));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Failed, authorize_credentials is empty array
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = jss::validated;
+            jvParams[jss::deposit_preauth][jss::owner] = bob.human();
+            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+                Json::arrayValue;
+
+            auto const jrr =
+                env.rpc("json", "ledger_entry", to_string(jvParams));
+            checkErrorValue(
+                jrr[jss::result], "malformedAuthorizeCredentials", "");
+        }
+
+        {
+            // Failed, authorize_credentials is too long
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = jss::validated;
+            jvParams[jss::deposit_preauth][jss::owner] = bob.human();
+            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+                Json::arrayValue;
+
+            auto& arr(
+                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+
+            Json::Value jo;
+            jo[jss::issuer] = issuer.human();
+            jo[jss::credential_type] = strHex(std::string_view(credType));
+
+            for (unsigned i = 0; i < credentialsArrayMaxSize + 1; ++i)
+                arr.append(jo);
+
+            auto const jrr =
+                env.rpc("json", "ledger_entry", to_string(jvParams));
+            checkErrorValue(
+                jrr[jss::result], "malformedAuthorizeCredentials", "");
+        }
+
+        {
+            // Failed, issuer isn't string
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = jss::validated;
+            jvParams[jss::deposit_preauth][jss::owner] = bob.human();
+            jvParams[jss::deposit_preauth][jss::authorized] = alice.human();
+
+            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+                Json::arrayValue;
+            auto& arr(
+                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+
+            Json::Value jo;
+            jo[jss::issuer] = 42;
+            jo[jss::credential_type] = strHex(std::string_view(credType));
+            arr.append(std::move(jo));
+
+            auto const jrr =
+                env.rpc("json", "ledger_entry", to_string(jvParams));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Failed, issuer isn't valid encoded account
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = jss::validated;
+            jvParams[jss::deposit_preauth][jss::owner] = bob.human();
+            jvParams[jss::deposit_preauth][jss::authorized] = alice.human();
+
+            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+                Json::arrayValue;
+            auto& arr(
+                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+
+            Json::Value jo;
+            jo[jss::issuer] = "invalid_account";
+            jo[jss::credential_type] = strHex(std::string_view(credType));
+            arr.append(std::move(jo));
+
+            auto const jrr =
+                env.rpc("json", "ledger_entry", to_string(jvParams));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Failed, credential_type isn't string
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = jss::validated;
+            jvParams[jss::deposit_preauth][jss::owner] = bob.human();
+            jvParams[jss::deposit_preauth][jss::authorized] = alice.human();
+
+            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+                Json::arrayValue;
+            auto& arr(
+                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+
+            Json::Value jo;
+            jo[jss::issuer] = issuer.human();
+            jo[jss::credential_type] = 42;
+            arr.append(std::move(jo));
+
+            auto const jrr =
+                env.rpc("json", "ledger_entry", to_string(jvParams));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+        }
+
+        {
+            // Failed, credential_type isn't hex encoded
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = jss::validated;
+            jvParams[jss::deposit_preauth][jss::owner] = bob.human();
+            jvParams[jss::deposit_preauth][jss::authorized] = alice.human();
+
+            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+                Json::arrayValue;
+            auto& arr(
+                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+
+            Json::Value jo;
+            jo[jss::issuer] = issuer.human();
+            jo[jss::credential_type] = "12KK";
+            arr.append(std::move(jo));
+
+            auto const jrr =
+                env.rpc("json", "ledger_entry", to_string(jvParams));
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
         }
     }
 
@@ -2447,7 +2824,9 @@ public:
         testLedgerAccounts();
         testLedgerEntryAccountRoot();
         testLedgerEntryCheck();
+        testLedgerEntryCredentials();
         testLedgerEntryDepositPreauth();
+        testLedgerEntryDepositPreauthCred();
         testLedgerEntryDirectory();
         testLedgerEntryEscrow();
         testLedgerEntryOffer();

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -1086,10 +1086,10 @@ class LedgerRPC_test : public beast::unit_test::suite
             jvParams[jss::ledger_index] = jss::validated;
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
 
-            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+            jvParams[jss::deposit_preauth][jss::authorized_credentials] =
                 Json::arrayValue;
             auto& arr(
-                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+                jvParams[jss::deposit_preauth][jss::authorized_credentials]);
 
             Json::Value jo;
             jo[jss::issuer] = issuer.human();
@@ -1114,10 +1114,10 @@ class LedgerRPC_test : public beast::unit_test::suite
             jvParams[jss::ledger_index] = jss::validated;
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
 
-            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+            jvParams[jss::deposit_preauth][jss::authorized_credentials] =
                 Json::arrayValue;
             auto& arr(
-                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+                jvParams[jss::deposit_preauth][jss::authorized_credentials]);
 
             Json::Value jo;
             jo[jss::issuer] = to_string(xrpAccount());
@@ -1135,10 +1135,10 @@ class LedgerRPC_test : public beast::unit_test::suite
             jvParams[jss::ledger_index] = jss::validated;
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
 
-            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+            jvParams[jss::deposit_preauth][jss::authorized_credentials] =
                 Json::arrayValue;
             auto& arr(
-                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+                jvParams[jss::deposit_preauth][jss::authorized_credentials]);
 
             Json::Value jo;
             jo[jss::issuer] = issuer.human();
@@ -1157,10 +1157,10 @@ class LedgerRPC_test : public beast::unit_test::suite
             jvParams[jss::ledger_index] = jss::validated;
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
 
-            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+            jvParams[jss::deposit_preauth][jss::authorized_credentials] =
                 Json::arrayValue;
             auto& arr(
-                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+                jvParams[jss::deposit_preauth][jss::authorized_credentials]);
 
             Json::Value jo;
             jo[jss::issuer] = issuer.human();
@@ -1174,16 +1174,16 @@ class LedgerRPC_test : public beast::unit_test::suite
         }
 
         {
-            // Failed, authorized and authorize_credentials both present
+            // Failed, authorized and authorized_credentials both present
             Json::Value jvParams;
             jvParams[jss::ledger_index] = jss::validated;
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
             jvParams[jss::deposit_preauth][jss::authorized] = alice.human();
 
-            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+            jvParams[jss::deposit_preauth][jss::authorized_credentials] =
                 Json::arrayValue;
             auto& arr(
-                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+                jvParams[jss::deposit_preauth][jss::authorized_credentials]);
 
             Json::Value jo;
             jo[jss::issuer] = issuer.human();
@@ -1196,11 +1196,11 @@ class LedgerRPC_test : public beast::unit_test::suite
         }
 
         {
-            // Failed, authorize_credentials is not an array
+            // Failed, authorized_credentials is not an array
             Json::Value jvParams;
             jvParams[jss::ledger_index] = jss::validated;
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
-            jvParams[jss::deposit_preauth][jss::authorize_credentials] = 42;
+            jvParams[jss::deposit_preauth][jss::authorized_credentials] = 42;
 
             auto const jrr =
                 env.rpc("json", "ledger_entry", to_string(jvParams));
@@ -1208,11 +1208,11 @@ class LedgerRPC_test : public beast::unit_test::suite
         }
 
         {
-            // Failed, authorize_credentials is empty array
+            // Failed, authorized_credentials is empty array
             Json::Value jvParams;
             jvParams[jss::ledger_index] = jss::validated;
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
-            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+            jvParams[jss::deposit_preauth][jss::authorized_credentials] =
                 Json::arrayValue;
 
             auto const jrr =
@@ -1222,7 +1222,7 @@ class LedgerRPC_test : public beast::unit_test::suite
         }
 
         {
-            // Failed, authorize_credentials is too long
+            // Failed, authorized_credentials is too long
 
             static const std::string_view credTypes[] = {
                 "cred1",
@@ -1241,11 +1241,11 @@ class LedgerRPC_test : public beast::unit_test::suite
             Json::Value jvParams;
             jvParams[jss::ledger_index] = jss::validated;
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
-            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+            jvParams[jss::deposit_preauth][jss::authorized_credentials] =
                 Json::arrayValue;
 
             auto& arr(
-                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+                jvParams[jss::deposit_preauth][jss::authorized_credentials]);
 
             for (unsigned i = 0; i < sizeof(credTypes) / sizeof(credTypes[0]);
                  ++i)
@@ -1269,10 +1269,10 @@ class LedgerRPC_test : public beast::unit_test::suite
             jvParams[jss::ledger_index] = jss::validated;
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
 
-            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+            jvParams[jss::deposit_preauth][jss::authorized_credentials] =
                 Json::arrayValue;
             auto& arr(
-                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+                jvParams[jss::deposit_preauth][jss::authorized_credentials]);
 
             Json::Value jo;
             jo[jss::issuer] = 42;
@@ -1291,10 +1291,10 @@ class LedgerRPC_test : public beast::unit_test::suite
             jvParams[jss::ledger_index] = jss::validated;
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
 
-            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+            jvParams[jss::deposit_preauth][jss::authorized_credentials] =
                 Json::arrayValue;
             auto& arr(
-                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+                jvParams[jss::deposit_preauth][jss::authorized_credentials]);
 
             Json::Value jo;
             jo[jss::issuer] = "invalid_account";
@@ -1314,10 +1314,10 @@ class LedgerRPC_test : public beast::unit_test::suite
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
             jvParams[jss::deposit_preauth][jss::authorized] = alice.human();
 
-            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+            jvParams[jss::deposit_preauth][jss::authorized_credentials] =
                 Json::arrayValue;
             auto& arr(
-                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+                jvParams[jss::deposit_preauth][jss::authorized_credentials]);
 
             Json::Value jo;
             jo[jss::issuer] = issuer.human();
@@ -1336,10 +1336,10 @@ class LedgerRPC_test : public beast::unit_test::suite
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
             jvParams[jss::deposit_preauth][jss::authorized] = alice.human();
 
-            jvParams[jss::deposit_preauth][jss::authorize_credentials] =
+            jvParams[jss::deposit_preauth][jss::authorized_credentials] =
                 Json::arrayValue;
             auto& arr(
-                jvParams[jss::deposit_preauth][jss::authorize_credentials]);
+                jvParams[jss::deposit_preauth][jss::authorized_credentials]);
 
             Json::Value jo;
             jo[jss::issuer] = issuer.human();

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -1191,7 +1191,6 @@ class LedgerRPC_test : public beast::unit_test::suite
             Json::Value jvParams;
             jvParams[jss::ledger_index] = jss::validated;
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
-            jvParams[jss::deposit_preauth][jss::authorized] = alice.human();
 
             jvParams[jss::deposit_preauth][jss::authorize_credentials] =
                 Json::arrayValue;
@@ -1205,7 +1204,8 @@ class LedgerRPC_test : public beast::unit_test::suite
 
             auto const jrr =
                 env.rpc("json", "ledger_entry", to_string(jvParams));
-            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+            checkErrorValue(
+                jrr[jss::result], "malformedAuthorizeCredentials", "");
         }
 
         {
@@ -1213,7 +1213,6 @@ class LedgerRPC_test : public beast::unit_test::suite
             Json::Value jvParams;
             jvParams[jss::ledger_index] = jss::validated;
             jvParams[jss::deposit_preauth][jss::owner] = bob.human();
-            jvParams[jss::deposit_preauth][jss::authorized] = alice.human();
 
             jvParams[jss::deposit_preauth][jss::authorize_credentials] =
                 Json::arrayValue;
@@ -1227,7 +1226,8 @@ class LedgerRPC_test : public beast::unit_test::suite
 
             auto const jrr =
                 env.rpc("json", "ledger_entry", to_string(jvParams));
-            checkErrorValue(jrr[jss::result], "malformedRequest", "");
+            checkErrorValue(
+                jrr[jss::result], "malformedAuthorizeCredentials", "");
         }
 
         {

--- a/src/test/rpc/RPCCall_test.cpp
+++ b/src/test/rpc/RPCCall_test.cpp
@@ -2458,7 +2458,15 @@ static RPCCallTestData const rpcCallTestArray[] = {
      {"deposit_authorized",
       "source_account_NotValidated",
       "destination_account_NotValidated",
-      "4294967295"},
+      "4294967295",
+      "cred1",
+      "cred2",
+      "cred3",
+      "cred4",
+      "cred5",
+      "cred6",
+      "cred7",
+      "cred8"},
      RPCCallTestData::no_exception,
      R"({
     "method" : "deposit_authorized",
@@ -2467,7 +2475,8 @@ static RPCCallTestData const rpcCallTestArray[] = {
          "api_version" : %API_VER%,
          "destination_account" : "destination_account_NotValidated",
          "ledger_index" : 4294967295,
-         "source_account" : "source_account_NotValidated"
+         "source_account" : "source_account_NotValidated",
+         "credentials": ["cred1", "cred2", "cred3", "cred4", "cred5", "cred6", "cred7", "cred8"]
       }
     ]
     })"},
@@ -2512,7 +2521,15 @@ static RPCCallTestData const rpcCallTestArray[] = {
       "source_account_NotValidated",
       "destination_account_NotValidated",
       "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
-      "spare"},
+      "cred1",
+      "cred2",
+      "cred3",
+      "cred4",
+      "cred5",
+      "cred6",
+      "cred7",
+      "cred8",
+      "too_much"},
      RPCCallTestData::no_exception,
      R"({
     "method" : "deposit_authorized",

--- a/src/xrpld/app/main/Main.cpp
+++ b/src/xrpld/app/main/Main.cpp
@@ -143,7 +143,7 @@ printHelp(const po::options_description& desc)
            "     connect <ip> [<port>]\n"
            "     consensus_info\n"
            "     deposit_authorized <source_account> <destination_account> "
-           "[<ledger>]\n"
+           "[<ledger> [<credentials>, ...]]\n"
            "     feature [<feature> [accept|reject]]\n"
            "     fetch_info [clear]\n"
            "     gateway_balances [<ledger>] <issuer_account> [ <hotwallet> [ "

--- a/src/xrpld/app/misc/CredentialHelpers.cpp
+++ b/src/xrpld/app/misc/CredentialHelpers.cpp
@@ -120,8 +120,7 @@ deleteSLE(
 NotTEC
 checkFields(PreflightContext const& ctx)
 {
-    if ((!ctx.rules.enabled(featureCredentials)) ||
-        !ctx.tx.isFieldPresent(sfCredentialIDs))
+    if (!ctx.tx.isFieldPresent(sfCredentialIDs))
         return tesSUCCESS;
 
     auto const& credentials = ctx.tx.getFieldV256(sfCredentialIDs);
@@ -151,8 +150,7 @@ checkFields(PreflightContext const& ctx)
 TER
 valid(PreclaimContext const& ctx, AccountID const& src)
 {
-    if ((!ctx.view.rules().enabled(featureCredentials)) ||
-        !ctx.tx.isFieldPresent(sfCredentialIDs))
+    if (!ctx.tx.isFieldPresent(sfCredentialIDs))
         return tesSUCCESS;
 
     auto const& credIDs(ctx.tx.getFieldV256(sfCredentialIDs));

--- a/src/xrpld/app/misc/CredentialHelpers.cpp
+++ b/src/xrpld/app/misc/CredentialHelpers.cpp
@@ -237,7 +237,8 @@ verifyDepositPreauth(
     // If depositPreauth is enabled, then an account that requires
     // authorization has at least two ways to get a payment in:
     //  1. If src == dst, or
-    //  2. If src is deposit preauthorized by dst.
+    //  2. If src is deposit preauthorized by dst (either by account or by
+    //  credentials).
 
     bool const credentialsPresent = ctx.tx.isFieldPresent(sfCredentialIDs);
 

--- a/src/xrpld/app/misc/CredentialHelpers.cpp
+++ b/src/xrpld/app/misc/CredentialHelpers.cpp
@@ -1,0 +1,198 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2024 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <xrpld/app/misc/CredentialHelpers.h>
+#include <xrpld/ledger/View.h>
+
+namespace ripple {
+namespace credentials {
+
+bool
+checkExpired(
+    std::shared_ptr<SLE const> const& sleCredential,
+    NetClock::time_point const& closed)
+{
+    std::uint32_t const exp = (*sleCredential)[~sfExpiration].value_or(
+        std::numeric_limits<std::uint32_t>::max());
+    std::uint32_t const now = closed.time_since_epoch().count();
+    return now > exp;
+}
+
+bool
+removeExpired(ApplyView& view, STTx const& tx, beast::Journal const j)
+{
+    auto const closeTime = view.info().parentCloseTime;
+    bool foundExpired = false;
+
+    STVector256 const& arr(tx.getFieldV256(sfCredentialIDs));
+    for (auto const& h : arr)
+    {
+        // Credentials already checked in preclaim. Look only for expired here.
+        auto const k = keylet::credential(h);
+        auto const sleCred = view.peek(k);
+
+        if (checkExpired(sleCred, closeTime))
+        {
+            JLOG(j.trace())
+                << "Credentials are expired. Cred: " << sleCred->getText();
+            // delete expired credentials even if the transaction failed
+            deleteSLE(view, sleCred, j);
+            foundExpired = true;
+        }
+    }
+
+    return foundExpired;
+}
+
+TER
+deleteSLE(
+    ApplyView& view,
+    std::shared_ptr<SLE> const& sleCredential,
+    beast::Journal j)
+{
+    if (!sleCredential)
+        return tecNO_ENTRY;
+
+    auto delSLE =
+        [&view, &sleCredential, j](
+            AccountID const& account, SField const& node, bool isOwner) -> TER {
+        auto const sleAccount = view.peek(keylet::account(account));
+        if (!sleAccount)
+        {
+            JLOG(j.fatal()) << "Internal error: can't retrieve Owner account.";
+            return tecINTERNAL;
+        }
+
+        // Remove object from owner directory
+        std::uint64_t const page = sleCredential->getFieldU64(node);
+        if (!view.dirRemove(
+                keylet::ownerDir(account), page, sleCredential->key(), false))
+        {
+            JLOG(j.fatal()) << "Unable to delete Credential from owner.";
+            return tefBAD_LEDGER;
+        }
+
+        if (isOwner)
+            adjustOwnerCount(view, sleAccount, -1, j);
+
+        return tesSUCCESS;
+    };
+
+    auto const issuer = sleCredential->getAccountID(sfIssuer);
+    auto const subject = sleCredential->getAccountID(sfSubject);
+    bool const accepted = sleCredential->getFlags() & lsfAccepted;
+
+    auto err = delSLE(issuer, sfIssuerNode, !accepted || (subject == issuer));
+    if (!isTesSuccess(err))
+        return err;
+
+    if (subject != issuer)
+    {
+        err = delSLE(subject, sfSubjectNode, accepted);
+        if (!isTesSuccess(err))
+            return err;
+    }
+
+    // Remove object from ledger
+    view.erase(sleCredential);
+
+    return tesSUCCESS;
+}
+
+NotTEC
+checkFields(PreflightContext const& ctx)
+{
+    if (!ctx.tx.isFieldPresent(sfCredentialIDs))
+        return tesSUCCESS;
+
+    auto const& credentials = ctx.tx.getFieldV256(sfCredentialIDs);
+    if (credentials.empty() || (credentials.size() > credentialsArrayMaxSize))
+    {
+        JLOG(ctx.j.trace())
+            << "Malformed transaction: Credentials array size is invalid: "
+            << credentials.size();
+        return temMALFORMED;
+    }
+
+    return tesSUCCESS;
+}
+
+TER
+valid(
+    PreclaimContext const& ctx,
+    AccountID const& src,
+    AccountID const& dst,
+    std::optional<std::reference_wrapper<std::shared_ptr<SLE const> const>>
+        sleDstOpt)
+{
+    if (!ctx.tx.isFieldPresent(sfCredentialIDs))
+        return tesSUCCESS;
+
+    std::shared_ptr<SLE const> const& sleDst =
+        sleDstOpt ? *sleDstOpt : ctx.view.read(keylet::account(dst));
+
+    bool const reqAuth =
+        sleDst && (sleDst->getFlags() & lsfDepositAuth) && (src != dst);
+
+    // credentials must be checked even if reqAuth is false
+    STArray authCreds;
+    for (auto const& h : ctx.tx.getFieldV256(sfCredentialIDs))
+    {
+        auto const sleCred = ctx.view.read(keylet::credential(h));
+        if (!sleCred)
+        {
+            JLOG(ctx.j.trace()) << "Credential doesn't exist. Cred: " << h;
+            return tecBAD_CREDENTIALS;
+        }
+
+        if (sleCred->getAccountID(sfSubject) != src)
+        {
+            JLOG(ctx.j.trace())
+                << "Credential doesn’t belong to the source account. Cred: "
+                << h;
+            return tecBAD_CREDENTIALS;
+        }
+
+        if (!(sleCred->getFlags() & lsfAccepted))
+        {
+            JLOG(ctx.j.trace()) << "Credential isn't accepted. Cred: " << h;
+            return tecBAD_CREDENTIALS;
+        }
+
+        if (reqAuth)
+        {
+            auto credential = STObject::makeInnerObject(sfCredential);
+            credential.setAccountID(sfIssuer, sleCred->getAccountID(sfIssuer));
+            credential.setFieldVL(
+                sfCredentialType, sleCred->getFieldVL(sfCredentialType));
+            authCreds.push_back(std::move(credential));
+        }
+    }
+
+    if (reqAuth && !ctx.view.exists(keylet::depositPreauth(dst, authCreds)))
+    {
+        JLOG(ctx.j.trace()) << "DepositPreauth doesn't exist";
+        return tecNO_PERMISSION;
+    }
+
+    return tesSUCCESS;
+}
+
+}  // namespace credentials
+}  // namespace ripple

--- a/src/xrpld/app/misc/CredentialHelpers.cpp
+++ b/src/xrpld/app/misc/CredentialHelpers.cpp
@@ -212,6 +212,49 @@ authorized(ApplyContext const& ctx, AccountID const& dst)
     return tesSUCCESS;
 }
 
+TER
+verify(
+    ApplyContext& ctx,
+    AccountID const& src,
+    AccountID const& dst,
+    bool requireAuth)
+{
+    // If depositPreauth is enabled, then an account that requires
+    // authorization has at least two ways to get a payment in:
+    //  1. If src == dst, or
+    //  2. If src is deposit preauthorized by dst.
+
+    bool const credentialsPresent = ctx.tx.isFieldPresent(sfCredentialIDs);
+
+    if (credentialsPresent &&
+        credentials::removeExpired(ctx.view(), ctx.tx, ctx.journal))
+        return tecEXPIRED;
+
+    if (!requireAuth || (src == dst))
+        return tesSUCCESS;
+
+    if (ctx.view().exists(keylet::depositPreauth(dst, src)))
+        return tesSUCCESS;
+
+    if (!credentialsPresent)
+        return tecNO_PERMISSION;
+
+    return credentials::authorized(ctx, dst);
+}
+
+TER
+verify(
+    ApplyContext& ctx,
+    AccountID const& src,
+    AccountID const& dst,
+    std::optional<std::reference_wrapper<std::shared_ptr<SLE> const>> sleDstOpt)
+{
+    std::shared_ptr<SLE const> const& sleDst =
+        sleDstOpt ? *sleDstOpt : ctx.view().peek(keylet::account(dst));
+    return verify(
+        ctx, src, dst, sleDst && (sleDst->getFlags() & lsfDepositAuth));
+}
+
 std::set<std::pair<AccountID, Slice>>
 makeSorted(STArray const& in)
 {

--- a/src/xrpld/app/misc/CredentialHelpers.h
+++ b/src/xrpld/app/misc/CredentialHelpers.h
@@ -1,0 +1,62 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2024 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include <xrpld/app/tx/detail/Transactor.h>
+
+namespace ripple {
+namespace credentials {
+
+// These function will be used by the code that use DepositPreauth / Credentials
+// (and any future preauthorization modes) as part of authorization (all the
+// transfer funds transactions)
+
+// Check if credential sfExpiration field has passed ledger's parentCloseTime
+bool
+checkExpired(
+    std::shared_ptr<SLE const> const& sleCredential,
+    NetClock::time_point const& closed);
+
+// Return true if at least 1 expired credentials was found(and deleted)
+bool
+removeExpired(ApplyView& view, STTx const& tx, beast::Journal const j);
+
+// Actually remove a credentials object from the ledger
+TER
+deleteSLE(
+    ApplyView& view,
+    std::shared_ptr<SLE> const& sleCredential,
+    beast::Journal j);
+
+// Amendment and parameters checks for sfCredentialIDs field
+NotTEC
+checkFields(PreflightContext const& ctx);
+
+// Accessing the ledger to check if provided credentials are valid
+TER
+valid(
+    PreclaimContext const& ctx,
+    AccountID const& src,
+    AccountID const& dst,
+    std::optional<std::reference_wrapper<std::shared_ptr<SLE const> const>>
+        sleDstOpt = {});
+
+}  // namespace credentials
+}  // namespace ripple

--- a/src/xrpld/app/misc/CredentialHelpers.h
+++ b/src/xrpld/app/misc/CredentialHelpers.h
@@ -51,12 +51,12 @@ checkFields(PreflightContext const& ctx);
 
 // Accessing the ledger to check if provided credentials are valid
 TER
-valid(
-    PreclaimContext const& ctx,
-    AccountID const& src,
-    AccountID const& dst,
-    std::optional<std::reference_wrapper<std::shared_ptr<SLE const> const>>
-        sleDstOpt = {});
+valid(PreclaimContext const& ctx, AccountID const& src);
+
+// This function is only called when we about to return tecNO_PERMISSION because
+// all the checks for the DepositPreauth authorization failed.
+TER
+authorized(ApplyContext const& ctx, AccountID const& dst);
 
 // return empty set if there are duplicates
 std::set<std::pair<AccountID, Slice>>

--- a/src/xrpld/app/misc/CredentialHelpers.h
+++ b/src/xrpld/app/misc/CredentialHelpers.h
@@ -58,5 +58,9 @@ valid(
     std::optional<std::reference_wrapper<std::shared_ptr<SLE const> const>>
         sleDstOpt = {});
 
+// return empty set if there are duplicates
+std::set<std::pair<AccountID, Slice>>
+makeSorted(STArray const& in);
+
 }  // namespace credentials
 }  // namespace ripple

--- a/src/xrpld/app/misc/CredentialHelpers.h
+++ b/src/xrpld/app/misc/CredentialHelpers.h
@@ -60,25 +60,18 @@ valid(PreclaimContext const& ctx, AccountID const& src);
 TER
 authorized(ApplyContext const& ctx, AccountID const& dst);
 
-// Check expired credentials and for existing DepositPreauth ledger object
-TER
-verify(
-    ApplyContext& ctx,
-    AccountID const& src,
-    AccountID const& dst,
-    std::optional<std::reference_wrapper<std::shared_ptr<SLE> const>>
-        sleDstOpt = {});
-
-TER
-verify(
-    ApplyContext& ctx,
-    AccountID const& src,
-    AccountID const& dst,
-    bool requireAuth);
-
 // return empty set if there are duplicates
 std::set<std::pair<AccountID, Slice>>
 makeSorted(STArray const& in);
 
 }  // namespace credentials
+
+// Check expired credentials and for existing DepositPreauth ledger object
+TER
+verifyDepositPreauth(
+    ApplyContext& ctx,
+    AccountID const& src,
+    AccountID const& dst,
+    std::shared_ptr<SLE> const& sleDst);
+
 }  // namespace ripple

--- a/src/xrpld/app/misc/CredentialHelpers.h
+++ b/src/xrpld/app/misc/CredentialHelpers.h
@@ -21,6 +21,8 @@
 
 #include <xrpld/app/tx/detail/Transactor.h>
 
+#include <optional>
+
 namespace ripple {
 namespace credentials {
 
@@ -57,6 +59,22 @@ valid(PreclaimContext const& ctx, AccountID const& src);
 // all the checks for the DepositPreauth authorization failed.
 TER
 authorized(ApplyContext const& ctx, AccountID const& dst);
+
+// Check expired credentials and for existing DepositPreauth ledger object
+TER
+verify(
+    ApplyContext& ctx,
+    AccountID const& src,
+    AccountID const& dst,
+    std::optional<std::reference_wrapper<std::shared_ptr<SLE> const>>
+        sleDstOpt = {});
+
+TER
+verify(
+    ApplyContext& ctx,
+    AccountID const& src,
+    AccountID const& dst,
+    bool requireAuth);
 
 // return empty set if there are duplicates
 std::set<std::pair<AccountID, Slice>>

--- a/src/xrpld/app/tx/detail/Credentials.cpp
+++ b/src/xrpld/app/tx/detail/Credentials.cpp
@@ -1,0 +1,366 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2024 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <xrpld/app/misc/CredentialHelpers.h>
+#include <xrpld/app/tx/detail/Credentials.h>
+
+#include <xrpld/core/TimeKeeper.h>
+#include <xrpld/ledger/ApplyView.h>
+#include <xrpld/ledger/View.h>
+#include <xrpl/basics/Log.h>
+#include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/Indexes.h>
+#include <xrpl/protocol/TxFlags.h>
+#include <xrpl/protocol/st.h>
+
+#include <chrono>
+
+namespace ripple {
+
+/*
+    Credentials
+    ======
+
+   A verifiable credentials (VC
+   https://en.wikipedia.org/wiki/Verifiable_credentials), as defined by the W3C
+   specification (https://www.w3.org/TR/vc-data-model-2.0/), is a
+   secure and tamper-evident way to represent information about a subject, such
+   as an individual, organization, or even an IoT device. These credentials are
+   issued by a trusted entity and can be verified by third parties without
+   directly involving the issuer at all.
+*/
+
+using namespace credentials;
+
+// ------- CREATE --------------------------
+
+NotTEC
+CredentialCreate::preflight(PreflightContext const& ctx)
+{
+    if (!ctx.rules.enabled(featureCredentials))
+    {
+        JLOG(ctx.j.trace()) << "featureCredentials is disabled.";
+        return temDISABLED;
+    }
+
+    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
+        return ret;
+
+    auto const& tx = ctx.tx;
+    auto& j = ctx.j;
+
+    if (!tx[sfSubject])
+    {
+        JLOG(j.trace()) << "Malformed transaction: Invalid Subject";
+        return temMALFORMED;
+    }
+
+    auto const uri = tx[~sfURI];
+    if (uri && (uri->empty() || (uri->size() > maxCredentialURILength)))
+    {
+        JLOG(j.trace()) << "Malformed transaction: invalid size of URI.";
+        return temMALFORMED;
+    }
+
+    auto const credType = tx[sfCredentialType];
+    if (credType.empty() || (credType.size() > maxCredentialTypeLength))
+    {
+        JLOG(j.trace())
+            << "Malformed transaction: invalid size of CredentialType.";
+        return temMALFORMED;
+    }
+
+    return preflight2(ctx);
+}
+
+TER
+CredentialCreate::preclaim(PreclaimContext const& ctx)
+{
+    auto const credType(ctx.tx[sfCredentialType]);
+    auto const subject = ctx.tx[sfSubject];
+
+    if (!ctx.view.exists(keylet::account(subject)))
+    {
+        JLOG(ctx.j.trace()) << "Subject doesn't exist.";
+        return tecNO_TARGET;
+    }
+
+    if (ctx.view.exists(
+            keylet::credential(subject, ctx.tx[sfAccount], credType)))
+    {
+        JLOG(ctx.j.trace()) << "Credential already exists.";
+        return tecDUPLICATE;
+    }
+
+    return tesSUCCESS;
+}
+
+TER
+CredentialCreate::doApply()
+{
+    auto const subject = ctx_.tx[sfSubject];
+    auto const credType(ctx_.tx[sfCredentialType]);
+    Keylet const credentialKey =
+        keylet::credential(subject, account_, credType);
+
+    auto const sleCred = std::make_shared<SLE>(credentialKey);
+    if (!sleCred)
+        return tefINTERNAL;
+
+    auto const optExp = ctx_.tx[~sfExpiration];
+    if (optExp)
+    {
+        std::uint32_t const closeTime =
+            ctx_.view().info().parentCloseTime.time_since_epoch().count();
+
+        if (closeTime > *optExp)
+        {
+            JLOG(j_.trace()) << "Malformed transaction: "
+                                "Expiration time is in the past.";
+            return tecEXPIRED;
+        }
+
+        sleCred->setFieldU32(sfExpiration, ctx_.tx.getFieldU32(sfExpiration));
+    }
+
+    auto const sleIssuer = view().peek(keylet::account(account_));
+    if (!sleIssuer)
+        return tefINTERNAL;
+
+    {
+        STAmount const reserve{view().fees().accountReserve(
+            sleIssuer->getFieldU32(sfOwnerCount) + 1)};
+        if (mPriorBalance < reserve)
+            return tecINSUFFICIENT_RESERVE;
+    }
+
+    sleCred->setAccountID(sfSubject, subject);
+    sleCred->setAccountID(sfIssuer, account_);
+    sleCred->setFieldVL(sfCredentialType, credType);
+
+    if (ctx_.tx.isFieldPresent(sfURI))
+        sleCred->setFieldVL(sfURI, ctx_.tx.getFieldVL(sfURI));
+
+    {
+        auto const page = view().dirInsert(
+            keylet::ownerDir(account_),
+            credentialKey,
+            describeOwnerDir(account_));
+        JLOG(j_.trace()) << "Adding Credential to owner directory "
+                         << to_string(credentialKey.key) << ": "
+                         << (page ? "success" : "failure");
+        if (!page)
+            return tecDIR_FULL;
+        sleCred->setFieldU64(sfIssuerNode, *page);
+
+        adjustOwnerCount(view(), sleIssuer, 1, j_);
+    }
+
+    if (subject == account_)
+    {
+        sleCred->setFieldU32(sfFlags, lsfAccepted);
+    }
+    else
+    {
+        auto const page = view().dirInsert(
+            keylet::ownerDir(subject),
+            credentialKey,
+            describeOwnerDir(subject));
+        JLOG(j_.trace()) << "Adding Credential to owner directory "
+                         << to_string(credentialKey.key) << ": "
+                         << (page ? "success" : "failure");
+        if (!page)
+            return tecDIR_FULL;
+        sleCred->setFieldU64(sfSubjectNode, *page);
+        view().update(view().peek(keylet::account(subject)));
+    }
+
+    view().insert(sleCred);
+
+    return tesSUCCESS;
+}
+
+// ------- DELETE --------------------------
+NotTEC
+CredentialDelete::preflight(PreflightContext const& ctx)
+{
+    if (!ctx.rules.enabled(featureCredentials))
+    {
+        JLOG(ctx.j.trace()) << "featureCredentials is disabled.";
+        return temDISABLED;
+    }
+
+    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
+        return ret;
+
+    auto const subject = ctx.tx[~sfSubject];
+    auto const issuer = ctx.tx[~sfIssuer];
+
+    if (!subject && !issuer)
+    {
+        // Neither field is present, the transaction is malformed.
+        JLOG(ctx.j.trace()) << "Malformed transaction: "
+                               "No Subject or Issuer fields.";
+        return temMALFORMED;
+    }
+
+    // Make sure that the passed account is valid.
+    if ((subject && subject->isZero()) || (issuer && issuer->isZero()))
+    {
+        JLOG(ctx.j.trace()) << "Malformed transaction: Subject or Issuer "
+                               "field zeroed.";
+        return temINVALID_ACCOUNT_ID;
+    }
+
+    return preflight2(ctx);
+}
+
+TER
+CredentialDelete::preclaim(PreclaimContext const& ctx)
+{
+    AccountID const account{ctx.tx[sfAccount]};
+    auto const subject = ctx.tx[~sfSubject].value_or(account);
+    auto const issuer = ctx.tx[~sfIssuer].value_or(account);
+    auto const credType(ctx.tx[sfCredentialType]);
+
+    if (!ctx.view.exists(keylet::credential(subject, issuer, credType)))
+        return tecNO_ENTRY;
+
+    return tesSUCCESS;
+}
+
+TER
+CredentialDelete::doApply()
+{
+    auto const subject = ctx_.tx[~sfSubject].value_or(account_);
+    auto const issuer = ctx_.tx[~sfIssuer].value_or(account_);
+
+    auto const credType(ctx_.tx[sfCredentialType]);
+    auto const sleCred =
+        view().peek(keylet::credential(subject, issuer, credType));
+    if (!sleCred)
+        return tefINTERNAL;
+
+    if ((subject != account_) && (issuer != account_) &&
+        !checkExpired(sleCred, ctx_.view().info().parentCloseTime))
+    {
+        JLOG(j_.trace()) << "Can't delete non-expired credential.";
+        return tecNO_PERMISSION;
+    }
+
+    return deleteSLE(view(), sleCred, j_);
+}
+
+// ------- APPLY --------------------------
+
+NotTEC
+CredentialAccept::preflight(PreflightContext const& ctx)
+{
+    if (!ctx.rules.enabled(featureCredentials))
+    {
+        JLOG(ctx.j.trace()) << "featureCredentials is disabled.";
+        return temDISABLED;
+    }
+
+    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
+        return ret;
+
+    if (!ctx.tx[sfIssuer])
+    {
+        JLOG(ctx.j.trace()) << "Malformed transaction: Issuer field zeroed.";
+        return temINVALID_ACCOUNT_ID;
+    }
+
+    return preflight2(ctx);
+}
+
+TER
+CredentialAccept::preclaim(PreclaimContext const& ctx)
+{
+    AccountID const subject = ctx.tx[sfAccount];
+    AccountID const issuer = ctx.tx[sfIssuer];
+    auto const credType(ctx.tx[sfCredentialType]);
+
+    if (!ctx.view.exists(keylet::account(issuer)))
+    {
+        JLOG(ctx.j.warn()) << "No issuer: " << to_string(issuer);
+        return tecNO_ISSUER;
+    }
+
+    auto const sleCred =
+        ctx.view.read(keylet::credential(subject, issuer, credType));
+    if (!sleCred)
+    {
+        JLOG(ctx.j.warn()) << "No credential: " << to_string(subject) << ", "
+                           << to_string(issuer) << ", " << credType;
+        return tecNO_ENTRY;
+    }
+
+    if (sleCred->getFieldU32(sfFlags) & lsfAccepted)
+    {
+        JLOG(ctx.j.warn()) << "Credential already accepted: "
+                           << to_string(subject) << ", " << to_string(issuer)
+                           << ", " << credType;
+        return tecDUPLICATE;
+    }
+
+    return tesSUCCESS;
+}
+
+TER
+CredentialAccept::doApply()
+{
+    AccountID const issuer{ctx_.tx[sfIssuer]};
+
+    // Both exist as credential object exist itself (checked in preclaim)
+    auto const sleSubject = view().peek(keylet::account(account_));
+    auto const sleIssuer = view().peek(keylet::account(issuer));
+
+    if (!sleSubject || !sleIssuer)
+        return tefINTERNAL;
+
+    {
+        STAmount const reserve{view().fees().accountReserve(
+            sleSubject->getFieldU32(sfOwnerCount) + 1)};
+        if (mPriorBalance < reserve)
+            return tecINSUFFICIENT_RESERVE;
+    }
+
+    auto const credType(ctx_.tx[sfCredentialType]);
+    Keylet const credentialKey = keylet::credential(account_, issuer, credType);
+    auto const sleCred = view().peek(credentialKey);  // Checked in preclaim()
+
+    if (checkExpired(sleCred, view().info().parentCloseTime))
+    {
+        JLOG(j_.trace()) << "Credential is expired: " << sleCred->getText();
+        // delete expired credentials even if the transaction failed
+        auto const err = credentials::deleteSLE(view(), sleCred, j_);
+        return isTesSuccess(err) ? tecEXPIRED : err;
+    }
+
+    sleCred->setFieldU32(sfFlags, lsfAccepted);
+    view().update(sleCred);
+
+    adjustOwnerCount(view(), sleIssuer, -1, j_);
+    adjustOwnerCount(view(), sleSubject, 1, j_);
+
+    return tesSUCCESS;
+}
+
+}  // namespace ripple

--- a/src/xrpld/app/tx/detail/Credentials.cpp
+++ b/src/xrpld/app/tx/detail/Credentials.cpp
@@ -228,6 +228,14 @@ CredentialDelete::preflight(PreflightContext const& ctx)
         return temINVALID_ACCOUNT_ID;
     }
 
+    auto const credType = ctx.tx[sfCredentialType];
+    if (credType.empty() || (credType.size() > maxCredentialTypeLength))
+    {
+        JLOG(ctx.j.trace())
+            << "Malformed transaction: invalid size of CredentialType.";
+        return temMALFORMED;
+    }
+
     return preflight2(ctx);
 }
 
@@ -285,6 +293,14 @@ CredentialAccept::preflight(PreflightContext const& ctx)
     {
         JLOG(ctx.j.trace()) << "Malformed transaction: Issuer field zeroed.";
         return temINVALID_ACCOUNT_ID;
+    }
+
+    auto const credType = ctx.tx[sfCredentialType];
+    if (credType.empty() || (credType.size() > maxCredentialTypeLength))
+    {
+        JLOG(ctx.j.trace())
+            << "Malformed transaction: invalid size of CredentialType.";
+        return temMALFORMED;
     }
 
     return preflight2(ctx);

--- a/src/xrpld/app/tx/detail/Credentials.h
+++ b/src/xrpld/app/tx/detail/Credentials.h
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2024 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -17,68 +17,18 @@
 */
 //==============================================================================
 
-#ifndef RIPPLE_TX_PAYCHAN_H_INCLUDED
-#define RIPPLE_TX_PAYCHAN_H_INCLUDED
+#pragma once
 
 #include <xrpld/app/tx/detail/Transactor.h>
 
 namespace ripple {
 
-class PayChanCreate : public Transactor
-{
-public:
-    static constexpr ConsequencesFactoryType ConsequencesFactory{Custom};
-
-    explicit PayChanCreate(ApplyContext& ctx) : Transactor(ctx)
-    {
-    }
-
-    static TxConsequences
-    makeTxConsequences(PreflightContext const& ctx);
-
-    static NotTEC
-    preflight(PreflightContext const& ctx);
-
-    static TER
-    preclaim(PreclaimContext const& ctx);
-
-    TER
-    doApply() override;
-};
-
-using PaymentChannelCreate = PayChanCreate;
-
-//------------------------------------------------------------------------------
-
-class PayChanFund : public Transactor
-{
-public:
-    static constexpr ConsequencesFactoryType ConsequencesFactory{Custom};
-
-    explicit PayChanFund(ApplyContext& ctx) : Transactor(ctx)
-    {
-    }
-
-    static TxConsequences
-    makeTxConsequences(PreflightContext const& ctx);
-
-    static NotTEC
-    preflight(PreflightContext const& ctx);
-
-    TER
-    doApply() override;
-};
-
-using PaymentChannelFund = PayChanFund;
-
-//------------------------------------------------------------------------------
-
-class PayChanClaim : public Transactor
+class CredentialCreate : public Transactor
 {
 public:
     static constexpr ConsequencesFactoryType ConsequencesFactory{Normal};
 
-    explicit PayChanClaim(ApplyContext& ctx) : Transactor(ctx)
+    explicit CredentialCreate(ApplyContext& ctx) : Transactor(ctx)
     {
     }
 
@@ -92,8 +42,46 @@ public:
     doApply() override;
 };
 
-using PaymentChannelClaim = PayChanClaim;
+//------------------------------------------------------------------------------
+
+class CredentialDelete : public Transactor
+{
+public:
+    static constexpr ConsequencesFactoryType ConsequencesFactory{Normal};
+
+    explicit CredentialDelete(ApplyContext& ctx) : Transactor(ctx)
+    {
+    }
+
+    static NotTEC
+    preflight(PreflightContext const& ctx);
+
+    static TER
+    preclaim(PreclaimContext const& ctx);
+
+    TER
+    doApply() override;
+};
+
+//------------------------------------------------------------------------------
+
+class CredentialAccept : public Transactor
+{
+public:
+    static constexpr ConsequencesFactoryType ConsequencesFactory{Normal};
+
+    explicit CredentialAccept(ApplyContext& ctx) : Transactor(ctx)
+    {
+    }
+
+    static NotTEC
+    preflight(PreflightContext const& ctx);
+
+    static TER
+    preclaim(PreclaimContext const& ctx);
+
+    TER
+    doApply() override;
+};
 
 }  // namespace ripple
-
-#endif

--- a/src/xrpld/app/tx/detail/DeleteAccount.cpp
+++ b/src/xrpld/app/tx/detail/DeleteAccount.cpp
@@ -42,6 +42,10 @@ DeleteAccount::preflight(PreflightContext const& ctx)
     if (!ctx.rules.enabled(featureDeletableAccounts))
         return temDISABLED;
 
+    if (ctx.tx.isFieldPresent(sfCredentialIDs) &&
+        !ctx.rules.enabled(featureCredentials))
+        return temDISABLED;
+
     if (ctx.tx.getFlags() & tfUniversalMask)
         return temINVALID_FLAG;
 

--- a/src/xrpld/app/tx/detail/DeleteAccount.cpp
+++ b/src/xrpld/app/tx/detail/DeleteAccount.cpp
@@ -229,8 +229,7 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
         return err;
 
     // if credentials then postpone auth check to doApply
-    if (!ctx.view.rules().enabled(featureCredentials) ||
-        !ctx.tx.isFieldPresent(sfCredentialIDs))
+    if (!ctx.tx.isFieldPresent(sfCredentialIDs))
     {
         // Check whether the destination account requires deposit authorization.
         if (ctx.view.rules().enabled(featureDepositAuth) &&
@@ -354,8 +353,7 @@ DeleteAccount::doApply()
     if (!src || !dst)
         return tefBAD_LEDGER;
 
-    if (ctx_.view().rules().enabled(featureCredentials) &&
-        ctx_.tx.isFieldPresent(sfCredentialIDs))
+    if (ctx_.tx.isFieldPresent(sfCredentialIDs))
     {
         if (credentials::removeExpired(view(), ctx_.tx, j_))
             return tecEXPIRED;

--- a/src/xrpld/app/tx/detail/DeleteAccount.cpp
+++ b/src/xrpld/app/tx/detail/DeleteAccount.cpp
@@ -357,7 +357,7 @@ DeleteAccount::doApply()
     if (ctx_.view().rules().enabled(featureDepositAuth) &&
         ctx_.tx.isFieldPresent(sfCredentialIDs))
     {
-        if (auto err = credentials::verify(ctx_, account_, dstID, dst);
+        if (auto err = verifyDepositPreauth(ctx_, account_, dstID, dst);
             !isTesSuccess(err))
             return err;
     }

--- a/src/xrpld/app/tx/detail/DepositPreauth.cpp
+++ b/src/xrpld/app/tx/detail/DepositPreauth.cpp
@@ -17,13 +17,18 @@
 */
 //==============================================================================
 
+#include <xrpld/app/tx/detail/Credentials.h>
 #include <xrpld/app/tx/detail/DepositPreauth.h>
 #include <xrpld/ledger/View.h>
 #include <xrpl/basics/Log.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/TxFlags.h>
+#include <xrpl/protocol/digest.h>
 #include <xrpl/protocol/st.h>
+
+#include <optional>
+#include <unordered_set>
 
 namespace ripple {
 
@@ -31,6 +36,15 @@ NotTEC
 DepositPreauth::preflight(PreflightContext const& ctx)
 {
     if (!ctx.rules.enabled(featureDepositPreauth))
+        return temDISABLED;
+
+    bool const authArrPresent = ctx.tx.isFieldPresent(sfAuthorizeCredentials);
+    bool const unauthArrPresent =
+        ctx.tx.isFieldPresent(sfUnauthorizeCredentials);
+    int const authCredPresent =
+        static_cast<int>(authArrPresent) + static_cast<int>(unauthArrPresent);
+
+    if (authCredPresent && !ctx.rules.enabled(featureCredentials))
         return temDISABLED;
 
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
@@ -47,7 +61,10 @@ DepositPreauth::preflight(PreflightContext const& ctx)
 
     auto const optAuth = ctx.tx[~sfAuthorize];
     auto const optUnauth = ctx.tx[~sfUnauthorize];
-    if (static_cast<bool>(optAuth) == static_cast<bool>(optUnauth))
+    int const authPresent = static_cast<int>(optAuth.has_value()) +
+        static_cast<int>(optUnauth.has_value());
+
+    if (authPresent + authCredPresent != 1)
     {
         // Either both fields are present or neither field is present.  In
         // either case the transaction is malformed.
@@ -58,20 +75,56 @@ DepositPreauth::preflight(PreflightContext const& ctx)
     }
 
     // Make sure that the passed account is valid.
-    AccountID const target{optAuth ? *optAuth : *optUnauth};
-    if (target == beast::zero)
+    if (authPresent)
     {
-        JLOG(j.trace()) << "Malformed transaction: Authorized or Unauthorized "
-                           "field zeroed.";
-        return temINVALID_ACCOUNT_ID;
-    }
+        AccountID const& target(optAuth ? *optAuth : *optUnauth);
+        if (!target)
+        {
+            JLOG(ctx.j.trace())
+                << "Malformed transaction: Authorized or Unauthorized "
+                   "field zeroed.";
+            return temINVALID_ACCOUNT_ID;
+        }
 
-    // An account may not preauthorize itself.
-    if (optAuth && (target == ctx.tx[sfAccount]))
+        // An account may not preauthorize itself.
+        if (target == ctx.tx[sfAccount])
+        {
+            JLOG(ctx.j.trace())
+                << "Malformed transaction: Attempting to DepositPreauth self.";
+            return temCANNOT_PREAUTH_SELF;
+        }
+    }
+    else
     {
-        JLOG(j.trace())
-            << "Malformed transaction: Attempting to DepositPreauth self.";
-        return temCANNOT_PREAUTH_SELF;
+        STArray const& arr(ctx.tx.getFieldArray(
+            authArrPresent ? sfAuthorizeCredentials
+                           : sfUnauthorizeCredentials));
+        if (arr.empty() || (arr.size() > credentialsArrayMaxSize))
+        {
+            JLOG(ctx.j.trace()) << "Malformed transaction: "
+                                   "Invalid AuthorizeCredentials size: "
+                                << arr.size();
+            return temMALFORMED;
+        }
+
+        for (auto const& o : arr)
+        {
+            if (!o[sfIssuer])
+            {
+                JLOG(ctx.j.trace())
+                    << "Malformed transaction: "
+                       "AuthorizeCredentials Issuer account is invalid.";
+                return temINVALID_ACCOUNT_ID;
+            }
+
+            auto const ct = o[sfCredentialType];
+            if (ct.empty() || (ct.size() > maxCredentialTypeLength))
+            {
+                JLOG(ctx.j.trace())
+                    << "Malformed transaction: invalid size of CredentialType.";
+                return temMALFORMED;
+            }
+        }
     }
 
     return preflight2(ctx);
@@ -80,6 +133,8 @@ DepositPreauth::preflight(PreflightContext const& ctx)
 TER
 DepositPreauth::preclaim(PreclaimContext const& ctx)
 {
+    AccountID const account(ctx.tx[sfAccount]);
+
     // Determine which operation we're performing: authorizing or unauthorizing.
     if (ctx.tx.isFieldPresent(sfAuthorize))
     {
@@ -90,14 +145,35 @@ DepositPreauth::preclaim(PreclaimContext const& ctx)
 
         // Verify that the Preauth entry they asked to add is not already
         // in the ledger.
-        if (ctx.view.exists(keylet::depositPreauth(ctx.tx[sfAccount], auth)))
+        if (ctx.view.exists(keylet::depositPreauth(account, auth)))
             return tecDUPLICATE;
     }
-    else
+    else if (ctx.tx.isFieldPresent(sfUnauthorize))
     {
         // Verify that the Preauth entry they asked to remove is in the ledger.
-        AccountID const unauth{ctx.tx[sfUnauthorize]};
-        if (!ctx.view.exists(keylet::depositPreauth(ctx.tx[sfAccount], unauth)))
+        if (!ctx.view.exists(
+                keylet::depositPreauth(account, ctx.tx[sfUnauthorize])))
+            return tecNO_ENTRY;
+    }
+    else if (ctx.tx.isFieldPresent(sfAuthorizeCredentials))
+    {
+        STArray const& authCred(ctx.tx.getFieldArray(sfAuthorizeCredentials));
+        for (auto const& o : authCred)
+        {
+            if (!ctx.view.exists(keylet::account(o[sfIssuer])))
+                return tecNO_ISSUER;
+        }
+
+        // Verify that the Preauth entry they asked to add is not already
+        // in the ledger.
+        if (ctx.view.exists(keylet::depositPreauth(account, authCred)))
+            return tecDUPLICATE;
+    }
+    else if (ctx.tx.isFieldPresent(sfUnauthorizeCredentials))
+    {
+        // Verify that the Preauth entry is in the ledger.
+        if (!ctx.view.exists(keylet::depositPreauth(
+                account, ctx.tx.getFieldArray(sfUnauthorizeCredentials))))
             return tecNO_ENTRY;
     }
     return tesSUCCESS;
@@ -133,7 +209,6 @@ DepositPreauth::doApply()
         slePreauth->setAccountID(sfAuthorize, auth);
         view().insert(slePreauth);
 
-        auto viewJ = ctx_.app.journal("View");
         auto const page = view().dirInsert(
             keylet::ownerDir(account_),
             preauthKeylet,
@@ -149,35 +224,98 @@ DepositPreauth::doApply()
         slePreauth->setFieldU64(sfOwnerNode, *page);
 
         // If we succeeded, the new entry counts against the creator's reserve.
-        adjustOwnerCount(view(), sleOwner, 1, viewJ);
+        adjustOwnerCount(view(), sleOwner, 1, j_);
     }
-    else
+    else if (ctx_.tx.isFieldPresent(sfUnauthorize))
     {
         auto const preauth =
             keylet::depositPreauth(account_, ctx_.tx[sfUnauthorize]);
 
-        return DepositPreauth::removeFromLedger(
-            ctx_.app, view(), preauth.key, j_);
+        return DepositPreauth::removeFromLedger(view(), preauth.key, j_);
     }
+    else if (ctx_.tx.isFieldPresent(sfAuthorizeCredentials))
+    {
+        auto const sleOwner = view().peek(keylet::account(account_));
+        if (!sleOwner)
+            return tefINTERNAL;
+
+        // A preauth counts against the reserve of the issuing account, but we
+        // check the starting balance because we want to allow dipping into the
+        // reserve to pay fees.
+        {
+            STAmount const reserve{view().fees().accountReserve(
+                sleOwner->getFieldU32(sfOwnerCount) + 1)};
+
+            if (mPriorBalance < reserve)
+                return tecINSUFFICIENT_RESERVE;
+        }
+
+        // Preclaim already verified that the Preauth entry does not yet exist.
+        // Create and populate the Preauth entry.
+
+        STArray const& authCred(ctx_.tx.getFieldArray(sfAuthorizeCredentials));
+        Keylet const preauthKey = keylet::depositPreauth(account_, authCred);
+        auto slePreauth = std::make_shared<SLE>(preauthKey);
+        if (!slePreauth)
+            return tefINTERNAL;
+
+        slePreauth->setAccountID(sfAccount, account_);
+        STArray& credentialsArray =
+            slePreauth->peekFieldArray(sfAuthorizeCredentials);
+        credentialsArray.reserve(authCred.size());
+
+        // eliminate duplicates
+        std::unordered_set<uint256> hashes;
+        for (auto const& o : authCred)
+        {
+            auto [it, ins] = hashes.insert(sha512Half(
+                o.getAccountID(sfIssuer), o.getFieldVL(sfCredentialType)));
+            if (ins)
+            {
+                credentialsArray.push_back(o);
+            }
+            else
+            {
+                JLOG(j_.trace())
+                    << "DepositPreauth duplicate removed: " << o.getText();
+            }
+        }
+
+        view().insert(slePreauth);
+
+        auto const page = view().dirInsert(
+            keylet::ownerDir(account_), preauthKey, describeOwnerDir(account_));
+
+        JLOG(j_.trace()) << "Adding DepositPreauth to owner directory "
+                         << to_string(preauthKey.key) << ": "
+                         << (page ? "success" : "failure");
+
+        if (!page)
+            return tecDIR_FULL;
+
+        slePreauth->setFieldU64(sfOwnerNode, *page);
+
+        // If we succeeded, the new entry counts against the creator's reserve.
+        adjustOwnerCount(view(), sleOwner, 1, j_);
+    }
+    else if (ctx_.tx.isFieldPresent(sfUnauthorizeCredentials))
+    {
+        auto const preauthKey = keylet::depositPreauth(
+            account_, ctx_.tx.getFieldArray(sfUnauthorizeCredentials));
+        return DepositPreauth::removeFromLedger(view(), preauthKey.key, j_);
+    }
+
     return tesSUCCESS;
 }
 
 TER
 DepositPreauth::removeFromLedger(
-    Application& app,
     ApplyView& view,
     uint256 const& preauthIndex,
     beast::Journal j)
 {
-    // Verify that the Preauth entry they asked to remove is
-    // in the ledger.
-    std::shared_ptr<SLE> const slePreauth{
-        view.peek(keylet::depositPreauth(preauthIndex))};
-    if (!slePreauth)
-    {
-        JLOG(j.warn()) << "Selected DepositPreauth does not exist.";
-        return tecNO_ENTRY;
-    }
+    // Existence already checked in preclaim and DeleteAccount
+    auto const slePreauth{view.peek(keylet::depositPreauth(preauthIndex))};
 
     AccountID const account{(*slePreauth)[sfAccount]};
     std::uint64_t const page{(*slePreauth)[sfOwnerNode]};
@@ -192,7 +330,7 @@ DepositPreauth::removeFromLedger(
     if (!sleOwner)
         return tefINTERNAL;
 
-    adjustOwnerCount(view, sleOwner, -1, app.journal("View"));
+    adjustOwnerCount(view, sleOwner, -1, j);
 
     // Remove DepositPreauth from ledger.
     view.erase(slePreauth);

--- a/src/xrpld/app/tx/detail/DepositPreauth.cpp
+++ b/src/xrpld/app/tx/detail/DepositPreauth.cpp
@@ -87,7 +87,7 @@ DepositPreauth::preflight(PreflightContext const& ctx)
         }
 
         // An account may not preauthorize itself.
-        if (target == ctx.tx[sfAccount])
+        if (optAuth && (target == ctx.tx[sfAccount]))
         {
             JLOG(ctx.j.trace())
                 << "Malformed transaction: Attempting to DepositPreauth self.";

--- a/src/xrpld/app/tx/detail/DepositPreauth.cpp
+++ b/src/xrpld/app/tx/detail/DepositPreauth.cpp
@@ -51,11 +51,10 @@ DepositPreauth::preflight(PreflightContext const& ctx)
         return ret;
 
     auto& tx = ctx.tx;
-    auto& j = ctx.j;
 
     if (tx.getFlags() & tfUniversalMask)
     {
-        JLOG(j.trace()) << "Malformed transaction: Invalid flags set.";
+        JLOG(ctx.j.trace()) << "Malformed transaction: Invalid flags set.";
         return temINVALID_FLAG;
     }
 
@@ -66,17 +65,16 @@ DepositPreauth::preflight(PreflightContext const& ctx)
 
     if (authPresent + authCredPresent != 1)
     {
-        // Either both fields are present or neither field is present.  In
-        // either case the transaction is malformed.
-        JLOG(j.trace())
+        // There can only be 1 field out of 4 or the transaction is malformed.
+        JLOG(ctx.j.trace())
             << "Malformed transaction: "
                "Invalid Authorize and Unauthorize field combination.";
         return temMALFORMED;
     }
 
-    // Make sure that the passed account is valid.
     if (authPresent)
     {
+        // Make sure that the passed account is valid.
         AccountID const& target(optAuth ? *optAuth : *optUnauth);
         if (!target)
         {

--- a/src/xrpld/app/tx/detail/DepositPreauth.h
+++ b/src/xrpld/app/tx/detail/DepositPreauth.h
@@ -45,7 +45,6 @@ public:
     // Interface used by DeleteAccount
     static TER
     removeFromLedger(
-        Application& app,
         ApplyView& view,
         uint256 const& delIndex,
         beast::Journal j);

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -487,8 +487,7 @@ EscrowFinish::doApply()
             {
                 if (!view().exists(keylet::depositPreauth(destID, account_)))
                 {
-                    if (!ctx_.view().rules().enabled(featureCredentials) ||
-                        !ctx_.tx.isFieldPresent(sfCredentialIDs))
+                    if (!ctx_.tx.isFieldPresent(sfCredentialIDs))
                         return tecNO_PERMISSION;
 
                     if (credentials::removeExpired(view(), ctx_.tx, j_))

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -310,6 +310,10 @@ EscrowFinish::preflight(PreflightContext const& ctx)
     if (ctx.rules.enabled(fix1543) && ctx.tx.getFlags() & tfUniversalMask)
         return temINVALID_FLAG;
 
+    if (ctx.tx.isFieldPresent(sfCredentialIDs) &&
+        !ctx.rules.enabled(featureCredentials))
+        return temDISABLED;
+
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
 

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -469,6 +469,7 @@ EscrowFinish::doApply()
             return tecCRYPTOCONDITION_ERROR;
     }
 
+    // NOTE: Escrow payments cannot be used to fund accounts.
     AccountID const destID = (*slep)[sfDestination];
     auto const sled = ctx_.view().peek(keylet::account(destID));
     if (!sled)

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -374,6 +374,9 @@ EscrowFinish::calculateBaseFee(ReadView const& view, STTx const& tx)
 TER
 EscrowFinish::preclaim(PreclaimContext const& ctx)
 {
+    if (!ctx.view.rules().enabled(featureCredentials))
+        return Transactor::preclaim(ctx);
+
     auto const escrowKey =
         keylet::escrow(ctx.tx[sfOwner], ctx.tx[sfOfferSequence]);
     auto const sleEscrow = ctx.view.read(escrowKey);

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -477,7 +477,7 @@ EscrowFinish::doApply()
 
     if (ctx_.view().rules().enabled(featureDepositAuth))
     {
-        if (auto err = credentials::verify(ctx_, account_, destID, sled);
+        if (auto err = verifyDepositPreauth(ctx_, account_, destID, sled);
             !isTesSuccess(err))
             return err;
     }

--- a/src/xrpld/app/tx/detail/Escrow.h
+++ b/src/xrpld/app/tx/detail/Escrow.h
@@ -63,6 +63,9 @@ public:
     static XRPAmount
     calculateBaseFee(ReadView const& view, STTx const& tx);
 
+    static TER
+    preclaim(PreclaimContext const& ctx);
+
     TER
     doApply() override;
 };

--- a/src/xrpld/app/tx/detail/InvariantCheck.cpp
+++ b/src/xrpld/app/tx/detail/InvariantCheck.cpp
@@ -481,6 +481,7 @@ LedgerEntryTypesMatch::visitEntry(
             case ltORACLE:
             case ltMPTOKEN_ISSUANCE:
             case ltMPTOKEN:
+            case ltCREDENTIAL:
                 break;
             default:
                 invalidTypeAdded_ = true;

--- a/src/xrpld/app/tx/detail/PayChan.cpp
+++ b/src/xrpld/app/tx/detail/PayChan.cpp
@@ -404,6 +404,10 @@ PayChanFund::doApply()
 NotTEC
 PayChanClaim::preflight(PreflightContext const& ctx)
 {
+    if (ctx.tx.isFieldPresent(sfCredentialIDs) &&
+        !ctx.rules.enabled(featureCredentials))
+        return temDISABLED;
+
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
 

--- a/src/xrpld/app/tx/detail/PayChan.cpp
+++ b/src/xrpld/app/tx/detail/PayChan.cpp
@@ -548,8 +548,7 @@ PayChanClaim::doApply()
             {
                 if (!view().exists(keylet::depositPreauth(dst, txAccount)))
                 {
-                    if (!ctx_.view().rules().enabled(featureCredentials) ||
-                        !ctx_.tx.isFieldPresent(sfCredentialIDs))
+                    if (!ctx_.tx.isFieldPresent(sfCredentialIDs))
                         return tecNO_PERMISSION;
 
                     if (credentials::removeExpired(view(), ctx_.tx, j_))

--- a/src/xrpld/app/tx/detail/PayChan.cpp
+++ b/src/xrpld/app/tx/detail/PayChan.cpp
@@ -467,6 +467,9 @@ PayChanClaim::preflight(PreflightContext const& ctx)
 TER
 PayChanClaim::preclaim(PreclaimContext const& ctx)
 {
+    if (!ctx.view.rules().enabled(featureCredentials))
+        return Transactor::preclaim(ctx);
+
     Keylet const k(ltPAYCHAN, ctx.tx[sfChannel]);
     auto const slep = ctx.view.read(k);
     if (!slep)

--- a/src/xrpld/app/tx/detail/PayChan.cpp
+++ b/src/xrpld/app/tx/detail/PayChan.cpp
@@ -539,8 +539,7 @@ PayChanClaim::doApply()
 
         if (depositAuth)
         {
-            if (auto err = credentials::verify(
-                    ctx_, txAccount, dst, sled->getFlags() & lsfDepositAuth);
+            if (auto err = verifyDepositPreauth(ctx_, txAccount, dst, sled);
                 !isTesSuccess(err))
                 return err;
         }

--- a/src/xrpld/app/tx/detail/Payment.cpp
+++ b/src/xrpld/app/tx/detail/Payment.cpp
@@ -400,8 +400,8 @@ Payment::doApply()
             //  1. If Account == Destination, or
             //  2. If Account is deposit preauthorized by destination.
 
-            if (auto err = credentials::verify(
-                    ctx_, account_, dstAccountID, reqDepositAuth);
+            if (auto err =
+                    verifyDepositPreauth(ctx_, account_, dstAccountID, sleDst);
                 !isTesSuccess(err))
                 return err;
         }
@@ -472,8 +472,8 @@ Payment::doApply()
 
         if (view().rules().enabled(featureCredentials))
         {
-            if (auto err = credentials::verify(
-                    ctx_, account_, dstAccountID, reqDepositAuth);
+            if (auto err =
+                    verifyDepositPreauth(ctx_, account_, dstAccountID, sleDst);
                 !isTesSuccess(err))
                 return err;
         }
@@ -594,8 +594,8 @@ Payment::doApply()
         if (dstAmount > dstReserve ||
             sleDst->getFieldAmount(sfBalance) > dstReserve)
         {
-            if (auto err = credentials::verify(
-                    ctx_, account_, dstAccountID, reqDepositAuth);
+            if (auto err =
+                    verifyDepositPreauth(ctx_, account_, dstAccountID, sleDst);
                 !isTesSuccess(err))
                 return err;
         }

--- a/src/xrpld/app/tx/detail/Payment.cpp
+++ b/src/xrpld/app/tx/detail/Payment.cpp
@@ -470,13 +470,10 @@ Payment::doApply()
             ter != tesSUCCESS)
             return ter;
 
-        if (view().rules().enabled(featureCredentials))
-        {
-            if (auto err =
-                    verifyDepositPreauth(ctx_, account_, dstAccountID, sleDst);
-                !isTesSuccess(err))
-                return err;
-        }
+        if (auto err =
+                verifyDepositPreauth(ctx_, account_, dstAccountID, sleDst);
+            !isTesSuccess(err))
+            return err;
 
         auto const& issuer = mptIssue.getIssuer();
 

--- a/src/xrpld/app/tx/detail/Payment.cpp
+++ b/src/xrpld/app/tx/detail/Payment.cpp
@@ -66,6 +66,10 @@ getMaxSourceAmount(
 NotTEC
 Payment::preflight(PreflightContext const& ctx)
 {
+    if (ctx.tx.isFieldPresent(sfCredentialIDs) &&
+        !ctx.rules.enabled(featureCredentials))
+        return temDISABLED;
+
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
 

--- a/src/xrpld/app/tx/detail/Payment.cpp
+++ b/src/xrpld/app/tx/detail/Payment.cpp
@@ -470,6 +470,14 @@ Payment::doApply()
             ter != tesSUCCESS)
             return ter;
 
+        if (view().rules().enabled(featureCredentials))
+        {
+            if (auto err = credentials::verify(
+                    ctx_, account_, dstAccountID, reqDepositAuth);
+                !isTesSuccess(err))
+                return err;
+        }
+
         auto const& issuer = mptIssue.getIssuer();
 
         // Transfer rate

--- a/src/xrpld/app/tx/detail/Payment.cpp
+++ b/src/xrpld/app/tx/detail/Payment.cpp
@@ -387,7 +387,6 @@ Payment::doApply()
     if (!depositPreauth && ripple && reqDepositAuth)
         return tecNO_PERMISSION;
 
-    bool const credentialsEnabled = view().rules().enabled(featureCredentials);
     bool const credentialsPresent = ctx_.tx.isFieldPresent(sfCredentialIDs);
 
     if (ripple)
@@ -406,7 +405,7 @@ Payment::doApply()
                 if (!view().exists(
                         keylet::depositPreauth(dstAccountID, account_)))
                 {
-                    if (!credentialsEnabled || !credentialsPresent)
+                    if (!credentialsPresent)
                         return tecNO_PERMISSION;
 
                     if (credentials::removeExpired(view(), ctx_.tx, j_))
@@ -601,7 +600,7 @@ Payment::doApply()
                 if (dstAmount > dstReserve ||
                     sleDst->getFieldAmount(sfBalance) > dstReserve)
                 {
-                    if (!credentialsEnabled || !credentialsPresent)
+                    if (!credentialsPresent)
                         return tecNO_PERMISSION;
 
                     if (credentials::removeExpired(view(), ctx_.tx, j_))

--- a/src/xrpld/app/tx/detail/applySteps.cpp
+++ b/src/xrpld/app/tx/detail/applySteps.cpp
@@ -34,6 +34,7 @@
 #include <xrpld/app/tx/detail/CreateCheck.h>
 #include <xrpld/app/tx/detail/CreateOffer.h>
 #include <xrpld/app/tx/detail/CreateTicket.h>
+#include <xrpld/app/tx/detail/Credentials.h>
 #include <xrpld/app/tx/detail/DID.h>
 #include <xrpld/app/tx/detail/DeleteAccount.h>
 #include <xrpld/app/tx/detail/DeleteOracle.h>

--- a/src/xrpld/net/detail/RPCCall.cpp
+++ b/src/xrpld/net/detail/RPCCall.cpp
@@ -416,7 +416,8 @@ private:
         return jvRequest;
     }
 
-    // deposit_authorized <source_account> <destination_account> [<ledger>]
+    // deposit_authorized <source_account> <destination_account>
+    // [<ledger> [<credentials>, ...]]
     Json::Value
     parseDepositAuthorized(Json::Value const& jvParams)
     {
@@ -424,8 +425,16 @@ private:
         jvRequest[jss::source_account] = jvParams[0u].asString();
         jvRequest[jss::destination_account] = jvParams[1u].asString();
 
-        if (jvParams.size() == 3)
+        if (jvParams.size() >= 3)
             jvParseLedger(jvRequest, jvParams[2u].asString());
+
+        // 8 credentials max
+        if ((jvParams.size() >= 4) && (jvParams.size() <= 11))
+        {
+            jvRequest[jss::credentials] = Json::Value(Json::arrayValue);
+            for (uint32_t i = 3; i < jvParams.size(); ++i)
+                jvRequest[jss::credentials].append(jvParams[i].asString());
+        }
 
         return jvRequest;
     }
@@ -1161,7 +1170,7 @@ public:
             {"channel_verify", &RPCParser::parseChannelVerify, 4, 4},
             {"connect", &RPCParser::parseConnect, 1, 2},
             {"consensus_info", &RPCParser::parseAsIs, 0, 0},
-            {"deposit_authorized", &RPCParser::parseDepositAuthorized, 2, 3},
+            {"deposit_authorized", &RPCParser::parseDepositAuthorized, 2, 11},
             {"feature", &RPCParser::parseFeature, 0, 2},
             {"fetch_info", &RPCParser::parseFetchInfo, 0, 1},
             {"gateway_balances", &RPCParser::parseGatewayBalances, 1, -1},

--- a/src/xrpld/rpc/detail/RPCHelpers.cpp
+++ b/src/xrpld/rpc/detail/RPCHelpers.cpp
@@ -33,7 +33,9 @@
 #include <xrpl/protocol/RPCErr.h>
 #include <xrpl/protocol/nftPageMask.h>
 #include <xrpl/resource/Fees.h>
+
 #include <boost/algorithm/string/case_conv.hpp>
+
 #include <regex>
 
 namespace ripple {
@@ -929,13 +931,14 @@ chooseLedgerEntryType(Json::Value const& params)
     std::pair<RPC::Status, LedgerEntryType> result{RPC::Status::OK, ltANY};
     if (params.isMember(jss::type))
     {
-        static constexpr std::array<std::pair<char const*, LedgerEntryType>, 24>
+        static constexpr std::array<std::pair<char const*, LedgerEntryType>, 25>
             types{
                 {{jss::account, ltACCOUNT_ROOT},
                  {jss::amendments, ltAMENDMENTS},
                  {jss::amm, ltAMM},
                  {jss::bridge, ltBRIDGE},
                  {jss::check, ltCHECK},
+                 {jss::credential, ltCREDENTIAL},
                  {jss::deposit_preauth, ltDEPOSIT_PREAUTH},
                  {jss::did, ltDID},
                  {jss::directory, ltDIR_NODE},

--- a/src/xrpld/rpc/handlers/DepositAuthorized.cpp
+++ b/src/xrpld/rpc/handlers/DepositAuthorized.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <xrpld/app/misc/CredentialHelpers.h>
 #include <xrpld/ledger/ReadView.h>
 #include <xrpld/rpc/Context.h>
 #include <xrpld/rpc/detail/RPCHelpers.h>
@@ -32,6 +33,7 @@ namespace ripple {
 //   destination_account : <ident>
 //   ledger_hash : <ledger>
 //   ledger_index : <ledger_index>
+//   credentials : [<credentialID>,...]
 // }
 
 Json::Value
@@ -88,23 +90,83 @@ doDepositAuthorized(RPC::JsonContext& context)
         return result;
     }
 
-    // If the two accounts are the same, then the deposit should be fine.
-    bool depositAuthorized{true};
-    if (srcAcct != dstAcct)
+    bool const reqAuth =
+        (sleDest->getFlags() & lsfDepositAuth) && (srcAcct != dstAcct);
+    bool const credentialsPresent = params.isMember(jss::credentials);
+
+    STArray authCreds;
+    if (credentialsPresent)
     {
-        // Check destination for the DepositAuth flag.  If that flag is
-        // not set then a deposit should be just fine.
-        if (sleDest->getFlags() & lsfDepositAuth)
+        auto const& creds(params[jss::credentials]);
+        if (!creds.isArray() || !creds)
         {
-            // See if a preauthorization entry is in the ledger.
-            auto const sleDepositAuth =
-                ledger->read(keylet::depositPreauth(dstAcct, srcAcct));
-            depositAuthorized = static_cast<bool>(sleDepositAuth);
+            return RPC::make_error(
+                rpcINVALID_PARAMS,
+                RPC::expected_field_message(
+                    jss::credentials, "an array of CredentialID(hash256)"));
+        }
+
+        for (auto const& jo : creds)
+        {
+            if (!jo.isString())
+            {
+                return RPC::make_error(
+                    rpcINVALID_PARAMS,
+                    RPC::expected_field_message(
+                        jss::credentials, "an array of CredentialID(hash256)"));
+            }
+
+            uint256 credH;
+            auto const credS = jo.asString();
+            if (!credH.parseHex(credS))
+            {
+                return RPC::make_error(
+                    rpcINVALID_PARAMS,
+                    RPC::expected_field_message(
+                        jss::credentials, "an array of CredentialID(hash256)"));
+            }
+
+            std::shared_ptr<SLE const> sleCred =
+                ledger->read(keylet::credential(credH));
+            if (!sleCred || (sleCred->getType() != ltCREDENTIAL) ||
+                !(sleCred->getFlags() & lsfAccepted))
+            {
+                RPC::inject_error(rpcBAD_CREDENTIALS, result);
+                return result;
+            }
+
+            if (credentials::checkExpired(
+                    sleCred, context.app.timeKeeper().now()))
+            {
+                RPC::inject_error(rpcBAD_CREDENTIALS, result);
+                return result;
+            }
+
+            if (reqAuth)
+            {
+                auto credential = STObject::makeInnerObject(sfCredential);
+                credential.setAccountID(sfIssuer, (*sleCred)[sfIssuer]);
+                credential.setFieldVL(
+                    sfCredentialType, (*sleCred)[sfCredentialType]);
+                authCreds.push_back(std::move(credential));
+            }
         }
     }
+
+    // If the two accounts are the same OR if that flag is
+    // not set, then the deposit should be fine.
+    bool depositAuthorized = true;
+
+    if (reqAuth)
+        depositAuthorized = credentialsPresent
+            ? ledger->exists(keylet::depositPreauth(dstAcct, authCreds))
+            : ledger->exists(keylet::depositPreauth(dstAcct, srcAcct));
+
     result[jss::source_account] = params[jss::source_account].asString();
     result[jss::destination_account] =
         params[jss::destination_account].asString();
+    if (credentialsPresent)
+        result[jss::credentials] = params[jss::credentials];
 
     result[jss::deposit_authorized] = depositAuthorized;
     return result;

--- a/src/xrpld/rpc/handlers/DepositAuthorized.cpp
+++ b/src/xrpld/rpc/handlers/DepositAuthorized.cpp
@@ -160,6 +160,15 @@ doDepositAuthorized(RPC::JsonContext& context)
                 return result;
             }
 
+            if ((*sleCred)[sfSubject] != srcAcct)
+            {
+                RPC::inject_error(
+                    rpcBAD_CREDENTIALS,
+                    "credentials doesn't belong to the root account",
+                    result);
+                return result;
+            }
+
             auto [it, ins] = sorted.emplace(
                 (*sleCred)[sfIssuer], (*sleCred)[sfCredentialType]);
             if (!ins)

--- a/src/xrpld/rpc/handlers/LedgerEntry.cpp
+++ b/src/xrpld/rpc/handlers/LedgerEntry.cpp
@@ -151,7 +151,7 @@ doLedgerEntry(RPC::JsonContext& context)
                 }
                 else
                 {
-                    auto const& ac(dp[jss::authorize_credentials]);
+                    auto const& ac(dp[jss::authorized_credentials]);
                     STArray const arr = parseAuthorizeCredentials(ac);
 
                     if (arr.empty() || (arr.size() > maxCredentialsArraySize))

--- a/src/xrpld/rpc/handlers/LedgerEntry.cpp
+++ b/src/xrpld/rpc/handlers/LedgerEntry.cpp
@@ -34,6 +34,30 @@
 
 namespace ripple {
 
+static STArray
+parseAuthorizeCredentials(Json::Value const& jv)
+{
+    STArray arr;
+    for (auto const& jo : jv)
+    {
+        auto const issuer = parseBase58<AccountID>(jo[jss::issuer].asString());
+        if (!issuer || !*issuer)
+            return {};
+
+        auto const credentialType =
+            strUnHex(jo[jss::credential_type].asString());
+        if (!credentialType || credentialType->empty())
+            return {};
+
+        auto credential = STObject::makeInnerObject(sfCredential);
+        credential.setAccountID(sfIssuer, *issuer);
+        credential.setFieldVL(sfCredentialType, *credentialType);
+        arr.push_back(std::move(credential));
+    }
+
+    return arr;
+}
+
 // {
 //   ledger_hash : <ledger>
 //   ledger_index : <ledger_index>
@@ -84,44 +108,55 @@ doLedgerEntry(RPC::JsonContext& context)
         else if (context.params.isMember(jss::deposit_preauth))
         {
             expectedType = ltDEPOSIT_PREAUTH;
+            auto const& dp = context.params[jss::deposit_preauth];
 
-            if (!context.params[jss::deposit_preauth].isObject())
+            if (!dp.isObject())
             {
-                if (!context.params[jss::deposit_preauth].isString() ||
-                    !uNodeIndex.parseHex(
-                        context.params[jss::deposit_preauth].asString()))
+                if (!dp.isString() || !uNodeIndex.parseHex(dp.asString()))
                 {
                     uNodeIndex = beast::zero;
                     jvResult[jss::error] = "malformedRequest";
                 }
             }
+            // clang-format off
             else if (
-                !context.params[jss::deposit_preauth].isMember(jss::owner) ||
-                !context.params[jss::deposit_preauth][jss::owner].isString() ||
-                !context.params[jss::deposit_preauth].isMember(
-                    jss::authorized) ||
-                !context.params[jss::deposit_preauth][jss::authorized]
-                     .isString())
+                (!dp.isMember(jss::owner) || !dp[jss::owner].isString()) ||
+                (dp.isMember(jss::authorized) == dp.isMember(jss::authorize_credentials)) ||
+                (dp.isMember(jss::authorized) && !dp[jss::authorized].isString()) ||
+                (dp.isMember(jss::authorize_credentials) && !dp[jss::authorize_credentials].isArray())
+                )
+            // clang-format on
             {
                 jvResult[jss::error] = "malformedRequest";
             }
             else
             {
-                auto const owner = parseBase58<AccountID>(
-                    context.params[jss::deposit_preauth][jss::owner]
-                        .asString());
-
-                auto const authorized = parseBase58<AccountID>(
-                    context.params[jss::deposit_preauth][jss::authorized]
-                        .asString());
-
+                auto const owner =
+                    parseBase58<AccountID>(dp[jss::owner].asString());
                 if (!owner)
+                {
                     jvResult[jss::error] = "malformedOwner";
-                else if (!authorized)
-                    jvResult[jss::error] = "malformedAuthorized";
+                }
+                else if (dp.isMember(jss::authorized))
+                {
+                    auto const authorized =
+                        parseBase58<AccountID>(dp[jss::authorized].asString());
+                    if (!authorized)
+                        jvResult[jss::error] = "malformedAuthorized";
+                    else
+                        uNodeIndex =
+                            keylet::depositPreauth(*owner, *authorized).key;
+                }
                 else
-                    uNodeIndex =
-                        keylet::depositPreauth(*owner, *authorized).key;
+                {
+                    auto const& ac(dp[jss::authorize_credentials]);
+                    STArray const arr = parseAuthorizeCredentials(ac);
+
+                    if (arr.empty() || (arr.size() > credentialsArrayMaxSize))
+                        jvResult[jss::error] = "malformedAuthorizeCredentials";
+                    else
+                        uNodeIndex = keylet::depositPreauth(*owner, arr).key;
+                }
             }
         }
         else if (context.params.isMember(jss::directory))
@@ -642,6 +677,52 @@ doLedgerEntry(RPC::JsonContext& context)
                     jvResult[jss::error] = "malformedDocumentID";
                 else
                     uNodeIndex = keylet::oracle(*account, *documentID).key;
+            }
+        }
+        else if (context.params.isMember(jss::credential))
+        {
+            expectedType = ltCREDENTIAL;
+            auto const& cred = context.params[jss::credential];
+
+            if (cred.isString())
+            {
+                if (!uNodeIndex.parseHex(cred.asString()))
+                {
+                    uNodeIndex = beast::zero;
+                    jvResult[jss::error] = "malformedRequest";
+                }
+            }
+            else if (
+                (!cred.isMember(jss::subject) ||
+                 !cred[jss::subject].isString()) ||
+                (!cred.isMember(jss::issuer) ||
+                 !cred[jss::issuer].isString()) ||
+                (!cred.isMember(jss::credential_type) ||
+                 !cred[jss::credential_type].isString()))
+            {
+                jvResult[jss::error] = "malformedRequest";
+            }
+            else
+            {
+                auto const subject =
+                    parseBase58<AccountID>(cred[jss::subject].asString());
+                auto const issuer =
+                    parseBase58<AccountID>(cred[jss::issuer].asString());
+                auto const credType =
+                    strUnHex(cred[jss::credential_type].asString());
+                if (!subject || subject->isZero() || !issuer ||
+                    issuer->isZero() || !credType || credType->empty())
+                {
+                    jvResult[jss::error] = "malformedRequest";
+                }
+                else
+                {
+                    uNodeIndex = keylet::credential(
+                                     *subject,
+                                     *issuer,
+                                     Slice(credType->data(), credType->size()))
+                                     .key;
+                }
             }
         }
         else if (context.params.isMember(jss::mpt_issuance))

--- a/src/xrpld/rpc/handlers/LedgerEntry.cpp
+++ b/src/xrpld/rpc/handlers/LedgerEntry.cpp
@@ -123,9 +123,9 @@ doLedgerEntry(RPC::JsonContext& context)
             // clang-format off
             else if (
                 (!dp.isMember(jss::owner) || !dp[jss::owner].isString()) ||
-                (dp.isMember(jss::authorized) == dp.isMember(jss::authorize_credentials)) ||
+                (dp.isMember(jss::authorized) == dp.isMember(jss::authorized_credentials)) ||
                 (dp.isMember(jss::authorized) && !dp[jss::authorized].isString()) ||
-                (dp.isMember(jss::authorize_credentials) && !dp[jss::authorize_credentials].isArray())
+                (dp.isMember(jss::authorized_credentials) && !dp[jss::authorized_credentials].isArray())
                 )
             // clang-format on
             {

--- a/src/xrpld/rpc/handlers/LedgerEntry.cpp
+++ b/src/xrpld/rpc/handlers/LedgerEntry.cpp
@@ -155,13 +155,13 @@ doLedgerEntry(RPC::JsonContext& context)
                     STArray const arr = parseAuthorizeCredentials(ac);
 
                     if (arr.empty() || (arr.size() > maxCredentialsArraySize))
-                        jvResult[jss::error] = "malformedAuthorizeCredentials";
+                        jvResult[jss::error] = "malformedAuthorizedCredentials";
                     else
                     {
                         auto sorted = credentials::makeSorted(arr);
                         if (sorted.empty())
                             jvResult[jss::error] =
-                                "malformedAuthorizeCredentials";
+                                "malformedAuthorizedCredentials";
                         else
                             uNodeIndex =
                                 keylet::depositPreauth(*owner, sorted).key;


### PR DESCRIPTION
## High Level Overview of Change

Implementation of Credentials feature. It extend usage of [Deposit Authorization](https://xrpl.org/docs/concepts/accounts/depositauth)
Now account that require pre-authorization can setup DepositPreauth object with allowed credentials. And only accounts that have been authorized by the specified issuer (and get credentials from them) will be allowed to send the payments. Please check [XLS-70d](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0070d-credentials) for detailed description of the feature.


### Context of Change

- Added new ledger object `CREDENTIAL` and its transactions - `CredentialCreate, CredentialAccept, CredentialDelete`
- `DEPOSIT_PREAUTH` ledger object updated to be able to use credentials. Updated transactions: `DepositPreauth`,  
- Updated transactions to use credentials in their parameters: `Payment, EscrowFinish, AccountDelete, PaymentChannelClaim`



### API Impact

- [x] Public API:  `deposit_authorized`  added `credentials` field.
- [x] Public API:  `ledger_entry`  added `authorize_credentials` to `deposit_preauth` field.
- [x] Public API:  `ledger_entry`  added `credential` parameter.
