### PR TITLE
Retry RPC commands to try to fix MacOS CI jobs

### DIFF
--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -317,6 +317,7 @@ Env::submit(JTx const& jt)
     auto const jr = [&]() {
         if (jt.stx)
         {
+            // We shouldn't need to retry, but it fixes the test on macOS for the moment.
             int retries = 3;
             do
             {

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -317,7 +317,8 @@ Env::submit(JTx const& jt)
     auto const jr = [&]() {
         if (jt.stx)
         {
-            // We shouldn't need to retry, but it fixes the test on macOS for the moment.
+            // We shouldn't need to retry, but it fixes the test on macOS for
+            // the moment.
             int retries = 3;
             do
             {

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -317,16 +317,22 @@ Env::submit(JTx const& jt)
     auto const jr = [&]() {
         if (jt.stx)
         {
-            txid_ = jt.stx->getTransactionID();
-            Serializer s;
-            jt.stx->add(s);
-            auto const jr = rpc("submit", strHex(s.slice()));
+            int retries = 3;
+            do
+            {
+                txid_ = jt.stx->getTransactionID();
+                Serializer s;
+                jt.stx->add(s);
+                auto const jr = rpc("submit", strHex(s.slice()));
 
-            parsedResult = parseResult(jr);
-            test.expect(parsedResult.ter, "ter uninitialized!");
-            ter_ = parsedResult.ter.value_or(telENV_RPC_FAILED);
-
-            return jr;
+                parsedResult = parseResult(jr);
+                test.expect(parsedResult.ter, "ter uninitialized!");
+                ter_ = parsedResult.ter.value_or(telENV_RPC_FAILED);
+                if (ter_ != telENV_RPC_FAILED ||
+                    parsedResult.rpcCode != rpcINTERNAL ||
+                    jt.ter == telENV_RPC_FAILED || --retries <= 0)
+                    return jr;
+            } while (true);
         }
         else
         {

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -2749,24 +2749,6 @@ NetworkOPsImp::pubProposedTransaction(
     pubProposedAccountTransaction(ledger, transaction, result);
 }
 
-static void
-getAccounts(Json::Value const& jvObj, std::vector<AccountID>& accounts)
-{
-    for (auto& jv : jvObj)
-    {
-        if (jv.isObject())
-        {
-            getAccounts(jv, accounts);
-        }
-        else if (jv.isString())
-        {
-            auto account = RPC::accountFromStringStrict(jv.asString());
-            if (account)
-                accounts.push_back(*account);
-        }
-    }
-}
-
 void
 NetworkOPsImp::pubLedger(std::shared_ptr<ReadView const> const& lpAccepted)
 {


### PR DESCRIPTION
## High Level Overview of Change

Retries failed RPC connection timeouts up to 3 times, unless the test is expecting a timeout. Geared toward fixing MacOS test run failures. 

Also remove an orphaned free function: `getAccounts`.

### Context of Change

MacOS CI jobs have been failing spuriously for a while due to timeouts. This seems to resolve the issue.

### Type of Change

- [X] Tests (you added tests for code that already exists, or your new feature included in this PR)

### API Impact

None
