### PR TITLE
fix: include `index` in `server_definitions` RPC

### DIFF
--- a/src/libxrpl/protocol/SField.cpp
+++ b/src/libxrpl/protocol/SField.cpp
@@ -72,7 +72,11 @@ TypedField<T>::TypedField(private_access_tag_t pat, Args&&... args)
 // SFields which, for historical reasons, do not follow naming conventions.
 SField const sfInvalid(access, -1);
 SField const sfGeneric(access, 0);
-SField const sfHash(access, STI_UINT256, 257, "hash");
+SField const sfHash(
+    access,
+    STI_UINT256,
+    257,
+    "hash");  // Not used anywhere, but STTx tests fail if it's removed
 
 #include <xrpl/protocol/detail/sfields.macro>
 

--- a/src/libxrpl/protocol/SField.cpp
+++ b/src/libxrpl/protocol/SField.cpp
@@ -72,11 +72,10 @@ TypedField<T>::TypedField(private_access_tag_t pat, Args&&... args)
 // SFields which, for historical reasons, do not follow naming conventions.
 SField const sfInvalid(access, -1);
 SField const sfGeneric(access, 0);
-SField const sfHash(
-    access,
-    STI_UINT256,
-    257,
-    "hash");  // Not used anywhere, but STTx tests fail if it's removed
+// The following two fields aren't used anywhere, but they break tests/have
+// downstream effects.
+SField const sfHash(access, STI_UINT256, 257, "hash");
+SField const sfIndex(access, STI_UINT256, 258, "index");
 
 #include <xrpl/protocol/detail/sfields.macro>
 

--- a/src/test/rpc/ServerInfo_test.cpp
+++ b/src/test/rpc/ServerInfo_test.cpp
@@ -198,6 +198,28 @@ admin = 127.0.0.1
             BEAST_EXPECT(
                 result[jss::result][jss::TYPES]["AccountID"].asUInt() == 8);
 
+            // check exception SFields
+            {
+                auto const fieldExists = [&](std::string name) {
+                    for (auto& field : result[jss::result][jss::FIELDS])
+                    {
+                        if (field[0u].asString() == name)
+                        {
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+                BEAST_EXPECT(fieldExists("Generic"));
+                BEAST_EXPECT(fieldExists("Invalid"));
+                BEAST_EXPECT(fieldExists("ObjectEndMarker"));
+                BEAST_EXPECT(fieldExists("ArrayEndMarker"));
+                BEAST_EXPECT(fieldExists("taker_gets_funded"));
+                BEAST_EXPECT(fieldExists("taker_pays_funded"));
+                BEAST_EXPECT(fieldExists("hash"));
+                BEAST_EXPECT(fieldExists("index"));
+            }
+
             // test that base_uint types are replaced with "Hash" prefix
             {
                 auto const types = result[jss::result][jss::TYPES];

--- a/src/xrpld/rpc/handlers/ServerInfo.cpp
+++ b/src/xrpld/rpc/handlers/ServerInfo.cpp
@@ -235,19 +235,6 @@ ServerDefinitions::ServerDefinitions() : defs_{Json::objectValue}
         defs_[jss::FIELDS][i++] = a;
     }
 
-    {
-        Json::Value a = Json::arrayValue;
-        a[0U] = "index";
-        Json::Value v = Json::objectValue;
-        v[jss::nth] = 258;
-        v[jss::isVLEncoded] = false;
-        v[jss::isSerialized] = false;
-        v[jss::isSigningField] = false;
-        v[jss::type] = "Hash256";
-        a[1U] = v;
-        defs_[jss::FIELDS][i++] = a;
-    }
-
     for (auto const& [code, f] : ripple::SField::getKnownCodeToField())
     {
         if (f->fieldName == "")

--- a/src/xrpld/rpc/handlers/ServerInfo.cpp
+++ b/src/xrpld/rpc/handlers/ServerInfo.cpp
@@ -235,6 +235,19 @@ ServerDefinitions::ServerDefinitions() : defs_{Json::objectValue}
         defs_[jss::FIELDS][i++] = a;
     }
 
+    {
+        Json::Value a = Json::arrayValue;
+        a[0U] = "index";
+        Json::Value v = Json::objectValue;
+        v[jss::nth] = 258;
+        v[jss::isVLEncoded] = false;
+        v[jss::isSerialized] = false;
+        v[jss::isSigningField] = false;
+        v[jss::type] = "Hash256";
+        a[1U] = v;
+        defs_[jss::FIELDS][i++] = a;
+    }
+
     for (auto const& [code, f] : ripple::SField::getKnownCodeToField())
     {
         if (f->fieldName == "")


### PR DESCRIPTION
## High Level Overview of Change

This PR re-adds the `"index"` field to the `server_definitions` RPC, and adds some tests to ensure this is caught in the future.

### Context of Change

#5122 removed `sfIndex`, which had the side effect of removing that field from the `server_definitions` RPC, and this broke client libraries.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### API Impact

- [x] Bugfix
- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
