### PR TITLE
Fix tokens comparison in Payment for temREDUNDANT error

### DIFF
--- a/include/xrpl/protocol/Asset.h
+++ b/include/xrpl/protocol/Asset.h
@@ -199,6 +199,9 @@ validJSONAsset(Json::Value const& jv);
 Asset
 assetFromJson(Json::Value const& jv);
 
+Json::Value
+to_json(Asset const& asset);
+
 }  // namespace ripple
 
 #endif  // RIPPLE_PROTOCOL_ASSET_H_INCLUDED

--- a/include/xrpl/protocol/Asset.h
+++ b/include/xrpl/protocol/Asset.h
@@ -97,6 +97,13 @@ public:
 
     friend constexpr bool
     operator==(Currency const& lhs, Asset const& rhs);
+
+    /** Return true if both asset's issue (Issue or MPTIssue)
+     * are the same and hold the same token (currency or MPTID).
+     * Otherwise return false.
+     */
+    friend constexpr bool
+    equalTokens(Asset const& lhs, Asset const& rhs);
 };
 
 template <ValidIssueType TIss>
@@ -155,6 +162,26 @@ constexpr bool
 operator==(Currency const& lhs, Asset const& rhs)
 {
     return rhs.holds<Issue>() && rhs.get<Issue>().currency == lhs;
+}
+
+constexpr bool
+equalTokens(Asset const& lhs, Asset const& rhs)
+{
+    return std::visit(
+        [&]<typename TLhs, typename TRhs>(
+            TLhs const& issLhs, TRhs const& issRhs) {
+            if constexpr (
+                std::is_same_v<TLhs, Issue> && std::is_same_v<TRhs, Issue>)
+                return issLhs.currency == issRhs.currency;
+            else if constexpr (
+                std::is_same_v<TLhs, MPTIssue> &&
+                std::is_same_v<TRhs, MPTIssue>)
+                return issLhs.getMptID() == issRhs.getMptID();
+            else
+                return false;
+        },
+        lhs.issue_,
+        rhs.issue_);
 }
 
 inline bool

--- a/include/xrpl/protocol/Asset.h
+++ b/include/xrpl/protocol/Asset.h
@@ -98,9 +98,8 @@ public:
     friend constexpr bool
     operator==(Currency const& lhs, Asset const& rhs);
 
-    /** Return true if both asset's issue (Issue or MPTIssue)
-     * are the same and hold the same token (currency or MPTID).
-     * Otherwise return false.
+    /** Return true if both assets refer to the same currency (regardless of
+     * issuer) or MPT issuance. Otherwise return false.
      */
     friend constexpr bool
     equalTokens(Asset const& lhs, Asset const& rhs);

--- a/src/libxrpl/protocol/Asset.cpp
+++ b/src/libxrpl/protocol/Asset.cpp
@@ -74,10 +74,7 @@ Json::Value
 to_json(Asset const& asset)
 {
     return std::visit(
-        [&](auto const& issue) {
-            return to_json(issue);
-        },
-        asset.value());
+        [&](auto const& issue) { return to_json(issue); }, asset.value());
 }
 
 }  // namespace ripple

--- a/src/libxrpl/protocol/Asset.cpp
+++ b/src/libxrpl/protocol/Asset.cpp
@@ -70,4 +70,14 @@ assetFromJson(Json::Value const& v)
     return mptIssueFromJson(v);
 }
 
+Json::Value
+to_json(Asset const& asset)
+{
+    return std::visit(
+        [&](auto const& issue) {
+            return to_json(issue);
+        },
+        asset.value());
+}
+
 }  // namespace ripple

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -1938,6 +1938,49 @@ class MPToken_test : public beast::unit_test::suite
         }
     }
 
+    void
+    testTokensEquality()
+    {
+        using namespace test::jtx;
+        testcase("Tokens Equality");
+        Currency const cur1{to_currency("CU1")};
+        Currency const cur2{to_currency("CU2")};
+        Account const gw1{"gw1"};
+        Account const gw2{"gw2"};
+        MPTID const mpt1 = makeMptID(1, gw1);
+        MPTID const mpt1a = makeMptID(1, gw1);
+        MPTID const mpt2 = makeMptID(1, gw2);
+        MPTID const mpt3 = makeMptID(2, gw2);
+        Asset const assetCur1Gw1{Issue{cur1, gw1}};
+        Asset const assetCur1Gw1a{Issue{cur1, gw1}};
+        Asset const assetCur2Gw1{Issue{cur2, gw1}};
+        Asset const assetCur2Gw2{Issue{cur2, gw2}};
+        Asset const assetMpt1Gw1{mpt1};
+        Asset const assetMpt1Gw1a{mpt1a};
+        Asset const assetMpt1Gw2{mpt2};
+        Asset const assetMpt2Gw2{mpt3};
+
+        // Assets holding Issue
+        // Currencies are equal regardless of the issuer
+        BEAST_EXPECT(equalTokens(assetCur1Gw1, assetCur1Gw1a));
+        BEAST_EXPECT(equalTokens(assetCur2Gw1, assetCur2Gw2));
+        // Currencies are different regardless of whether the issuers
+        // are the same or not
+        BEAST_EXPECT(!equalTokens(assetCur1Gw1, assetCur2Gw1));
+        BEAST_EXPECT(!equalTokens(assetCur1Gw1, assetCur2Gw2));
+
+        // Assets holding MPTIssue
+        // MPTIDs are the same if the sequence and the issuer are the same
+        BEAST_EXPECT(equalTokens(assetMpt1Gw1, assetMpt1Gw1a));
+        // MPTIDs are different if sequence and the issuer don't match
+        BEAST_EXPECT(!equalTokens(assetMpt1Gw1, assetMpt1Gw2));
+        BEAST_EXPECT(!equalTokens(assetMpt1Gw2, assetMpt2Gw2));
+
+        // Assets holding Issue and MPTIssue
+        BEAST_EXPECT(!equalTokens(assetCur1Gw1, assetMpt1Gw1));
+        BEAST_EXPECT(!equalTokens(assetMpt2Gw2, assetCur2Gw2));
+    }
+
 public:
     void
     run() override
@@ -1973,6 +2016,9 @@ public:
 
         // Test parsed MPTokenIssuanceID in API response metadata
         testTxJsonMetaFields(all);
+
+        // Test tokens equality
+        testTokensEquality();
     }
 };
 

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -2006,7 +2006,7 @@ class MPToken_test : public beast::unit_test::suite
             BEAST_EXPECT(res == amt3);
 
             // overflow, any value > 3037000499ull
-            STAmount mptOverflow{asset2, 3037000500ull};
+            STAmount mptOverflow{asset2, UINT64_C(3037000500)};
             try
             {
                 res = multiply(mptOverflow, mptOverflow, asset3);
@@ -2017,11 +2017,11 @@ class MPToken_test : public beast::unit_test::suite
                 BEAST_EXPECTS(e.what() == "MPT value overflow"s, e.what());
             }
             // overflow, (v1 >> 32) * v2 > 2147483648ull
-            mptOverflow = STAmount{asset2, 2147483648ull};
+            mptOverflow = STAmount{asset2, UINT64_C(2147483648)};
+            uint64_t const mantissa = (2ull << 32) + 2;
             try
             {
-                res = multiply(
-                    STAmount{asset1, (2ull << 32) + 2}, mptOverflow, asset3);
+                res = multiply(STAmount{asset1, mantissa}, mptOverflow, asset3);
                 fail("should throw runtime exception 2");
             }
             catch (std::runtime_error const& e)

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -1995,6 +1995,7 @@ class MPToken_test : public beast::unit_test::suite
 
         {
             testcase("Test STAmount MPT arithmetics");
+            using namespace std::string_literals;
             STAmount res = multiply(amt1, amt2, asset3);
             BEAST_EXPECT(res == amt3);
 
@@ -2011,9 +2012,9 @@ class MPToken_test : public beast::unit_test::suite
                 res = multiply(mptOverflow, mptOverflow, asset3);
                 fail("should throw runtime exception 1");
             }
-            catch (std::runtime_error const&)
+            catch (std::runtime_error const& e)
             {
-                pass();
+                BEAST_EXPECTS(e.what() == "MPT value overflow"s, e.what());
             }
             // overflow, (v1 >> 32) * v2 > 2147483648ull
             mptOverflow = STAmount{asset2, 2147483648ull};
@@ -2023,9 +2024,9 @@ class MPToken_test : public beast::unit_test::suite
                     STAmount{asset1, (2ull << 32) + 2}, mptOverflow, asset3);
                 fail("should throw runtime exception 2");
             }
-            catch (std::runtime_error const&)
+            catch (std::runtime_error const& e)
             {
-                pass();
+                BEAST_EXPECTS(e.what() == "MPT value overflow"s, e.what());
             }
         }
 
@@ -2034,6 +2035,7 @@ class MPToken_test : public beast::unit_test::suite
             MPTAmount mptAmt1{100};
             MPTAmount const mptAmt2{100};
             BEAST_EXPECT((mptAmt1 += mptAmt2) == MPTAmount{200});
+            BEAST_EXPECT(mptAmt1 == 200);
             BEAST_EXPECT((mptAmt1 -= mptAmt2) == mptAmt1);
             BEAST_EXPECT(mptAmt1 == mptAmt2);
             BEAST_EXPECT(mptAmt1 == 100);
@@ -2054,6 +2056,10 @@ class MPToken_test : public beast::unit_test::suite
             Json::Value const jv = to_json(asset1);
             BEAST_EXPECT(
                 jv[jss::mpt_issuance_id] == to_string(asset1.get<MPTIssue>()));
+            BEAST_EXPECT(
+                to_string(jv) ==
+                "{\"mpt_issuance_id\":"
+                "\"00000001A407AF5856CCF3C42619DAA925813FC955C72983\"}");
             BEAST_EXPECT(asset1 == assetFromJson(jv));
         }
     }

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -2044,14 +2044,16 @@ class MPToken_test : public beast::unit_test::suite
             testcase("Test MPTIssue from/to Json");
             MPTIssue const issue1{asset1.get<MPTIssue>()};
             Json::Value const jv = to_json(issue1);
-            MPTIssue const issue2 = mptIssueFromJson(jv);
-            BEAST_EXPECT(issue1 == issue2);
+            BEAST_EXPECT(
+                jv[jss::mpt_issuance_id] == to_string(asset1.get<MPTIssue>()));
+            BEAST_EXPECT(issue1 == mptIssueFromJson(jv));
         }
 
         {
             testcase("Test Asset from/to Json");
-            Json::Value jv;
-            asset1.setJson(jv);
+            Json::Value const jv = to_json(asset1);
+            BEAST_EXPECT(
+                jv[jss::mpt_issuance_id] == to_string(asset1.get<MPTIssue>()));
             BEAST_EXPECT(asset1 == assetFromJson(jv));
         }
     }

--- a/src/xrpld/app/tx/detail/Payment.cpp
+++ b/src/xrpld/app/tx/detail/Payment.cpp
@@ -145,7 +145,7 @@ Payment::preflight(PreflightContext const& ctx)
         JLOG(j.trace()) << "Malformed transaction: " << "Bad currency.";
         return temBAD_CURRENCY;
     }
-    if (account == dstAccountID && srcAsset == dstAsset && !hasPaths)
+    if (account == dstAccountID && equalTokens(srcAsset, dstAsset) && !hasPaths)
     {
         // You're signing yourself a payment.
         // If hasPaths is true, you might be trying some arbitrage.


### PR DESCRIPTION
## High Level Overview of Change

Fix semantics of tokens comparison in the payment transactor when checking for temREDUNDANT.
This check prevents an account sending tokens to self.
Current code checks for equal tokens (currency or MPTID) AND the issuers. It should only check
if currency or MPTID are equal.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
