### PR TITLE
Migrate to Conan 2.x

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -27,7 +27,7 @@ runs:
         # `conan remote auth` implicitly uses the environment variables
         # CONAN_LOGIN_USERNAME_<REMOTE> and CONAN_PASSWORD_<REMOTE>.
         # https://docs.conan.io/2/reference/commands/remote.html
-        echo outcome=$((conan remote auth ripple | grep -q error) \
+        echo outcome=$((conan remote auth ripple | tee /dev/tty | grep -q error) \
           && echo failure || echo success) | tee ${GITHUB_OUTPUT}
     - name: list missing binaries
       id: binaries
@@ -47,6 +47,6 @@ runs:
           --settings build_type=${{ inputs.configuration }} \
           ..
     - name: upload dependencies to remote
-      if: (steps.binaries.outputs.missing != '[]') && (steps.remote.outputs.outcome == 'success')
+      if: false && (steps.binaries.outputs.missing != '[]') && (steps.remote.outputs.outcome == 'success')
       shell: bash
       run: conan upload --remote ripple --confirm '*'

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -27,8 +27,8 @@ runs:
         # `conan remote auth` implicitly uses the environment variables
         # CONAN_LOGIN_USERNAME_<REMOTE> and CONAN_PASSWORD_<REMOTE>.
         # https://docs.conan.io/2/reference/commands/remote.html
-        echo outcome=$(conan remote auth ripple >&2 \
-          && echo success || echo failure) | tee ${GITHUB_OUTPUT}
+        echo outcome=$((conan remote auth ripple | grep -q error) \
+          && echo failure || echo success) | tee ${GITHUB_OUTPUT}
     - name: list missing binaries
       id: binaries
       shell: bash
@@ -44,8 +44,6 @@ runs:
         conan install \
           --output-folder . \
           --build missing \
-          --options tests=True \
-          --options xrpld=True \
           --settings build_type=${{ inputs.configuration }} \
           ..
     - name: upload dependencies to remote

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -13,7 +13,7 @@ runs:
         conan remote remove ripple || true
         # Do not quote the URL. An empty string will be accepted (with
         # a non-fatal warning), but a missing argument will not.
-        conan remote add ripple ${{ env.CONAN_URL }} --index 0
+        conan remote add --index 0 ripple ${{ env.CONAN_URL }}
     - name: try to authenticate to Ripple Conan remote
       id: remote
       shell: bash

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -36,7 +36,8 @@ runs:
       # Print the list of dependencies that would need to be built locally.
       # A non-empty list means we have "failed" to cache binaries remotely.
       run: |
-        echo missing=$(conan graph build-order --build missing --settings build_type=${{ inputs.configuration }} --reduce --order-by configuration --format json 2>/dev/null | jq .order) | tee ${GITHUB_OUTPUT}
+        echo missing=$(conan graph build-order --build missing --settings build_type=${{ inputs.configuration }} --reduce --order-by configuration --format json 2>error | jq .order) | tee ${GITHUB_OUTPUT}
+        cat error
     - name: install dependencies
       shell: bash
       run: |

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -6,6 +6,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Conan profile
+      shell: bash
+      run : |
+        echo '```' >> "${GITHUB_STEP_SUMMARY}"
+        conan profile show --profile default | tee -a "${GITHUB_STEP_SUMMARY}"
+        echo '```' >> "${GITHUB_STEP_SUMMARY}"
     - name: add Ripple Conan remote
       shell: bash
       run: |
@@ -18,12 +24,10 @@ runs:
       id: remote
       shell: bash
       run: |
-        # `conan user` implicitly uses the environment variables
+        # `conan remote auth` implicitly uses the environment variables
         # CONAN_LOGIN_USERNAME_<REMOTE> and CONAN_PASSWORD_<REMOTE>.
-        # https://docs.conan.io/1/reference/commands/misc/user.html#using-environment-variables
-        # https://docs.conan.io/1/reference/env_vars.html#conan-login-username-conan-login-username-remote-name
-        # https://docs.conan.io/1/reference/env_vars.html#conan-password-conan-password-remote-name
-        echo outcome=$(conan user --remote ripple --password >&2 \
+        # https://docs.conan.io/2/reference/commands/remote.html
+        echo outcome=$(conan remote auth ripple >&2 \
           && echo success || echo failure) | tee ${GITHUB_OUTPUT}
     - name: list missing binaries
       id: binaries
@@ -47,4 +51,4 @@ runs:
     - name: upload dependencies to remote
       if: (steps.binaries.outputs.missing != '[]') && (steps.remote.outputs.outcome == 'success')
       shell: bash
-      run: conan upload --remote ripple '*' --all --parallel --confirm
+      run: conan upload --remote ripple --confirm '*'

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -28,16 +28,15 @@ runs:
         # CONAN_LOGIN_USERNAME_<REMOTE> and CONAN_PASSWORD_<REMOTE>.
         # https://docs.conan.io/2/reference/commands/remote.html
         conan remote auth ripple
-        echo outcome=$((conan remote login ripple 2>&1 | tee output | grep -q error) \
-          && echo failure || echo success) | tee ${GITHUB_OUTPUT}
-        cat output
+        echo outcome=$(conan remote login ripple 1>&2 \
+          && echo success || echo failure) | tee ${GITHUB_OUTPUT}
     - name: list missing binaries
       id: binaries
       shell: bash
       # Print the list of dependencies that would need to be built locally.
       # A non-empty list means we have "failed" to cache binaries remotely.
       run: |
-        echo missing=$(conan info . --build missing --settings build_type=${{ inputs.configuration }} --json 2>/dev/null  | grep '^\[') | tee ${GITHUB_OUTPUT}
+        echo missing=$(conan graph build-order --build missing --settings build_type=${{ inputs.configuration }} --reduce --order-by configuration --format json 2>/dev/null | jq .order) | tee ${GITHUB_OUTPUT}
     - name: install dependencies
       shell: bash
       run: |
@@ -49,6 +48,6 @@ runs:
           --settings build_type=${{ inputs.configuration }} \
           ..
     - name: upload dependencies to remote
-      if: false && (steps.binaries.outputs.missing != '[]') && (steps.remote.outputs.outcome == 'success')
+      if: (steps.binaries.outputs.missing != '[]') && (steps.remote.outputs.outcome == 'success')
       shell: bash
       run: conan upload --remote ripple --confirm '*'

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -27,7 +27,8 @@ runs:
         # `conan remote auth` implicitly uses the environment variables
         # CONAN_LOGIN_USERNAME_<REMOTE> and CONAN_PASSWORD_<REMOTE>.
         # https://docs.conan.io/2/reference/commands/remote.html
-        echo outcome=$((conan remote auth ripple 2>&1 | tee output | grep -q error) \
+        conan remote auth ripple
+        echo outcome=$((conan remote login ripple 2>&1 | tee output | grep -q error) \
           && echo failure || echo success) | tee ${GITHUB_OUTPUT}
         cat output
     - name: list missing binaries

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -13,7 +13,7 @@ runs:
         conan remote remove ripple || true
         # Do not quote the URL. An empty string will be accepted (with
         # a non-fatal warning), but a missing argument will not.
-        conan remote add ripple ${{ env.CONAN_URL }} --insert 0
+        conan remote add ripple ${{ env.CONAN_URL }} --index 0
     - name: try to authenticate to Ripple Conan remote
       id: remote
       shell: bash

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -6,16 +6,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: unlock Conan
-      shell: bash
-      run: conan remove --locks
-    - name: export custom recipes
-      shell: bash
-      run: |
-        conan config set general.revisions_enabled=1
-        conan export external/snappy snappy/1.1.10@
-        conan export external/rocksdb rocksdb/6.29.5@
-        conan export external/soci soci/4.0.3@
     - name: add Ripple Conan remote
       shell: bash
       run: |

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -27,8 +27,9 @@ runs:
         # `conan remote auth` implicitly uses the environment variables
         # CONAN_LOGIN_USERNAME_<REMOTE> and CONAN_PASSWORD_<REMOTE>.
         # https://docs.conan.io/2/reference/commands/remote.html
-        echo outcome=$((conan remote auth ripple | tee /dev/tty | grep -q error) \
+        echo outcome=$((conan remote auth ripple 2>&1 | tee output | grep -q error) \
           && echo failure || echo success) | tee ${GITHUB_OUTPUT}
+        cat output
     - name: list missing binaries
       id: binaries
       shell: bash

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -1,0 +1,26 @@
+name: environment
+runs:
+  using: composite
+  steps:
+    - name: install Conan
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        pip install --upgrade conan
+    - name: install Conan and Ninja
+      if: runner.os == 'macOS'
+      run: |
+        brew install conan
+        brew install ninja
+        echo '/opt/homebrew/opt/conan/bin' >> ${GITHUB_PATH}
+    - name: check environment
+      shell: bash
+      run: |
+        env | sort
+        echo ${PATH} | tr ':' '\n'
+        type python
+        python --version
+        type conan
+        conan --version
+        type cmake
+        cmake --version

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -9,6 +9,7 @@ runs:
         pip install --upgrade conan
     - name: install Conan and Ninja
       if: runner.os == 'macOS'
+      shell: bash
       run: |
         brew install conan
         brew install ninja

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -19,8 +19,6 @@ runs:
       run: |
         env | sort
         echo ${PATH} | tr ':' '\n'
-        type python
-        python --version
         type conan
         conan --version
         type cmake

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -3,7 +3,7 @@ runs:
   using: composite
   steps:
     - name: install Conan
-      if: runner.os == 'Linux'
+      if: contains(['Linux', 'Windows'], runner.os)
       shell: bash
       run: |
         pip install --upgrade conan

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -3,7 +3,7 @@ runs:
   using: composite
   steps:
     - name: install Conan
-      if: contains(['Linux', 'Windows'], runner.os)
+      if: runner.os == 'Linux' || runner.os == 'Windows'
       shell: bash
       run: |
         pip install --upgrade conan

--- a/.github/conan/profiles/default
+++ b/.github/conan/profiles/default
@@ -1,0 +1,30 @@
+include(detected)
+
+{% import "matrix" as matrix %}
+
+[settings]
+compiler.cppstd=20
+
+{% if platform.system() == "Linux" %}
+compiler={{ matrix.compiler }}
+compiler.version={{ matrix.version }}
+compiler.libcxx=libstdc++11
+{% endif %}
+
+{% if platform.system() == "Window" %}
+compiler.runtime={{ matrix.runtime }}
+{% endif %}
+
+[conf]
+tools.build:cxxflags+=["-DBOOST_BEAST_USE_STD_STRING_VIEW"]
+tools.build:cxxflags+=["-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"]
+tools.build:cxxflags+=["-DBOOST_ASIO_DISABLE_CONCEPTS"]
+
+{% if platform.system() == "Linux" %}
+tools.build:compiler_executables='{"c": "{{ matrix.cc }}", "cpp": "{{ matrix.cxx }}"}'
+{% endif %}
+
+[options]
+boost/*:extra_b2_flags="define=BOOST_ASIO_HAS_STD_INVOKE_RESULT"
+xrpl/*:xrpld=True
+xrpl/*:tests=True

--- a/.github/conan/profiles/default
+++ b/.github/conan/profiles/default
@@ -21,7 +21,7 @@ tools.build:cxxflags+=["-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"]
 tools.build:cxxflags+=["-DBOOST_ASIO_DISABLE_CONCEPTS"]
 
 {% if platform.system() == "Linux" %}
-tools.build:compiler_executables='{"c": "{{ matrix.cc }}", "cpp": "{{ matrix.cxx }}"}'
+tools.build:compiler_executables={"c": "{{ matrix.cc }}", "cpp": "{{ matrix.cxx }}"}
 {% endif %}
 
 [options]

--- a/.github/workflows/libxrpl.yml
+++ b/.github/workflows/libxrpl.yml
@@ -47,7 +47,7 @@ jobs:
           conan remote list
           conan remote remove ripple || true
           # Do not quote the URL. An empty string will be accepted (with a non-fatal warning), but a missing argument will not.
-          conan remote add --index 0 ripple ${{ env.CONAN_URL }}
+          conan remote add ripple ${{ env.CONAN_URL }} --insert 0
       - name: Parse new version
         id: version
         shell: bash

--- a/.github/workflows/libxrpl.yml
+++ b/.github/workflows/libxrpl.yml
@@ -47,7 +47,7 @@ jobs:
           conan remote list
           conan remote remove ripple || true
           # Do not quote the URL. An empty string will be accepted (with a non-fatal warning), but a missing argument will not.
-          conan remote add ripple ${{ env.CONAN_URL }} --insert 0
+          conan remote add --index 0 ripple ${{ env.CONAN_URL }}
       - name: Parse new version
         id: version
         shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ jobs:
       - name: install Conan
         run: |
           brew install conan
-          echo '/opt/homebrew/opt/conan/bin' >> $GITHUB_PATH
+          echo '/opt/homebrew/opt/conan/bin' >> ${GITHUB_PATH}
       - name: install Ninja
         if: matrix.generator == 'Ninja'
         run: brew install ninja
@@ -45,9 +45,9 @@ jobs:
         run: |
           env | sort
           echo ${PATH} | tr ':' '\n'
-          python --version | tee "${GITHUB_STEP_SUMMARY}"
-          conan --version | tee "${GITHUB_STEP_SUMMARY}"
-          cmake --version | tee "${GITHUB_STEP_SUMMARY}"
+          python --version | tee --append "${GITHUB_STEP_SUMMARY}"
+          conan --version | tee --append "${GITHUB_STEP_SUMMARY}"
+          cmake --version | tee --append "${GITHUB_STEP_SUMMARY}"
       - name: configure Conan
         run : |
           conan config install .github/conan/

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,6 +32,9 @@ jobs:
       build_dir: .build
       NUM_PROCESSORS: 12
     steps:
+      # We must checkout first to make local actions available.
+      - name: checkout
+        uses: actions/checkout@v4
       - name: environment
         uses: ./.github/actions/environment
       - name: configure Conan
@@ -39,8 +42,6 @@ jobs:
           conan config install .github/conan/
           conan profile detect --name detected || true
           touch $(conan config home)/profiles/matrix
-      - name: checkout
-        uses: actions/checkout@v4
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -52,6 +52,7 @@ jobs:
         run : |
           conan config install .github/conan/
           conan profile detect --name detected || true
+          touch $(conan config home)/profiles/matrix
           conan profile show --profile default
       - name: build dependencies
         uses: ./.github/actions/dependencies

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,8 +36,8 @@ jobs:
         uses: actions/checkout@v4
       - name: install Conan
         run: |
-          brew install conan@1
-          echo '/opt/homebrew/opt/conan@1/bin' >> $GITHUB_PATH
+          brew install conan
+          echo '/opt/homebrew/opt/conan/bin' >> $GITHUB_PATH
       - name: install Ninja
         if: matrix.generator == 'Ninja'
         run: brew install ninja
@@ -45,9 +45,9 @@ jobs:
         run: |
           env | sort
           echo ${PATH} | tr ':' '\n'
-          python --version
-          conan --version
-          cmake --version
+          python --version | tee "${GITHUB_STEP_SUMMARY}"
+          conan --version | tee "${GITHUB_STEP_SUMMARY}"
+          cmake --version | tee "${GITHUB_STEP_SUMMARY}"
       - name: configure Conan
         run : |
           conan config install .github/conan/

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,30 +32,15 @@ jobs:
       build_dir: .build
       NUM_PROCESSORS: 12
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: install Conan
-        run: |
-          brew install conan
-          echo '/opt/homebrew/opt/conan/bin' >> ${GITHUB_PATH}
-      - name: install Ninja
-        if: matrix.generator == 'Ninja'
-        run: brew install ninja
-      - name: check environment
-        run: |
-          env | sort
-          echo ${PATH} | tr ':' '\n'
-          python --version | tee -a "${GITHUB_STEP_SUMMARY}"
-          conan --version | tee -a "${GITHUB_STEP_SUMMARY}"
-          cmake --version | tee -a "${GITHUB_STEP_SUMMARY}"
+      - name: environment
+        uses: ./.github/actions/environment
       - name: configure Conan
         run : |
           conan config install .github/conan/
           conan profile detect --name detected || true
           touch $(conan config home)/profiles/matrix
-          echo '```' >> "${GITHUB_STEP_SUMMARY}"
-          conan profile show --profile default | tee -a "${GITHUB_STEP_SUMMARY}"
-          echo '```' >> "${GITHUB_STEP_SUMMARY}"
+      - name: checkout
+        uses: actions/checkout@v4
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -52,6 +52,7 @@ jobs:
         run : |
           conan config install .github/conan/
           conan profile detect --name detected || true
+          conan profile show --profile default
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -53,7 +53,7 @@ jobs:
           conan config install .github/conan/
           conan profile detect --name detected || true
           touch $(conan config home)/profiles/matrix
-          conan profile show --profile default
+          conan profile show --profile default | tee "${GITHUB_STEP_SUMMARY}"
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -53,7 +53,9 @@ jobs:
           conan config install .github/conan/
           conan profile detect --name detected || true
           touch $(conan config home)/profiles/matrix
-          conan profile show --profile default | tee "${GITHUB_STEP_SUMMARY}"
+          echo '```' >> "${GITHUB_STEP_SUMMARY}"
+          conan profile show --profile default | tee --append "${GITHUB_STEP_SUMMARY}"
+          echo '```' >> "${GITHUB_STEP_SUMMARY}"
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,9 +50,8 @@ jobs:
           cmake --version
       - name: configure Conan
         run : |
-          conan profile new default --detect || true
-          conan profile update settings.compiler.cppstd=20 default
-          conan profile update 'conf.tools.build:cxxflags+=["-DBOOST_ASIO_DISABLE_CONCEPTS"]' default
+          conan config install .github/conan/
+          conan profile detect --name detected || true
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,16 +45,16 @@ jobs:
         run: |
           env | sort
           echo ${PATH} | tr ':' '\n'
-          python --version | tee --append "${GITHUB_STEP_SUMMARY}"
-          conan --version | tee --append "${GITHUB_STEP_SUMMARY}"
-          cmake --version | tee --append "${GITHUB_STEP_SUMMARY}"
+          python --version | tee -a "${GITHUB_STEP_SUMMARY}"
+          conan --version | tee -a "${GITHUB_STEP_SUMMARY}"
+          cmake --version | tee -a "${GITHUB_STEP_SUMMARY}"
       - name: configure Conan
         run : |
           conan config install .github/conan/
           conan profile detect --name detected || true
           touch $(conan config home)/profiles/matrix
           echo '```' >> "${GITHUB_STEP_SUMMARY}"
-          conan profile show --profile default | tee --append "${GITHUB_STEP_SUMMARY}"
+          conan profile show --profile default | tee -a "${GITHUB_STEP_SUMMARY}"
           echo '```' >> "${GITHUB_STEP_SUMMARY}"
       - name: build dependencies
         uses: ./.github/actions/dependencies

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -72,9 +72,9 @@ jobs:
       - name: check environment
         run: |
           echo ${PATH} | tr ':' '\n'
-          python --version | tee "${GITHUB_STEP_SUMMARY}"
-          conan --version | tee "${GITHUB_STEP_SUMMARY}"
-          cmake --version | tee "${GITHUB_STEP_SUMMARY}"
+          python --version | tee --append "${GITHUB_STEP_SUMMARY}"
+          conan --version | tee --append "${GITHUB_STEP_SUMMARY}"
+          cmake --version | tee --append "${GITHUB_STEP_SUMMARY}"
           env | sort
       - name: configure Conan
         run: |
@@ -139,9 +139,9 @@ jobs:
         run: |
           env | sort
           echo ${PATH} | tr ':' '\n'
-          python --version | tee "${GITHUB_STEP_SUMMARY}"
-          conan --version | tee "${GITHUB_STEP_SUMMARY}"
-          cmake --version | tee "${GITHUB_STEP_SUMMARY}"
+          python --version
+          conan --version
+          cmake --version
       - name: checkout
         uses: actions/checkout@v4
       - name: dependencies
@@ -191,9 +191,9 @@ jobs:
         run: |
           echo ${PATH} | tr ':' '\n'
           env | sort
-          conan --version | tee "${GITHUB_STEP_SUMMARY}"
-          cmake --version | tee "${GITHUB_STEP_SUMMARY}"
-          gcovr --version | tee "${GITHUB_STEP_SUMMARY}"
+          conan --version
+          cmake --version
+          gcovr --version
           ls ~/.conan2
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -172,12 +172,12 @@ jobs:
         run: |
           mkdir -p ~/.conan2
           tar -xzf conan.tar -C ~/.conan2
-      - name: install gcovr
-        run: pip install "gcovr>=7,<8"
-      - name: environment
-        uses: ./.github/actions/environment
       - name: checkout
         uses: actions/checkout@v4
+      - name: environment
+        uses: ./.github/actions/environment
+      - name: install gcovr
+        run: pip install "gcovr>=7,<8"
       - name: dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -129,6 +129,9 @@ jobs:
     env:
       build_dir: .build
     steps:
+      - name: install Conan
+        run: |
+          pip install --upgrade conan
       - name: download cache
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -252,7 +252,7 @@ jobs:
           version=$(conan inspect --format json . | jq --raw-output .version)
           reference="xrpl/${version}@local/test"
           conan remove -f ${reference} || true
-          conan export . local/test
+          conan export --user local --channel test .
           echo "reference=${reference}" >> "${GITHUB_ENV}"
       - name: build
         run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -236,14 +236,10 @@ jobs:
         run: |
           mkdir -p ~/.conan2
           tar -xzf conan.tar -C ~/.conan2
-      - name: check environment
-        run: |
-          env | sort
-          echo ${PATH} | tr ':' '\n'
-          conan --version
-          cmake --version
       - name: checkout
         uses: actions/checkout@v4
+      - name: environment
+        uses: ./.github/actions/environment
       - name: dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -248,7 +248,7 @@ jobs:
           configuration: ${{ env.configuration }}
       - name: export
         run: |
-          version=$(conan inspect --raw version .)
+          version=$(conan inspect --format json . | jq --raw-output .version)
           reference="xrpl/${version}@local/test"
           conan remove -f ${reference} || true
           conan export . local/test

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -86,7 +86,7 @@ jobs:
           {% set cc = "${{ matrix.profile.cc }}" %}
           {% set cxx = "${{ matrix.profile.cxx }}" %}
           EOF
-          conan profile show --profile default
+          conan profile show --profile default | tee "${GITHUB_STEP_SUMMARY}"
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar -C ~/.conan2 .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -64,6 +64,9 @@ jobs:
     env:
       build_dir: .build
     steps:
+      # We must checkout first to make local actions available.
+      - name: checkout
+        uses: actions/checkout@v4
       - name: environment
         uses: ./.github/actions/environment
       - name: configure Conan
@@ -79,8 +82,6 @@ jobs:
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar -C ~/.conan2 .
-      - name: checkout
-        uses: actions/checkout@v4
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -71,11 +71,11 @@ jobs:
           pip install --upgrade conan
       - name: check environment
         run: |
+          env | sort
           echo ${PATH} | tr ':' '\n'
           python --version | tee --append "${GITHUB_STEP_SUMMARY}"
           conan --version | tee --append "${GITHUB_STEP_SUMMARY}"
           cmake --version | tee --append "${GITHUB_STEP_SUMMARY}"
-          env | sort
       - name: configure Conan
         run: |
           conan config install .github/conan/
@@ -86,7 +86,9 @@ jobs:
           {% set cc = "${{ matrix.profile.cc }}" %}
           {% set cxx = "${{ matrix.profile.cxx }}" %}
           EOF
-          conan profile show --profile default | tee "${GITHUB_STEP_SUMMARY}"
+          echo '```' >> "${GITHUB_STEP_SUMMARY}"
+          conan profile show --profile default | tee --append "${GITHUB_STEP_SUMMARY}"
+          echo '```' >> "${GITHUB_STEP_SUMMARY}"
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar -C ~/.conan2 .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -248,6 +248,7 @@ jobs:
           configuration: ${{ env.configuration }}
       - name: export
         run: |
+          apt install jq
           version=$(conan inspect --format json . | jq --raw-output .version)
           reference="xrpl/${version}@local/test"
           conan remove -f ${reference} || true

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -86,6 +86,7 @@ jobs:
           {% set cc = "${{ matrix.profile.cc }}" %}
           {% set cxx = "${{ matrix.profile.cxx }}" %}
           EOF
+          conan profile show --profile default
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar -C ~/.conan2 .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -260,7 +260,7 @@ jobs:
           mkdir ${build_dir}
           cd ${build_dir}
           conan install .. --output-folder . \
-            --require-override ${reference} --build missing
+            --requires ${reference} --build missing
           cmake .. \
             -DCMAKE_TOOLCHAIN_FILE:FILEPATH=./build/${configuration}/generators/conan_toolchain.cmake \
             -DCMAKE_BUILD_TYPE=${configuration}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -119,7 +119,6 @@ jobs:
     env:
       build_dir: .build
     steps:
-
       - name: download cache
         uses: actions/download-artifact@v3
         with:
@@ -128,10 +127,10 @@ jobs:
         run: |
           mkdir -p ~/.conan2
           tar -xzf conan.tar -C ~/.conan2
-      - name: environment
-        uses: ./.github/actions/environment
       - name: checkout
         uses: actions/checkout@v4
+      - name: environment
+        uses: ./.github/actions/environment
       - name: dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -64,18 +64,8 @@ jobs:
     env:
       build_dir: .build
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: install Conan
-        run: |
-          pip install --upgrade conan
-      - name: check environment
-        run: |
-          env | sort
-          echo ${PATH} | tr ':' '\n'
-          python --version | tee --append "${GITHUB_STEP_SUMMARY}"
-          conan --version | tee --append "${GITHUB_STEP_SUMMARY}"
-          cmake --version | tee --append "${GITHUB_STEP_SUMMARY}"
+      - name: environment
+        uses: ./.github/actions/environment
       - name: configure Conan
         run: |
           conan config install .github/conan/
@@ -86,12 +76,11 @@ jobs:
           {% set cc = "${{ matrix.profile.cc }}" %}
           {% set cxx = "${{ matrix.profile.cxx }}" %}
           EOF
-          echo '```' >> "${GITHUB_STEP_SUMMARY}"
-          conan profile show --profile default | tee --append "${GITHUB_STEP_SUMMARY}"
-          echo '```' >> "${GITHUB_STEP_SUMMARY}"
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar -C ~/.conan2 .
+      - name: checkout
+        uses: actions/checkout@v4
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:
@@ -129,9 +118,7 @@ jobs:
     env:
       build_dir: .build
     steps:
-      - name: install Conan
-        run: |
-          pip install --upgrade conan
+
       - name: download cache
         uses: actions/download-artifact@v3
         with:
@@ -140,13 +127,8 @@ jobs:
         run: |
           mkdir -p ~/.conan2
           tar -xzf conan.tar -C ~/.conan2
-      - name: check environment
-        run: |
-          env | sort
-          echo ${PATH} | tr ':' '\n'
-          python --version
-          conan --version
-          cmake --version
+      - name: environment
+        uses: ./.github/actions/environment
       - name: checkout
         uses: actions/checkout@v4
       - name: dependencies
@@ -192,14 +174,8 @@ jobs:
           tar -xzf conan.tar -C ~/.conan2
       - name: install gcovr
         run: pip install "gcovr>=7,<8"
-      - name: check environment
-        run: |
-          echo ${PATH} | tr ':' '\n'
-          env | sort
-          conan --version
-          cmake --version
-          gcovr --version
-          ls ~/.conan2
+      - name: environment
+        uses: ./.github/actions/environment
       - name: checkout
         uses: actions/checkout@v4
       - name: dependencies

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -248,7 +248,7 @@ jobs:
           configuration: ${{ env.configuration }}
       - name: export
         run: |
-          apt install jq
+          apt install --yes jq
           version=$(conan inspect --format json . | jq --raw-output .version)
           reference="xrpl/${version}@local/test"
           conan remove -f ${reference} || true

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -68,20 +68,21 @@ jobs:
         uses: actions/checkout@v4
       - name: check environment
         run: |
+          pip install --upgrade conan
           echo ${PATH} | tr ':' '\n'
           conan --version
           cmake --version
           env | sort
       - name: configure Conan
         run: |
-          conan profile new default --detect
-          conan profile update settings.compiler.cppstd=20 default
-          conan profile update settings.compiler=${{ matrix.compiler }} default
-          conan profile update settings.compiler.version=${{ matrix.profile.version }} default
-          conan profile update settings.compiler.libcxx=libstdc++11 default
-          conan profile update env.CC=${{ matrix.profile.cc }} default
-          conan profile update env.CXX=${{ matrix.profile.cxx }} default
-          conan profile update conf.tools.build:compiler_executables='{"c": "${{ matrix.profile.cc }}", "cpp": "${{ matrix.profile.cxx }}"}' default
+          conan config install .github/conan/
+          conan profile detect --name detected
+          cat >$(conan config home)/profiles/matrix <<EOF
+          {% set compiler = "${{ matrix.compiler }}" %}
+          {% set version = "${{ matrix.profile.version }}" %}
+          {% set cc = "${{ matrix.profile.cc }}" %}
+          {% set cxx = "${{ matrix.profile.cxx }}" %}
+          EOF
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar -C ~/.conan .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -66,12 +66,15 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - name: check environment
+      - name: install Conan
         run: |
           pip install --upgrade conan
+      - name: check environment
+        run: |
           echo ${PATH} | tr ':' '\n'
-          conan --version
-          cmake --version
+          python --version | tee "${GITHUB_STEP_SUMMARY}"
+          conan --version | tee "${GITHUB_STEP_SUMMARY}"
+          cmake --version | tee "${GITHUB_STEP_SUMMARY}"
           env | sort
       - name: configure Conan
         run: |
@@ -85,7 +88,7 @@ jobs:
           EOF
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
-        run: tar -czf conan.tar -C ~/.conan .
+        run: tar -czf conan.tar -C ~/.conan2 .
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:
@@ -129,14 +132,15 @@ jobs:
           name: ${{ matrix.platform }}-${{ matrix.compiler }}-${{ matrix.configuration }}
       - name: extract cache
         run: |
-          mkdir -p ~/.conan
-          tar -xzf conan.tar -C ~/.conan
+          mkdir -p ~/.conan2
+          tar -xzf conan.tar -C ~/.conan2
       - name: check environment
         run: |
           env | sort
           echo ${PATH} | tr ':' '\n'
-          conan --version
-          cmake --version
+          python --version | tee "${GITHUB_STEP_SUMMARY}"
+          conan --version | tee "${GITHUB_STEP_SUMMARY}"
+          cmake --version | tee "${GITHUB_STEP_SUMMARY}"
       - name: checkout
         uses: actions/checkout@v4
       - name: dependencies
@@ -178,18 +182,18 @@ jobs:
           name: ${{ matrix.platform }}-${{ matrix.compiler }}-${{ matrix.configuration }}
       - name: extract cache
         run: |
-          mkdir -p ~/.conan
-          tar -xzf conan.tar -C ~/.conan
+          mkdir -p ~/.conan2
+          tar -xzf conan.tar -C ~/.conan2
       - name: install gcovr
         run: pip install "gcovr>=7,<8"
       - name: check environment
         run: |
           echo ${PATH} | tr ':' '\n'
-          conan --version
-          cmake --version
-          gcovr --version
           env | sort
-          ls ~/.conan
+          conan --version | tee "${GITHUB_STEP_SUMMARY}"
+          cmake --version | tee "${GITHUB_STEP_SUMMARY}"
+          gcovr --version | tee "${GITHUB_STEP_SUMMARY}"
+          ls ~/.conan2
       - name: checkout
         uses: actions/checkout@v4
       - name: dependencies
@@ -248,8 +252,8 @@ jobs:
           name: linux-gcc-${{ env.configuration }}
       - name: extract cache
         run: |
-          mkdir -p ~/.conan
-          tar -xzf conan.tar -C ~/.conan
+          mkdir -p ~/.conan2
+          tar -xzf conan.tar -C ~/.conan2
       - name: check environment
         run: |
           env | sort

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,7 +71,9 @@ jobs:
           cat >$(conan config home)/profiles/matrix <<EOF
           {% set runtime = "MT${{ matrix.configuration == 'Debug' && 'd' || '' }}" %}
           EOF
-          conan profile show --profile default | tee "${GITHUB_STEP_SUMMARY}"
+          echo '```' >> "${GITHUB_STEP_SUMMARY}"
+          conan profile show --profile default | tee --append "${GITHUB_STEP_SUMMARY}"
+          echo '```' >> "${GITHUB_STEP_SUMMARY}"
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,6 +52,9 @@ jobs:
         with:
             path: ${{ steps.pip-cache.outputs.dir }}
             key: ${{ runner.os }}-${{ hashFiles('.github/workflows/windows.yml') }}
+      # We must checkout first to make local actions available.
+      - name: checkout
+        uses: actions/checkout@v4
       - name: environment
         uses: ./.github/actions/environment
       - name: configure Conan
@@ -62,8 +65,6 @@ jobs:
           cat >$(conan config home)/profiles/matrix <<EOF
           {% set runtime = "MT${{ matrix.configuration == 'Debug' && 'd' || '' }}" %}
           EOF
-      - name: checkout
-        uses: actions/checkout@v4
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,7 +71,7 @@ jobs:
           cat >$(conan config home)/profiles/matrix <<EOF
           {% set runtime = "MT${{ matrix.configuration == 'Debug' && 'd' || '' }}" %}
           EOF
-          conan profile show --profile default
+          conan profile show --profile default | tee "${GITHUB_STEP_SUMMARY}"
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,9 +60,9 @@ jobs:
         run: |
           dir env:
           $env:PATH -split ';'
-          python --version | tee "${GITHUB_STEP_SUMMARY}"
-          conan --version | tee "${GITHUB_STEP_SUMMARY}"
-          cmake --version | tee "${GITHUB_STEP_SUMMARY}"
+          python --version | tee "$env:GITHUB_STEP_SUMMARY"
+          conan --version | tee "$env:GITHUB_STEP_SUMMARY"
+          cmake --version | tee "$env:GITHUB_STEP_SUMMARY"
       - name: configure Conan
         shell: bash
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,9 +60,9 @@ jobs:
         run: |
           dir env:
           $env:PATH -split ';'
-          python --version | tee "$env:GITHUB_STEP_SUMMARY"
-          conan --version | tee "$env:GITHUB_STEP_SUMMARY"
-          cmake --version | tee "$env:GITHUB_STEP_SUMMARY"
+          python --version | tee --append "$env:GITHUB_STEP_SUMMARY"
+          conan --version | tee --append "$env:GITHUB_STEP_SUMMARY"
+          cmake --version | tee --append "$env:GITHUB_STEP_SUMMARY"
       - name: configure Conan
         shell: bash
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,6 +71,7 @@ jobs:
           cat >$(conan config home)/profiles/matrix <<EOF
           {% set runtime = "MT${{ matrix.configuration == 'Debug' && 'd' || '' }}" %}
           EOF
+          conan profile show --profile default
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,7 +55,7 @@ jobs:
             path: ${{ steps.pip-cache.outputs.dir }}
             key: ${{ runner.os }}-${{ hashFiles('.github/workflows/windows.yml') }}
       - name: install Conan
-        run: pip install wheel 'conan<2'
+        run: pip install wheel conan
       - name: check environment
         run: |
           dir env:
@@ -66,9 +66,11 @@ jobs:
       - name: configure Conan
         shell: bash
         run: |
-          conan profile new default --detect
-          conan profile update settings.compiler.cppstd=20 default
-          conan profile update settings.compiler.runtime=MT${{ matrix.configuration == 'Debug' && 'd' || '' }} default
+          conan config install .github/conan/
+          conan profile detect --name detected
+          cat >$(conan config home)/profiles/matrix <<EOF
+          {% set runtime = "MT${{ matrix.configuration == 'Debug' && 'd' || '' }}" %}
+          EOF
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,9 +60,9 @@ jobs:
         run: |
           dir env:
           $env:PATH -split ';'
-          python --version | tee --append "$env:GITHUB_STEP_SUMMARY"
-          conan --version | tee --append "$env:GITHUB_STEP_SUMMARY"
-          cmake --version | tee --append "$env:GITHUB_STEP_SUMMARY"
+          python --version | tee -Append "$env:GITHUB_STEP_SUMMARY"
+          conan --version | tee -Append "$env:GITHUB_STEP_SUMMARY"
+          cmake --version | tee -Append "$env:GITHUB_STEP_SUMMARY"
       - name: configure Conan
         shell: bash
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,9 +60,9 @@ jobs:
         run: |
           dir env:
           $env:PATH -split ';'
-          python --version
-          conan --version
-          cmake --version
+          python --version | tee "${GITHUB_STEP_SUMMARY}"
+          conan --version | tee "${GITHUB_STEP_SUMMARY}"
+          cmake --version | tee "${GITHUB_STEP_SUMMARY}"
       - name: configure Conan
         shell: bash
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,8 +37,6 @@ jobs:
     env:
       build_dir: .build
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
       - name: choose Python
         uses: actions/setup-python@v5
         with:
@@ -54,15 +52,8 @@ jobs:
         with:
             path: ${{ steps.pip-cache.outputs.dir }}
             key: ${{ runner.os }}-${{ hashFiles('.github/workflows/windows.yml') }}
-      - name: install Conan
-        run: pip install wheel conan
-      - name: check environment
-        run: |
-          dir env:
-          $env:PATH -split ';'
-          python --version | tee -Append "$env:GITHUB_STEP_SUMMARY"
-          conan --version | tee -Append "$env:GITHUB_STEP_SUMMARY"
-          cmake --version | tee -Append "$env:GITHUB_STEP_SUMMARY"
+      - name: environment
+        uses: ./.github/actions/environment
       - name: configure Conan
         shell: bash
         run: |
@@ -71,9 +62,8 @@ jobs:
           cat >$(conan config home)/profiles/matrix <<EOF
           {% set runtime = "MT${{ matrix.configuration == 'Debug' && 'd' || '' }}" %}
           EOF
-          echo '```' >> "${GITHUB_STEP_SUMMARY}"
-          conan profile show --profile default | tee --append "${GITHUB_STEP_SUMMARY}"
-          echo '```' >> "${GITHUB_STEP_SUMMARY}"
+      - name: checkout
+        uses: actions/checkout@v4
       - name: build dependencies
         uses: ./.github/actions/dependencies
         env:

--- a/BUILD.md
+++ b/BUILD.md
@@ -36,14 +36,13 @@ See [System Requirements](https://xrpl.org/system-requirements.html).
 Building rippled generally requires git, Python, Conan, CMake, and a C++ compiler. Some guidance on setting up such a [C++ development environment can be found here](./docs/build/environment.md).
 
 - [Python 3.7](https://www.python.org/downloads/)
-- [Conan 1.60](https://conan.io/downloads.html)[^1]
+- [Conan 2.0](https://conan.io/downloads.html)[^1]
 - [CMake 3.16](https://cmake.org/download/)
 
-[^1]: It is possible to build with Conan 2.x,
-but the instructions are significantly different,
-which is why we are not recommending it yet.
-Notably, the `conan profile update` command is removed in 2.x.
-Profiles must be edited by hand.
+[^1]: It has been possible to build with Conan 1.x,
+and it may still be,
+but we are no longer promising it,
+and the instructions are significantly different.
 
 `rippled` is written in the C++20 dialect and includes the `<concepts>` header.
 The [minimum compiler versions][2] required are:
@@ -86,56 +85,11 @@ These instructions assume a basic familiarity with Conan and CMake.
 
 If you are unfamiliar with Conan, then please read [this crash course](./docs/build/conan.md) or the official [Getting Started][3] walkthrough.
 
-You'll need at least one Conan profile:
+The easiest way to configure Conan is to install the sample profiles in this project:
 
    ```
-   conan profile new default --detect
-   ```
-
-Update the compiler settings:
-
-   ```
-   conan profile update settings.compiler.cppstd=20 default
-   ```
-
-Configure Conan (1.x only) to use recipe revisions:
-
-   ```
-   conan config set general.revisions_enabled=1
-   ```
-
-**Linux** developers will commonly have a default Conan [profile][] that compiles
-with GCC and links with libstdc++.
-If you are linking with libstdc++ (see profile setting `compiler.libcxx`),
-then you will need to choose the `libstdc++11` ABI:
-
-   ```
-   conan profile update settings.compiler.libcxx=libstdc++11 default
-   ```
-
-
-Ensure inter-operability between `boost::string_view` and `std::string_view` types:
-
-```
-conan profile update 'conf.tools.build:cxxflags+=["-DBOOST_BEAST_USE_STD_STRING_VIEW"]' default
-conan profile update 'env.CXXFLAGS="-DBOOST_BEAST_USE_STD_STRING_VIEW"' default
-```
-
-If you have other flags in the `conf.tools.build` or `env.CXXFLAGS` sections, make sure to retain the existing flags and append the new ones. You can check them with:
-```
-conan profile show default
-```
-
-
-**Windows** developers may need to use the x64 native build tools.
-An easy way to do that is to run the shortcut "x64 Native Tools Command
-Prompt" for the version of Visual Studio that you have installed.
-
-   Windows developers must also build `rippled` and its dependencies for the x64
-   architecture:
-
-   ```
-   conan profile update settings.arch=x86_64 default
+   conan profile detect
+   conan config install conan/
    ```
 
 ### Multiple compilers
@@ -153,56 +107,6 @@ conan profile update 'conf.tools.build:compiler_executables={"c": "/usr/bin/gcc"
 ```
 
 Replace `/usr/bin/gcc` and `/usr/bin/g++` with paths to the desired compilers.
-
-It should choose the compiler for dependencies as well,
-but not all of them have a Conan recipe that respects this setting (yet).
-For the rest, you can set these environment variables.
-Replace `<path>` with paths to the desired compilers:
-
-- `conan profile update env.CC=<path> default`
-- `conan profile update env.CXX=<path> default`
-
-Export our [Conan recipe for Snappy](./external/snappy).
-It does not explicitly link the C++ standard library,
-which allows you to statically link it with GCC, if you want.
-
-   ```
-   # Conan 1.x
-   conan export external/snappy snappy/1.1.10@
-   # Conan 2.x
-   conan export --version 1.1.10 external/snappy
-   ```
-
-Export our [Conan recipe for RocksDB](./external/rocksdb).
-It does not override paths to dependencies when building with Visual Studio.
-
-   ```
-   # Conan 1.x
-   conan export external/rocksdb rocksdb/6.29.5@
-   # Conan 2.x
-   conan export --version 6.29.5 external/rocksdb
-   ```
-
-Export our [Conan recipe for SOCI](./external/soci).
-It patches their CMake to correctly import its dependencies.
-
-   ```
-   # Conan 1.x
-   conan export external/soci soci/4.0.3@
-   # Conan 2.x
-   conan export --version 4.0.3 external/soci
-   ```
-
-Export our [Conan recipe for NuDB](./external/nudb).
-It fixes some source files to add missing `#include`s.
-
-
-   ```
-   # Conan 1.x
-   conan export external/nudb nudb/2.0.8@
-   # Conan 2.x
-   conan export --version 2.0.8 external/nudb
-   ```
 
 ### Build and Test
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -101,9 +101,11 @@ However, if this compiler cannot build rippled or its dependencies, then you can
 install another compiler and set Conan and CMake to use it.
 Update the `conf.tools.build:compiler_executables` setting in order to set the correct variables (`CMAKE_<LANG>_COMPILER`) in the
 generated CMake toolchain file.
-For example, on Ubuntu 20, you may have gcc at `/usr/bin/gcc` and g++ at `/usr/bin/g++`; if that is the case, you can select those compilers with:
+For example, on Ubuntu 20, you may have gcc at `/usr/bin/gcc` and g++ at `/usr/bin/g++`; if that is the case, then you can select those compilers with:
 ```
-conan profile update 'conf.tools.build:compiler_executables={"c": "/usr/bin/gcc", "cpp": "/usr/bin/g++"}' default
+> $EDITOR $(conan config home)/profiles/libxrpl
+# Add this line to the [conf] section.
+tools.build:compiler_executables={"c": "/usr/bin/gcc", "cpp": "/usr/bin/g++"}
 ```
 
 Replace `/usr/bin/gcc` and `/usr/bin/g++` with paths to the desired compilers.
@@ -307,33 +309,6 @@ After any updates or changes to dependencies, you may need to do the following:
 4. Re-run [conan install](#build-and-test).
 
 
-### no std::result_of
-
-If your compiler version is recent enough to have removed `std::result_of` as
-part of C++20, e.g. Apple Clang 15.0, then you might need to add a preprocessor
-definition to your build.
-
-```
-conan profile update 'options.boost:extra_b2_flags="define=BOOST_ASIO_HAS_STD_INVOKE_RESULT"' default
-conan profile update 'env.CFLAGS="-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"' default
-conan profile update 'env.CXXFLAGS="-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"' default
-conan profile update 'conf.tools.build:cflags+=["-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"]' default
-conan profile update 'conf.tools.build:cxxflags+=["-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"]' default
-```
-
-
-### call to 'async_teardown' is ambiguous
-
-If you are compiling with an early version of Clang 16, then you might hit
-a [regression][6] when compiling C++20 that manifests as an [error in a Boost
-header][7]. You can workaround it by adding this preprocessor definition:
-
-```
-conan profile update 'env.CXXFLAGS="-DBOOST_ASIO_DISABLE_CONCEPTS"' default
-conan profile update 'conf.tools.build:cxxflags+=["-DBOOST_ASIO_DISABLE_CONCEPTS"]' default
-```
-
-
 ### recompile with -fPIC
 
 If you get a linker error suggesting that you recompile Boost with
@@ -374,8 +349,6 @@ If you want to experiment with a new package, follow these steps:
 [2]: https://en.cppreference.com/w/cpp/compiler_support/20
 [3]: https://docs.conan.io/en/latest/getting_started.html
 [5]: https://en.wikipedia.org/wiki/Unity_build
-[6]: https://github.com/boostorg/beast/issues/2648
-[7]: https://github.com/boostorg/beast/issues/2661
 [gcovr]: https://gcovr.com/en/stable/getting-started.html
 [python-pip]: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/
 [build_type]: https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html

--- a/conan/profiles/libxrpl
+++ b/conan/profiles/libxrpl
@@ -1,0 +1,18 @@
+include(default)
+
+[settings]
+compiler.cppstd=20
+{% if platform.system() == "Windows" %}
+arch=x86_64
+{% endif %}
+{% if platform.system() == "Linux" %}
+compiler.libcxx=libstdc++11
+{% endif %}
+
+[conf]
+tools.build:cxxflags+=["-DBOOST_BEAST_USE_STD_STRING_VIEW"]
+tools.build:cxxflags+=["-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"]
+tools.build:cxxflags+=["-DBOOST_ASIO_DISABLE_CONCEPTS"]
+
+[options]
+boost/*:extra_b2_flags="define=BOOST_ASIO_HAS_STD_INVOKE_RESULT"

--- a/conan/profiles/libxrpl
+++ b/conan/profiles/libxrpl
@@ -11,7 +11,17 @@ compiler.libcxx=libstdc++11
 
 [conf]
 tools.build:cxxflags+=["-DBOOST_BEAST_USE_STD_STRING_VIEW"]
+
+# If your compiler version is recent enough to have removed `std::result_of`
+# as part of C++20, e.g. Apple Clang 15.0, then you need to tell Boost to use
+# `std::invoke_result` instead.
 tools.build:cxxflags+=["-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"]
+
+# If you are compiling with an early version of Clang 16, then you might hit
+# a regression when compiling C++20 that manifests as an error in a Boost
+# header: "call to 'async_teardown' is ambiguous".
+# https://github.com/boostorg/beast/issues/2648
+# https://github.com/boostorg/beast/issues/2661
 tools.build:cxxflags+=["-DBOOST_ASIO_DISABLE_CONCEPTS"]
 
 [options]

--- a/conan/profiles/xrpld
+++ b/conan/profiles/xrpld
@@ -1,0 +1,4 @@
+include(libxrpl)
+[options]
+xrpl/*:xrpld=True
+xrpl/*:tests=True


### PR DESCRIPTION
This is a draft branch for testing CI with Conan 2.x. Contributors should switch soon. Conan 1.x package recipes are now frozen. They will no longer receive updates. The project builds just fine with Conan 2.x, and we can even simplify the build instructions.