### PR TITLE
Bug: Replace Uint192 with Hash192 in server_definitions response

### DIFF
--- a/src/test/rpc/ServerInfo_test.cpp
+++ b/src/test/rpc/ServerInfo_test.cpp
@@ -197,6 +197,15 @@ admin = 127.0.0.1
                     .asUInt() == 0);
             BEAST_EXPECT(
                 result[jss::result][jss::TYPES]["AccountID"].asUInt() == 8);
+
+            // test that base_uint types are replaced with "Hash" prefix
+            {
+                auto const types = result[jss::result][jss::TYPES];
+                BEAST_EXPECT(types["Hash128"].asUInt() == 4);
+                BEAST_EXPECT(types["Hash160"].asUInt() == 17);
+                BEAST_EXPECT(types["Hash192"].asUInt() == 21);
+                BEAST_EXPECT(types["Hash256"].asUInt() == 5);
+            }
         }
 
         // test providing the same hash

--- a/src/xrpld/rpc/handlers/ServerInfo.cpp
+++ b/src/xrpld/rpc/handlers/ServerInfo.cpp
@@ -80,7 +80,8 @@ ServerDefinitions::translate(std::string const& inp)
 
     if (contains("UINT"))
     {
-        if (contains("256") || contains("160") || contains("128"))
+        if (contains("256") || contains("192") || contains("160") ||
+            contains("128"))
             return replace("UINT", "Hash");
         else
             return replace("UINT", "UInt");


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change
All base_uint types are returned with "Hash" prefix in server_definitions response except for Uint192.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change
Before 
```

"TYPES": {
    "AccountID": 8,
    "Amount": 6,
    "Blob": 7,
    "Currency": 26,
    "Done": -1,
    "Hash128": 4,
    "Hash160": 17,
    "Hash256": 5,
    "Issue": 24,
    "LedgerEntry": 10002,
    "Metadata": 10004,
    "NotPresent": 0,
    "PathSet": 18,
    "STArray": 15,
    "STObject": 14,
    "Transaction": 10001,
    "UInt16": 1,
    "Uint192": 21, //wrong
    "UInt32": 2,
    "UInt384": 22,
    "UInt512": 23,
    "UInt64": 3,
    "UInt8": 16,
    "UInt96": 20,
    "Unknown": -2,
    "Validation": 10003,
    "Vector256": 19,
    "XChainBridge": 25
  }
```

After:

```
 "TYPES": {
            "AccountID": 8,
            "Amount": 6,
            "Blob": 7,
            "Currency": 26,
            "Done": -1,
            "Hash128": 4,
            "Hash160": 17,
            "Hash192": 21, //correct
            "Hash256": 5,
            "Issue": 24,
            "LedgerEntry": 10002,
            "Metadata": 10004,
            "NotPresent": 0,
            "PathSet": 18,
            "STArray": 15,
            "STObject": 14,
            "Transaction": 10001,
            "UInt16": 1,
            "UInt32": 2,
            "UInt384": 22,
            "UInt512": 23,
            "UInt64": 3,
            "UInt8": 16,
            "UInt96": 20,
            "Unknown": -2,
            "Validation": 10003,
            "Vector256": 19,
            "XChainBridge": 25
        }
```
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
