### PR TITLE
Fix  checking ammID field of account

### DIFF
--- a/src/test/rpc/AMMInfo_test.cpp
+++ b/src/test/rpc/AMMInfo_test.cpp
@@ -322,29 +322,16 @@ public:
         using namespace jtx;
         testcase("Invalid amm field");
 
-        Env env{*this};
-
-        Account const gw("gw");
-        env.fund(XRP(10000), gw);
-
-        Json::Value jv;
-        jv[jss::TransactionType] = jss::AMMCreate;
-        jv[jss::Account] = gw.human();
-        jv[jss::TradingFee] = "0";
-        jv[jss::Amount] = "10000000";
-        jv[jss::Amount2] =
-            AnyAmount(gw["USD"](10)).value.getJson(JsonOptions::none);
-
-        env(jv, fee(drops(env.current()->fees().increment)));
-        env.close();
-
-        Json::Value jvParams;
-        jvParams[jss::ledger_index] = jss::validated;
-        jvParams[jss::amm_account] = gw.human();
-        auto const resp = env.rpc("json", "amm_info", to_string(jvParams));
-        BEAST_EXPECT(
-            resp.isMember("result") && resp["result"].isMember("error") &&
-            resp["result"]["error"] == "actNotFound");
+        testAMM([&](AMM& amm, Env&) {
+            auto const resp = amm.ammRpcInfo(
+                std::nullopt,
+                jss::validated.c_str(),
+                std::nullopt,
+                std::nullopt,
+                gw);
+            BEAST_EXPECT(
+                resp.isMember("error") && resp["error"] == "actNotFound");
+        });
     }
 
     void

--- a/src/xrpld/rpc/handlers/AMMInfo.cpp
+++ b/src/xrpld/rpc/handlers/AMMInfo.cpp
@@ -132,6 +132,8 @@ doAMMInfo(RPC::JsonContext& context)
             if (!sle)
                 return Unexpected(rpcACT_MALFORMED);
             ammID = sle->getFieldH256(sfAMMID);
+            if (ammID->isZero())
+                return Unexpected(rpcACT_NOT_FOUND);
         }
 
         if (params.isMember(jss::account))


### PR DESCRIPTION
## High Level Overview of Change

This fix add check for sfAMMID field in amm_info handler. 

### Context of Change

Without this check debug version of rippled crash on assert in [ledger::read()](https://github.com/XRPLF/rippled/blob/9d58f11a60881b3edb5de80cae52d8b758ae30a8/src/xrpld/app/ledger/Ledger.cpp#L445)
Bug was found during automation testing. 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### API Impact

- [x] Public API:  amm_info will not crash debug version of the rippled