### PR TITLE
fix: allow overlapping types in `Expected`

### DIFF
--- a/include/xrpl/basics/Expected.h
+++ b/include/xrpl/basics/Expected.h
@@ -137,13 +137,15 @@ class [[nodiscard]] Expected
 public:
     template <typename U>
         requires std::convertible_to<U, T>
-    constexpr Expected(U&& r) : Base(T(std::forward<U>(r)))
+    constexpr Expected(U&& r)
+        : Base(boost::outcome_v2::in_place_type_t<T>{}, std::forward<U>(r))
     {
     }
 
     template <typename U>
         requires std::convertible_to<U, E> && (!std::is_reference_v<U>)
-    constexpr Expected(Unexpected<U> e) : Base(E(std::move(e.value())))
+    constexpr Expected(Unexpected<U> e)
+        : Base(boost::outcome_v2::in_place_type_t<E>{}, std::move(e.value()))
     {
     }
 

--- a/src/test/basics/Expected_test.cpp
+++ b/src/test/basics/Expected_test.cpp
@@ -84,6 +84,29 @@ struct Expected_test : beast::unit_test::suite
             }
             BEAST_EXPECT(throwOccurred);
         }
+        // Test non-error overlapping type construction.
+        {
+            auto expected = []() -> Expected<std::uint32_t, std::uint16_t> {
+                return 1;
+            }();
+            BEAST_EXPECT(expected);
+            BEAST_EXPECT(expected.has_value());
+            BEAST_EXPECT(expected.value() == 1);
+            BEAST_EXPECT(*expected == 1);
+
+            bool throwOccurred = false;
+            try
+            {
+                // There's no error, so should throw.
+                [[maybe_unused]] std::uint16_t const t = expected.error();
+            }
+            catch (std::runtime_error const& e)
+            {
+                BEAST_EXPECT(e.what() == std::string("bad expected access"));
+                throwOccurred = true;
+            }
+            BEAST_EXPECT(throwOccurred);
+        }
         // Test error construction from rvalue.
         {
             auto const expected = []() -> Expected<std::string, TER> {


### PR DESCRIPTION
## High Level Overview of Change

This PR allows `Expected` to have overlapping types.

### Context of Change

I ran into an issue with `Expected<std::uint32_t, Json::Value>`, which wouldn't build because of implicit conversion from `unsigned int` to `Json::Value`. This fixed the issue.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### API Impact

N/A

## Test Plan
Added a test