### PR TITLE
Enforce non-standard currency rule of not starting with 0x00

### DIFF
--- a/include/xrpl/protocol/Feature.h
+++ b/include/xrpl/protocol/Feature.h
@@ -80,7 +80,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 79;
+static constexpr std::size_t numFeatures = 80;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -372,6 +372,7 @@ extern uint256 const fixEnforceNFTokenTrustline;
 extern uint256 const fixInnerObjTemplate2;
 extern uint256 const featureInvariantsV1_1;
 extern uint256 const fixNFTokenPageLinks;
+extern uint256 const fixNonStandardCurrency;
 
 }  // namespace ripple
 

--- a/include/xrpl/protocol/UintTypes.h
+++ b/include/xrpl/protocol/UintTypes.h
@@ -71,6 +71,9 @@ noCurrency();
 Currency const&
 badCurrency();
 
+bool
+validCurrency(Currency const&);
+
 inline bool
 isXRP(Currency const& c)
 {

--- a/include/xrpl/protocol/UintTypes.h
+++ b/include/xrpl/protocol/UintTypes.h
@@ -71,8 +71,12 @@ noCurrency();
 Currency const&
 badCurrency();
 
+enum class PaymentTx : bool { Yes = true, No = false };
+/** Valid currency as described in
+ * https://xrpl.org/docs/references/protocol/data-types
+ */
 bool
-validCurrency(Currency const&);
+validCurrency(Currency const&, PaymentTx paymentTx = PaymentTx::No);
 
 inline bool
 isXRP(Currency const& c)

--- a/src/libxrpl/protocol/Feature.cpp
+++ b/src/libxrpl/protocol/Feature.cpp
@@ -498,6 +498,7 @@ REGISTER_FIX    (fixReducedOffersV2,            Supported::yes, VoteBehavior::De
 REGISTER_FIX    (fixEnforceNFTokenTrustline,    Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixInnerObjTemplate2,          Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FIX    (fixNFTokenPageLinks,           Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FIX    (fixNonStandardCurrency,        Supported::yes, VoteBehavior::DefaultNo);
 // InvariantsV1_1 will be changes to Supported::yes when all the
 // invariants expected to be included under it are complete.
 REGISTER_FEATURE(InvariantsV1_1,                Supported::no, VoteBehavior::DefaultNo);

--- a/src/libxrpl/protocol/UintTypes.cpp
+++ b/src/libxrpl/protocol/UintTypes.cpp
@@ -133,8 +133,31 @@ badCurrency()
 }
 
 bool
-validCurrency(Currency const& currency)
+validCurrency(Currency const& currency, PaymentTx paymentTx)
 {
+    // Allow payments for invalid non-standard currencies
+    // created pre fixNonStandardCurrency amendment
+    static std::set<Currency> whiteList = {
+        Currency{"0000000000000000000000000000000078415059"},
+        Currency{"00000000004150756E6B30310000000000000000"},
+        Currency{"0000000000D9A928EFBCBEE297A1EFBCBE29DBB6"},
+        Currency{"0000000000414C6F676F30330000000000000000"},
+        Currency{"0000000000000000000000005852500000000000"},
+        Currency{"000028E0B2A05FE0B2A029E2948CE288A9E29490"},
+        Currency{"00000028E2989EEFBE9FE28880EFBE9F29E2989E"},
+        Currency{"00000028E381A3E29795E280BFE2979529E381A3"},
+        Currency{"000000000000005C6D2F5F283E5F3C295F5C6D2F"},
+        Currency{"00000028E295AFC2B0E296A1C2B0EFBC89E295AF"},
+        Currency{"0000000000000000000000005852527570656500"},
+        Currency{"000000000000000000000000302E310000000000"},
+        Currency{"0000000000E1839A28E0B2A05FE0B2A0E1839A29"},
+        Currency{"0000000048617070794E6577596561725852504C"},
+        Currency{"0000E29D9AE29688E29590E29590E29688E29D9A"},
+        Currency{"000028E297A35FE297A229E2948CE288A9E29490"},
+        Currency{"00000000CA95E0B2A0E0B2BFE1B4A5E0B2A0CA94"},
+        Currency{"000000282D5F282D5F282D5F2D295F2D295F2D29"},
+        Currency{"0000000000000000000000000000000078415049"},
+        Currency{"00000000000028E295ADE0B2B05FE280A2CC8129"}};
     static constexpr Currency sIsoBits(
         "FFFFFFFFFFFFFFFFFFFFFFFF000000FFFFFFFFFF");
 
@@ -146,7 +169,7 @@ validCurrency(Currency const& currency)
     if (*currency.cbegin() != 0x00)
         return true;
 
-    return false;
+    return paymentTx == PaymentTx::Yes && whiteList.contains(currency);
 }
 
 }  // namespace ripple

--- a/src/libxrpl/protocol/UintTypes.cpp
+++ b/src/libxrpl/protocol/UintTypes.cpp
@@ -132,4 +132,21 @@ badCurrency()
     return currency;
 }
 
+bool
+validCurrency(Currency const& currency)
+{
+    static constexpr Currency sIsoBits(
+        "FFFFFFFFFFFFFFFFFFFFFFFF000000FFFFFFFFFF");
+
+    // XRP or standard currency
+    if (currency == xrpCurrency() || ((currency & sIsoBits).isZero()))
+        return true;
+
+    // Non-standard currency must not start with 0x00
+    if (*currency.cbegin() != 0x00)
+        return true;
+
+    return false;
+}
+
 }  // namespace ripple

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -431,6 +431,26 @@ private:
             // Can't be cleared
             AMM amm2(env, gw, XRP(100), USD(100), ter(tecNO_PERMISSION));
         }
+
+        // Invalid non-standard currency
+        auto const invalid =
+            gw["0011111111111111111111111111111111111111"](100);
+        auto const valid = gw["0111111111111111111111111111111111111111"](100);
+        FeatureBitset const all{jtx::supported_amendments()};
+        for (auto const& features : {all, all - fixNonStandardCurrency})
+        {
+            Env env(*this, features);
+            env.fund(XRP(1'000), gw);
+            for (auto const& amt : {valid, invalid})
+            {
+                auto const err =
+                    features[fixNonStandardCurrency] && amt == invalid
+                    ? ter(temBAD_CURRENCY)
+                    : ter(tesSUCCESS);
+                AMM amm(env, gw, USD(100), amt, err);
+                AMM amm1(env, gw, amt, EUR(100), err);
+            }
+        }
     }
 
     void

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -436,15 +436,17 @@ private:
         auto const invalid =
             gw["0011111111111111111111111111111111111111"](100);
         auto const valid = gw["0111111111111111111111111111111111111111"](100);
+        auto const invalidWhiteListed =
+            gw["0000000000000000000000000000000078415059"](100);
         FeatureBitset const all{jtx::supported_amendments()};
         for (auto const& features : {all, all - fixNonStandardCurrency})
         {
             Env env(*this, features);
             env.fund(XRP(1'000), gw);
-            for (auto const& amt : {valid, invalid})
+            for (auto const& amt : {valid, invalid, invalidWhiteListed})
             {
-                auto const err =
-                    features[fixNonStandardCurrency] && amt == invalid
+                auto const err = features[fixNonStandardCurrency] &&
+                        (amt == invalid || amt == invalidWhiteListed)
                     ? ter(temBAD_CURRENCY)
                     : ter(tesSUCCESS);
                 AMM amm(env, gw, USD(100), amt, err);

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -2703,16 +2703,18 @@ class Check_test : public beast::unit_test::suite
         auto const invalid =
             gw["0011111111111111111111111111111111111111"](100);
         auto const valid = gw["0111111111111111111111111111111111111111"](100);
+        auto const invalidWhiteListed =
+            gw["0000000000000000000000000000000078415059"](100);
         auto const USD = gw["USD"];
         for (auto const& features_ :
              {features, features - fixNonStandardCurrency})
         {
-            for (auto const& amt : {valid, invalid})
+            for (auto const& amt : {valid, invalid, invalidWhiteListed})
             {
                 Env env(*this, features_);
                 env.fund(XRP(1'000), gw, alice);
-                auto const err =
-                    features_[fixNonStandardCurrency] && amt == invalid
+                auto const err = features_[fixNonStandardCurrency] &&
+                        (amt == invalid || amt == invalidWhiteListed)
                     ? ter(temBAD_CURRENCY)
                     : ter(tesSUCCESS);
                 env(check::create(gw, alice, amt), err);

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -1415,7 +1415,9 @@ struct Flow_test : public beast::unit_test::suite
         auto const invalid =
             gw["0011111111111111111111111111111111111111"](100);
         auto const valid = gw["0111111111111111111111111111111111111111"](100);
-        for (auto const& amt : {valid, invalid})
+        auto const invalidWhiteListed =
+            gw["0000000000000000000000000000000078415059"](100);
+        for (auto const& amt : {valid, invalid, invalidWhiteListed})
         {
             Env env(*this, features - fixNonStandardCurrency);
             env.fund(XRP(1'000), gw, alice, bob);

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -5300,6 +5300,33 @@ public:
     }
 
     void
+    testInvalidNonStandardCurrency(FeatureBitset features)
+    {
+        testcase("Invalid Non-Standard Currency");
+        using namespace jtx;
+        auto const gw = Account("gw");
+        auto const invalid =
+            gw["0011111111111111111111111111111111111111"](100);
+        auto const valid = gw["0111111111111111111111111111111111111111"](100);
+        auto const USD = gw["USD"];
+        for (auto const& features_ :
+             {features, features - fixNonStandardCurrency})
+        {
+            for (auto const& amt : {valid, invalid})
+            {
+                Env env(*this, features_);
+                env.fund(XRP(1'000), gw);
+                auto const err =
+                    features_[fixNonStandardCurrency] && amt == invalid
+                    ? ter(temBAD_CURRENCY)
+                    : ter(tesSUCCESS);
+                env(offer(gw, amt, USD(100)), err);
+                env(offer(gw, USD(100), amt), err);
+            }
+        }
+    }
+
+    void
     testAll(FeatureBitset features)
     {
         testCanceledOffer(features);
@@ -5361,6 +5388,7 @@ public:
         testRmSmallIncreasedQOffersXRP(features);
         testRmSmallIncreasedQOffersIOU(features);
         testFillOrKill(features);
+        testInvalidNonStandardCurrency(features);
     }
 
     void

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -5308,16 +5308,18 @@ public:
         auto const invalid =
             gw["0011111111111111111111111111111111111111"](100);
         auto const valid = gw["0111111111111111111111111111111111111111"](100);
+        auto const invalidWhiteListed =
+            gw["0000000000000000000000000000000078415059"](100);
         auto const USD = gw["USD"];
         for (auto const& features_ :
              {features, features - fixNonStandardCurrency})
         {
-            for (auto const& amt : {valid, invalid})
+            for (auto const& amt : {valid, invalid, invalidWhiteListed})
             {
                 Env env(*this, features_);
                 env.fund(XRP(1'000), gw);
-                auto const err =
-                    features_[fixNonStandardCurrency] && amt == invalid
+                auto const err = features_[fixNonStandardCurrency] &&
+                        (amt == invalid || amt == invalidWhiteListed)
                     ? ter(temBAD_CURRENCY)
                     : ter(tesSUCCESS);
                 env(offer(gw, amt, USD(100)), err);

--- a/src/test/app/SetTrust_test.cpp
+++ b/src/test/app/SetTrust_test.cpp
@@ -628,16 +628,18 @@ public:
         auto const invalid =
             gw["0011111111111111111111111111111111111111"](100);
         auto const valid = gw["0111111111111111111111111111111111111111"](100);
+        auto const invalidWhiteListed =
+            gw["0000000000000000000000000000000078415059"](100);
         auto const USD = gw["USD"];
         for (auto const& features_ :
              {features, features - fixNonStandardCurrency})
         {
-            for (auto const& amt : {valid, invalid})
+            for (auto const& amt : {valid, invalid, invalidWhiteListed})
             {
                 Env env(*this, features_);
                 env.fund(XRP(1'000), gw, alice);
-                auto const err =
-                    features_[fixNonStandardCurrency] && amt == invalid
+                auto const err = features_[fixNonStandardCurrency] &&
+                        (amt == invalid || amt == invalidWhiteListed)
                     ? ter(temBAD_CURRENCY)
                     : ter(tesSUCCESS);
                 env(trust(alice, amt), err);

--- a/src/test/app/SetTrust_test.cpp
+++ b/src/test/app/SetTrust_test.cpp
@@ -619,6 +619,33 @@ public:
     }
 
     void
+    testInvalidNonStandardCurrency(FeatureBitset features)
+    {
+        testcase("Invalid Non-Standard Currency");
+        using namespace test::jtx;
+        auto const gw = Account("gw");
+        auto const alice = Account("alice");
+        auto const invalid =
+            gw["0011111111111111111111111111111111111111"](100);
+        auto const valid = gw["0111111111111111111111111111111111111111"](100);
+        auto const USD = gw["USD"];
+        for (auto const& features_ :
+             {features, features - fixNonStandardCurrency})
+        {
+            for (auto const& amt : {valid, invalid})
+            {
+                Env env(*this, features_);
+                env.fund(XRP(1'000), gw, alice);
+                auto const err =
+                    features_[fixNonStandardCurrency] && amt == invalid
+                    ? ter(temBAD_CURRENCY)
+                    : ter(tesSUCCESS);
+                env(trust(alice, amt), err);
+            }
+        }
+    }
+
+    void
     testWithFeats(FeatureBitset features)
     {
         testFreeTrustlines(features, true, false);
@@ -639,6 +666,7 @@ public:
         testExceedTrustLineLimit();
         testAuthFlagTrustLines();
         testTrustLineLimitsWithRippling();
+        testInvalidNonStandardCurrency(features);
     }
 
 public:

--- a/src/xrpld/app/tx/detail/AMMCreate.cpp
+++ b/src/xrpld/app/tx/detail/AMMCreate.cpp
@@ -75,6 +75,14 @@ AMMCreate::preflight(PreflightContext const& ctx)
         return temBAD_FEE;
     }
 
+    if (ctx.rules.enabled(fixNonStandardCurrency) &&
+        (!validCurrency(amount.getCurrency()) ||
+         !validCurrency(amount2.getCurrency())))
+    {
+        JLOG(ctx.j.debug()) << "AMM Instance: bad non-standard currency";
+        return temBAD_CURRENCY;
+    }
+
     return preflight2(ctx);
 }
 

--- a/src/xrpld/app/tx/detail/CreateCheck.cpp
+++ b/src/xrpld/app/tx/detail/CreateCheck.cpp
@@ -65,6 +65,14 @@ CreateCheck::preflight(PreflightContext const& ctx)
             JLOG(ctx.j.warn()) << "Malformed transaction: Bad currency.";
             return temBAD_CURRENCY;
         }
+
+        if (ctx.rules.enabled(fixNonStandardCurrency) &&
+            !validCurrency(sendMax.getCurrency()))
+        {
+            JLOG(ctx.j.debug())
+                << "Malformed transaction: bad non-standard currency";
+            return temBAD_CURRENCY;
+        }
     }
 
     if (auto const optExpiry = ctx.tx[~sfExpiration])

--- a/src/xrpld/app/tx/detail/CreateOffer.cpp
+++ b/src/xrpld/app/tx/detail/CreateOffer.cpp
@@ -115,6 +115,13 @@ CreateOffer::preflight(PreflightContext const& ctx)
         return temBAD_CURRENCY;
     }
 
+    if (ctx.rules.enabled(fixNonStandardCurrency) &&
+        (!validCurrency(uPaysCurrency) || !validCurrency(uGetsCurrency)))
+    {
+        JLOG(j.debug()) << "Malformed offer: bad non-standard currency";
+        return temBAD_CURRENCY;
+    }
+
     if (saTakerPays.native() != !uPaysIssuerID ||
         saTakerGets.native() != !uGetsIssuerID)
     {

--- a/src/xrpld/app/tx/detail/NFTokenUtils.cpp
+++ b/src/xrpld/app/tx/detail/NFTokenUtils.cpp
@@ -850,6 +850,11 @@ tokenOfferCreatePreflight(
         if (dest == acctID)
             return temMALFORMED;
     }
+
+    if (rules.enabled(fixNonStandardCurrency) &&
+        !validCurrency(amount.getCurrency()))
+        return temBAD_CURRENCY;
+
     return tesSUCCESS;
 }
 

--- a/src/xrpld/app/tx/detail/Payment.cpp
+++ b/src/xrpld/app/tx/detail/Payment.cpp
@@ -118,6 +118,15 @@ Payment::preflight(PreflightContext const& ctx)
                         << "Bad currency.";
         return temBAD_CURRENCY;
     }
+
+    if (ctx.rules.enabled(fixNonStandardCurrency) &&
+        (!validCurrency(uSrcCurrency) || !validCurrency(uDstCurrency)))
+    {
+        JLOG(j.trace()) << "Malformed transaction: "
+                        << "Bad non-standard currency.";
+        return temBAD_CURRENCY;
+    }
+
     if (account == uDstAccountID && uSrcCurrency == uDstCurrency && !bPaths)
     {
         // You're signing yourself a payment.

--- a/src/xrpld/app/tx/detail/Payment.cpp
+++ b/src/xrpld/app/tx/detail/Payment.cpp
@@ -120,7 +120,8 @@ Payment::preflight(PreflightContext const& ctx)
     }
 
     if (ctx.rules.enabled(fixNonStandardCurrency) &&
-        (!validCurrency(uSrcCurrency) || !validCurrency(uDstCurrency)))
+        (!validCurrency(uSrcCurrency, PaymentTx::Yes) ||
+         !validCurrency(uDstCurrency, PaymentTx::Yes)))
     {
         JLOG(j.trace()) << "Malformed transaction: "
                         << "Bad non-standard currency.";

--- a/src/xrpld/app/tx/detail/SetTrust.cpp
+++ b/src/xrpld/app/tx/detail/SetTrust.cpp
@@ -63,6 +63,14 @@ SetTrust::preflight(PreflightContext const& ctx)
         return temBAD_CURRENCY;
     }
 
+    if (ctx.rules.enabled(fixNonStandardCurrency) &&
+        !validCurrency(saLimitAmount.getCurrency()))
+    {
+        JLOG(ctx.j.debug())
+            << "Malformed transaction: bad non-standard currency";
+        return temBAD_CURRENCY;
+    }
+
     if (saLimitAmount < beast::zero)
     {
         JLOG(j.trace()) << "Malformed transaction: Negative credit limit.";


### PR DESCRIPTION
## High Level Overview of Change

This amendment enforces non-standard currency rule per [XRPL documentation](https://xrpl.org/docs/references/protocol/data-types/currency-formats#nonstandard-currency-codes).

* Add amendment fixNonStandardCurrency
* Fail AMMCreate, CheckCreate, OfferCreate, TrustSet, and Payment transactions if non-standard currency starts with 0x00

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [x] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

## Test Plan
Updated unit-tests:
- AMM
- Check
- Flow
- Offer
- SetTrust
