### PR TITLE
Add fixAMMv1_2 amendment

### DIFF
--- a/include/xrpl/protocol/Feature.h
+++ b/include/xrpl/protocol/Feature.h
@@ -80,7 +80,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 80;
+static constexpr std::size_t numFeatures = 81;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated

--- a/include/xrpl/protocol/Feature.h
+++ b/include/xrpl/protocol/Feature.h
@@ -80,7 +80,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 81;
+static constexpr std::size_t numFeatures = 82;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated

--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -29,6 +29,7 @@
 // If you add an amendment here, then do not forget to increment `numFeatures`
 // in include/xrpl/protocol/Feature.h.
 
+XRPL_FIX    (AMMv1_2,                    Supported::yes, VoteBehavior::DefaultNo)
 // InvariantsV1_1 will be changes to Supported::yes when all the
 // invariants expected to be included under it are complete.
 XRPL_FEATURE(MPTokensV1,                 Supported::yes, VoteBehavior::DefaultNo)

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -6889,10 +6889,25 @@ private:
         // Equal withdraw
         test([&](AMM& amm) { amm.withdrawAll(alice, std::nullopt, err); });
 
+        // Equal withdraw with a limit
+        test([&](AMM& amm) {
+            amm.withdraw(WithdrawArg{
+                .account = alice,
+                .asset1Out = EUR(0.1),
+                .asset2Out = USD(0.1),
+                .err = err});
+            amm.withdraw(WithdrawArg{
+                .account = alice,
+                .asset1Out = USD(0.1),
+                .asset2Out = EUR(0.1),
+                .err = err});
+        });
+
         // Single withdraw
         test([&](AMM& amm) {
             amm.withdraw(WithdrawArg{
                 .account = alice, .asset1Out = EUR(0.1), .err = err});
+            amm.withdraw(WithdrawArg{.account = alice, .asset1Out = USD(0.1)});
         });
     }
 

--- a/src/xrpld/app/paths/detail/AMMLiquidity.cpp
+++ b/src/xrpld/app/paths/detail/AMMLiquidity.cpp
@@ -211,6 +211,13 @@ AMMLiquidity<TIn, TOut>::getOffer(
                 return AMMOffer<TIn, TOut>(
                     *this, *amounts, balances, Quality{*amounts});
             }
+            else if (view.rules().enabled(fixAMMv1_2))
+            {
+                if (auto const maxAMMOffer = maxOffer(balances, view.rules());
+                    maxAMMOffer &&
+                    Quality{maxAMMOffer->amount()} > *clobQuality)
+                    return maxAMMOffer;
+            }
         }
         catch (std::overflow_error const& e)
         {

--- a/src/xrpld/app/tx/detail/AMMClawback.cpp
+++ b/src/xrpld/app/tx/detail/AMMClawback.cpp
@@ -188,6 +188,7 @@ AMMClawback::applyGuts(Sandbox& sb)
                 0,
                 FreezeHandling::fhIGNORE_FREEZE,
                 WithdrawAll::Yes,
+                mPriorBalance,
                 ctx_.journal);
     else
         std::tie(result, newLPTokenBalance, amountWithdraw, amount2Withdraw) =
@@ -267,6 +268,7 @@ AMMClawback::equalWithdrawMatchingOneAmount(
             0,
             FreezeHandling::fhIGNORE_FREEZE,
             WithdrawAll::Yes,
+            mPriorBalance,
             ctx_.journal);
 
     // Because we are doing a two-asset withdrawal,
@@ -284,6 +286,7 @@ AMMClawback::equalWithdrawMatchingOneAmount(
         0,
         FreezeHandling::fhIGNORE_FREEZE,
         WithdrawAll::No,
+        mPriorBalance,
         ctx_.journal);
 }
 

--- a/src/xrpld/app/tx/detail/AMMWithdraw.cpp
+++ b/src/xrpld/app/tx/detail/AMMWithdraw.cpp
@@ -567,9 +567,8 @@ AMMWithdraw::withdraw(
 
             // See also SetTrust::doApply()
             XRPAmount const reserve(
-                (ownerCount < 2)
-                    ? XRPAmount(beast::zero)
-                    : view.fees().accountReserve(ownerCount + 1));
+                (ownerCount < 2) ? XRPAmount(beast::zero)
+                                 : view.fees().accountReserve(ownerCount + 1));
 
             if (std::max(mPriorBalance, balance) < reserve)
                 return tecINSUFFICIENT_RESERVE;

--- a/src/xrpld/app/tx/detail/AMMWithdraw.cpp
+++ b/src/xrpld/app/tx/detail/AMMWithdraw.cpp
@@ -563,14 +563,15 @@ AMMWithdraw::withdraw(
             if (!sleAccount)
                 return tecINTERNAL;  // LCOV_EXCL_LINE
             auto const balance = (*sleAccount)[sfBalance].xrp();
-            std::uint32_t const ownerCount = sle->at(sfOwnerCount);
+            std::uint32_t const ownerCount = sleAccount->at(sfOwnerCount);
 
             // See also SetTrust::doApply()
             XRPAmount const reserve(
-                (ownerCount < 2) ? XRPAmount(beast::zero)
-                          : view().fees().accountReserve(ownerCount + 1));
+                (ownerCount < 2)
+                    ? XRPAmount(beast::zero)
+                    : view.fees().accountReserve(ownerCount + 1));
 
-            if (max(mPriorBalance, balance) < reserve)
+            if (std::max(mPriorBalance, balance) < reserve)
                 return tecINSUFFICIENT_RESERVE;
         }
         return tesSUCCESS;

--- a/src/xrpld/app/tx/detail/AMMWithdraw.cpp
+++ b/src/xrpld/app/tx/detail/AMMWithdraw.cpp
@@ -561,7 +561,7 @@ AMMWithdraw::withdraw(
         {
             auto const sleAccount = view.read(keylet::account(account_));
             if (!sleAccount)
-                return tecINTERNAL;
+                return tecINTERNAL;  // LCOV_EXCL_LINE
             auto const balance = (*sleAccount)[sfBalance].xrp();
             auto const reserve =
                 view.fees().accountReserve((*sleAccount)[sfOwnerCount] + 1);

--- a/src/xrpld/app/tx/detail/AMMWithdraw.cpp
+++ b/src/xrpld/app/tx/detail/AMMWithdraw.cpp
@@ -563,10 +563,14 @@ AMMWithdraw::withdraw(
             if (!sleAccount)
                 return tecINTERNAL;  // LCOV_EXCL_LINE
             auto const balance = (*sleAccount)[sfBalance].xrp();
-            auto const reserve =
-                view.fees().accountReserve((*sleAccount)[sfOwnerCount] + 1);
+            std::uint32_t const ownerCount = sle->at(sfOwnerCount);
 
-            if (balance < reserve)
+            // See also SetTrust::doApply()
+            XRPAmount const reserve(
+                (ownerCount < 2) ? XRPAmount(beast::zero)
+                          : view().fees().accountReserve(ownerCount + 1));
+
+            if (max(mPriorBalance, balance) < reserve)
                 return tecINSUFFICIENT_RESERVE;
         }
         return tesSUCCESS;

--- a/src/xrpld/app/tx/detail/AMMWithdraw.h
+++ b/src/xrpld/app/tx/detail/AMMWithdraw.h
@@ -96,6 +96,7 @@ public:
      * @param lpTokensWithdraw amount of tokens to withdraw
      * @param tfee trading fee in basis points
      * @param withdrawAll if withdrawing all lptokens
+     * @param priorBalance balance before fees
      * @return
      */
     static std::tuple<TER, STAmount, STAmount, std::optional<STAmount>>
@@ -112,6 +113,7 @@ public:
         std::uint16_t tfee,
         FreezeHandling freezeHanding,
         WithdrawAll withdrawAll,
+        XRPAmount const& priorBalance,
         beast::Journal const& journal);
 
     /** Withdraw requested assets and token from AMM into LP account.
@@ -127,6 +129,7 @@ public:
      * @param lpTokensWithdraw amount of lptokens to withdraw
      * @param tfee trading fee in basis points
      * @param withdrawAll if withdraw all lptokens
+     * @param priorBalance balance before fees
      * @return
      */
     static std::tuple<TER, STAmount, STAmount, std::optional<STAmount>>
@@ -143,6 +146,7 @@ public:
         std::uint16_t tfee,
         FreezeHandling freezeHandling,
         WithdrawAll withdrawAll,
+        XRPAmount const& priorBalance,
         beast::Journal const& journal);
 
     static std::pair<TER, bool>


### PR DESCRIPTION
## High Level Overview of Change

Add fixAMMv1_2 amendment:

- It adds reserve check on AMMWithdraw
- It generates AMM max offer if changeSpotPriceQuality() fails

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [x] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

## Test Plan

Added unit test to check reserve requirements on AMMWithdraw.