### PR TITLE
fix amendment: flag check for credentials

### DIFF
--- a/include/xrpl/protocol/Feature.h
+++ b/include/xrpl/protocol/Feature.h
@@ -80,7 +80,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 87;
+static constexpr std::size_t numFeatures = 88;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated

--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -30,7 +30,7 @@
 // in include/xrpl/protocol/Feature.h.
 
 // Check flags in Credential transactions
-XRPL_FIX    (CredentialFlags,            Supported::yes, VoteBehavior::DefaultYes)
+XRPL_FIX    (TransactionFlags,           Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (FrozenLPTokenTransfer,      Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(DeepFreeze,                 Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(PermissionedDomains,        Supported::no,  VoteBehavior::DefaultNo)

--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -30,7 +30,7 @@
 // in include/xrpl/protocol/Feature.h.
 
 // Check flags in Credential transactions
-XRPL_FIX    (TransactionFlags,           Supported::yes, VoteBehavior::DefaultNo)
+XRPL_FIX    (InvalidTxFlags,             Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (FrozenLPTokenTransfer,      Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(DeepFreeze,                 Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(PermissionedDomains,        Supported::no,  VoteBehavior::DefaultNo)

--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -29,8 +29,8 @@
 // If you add an amendment here, then do not forget to increment `numFeatures`
 // in include/xrpl/protocol/Feature.h.
 
-// fix1782: Check flags in Credential transactions
-XRPL_FIX    (1782,                       Supported::yes, VoteBehavior::DefaultNo)
+// Check flags in Credential transactions
+XRPL_FIX    (CredentialFlags,            Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FIX    (FrozenLPTokenTransfer,      Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(DeepFreeze,                 Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(PermissionedDomains,        Supported::no,  VoteBehavior::DefaultNo)

--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -29,6 +29,8 @@
 // If you add an amendment here, then do not forget to increment `numFeatures`
 // in include/xrpl/protocol/Feature.h.
 
+// fix1782: Check flags in Credential transactions
+XRPL_FIX    (1782,                       Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (FrozenLPTokenTransfer,      Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(DeepFreeze,                 Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(PermissionedDomains,        Supported::no,  VoteBehavior::DefaultNo)

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -1075,7 +1075,7 @@ struct Credentials_test : public beast::unit_test::suite
             env.close();
 
             {
-                bool const enabled = features[fixCredentialFlags];
+                bool const enabled = features[fixTransactionFlags];
                 testcase(
                     std::string("Test flag, fix ") +
                     (enabled ? "enabled" : "disabled"));
@@ -1106,7 +1106,7 @@ struct Credentials_test : public beast::unit_test::suite
         testAcceptFailed(all);
         testDeleteFailed(all);
         testFeatureFailed(all - featureCredentials);
-        testFlags(all - fixCredentialFlags);
+        testFlags(all - fixTransactionFlags);
         testFlags(all);
         testRPC();
     }

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -1063,7 +1063,7 @@ struct Credentials_test : public beast::unit_test::suite
     {
         using namespace test::jtx;
 
-        bool const enabled = features[fixTransactionFlags];
+        bool const enabled = features[fixInvalidTxFlags];
         testcase(
             std::string("Test flag, fix ") +
             (enabled ? "enabled" : "disabled"));
@@ -1106,7 +1106,7 @@ struct Credentials_test : public beast::unit_test::suite
         testAcceptFailed(all);
         testDeleteFailed(all);
         testFeatureFailed(all - featureCredentials);
-        testFlags(all - fixTransactionFlags);
+        testFlags(all - fixInvalidTxFlags);
         testFlags(all);
         testRPC();
     }

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -1075,9 +1075,9 @@ struct Credentials_test : public beast::unit_test::suite
             env.close();
 
             {
-                bool const enabled = features[fix1782];
+                bool const enabled = features[fixCredentialFlags];
                 testcase(
-                    std::string("Tets flag, fix ") +
+                    std::string("Test flag, fix ") +
                     (enabled ? "enabled" : "disabled"));
 
                 ter const expected(
@@ -1106,7 +1106,7 @@ struct Credentials_test : public beast::unit_test::suite
         testAcceptFailed(all);
         testDeleteFailed(all);
         testFeatureFailed(all - featureCredentials);
-        testFlags(all - fix1782);
+        testFlags(all - fixCredentialFlags);
         testFlags(all);
         testRPC();
     }

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -1063,6 +1063,11 @@ struct Credentials_test : public beast::unit_test::suite
     {
         using namespace test::jtx;
 
+        bool const enabled = features[fixTransactionFlags];
+        testcase(
+            std::string("Test flag, fix ") +
+            (enabled ? "enabled" : "disabled"));
+
         const char credType[] = "abcde";
         Account const issuer{"issuer"};
         Account const subject{"subject"};
@@ -1075,11 +1080,6 @@ struct Credentials_test : public beast::unit_test::suite
             env.close();
 
             {
-                bool const enabled = features[fixTransactionFlags];
-                testcase(
-                    std::string("Test flag, fix ") +
-                    (enabled ? "enabled" : "disabled"));
-
                 ter const expected(
                     enabled ? TER(temINVALID_FLAG) : TER(tesSUCCESS));
                 env(credentials::create(subject, issuer, credType),

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -1059,6 +1059,43 @@ struct Credentials_test : public beast::unit_test::suite
     }
 
     void
+    testFlags(FeatureBitset features)
+    {
+        using namespace test::jtx;
+
+        const char credType[] = "abcde";
+        Account const issuer{"issuer"};
+        Account const subject{"subject"};
+
+        {
+            using namespace jtx;
+            Env env{*this, features};
+
+            env.fund(XRP(5000), subject, issuer);
+            env.close();
+
+            {
+                bool const enabled = features[fix1782];
+                testcase(
+                    std::string("Tets flag, fix ") +
+                    (enabled ? "enabled" : "disabled"));
+
+                ter const expected(
+                    enabled ? TER(temINVALID_FLAG) : TER(tesSUCCESS));
+                env(credentials::create(subject, issuer, credType),
+                    txflags(tfTransferable),
+                    expected);
+                env(credentials::accept(subject, issuer, credType),
+                    txflags(tfSellNFToken),
+                    expected);
+                env(credentials::deleteCred(subject, subject, issuer, credType),
+                    txflags(tfPassive),
+                    expected);
+            }
+        }
+    }
+
+    void
     run() override
     {
         using namespace test::jtx;
@@ -1069,6 +1106,8 @@ struct Credentials_test : public beast::unit_test::suite
         testAcceptFailed(all);
         testDeleteFailed(all);
         testFeatureFailed(all - featureCredentials);
+        testFlags(all - fix1782);
+        testFlags(all);
         testRPC();
     }
 };

--- a/src/test/app/MultiSign_test.cpp
+++ b/src/test/app/MultiSign_test.cpp
@@ -1683,7 +1683,7 @@ public:
         env.fund(XRP(1000), alice);
         env.close();
 
-        bool const enabled = features[fixTransactionFlags];
+        bool const enabled = features[fixInvalidTxFlags];
         testcase(
             std::string("SignerListSet flag, fix ") +
             (enabled ? "enabled" : "disabled"));
@@ -1732,7 +1732,7 @@ public:
         testAll(all - featureExpandedSignerList);
         testAll(all);
 
-        test_signerListSetFlags(all - fixTransactionFlags);
+        test_signerListSetFlags(all - fixInvalidTxFlags);
         test_signerListSetFlags(all);
 
         test_amendmentTransition();

--- a/src/test/app/MultiSign_test.cpp
+++ b/src/test/app/MultiSign_test.cpp
@@ -1673,7 +1673,7 @@ public:
     }
 
     void
-    test_SignerListSet_Flags(FeatureBitset features)
+    test_signerListSetFlags(FeatureBitset features)
     {
         using namespace test::jtx;
 
@@ -1732,8 +1732,8 @@ public:
         testAll(all - featureExpandedSignerList);
         testAll(all);
 
-        test_SignerListSet_Flags(all - fixTransactionFlags);
-        test_SignerListSet_Flags(all);
+        test_signerListSetFlags(all - fixTransactionFlags);
+        test_signerListSetFlags(all);
 
         test_amendmentTransition();
     }

--- a/src/test/app/MultiSign_test.cpp
+++ b/src/test/app/MultiSign_test.cpp
@@ -1673,6 +1673,29 @@ public:
     }
 
     void
+    test_SignerListSet_Flags(FeatureBitset features)
+    {
+        using namespace test::jtx;
+
+        Env env{*this, features};
+        Account const alice{"alice"};
+
+        env.fund(XRP(1000), alice);
+        env.close();
+
+        bool const enabled = features[fixTransactionFlags];
+        testcase(
+            std::string("SignerListSet flag, fix ") +
+            (enabled ? "enabled" : "disabled"));
+
+        ter const expected(enabled ? TER(temINVALID_FLAG) : TER(tesSUCCESS));
+        env(signers(alice, 2, {{bogie, 1}, {ghost, 1}}),
+            expected,
+            txflags(tfPassive));
+        env.close();
+    }
+
+    void
     testAll(FeatureBitset features)
     {
         test_noReserve(features);
@@ -1708,6 +1731,10 @@ public:
         testAll(all - featureMultiSignReserve - featureExpandedSignerList);
         testAll(all - featureExpandedSignerList);
         testAll(all);
+
+        test_SignerListSet_Flags(all - fixTransactionFlags);
+        test_SignerListSet_Flags(all);
+
         test_amendmentTransition();
     }
 };

--- a/src/xrpld/app/tx/detail/Credentials.cpp
+++ b/src/xrpld/app/tx/detail/Credentials.cpp
@@ -65,7 +65,7 @@ CredentialCreate::preflight(PreflightContext const& ctx)
     auto const& tx = ctx.tx;
     auto& j = ctx.j;
 
-    if (ctx.rules.enabled(fixCredentialFlags) &&
+    if (ctx.rules.enabled(fixTransactionFlags) &&
         (tx.getFlags() & tfUniversalMask))
     {
         JLOG(ctx.j.debug()) << "CredentialCreate: invalid flags.";
@@ -216,7 +216,7 @@ CredentialDelete::preflight(PreflightContext const& ctx)
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
 
-    if (ctx.rules.enabled(fixCredentialFlags) &&
+    if (ctx.rules.enabled(fixTransactionFlags) &&
         (ctx.tx.getFlags() & tfUniversalMask))
     {
         JLOG(ctx.j.debug()) << "CredentialDelete: invalid flags.";
@@ -303,7 +303,7 @@ CredentialAccept::preflight(PreflightContext const& ctx)
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
 
-    if (ctx.rules.enabled(fixCredentialFlags) &&
+    if (ctx.rules.enabled(fixTransactionFlags) &&
         (ctx.tx.getFlags() & tfUniversalMask))
     {
         JLOG(ctx.j.debug()) << "CredentialAccept: invalid flags.";

--- a/src/xrpld/app/tx/detail/Credentials.cpp
+++ b/src/xrpld/app/tx/detail/Credentials.cpp
@@ -65,6 +65,12 @@ CredentialCreate::preflight(PreflightContext const& ctx)
     auto const& tx = ctx.tx;
     auto& j = ctx.j;
 
+    if (ctx.rules.enabled(fix1782) && (tx.getFlags() & tfUniversalMask))
+    {
+        JLOG(ctx.j.debug()) << "CredentialCreate: invalid flags.";
+        return temINVALID_FLAG;
+    }
+
     if (!tx[sfSubject])
     {
         JLOG(j.trace()) << "Malformed transaction: Invalid Subject";
@@ -209,6 +215,12 @@ CredentialDelete::preflight(PreflightContext const& ctx)
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
 
+    if (ctx.rules.enabled(fix1782) && (ctx.tx.getFlags() & tfUniversalMask))
+    {
+        JLOG(ctx.j.debug()) << "CredentialDelete: invalid flags.";
+        return temINVALID_FLAG;
+    }
+
     auto const subject = ctx.tx[~sfSubject];
     auto const issuer = ctx.tx[~sfIssuer];
 
@@ -288,6 +300,12 @@ CredentialAccept::preflight(PreflightContext const& ctx)
 
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
+
+    if (ctx.rules.enabled(fix1782) && (ctx.tx.getFlags() & tfUniversalMask))
+    {
+        JLOG(ctx.j.debug()) << "CredentialAccept: invalid flags.";
+        return temINVALID_FLAG;
+    }
 
     if (!ctx.tx[sfIssuer])
     {

--- a/src/xrpld/app/tx/detail/Credentials.cpp
+++ b/src/xrpld/app/tx/detail/Credentials.cpp
@@ -65,7 +65,7 @@ CredentialCreate::preflight(PreflightContext const& ctx)
     auto const& tx = ctx.tx;
     auto& j = ctx.j;
 
-    if (ctx.rules.enabled(fixTransactionFlags) &&
+    if (ctx.rules.enabled(fixInvalidTxFlags) &&
         (tx.getFlags() & tfUniversalMask))
     {
         JLOG(ctx.j.debug()) << "CredentialCreate: invalid flags.";
@@ -216,7 +216,7 @@ CredentialDelete::preflight(PreflightContext const& ctx)
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
 
-    if (ctx.rules.enabled(fixTransactionFlags) &&
+    if (ctx.rules.enabled(fixInvalidTxFlags) &&
         (ctx.tx.getFlags() & tfUniversalMask))
     {
         JLOG(ctx.j.debug()) << "CredentialDelete: invalid flags.";
@@ -303,7 +303,7 @@ CredentialAccept::preflight(PreflightContext const& ctx)
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
 
-    if (ctx.rules.enabled(fixTransactionFlags) &&
+    if (ctx.rules.enabled(fixInvalidTxFlags) &&
         (ctx.tx.getFlags() & tfUniversalMask))
     {
         JLOG(ctx.j.debug()) << "CredentialAccept: invalid flags.";

--- a/src/xrpld/app/tx/detail/Credentials.cpp
+++ b/src/xrpld/app/tx/detail/Credentials.cpp
@@ -65,7 +65,8 @@ CredentialCreate::preflight(PreflightContext const& ctx)
     auto const& tx = ctx.tx;
     auto& j = ctx.j;
 
-    if (ctx.rules.enabled(fix1782) && (tx.getFlags() & tfUniversalMask))
+    if (ctx.rules.enabled(fixCredentialFlags) &&
+        (tx.getFlags() & tfUniversalMask))
     {
         JLOG(ctx.j.debug()) << "CredentialCreate: invalid flags.";
         return temINVALID_FLAG;
@@ -215,7 +216,8 @@ CredentialDelete::preflight(PreflightContext const& ctx)
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
 
-    if (ctx.rules.enabled(fix1782) && (ctx.tx.getFlags() & tfUniversalMask))
+    if (ctx.rules.enabled(fixCredentialFlags) &&
+        (ctx.tx.getFlags() & tfUniversalMask))
     {
         JLOG(ctx.j.debug()) << "CredentialDelete: invalid flags.";
         return temINVALID_FLAG;
@@ -301,7 +303,8 @@ CredentialAccept::preflight(PreflightContext const& ctx)
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
 
-    if (ctx.rules.enabled(fix1782) && (ctx.tx.getFlags() & tfUniversalMask))
+    if (ctx.rules.enabled(fixCredentialFlags) &&
+        (ctx.tx.getFlags() & tfUniversalMask))
     {
         JLOG(ctx.j.debug()) << "CredentialAccept: invalid flags.";
         return temINVALID_FLAG;

--- a/src/xrpld/app/tx/detail/SetSignerList.cpp
+++ b/src/xrpld/app/tx/detail/SetSignerList.cpp
@@ -83,7 +83,7 @@ SetSignerList::preflight(PreflightContext const& ctx)
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
 
-    if (ctx.rules.enabled(fixTransactionFlags) &&
+    if (ctx.rules.enabled(fixInvalidTxFlags) &&
         (ctx.tx.getFlags() & tfUniversalMask))
     {
         JLOG(ctx.j.debug()) << "SetSignerList: invalid flags.";

--- a/src/xrpld/app/tx/detail/SetSignerList.cpp
+++ b/src/xrpld/app/tx/detail/SetSignerList.cpp
@@ -27,6 +27,8 @@
 #include <xrpl/protocol/STArray.h>
 #include <xrpl/protocol/STObject.h>
 #include <xrpl/protocol/STTx.h>
+#include <xrpl/protocol/TxFlags.h>
+
 #include <algorithm>
 #include <cstdint>
 
@@ -80,6 +82,13 @@ SetSignerList::preflight(PreflightContext const& ctx)
 {
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
+
+    if (ctx.rules.enabled(fixTransactionFlags) &&
+        (ctx.tx.getFlags() & tfUniversalMask))
+    {
+        JLOG(ctx.j.debug()) << "SetSignerList: invalid flags.";
+        return temINVALID_FLAG;
+    }
 
     auto const result = determineOperation(ctx.tx, ctx.flags, ctx.j);
 


### PR DESCRIPTION
## High Level Overview of Change

Add transaction flag checking functionality for Credentials

### Context of Change

CredentialCreate / CredentialAccept / CredentialDelete transactions will check sfFlags field in preflight()

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
