### PR TITLE
Add hubs.xrpkuwait.com to example rippled.cfg

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -417,6 +417,7 @@
 #   The default list of entries is:
 #     - r.ripple.com 51235
 #     - sahyadri.isrdc.in 51235
+#     - hubs.xrpkuwait.com 51235
 #
 #   Examples:
 #


### PR DESCRIPTION
Comment added to indicate that hubs.xrpkuwait.com is also in the bootstrap list