### PR TITLE
Update SQLite3 max_page_count to match current defaults

### DIFF
--- a/src/ripple/app/main/DBInit.h
+++ b/src/ripple/app/main/DBInit.h
@@ -77,7 +77,7 @@ inline constexpr auto TxDBName{"transaction.db"};
 inline constexpr std::array<char const*, 4> TxDBPragma
 {
     "PRAGMA page_size=4096;", "PRAGMA journal_size_limit=1582080;",
-        "PRAGMA max_page_count=2147483646;",
+        "PRAGMA max_page_count=4294967294;",
 
 #if (ULONG_MAX > UINT_MAX) && !defined(NO_SQLITE_MMAP)
         "PRAGMA mmap_size=17179869184;"


### PR DESCRIPTION
## High Level Overview of Change
When rippled initiates a connection to SQLite3, rippled sends a "PRAGMA" statement defining the maximum number of pages allowed in the database. This commit updates the max_page_count so it is consistent with the default for newer versions of SQLite3. Increasing max_page_count is critical for keeping full history servers online.

### Context of Change
Fixes XRPLF/rippled#5102

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance (increase or change in throughput and/or latency)


## Future Tasks
Older versions of SQLite3 should be tested to ensure they can successfully use the larger max_page_count
