### PR TITLE
Add hubs.xrpkuwait.com to bootstrap

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -417,6 +417,7 @@
 #   The default list of entries is:
 #     - r.ripple.com 51235
 #     - sahyadri.isrdc.in 51235
+#     - hubs.xrpkuwait.com 51235
 #
 #   Examples:
 #

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -491,6 +491,9 @@ OverlayImpl::start()
 
         // Pool of servers operated by ISRDC - https://isrdc.in
         bootstrapIps.push_back("sahyadri.isrdc.in 51235");
+
+        // Pool of servers operated by @Xrpkuwait - https://xrpkuwait.com
+        bootstrapIps.push_back("hubs.xrpkuwait.com 51235");
     }
 
     m_resolver.resolve(


### PR DESCRIPTION
Add hubs.xrpkuwait.com to default bootstrap and update example rippled.cfg file. Combines 5166 and 5167
