### PR TITLE
Add a new serialized type: STNumber

### DIFF
--- a/include/xrpl/protocol/SField.h
+++ b/include/xrpl/protocol/SField.h
@@ -70,8 +70,9 @@ class STCurrency;
     STYPE(STI_AMOUNT, 6)                          \
     STYPE(STI_VL, 7)                              \
     STYPE(STI_ACCOUNT, 8)                         \
+    STYPE(STI_NUMBER, 9)                          \
                                                   \
-    /* 9-13 are reserved */                       \
+    /* 10-13 are reserved */                      \
     STYPE(STI_OBJECT, 14)                         \
     STYPE(STI_ARRAY, 15)                          \
                                                   \

--- a/include/xrpl/protocol/SField.h
+++ b/include/xrpl/protocol/SField.h
@@ -49,6 +49,7 @@ template <int>
 class STBitString;
 template <class>
 class STInteger;
+class STNumber;
 class STXChainBridge;
 class STVector256;
 class STCurrency;
@@ -350,6 +351,7 @@ using SF_ACCOUNT = TypedField<STAccount>;
 using SF_AMOUNT = TypedField<STAmount>;
 using SF_ISSUE = TypedField<STIssue>;
 using SF_CURRENCY = TypedField<STCurrency>;
+using SF_NUMBER = TypedField<STNumber>;
 using SF_VL = TypedField<STBlob>;
 using SF_VECTOR256 = TypedField<STVector256>;
 using SF_XCHAIN_BRIDGE = TypedField<STXChainBridge>;
@@ -597,6 +599,9 @@ extern SF_ACCOUNT const sfAttestationSignerAccount;
 extern SF_ACCOUNT const sfAttestationRewardAccount;
 extern SF_ACCOUNT const sfLockingChainDoor;
 extern SF_ACCOUNT const sfIssuingChainDoor;
+
+// number (common)
+extern SF_NUMBER const sfQuantity;
 
 // path set
 extern SField const sfPaths;

--- a/include/xrpl/protocol/STNumber.h
+++ b/include/xrpl/protocol/STNumber.h
@@ -1,0 +1,54 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2024 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef XRPL_PROTOCOL_STNUMBER_H_INCLUDED
+#define XRPL_PROTOCOL_STNUMBER_H_INCLUDED
+
+#include <xrpl/basics/Number.h>
+#include <xrpl/protocol/STBase.h>
+
+namespace ripple {
+
+class STNumber final : public STBase
+{
+private:
+    Number value_;
+
+public:
+    STNumber(SField const& n, Number const& v = Number());
+    STNumber(SerialIter& sit, SField const& name);
+
+    SerializedTypeID getSType() const override;
+    std::string getText() const override;
+    Json::Value getJson(JsonOptions) const override;
+    void add(Serializer& s) const override;
+
+    Number value() const;
+    void setValue(Number const& v);
+
+    STBase* copy(std::size_t n, void* buf) const override;
+    STBase* move(std::size_t n, void* buf) override;
+
+    bool isEquivalent(const STBase& t) const override;
+    bool isDefault() const override;
+};
+
+} // namespace ripple
+
+#endif

--- a/include/xrpl/protocol/Serializer.h
+++ b/include/xrpl/protocol/Serializer.h
@@ -89,6 +89,11 @@ public:
     add32(HashPrefix p);
     int
     add64(std::uint64_t i);  // native currency amounts
+                             //
+    int
+    addi32(std::int32_t i);  // Number::exponent_
+    int
+    addi64(std::int64_t i);  // Number::mantissa_
 
     template <typename Integer>
     int addInteger(Integer);
@@ -356,6 +361,12 @@ public:
 
     std::uint64_t
     get64();
+
+    std::int32_t
+    geti32();
+
+    std::int64_t
+    geti64();
 
     template <std::size_t Bits, class Tag = void>
     base_uint<Bits, Tag>

--- a/src/libxrpl/protocol/SField.cpp
+++ b/src/libxrpl/protocol/SField.cpp
@@ -239,6 +239,8 @@ CONSTRUCT_TYPED_SFIELD(sfHookHash,              "HookHash",             UINT256,
 CONSTRUCT_TYPED_SFIELD(sfHookNamespace,         "HookNamespace",        UINT256,   32);
 CONSTRUCT_TYPED_SFIELD(sfHookSetTxnID,          "HookSetTxnID",         UINT256,   33);
 
+CONSTRUCT_TYPED_SFIELD(sfQuantity,              "Quantity",             NUMBER,     1);
+
 // currency amount (common)
 CONSTRUCT_TYPED_SFIELD(sfAmount,                "Amount",               AMOUNT,     1);
 CONSTRUCT_TYPED_SFIELD(sfBalance,               "Balance",              AMOUNT,     2);

--- a/src/libxrpl/protocol/STNumber.cpp
+++ b/src/libxrpl/protocol/STNumber.cpp
@@ -1,0 +1,107 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2023 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <xrpl/protocol/STNumber.h>
+
+#include <xrpl/protocol/SField.h>
+
+namespace ripple {
+
+STNumber::STNumber(SField const& n, Number const& v)
+    : STBase(n), value_(v)
+{
+}
+
+STNumber::STNumber(SerialIter& sit, SField const& name)
+    : STBase(name)
+{
+    // We must call these methods in separate statements
+    // to guarantee their order of execution.
+    auto mantissa = sit.geti64();
+    auto exponent = sit.geti32();
+    value_ = Number{mantissa, exponent};
+}
+
+SerializedTypeID
+STNumber::getSType() const
+{
+    return STI_NUMBER;
+}
+
+std::string
+STNumber::getText() const
+{
+    return to_string(value_);
+}
+
+Json::Value
+STNumber::getJson(JsonOptions) const
+{
+    // TODO: come up with a string representation.
+    return to_string(value_);
+}
+
+void
+STNumber::add(Serializer& s) const
+{
+    assert(getFName().isBinary());
+    assert(getFName().fieldType == getSType());
+    s.addi64(value_.mantissa());
+    s.addi32(value_.exponent());
+}
+
+Number
+STNumber::value() const
+{
+    return value_;
+}
+
+void
+STNumber::setValue(Number const& v)
+{
+    value_ = v;
+}
+
+STBase*
+STNumber::copy(std::size_t n, void* buf) const
+{
+    return emplace(n, buf, *this);
+}
+
+STBase*
+STNumber::move(std::size_t n, void* buf)
+{
+    return emplace(n, buf, std::move(*this));
+}
+
+bool
+STNumber::isEquivalent(const STBase& t) const
+{
+    assert(t.getSType() == this->getSType());
+    const STNumber* v = dynamic_cast<const STNumber*>(&t);
+    return v && (value_ == v->value_);
+}
+
+bool
+STNumber::isDefault() const
+{
+    return value_ == Number();
+}
+
+} // namespace ripple

--- a/src/libxrpl/protocol/STVar.cpp
+++ b/src/libxrpl/protocol/STVar.cpp
@@ -29,6 +29,7 @@
 #include <xrpl/protocol/STCurrency.h>
 #include <xrpl/protocol/STInteger.h>
 #include <xrpl/protocol/STIssue.h>
+#include <xrpl/protocol/STNumber.h>
 #include <xrpl/protocol/STObject.h>
 #include <xrpl/protocol/STPathSet.h>
 #include <xrpl/protocol/STVector256.h>
@@ -135,6 +136,9 @@ STVar::STVar(SerialIter& sit, SField const& name, int depth)
         case STI_AMOUNT:
             construct<STAmount>(sit, name);
             return;
+        case STI_NUMBER:
+            construct<STNumber>(sit, name);
+            return;
         case STI_UINT128:
             construct<STUInt128>(sit, name);
             return;
@@ -198,6 +202,9 @@ STVar::STVar(SerializedTypeID id, SField const& name)
             return;
         case STI_AMOUNT:
             construct<STAmount>(name);
+            return;
+        case STI_NUMBER:
+            construct<STNumber>(name);
             return;
         case STI_UINT128:
             construct<STUInt128>(name);

--- a/src/libxrpl/protocol/Serializer.cpp
+++ b/src/libxrpl/protocol/Serializer.cpp
@@ -21,6 +21,7 @@
 #include <xrpl/basics/contract.h>
 #include <xrpl/protocol/Serializer.h>
 #include <xrpl/protocol/digest.h>
+#include <boost/endian/conversion.hpp>
 #include <type_traits>
 
 namespace ripple {
@@ -68,6 +69,30 @@ Serializer::add64(std::uint64_t i)
     mData.push_back(static_cast<unsigned char>((i >> 16) & 0xff));
     mData.push_back(static_cast<unsigned char>((i >> 8) & 0xff));
     mData.push_back(static_cast<unsigned char>(i & 0xff));
+    return ret;
+}
+
+int
+Serializer::addi32(std::int32_t i)
+{
+    int ret = mData.size();
+    static constexpr std::size_t SIZE = sizeof(std::int32_t) / sizeof(unsigned char);
+    static_assert(SIZE == 4);
+    mData.resize(ret + SIZE);
+    unsigned char* p = &mData.back() + 1 - SIZE;
+    boost::endian::store_big_s32(p, i);
+    return ret;
+}
+
+int
+Serializer::addi64(std::int64_t i)
+{
+    int ret = mData.size();
+    static constexpr std::size_t SIZE = sizeof(std::int64_t) / sizeof(unsigned char);
+    static_assert(SIZE == 8);
+    mData.resize(ret + SIZE);
+    unsigned char* p = &mData.back() + 1 - SIZE;
+    boost::endian::store_big_s64(p, i);
     return ret;
 }
 
@@ -408,6 +433,30 @@ SerialIter::get64()
         (std::uint64_t(t[2]) << 40) + (std::uint64_t(t[3]) << 32) +
         (std::uint64_t(t[4]) << 24) + (std::uint64_t(t[5]) << 16) +
         (std::uint64_t(t[6]) << 8) + std::uint64_t(t[7]);
+}
+
+std::int32_t
+SerialIter::geti32()
+{
+    if (remain_ < 4)
+        Throw<std::runtime_error>("invalid SerialIter geti32");
+    auto t = p_;
+    p_ += 4;
+    used_ += 4;
+    remain_ -= 4;
+    return boost::endian::load_big_s32(t);
+}
+
+std::int64_t
+SerialIter::geti64()
+{
+    if (remain_ < 8)
+        Throw<std::runtime_error>("invalid SerialIter geti64");
+    auto t = p_;
+    p_ += 8;
+    used_ += 8;
+    remain_ -= 8;
+    return boost::endian::load_big_s64(t);
 }
 
 void

--- a/src/test/protocol/STNumber_test.cpp
+++ b/src/test/protocol/STNumber_test.cpp
@@ -1,0 +1,62 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2024 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <xrpl/beast/unit_test.h>
+#include <xrpl/protocol/STNumber.h>
+
+#include <limits>
+
+namespace ripple {
+
+struct STNumber_test : public beast::unit_test::suite
+{
+    void
+    run() override
+    {
+        {
+            STNumber const stnum{sfQuantity};
+            BEAST_EXPECT(stnum.getSType() == STI_NUMBER);
+            BEAST_EXPECT(stnum.getText() == "0");
+            BEAST_EXPECT(stnum.isDefault() == true);
+            BEAST_EXPECT(stnum.value() == Number{0});
+        }
+
+        std::initializer_list<std::int64_t> const values = {
+            std::numeric_limits<std::int64_t>::min(),
+            -1,
+            0,
+            1,
+            std::numeric_limits<std::int64_t>::max()
+        };
+        for (std::int64_t value : values)
+        {
+            STNumber const before{sfQuantity, value};
+            Serializer s;
+            before.add(s);
+            BEAST_EXPECT(s.size() == 12);
+            SerialIter sit(s.slice());
+            STNumber const after{sit, sfQuantity};
+            BEAST_EXPECT(after.isEquivalent(before));
+        }
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(STNumber, protocol, ripple);
+
+}  // namespace ripple

--- a/src/test/protocol/Serializer_test.cpp
+++ b/src/test/protocol/Serializer_test.cpp
@@ -1,0 +1,52 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2024 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <xrpl/beast/unit_test.h>
+#include <xrpl/protocol/Serializer.h>
+
+#include <limits>
+
+namespace ripple {
+
+struct Serializer_test : public beast::unit_test::suite
+{
+    void
+    run() override
+    {
+        std::initializer_list<std::int64_t> const values = {
+            std::numeric_limits<std::int64_t>::min(),
+            -1,
+            0,
+            1,
+            std::numeric_limits<std::int64_t>::max()
+        };
+        for (std::int64_t value : values)
+        {
+            Serializer s;
+            s.addi64(value);
+            BEAST_EXPECT(s.size() == 8);
+            SerialIter sit(s.slice());
+            BEAST_EXPECT(sit.geti64() == value);
+        }
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(Serializer, protocol, ripple);
+
+}  // namespace ripple


### PR DESCRIPTION
This type should let objects and transactions contain multiple fields for quantities of XRP, IOU, or [MPT](https://github.com/XRPLF/rippled/pull/5108) without duplicating information about the "issue" (represented by `STIssue`). It is a straightforward serialization of our internal `Number` type that uniformly represents those quantities.