### PR TITLE
chore: update deprecated Github Actions

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -28,7 +28,7 @@ jobs:
           git diff --exit-code | tee "clang-format.patch"
       - name: Upload patch
         if: failure() && steps.assert.outcome == 'failure'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: clang-format.patch

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -8,52 +8,52 @@ jobs:
     env:
       CLANG_VERSION: 18
     steps:
-    - uses: actions/checkout@v4
-    - name: Install clang-format
-      run: |
-        codename=$( lsb_release --codename --short )
-        sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null <<EOF
-        deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${CLANG_VERSION} main
-        deb-src http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${CLANG_VERSION} main
-        EOF
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add
-        sudo apt-get update
-        sudo apt-get install clang-format-${CLANG_VERSION}
-    - name: Format first-party sources
-      run: find include src -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -o -name '*.ipp' \) -exec clang-format-${CLANG_VERSION} -i {} +
-    - name: Check for differences
-      id: assert
-      run: |
-        set -o pipefail
-        git diff --exit-code | tee "clang-format.patch"
-    - name: Upload patch
-      if: failure() && steps.assert.outcome == 'failure'
-      uses: actions/upload-artifact@v3
-      continue-on-error: true
-      with:
-        name: clang-format.patch
-        if-no-files-found: ignore
-        path: clang-format.patch
-    - name: What happened?
-      if: failure() && steps.assert.outcome == 'failure'
-      env:
-        PREAMBLE: |
-          If you are reading this, you are looking at a failed Github Actions
-          job.  That means you pushed one or more files that did not conform
-          to the formatting specified in .clang-format. That may be because
-          you neglected to run 'git clang-format' or 'clang-format' before
-          committing, or that your version of clang-format has an
-          incompatibility with the one on this
-          machine, which is:
-        SUGGESTION: |
+      - uses: actions/checkout@v4
+      - name: Install clang-format
+        run: |
+          codename=$( lsb_release --codename --short )
+          sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null <<EOF
+          deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${CLANG_VERSION} main
+          deb-src http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${CLANG_VERSION} main
+          EOF
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add
+          sudo apt-get update
+          sudo apt-get install clang-format-${CLANG_VERSION}
+      - name: Format first-party sources
+        run: find include src -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -o -name '*.ipp' \) -exec clang-format-${CLANG_VERSION} -i {} +
+      - name: Check for differences
+        id: assert
+        run: |
+          set -o pipefail
+          git diff --exit-code | tee "clang-format.patch"
+      - name: Upload patch
+        if: failure() && steps.assert.outcome == 'failure'
+        uses: actions/upload-artifact@v3
+        continue-on-error: true
+        with:
+          name: clang-format.patch
+          if-no-files-found: ignore
+          path: clang-format.patch
+      - name: What happened?
+        if: failure() && steps.assert.outcome == 'failure'
+        env:
+          PREAMBLE: |
+            If you are reading this, you are looking at a failed Github Actions
+            job.  That means you pushed one or more files that did not conform
+            to the formatting specified in .clang-format. That may be because
+            you neglected to run 'git clang-format' or 'clang-format' before
+            committing, or that your version of clang-format has an
+            incompatibility with the one on this
+            machine, which is:
+          SUGGESTION: |
 
-          To fix it, you can do one of two things:
-          1. Download and apply the patch generated as an artifact of this
-             job to your repo, commit, and push.
-          2. Run 'git-clang-format --extensions cpp,h,hpp,ipp develop'
-             in your repo, commit, and push.
-      run: |
-        echo "${PREAMBLE}"
-        clang-format-${CLANG_VERSION} --version
-        echo "${SUGGESTION}"
-        exit 1
+            To fix it, you can do one of two things:
+            1. Download and apply the patch generated as an artifact of this
+               job to your repo, commit, and push.
+            2. Run 'git-clang-format --extensions cpp,h,hpp,ipp develop'
+               in your repo, commit, and push.
+        run: |
+          echo "${PREAMBLE}"
+          clang-format-${CLANG_VERSION} --version
+          echo "${SUGGESTION}"
+          exit 1

--- a/.github/workflows/levelization.yml
+++ b/.github/workflows/levelization.yml
@@ -8,42 +8,42 @@ jobs:
     env:
       CLANG_VERSION: 10
     steps:
-    - uses: actions/checkout@v4
-    - name: Check levelization
-      run: Builds/levelization/levelization.sh
-    - name: Check for differences
-      id: assert
-      run: |
-        set -o pipefail
-        git diff --exit-code | tee "levelization.patch"
-    - name: Upload patch
-      if: failure() && steps.assert.outcome == 'failure'
-      uses: actions/upload-artifact@v3
-      continue-on-error: true
-      with:
-        name: levelization.patch
-        if-no-files-found: ignore
-        path: levelization.patch
-    - name: What happened?
-      if: failure() && steps.assert.outcome == 'failure'
-      env:
-        MESSAGE: |
-          If you are reading this, you are looking at a failed Github
-          Actions job. That means you changed the dependency relationships
-          between the modules in rippled. That may be an improvement or a
-          regression. This check doesn't judge.
+      - uses: actions/checkout@v4
+      - name: Check levelization
+        run: Builds/levelization/levelization.sh
+      - name: Check for differences
+        id: assert
+        run: |
+          set -o pipefail
+          git diff --exit-code | tee "levelization.patch"
+      - name: Upload patch
+        if: failure() && steps.assert.outcome == 'failure'
+        uses: actions/upload-artifact@v3
+        continue-on-error: true
+        with:
+          name: levelization.patch
+          if-no-files-found: ignore
+          path: levelization.patch
+      - name: What happened?
+        if: failure() && steps.assert.outcome == 'failure'
+        env:
+          MESSAGE: |
+            If you are reading this, you are looking at a failed Github
+            Actions job. That means you changed the dependency relationships
+            between the modules in rippled. That may be an improvement or a
+            regression. This check doesn't judge.
 
-          A rule of thumb, though, is that if your changes caused
-          something to be removed from loops.txt, that's probably an
-          improvement. If something was added, it's probably a regression.
+            A rule of thumb, though, is that if your changes caused
+            something to be removed from loops.txt, that's probably an
+            improvement. If something was added, it's probably a regression.
 
-          To fix it, you can do one of two things:
-          1. Download and apply the patch generated as an artifact of this
-             job to your repo, commit, and push.
-          2. Run './Builds/levelization/levelization.sh' in your repo,
-             commit, and push.
+            To fix it, you can do one of two things:
+            1. Download and apply the patch generated as an artifact of this
+               job to your repo, commit, and push.
+            2. Run './Builds/levelization/levelization.sh' in your repo,
+               commit, and push.
 
-          See Builds/levelization/README.md for more info.
-      run: |
-        echo "${MESSAGE}"
-        exit 1
+            See Builds/levelization/README.md for more info.
+        run: |
+          echo "${MESSAGE}"
+          exit 1

--- a/.github/workflows/levelization.yml
+++ b/.github/workflows/levelization.yml
@@ -18,7 +18,7 @@ jobs:
           git diff --exit-code | tee "levelization.patch"
       - name: Upload patch
         if: failure() && steps.assert.outcome == 'failure'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: levelization.patch

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -10,7 +10,7 @@ on:
       - release
       - master
       # Branches that opt-in to running
-      - 'ci/**'
+      - "ci/**"
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -35,7 +35,6 @@ concurrency:
 # and builds and tests rippled.
 
 jobs:
-
   dependencies:
     strategy:
       fail-fast: false
@@ -100,7 +99,6 @@ jobs:
           path: conan.tar
           if-no-files-found: error
 
-
   test:
     strategy:
       fail-fast: false
@@ -153,7 +151,6 @@ jobs:
       - name: test
         run: |
           ${build_dir}/rippled --unittest --unittest-jobs $(nproc)
-
 
   coverage:
     strategy:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           configuration: ${{ matrix.configuration }}
       - name: upload archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform }}-${{ matrix.compiler }}-${{ matrix.configuration }}
           path: conan.tar
@@ -121,7 +121,7 @@ jobs:
       build_dir: .build
     steps:
       - name: download cache
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.platform }}-${{ matrix.compiler }}-${{ matrix.configuration }}
       - name: extract cache
@@ -169,7 +169,7 @@ jobs:
       build_dir: .build
     steps:
       - name: download cache
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.platform }}-${{ matrix.compiler }}-${{ matrix.configuration }}
       - name: extract cache
@@ -211,7 +211,7 @@ jobs:
         run: |
           mv "${build_dir}/coverage.xml" ./
       - name: archive coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage.xml
           path: coverage.xml
@@ -239,7 +239,7 @@ jobs:
       configuration: Release
     steps:
       - name: download cache
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: linux-gcc-${{ env.configuration }}
       - name: extract cache


### PR DESCRIPTION
## High Level Overview of Change

This PR updates `actions/upload-artifact` and `actions-download-artifact` from v3 to v4 (the current version).

### Context of Change

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

> Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact).

Some actions are already starting to fail for this reason.

### Type of Change

- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)

### API Impact

N/A

## Test Plan

CI passes.
