### PR TITLE
fix: Errors consistency in LedgerEntry::parsePermissionedDomains()

### DIFF
--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -3171,7 +3171,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             params[jss::ledger_index] = jss::validated;
             params[jss::permissioned_domain] = "NotAHexString";
             auto const jrr = env.rpc("json", "ledger_entry", to_string(params));
-            checkErrorValue(jrr[jss::result], "malformedObjectId", "");
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
         }
 
         {
@@ -3180,7 +3180,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             params[jss::ledger_index] = jss::validated;
             params[jss::permissioned_domain] = 10;
             auto const jrr = env.rpc("json", "ledger_entry", to_string(params));
-            checkErrorValue(jrr[jss::result], "malformedObject", "");
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
         }
 
         {
@@ -3190,7 +3190,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             params[jss::permissioned_domain][jss::account] = 1;
             params[jss::permissioned_domain][jss::seq] = seq;
             auto const jrr = env.rpc("json", "ledger_entry", to_string(params));
-            checkErrorValue(jrr[jss::result], "malformedAccount", "");
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
         }
 
         {
@@ -3200,7 +3200,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             params[jss::permissioned_domain][jss::account] = "";
             params[jss::permissioned_domain][jss::seq] = seq;
             auto const jrr = env.rpc("json", "ledger_entry", to_string(params));
-            checkErrorValue(jrr[jss::result], "malformedAccount", "");
+            checkErrorValue(jrr[jss::result], "malformedAddress", "");
         }
 
         {
@@ -3210,7 +3210,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             params[jss::permissioned_domain][jss::account] = alice.human();
             params[jss::permissioned_domain][jss::seq] = "12g";
             auto const jrr = env.rpc("json", "ledger_entry", to_string(params));
-            checkErrorValue(jrr[jss::result], "malformedSequence", "");
+            checkErrorValue(jrr[jss::result], "malformedRequest", "");
         }
     }
 

--- a/src/xrpld/rpc/handlers/LedgerEntry.cpp
+++ b/src/xrpld/rpc/handlers/LedgerEntry.cpp
@@ -811,22 +811,19 @@ parsePermissionedDomains(Json::Value const& pd, Json::Value& jvResult)
 {
     if (pd.isString())
     {
-        Json::Value result;
-        auto const index = parseIndex(pd, result);
-        if (!index)
-            jvResult[jss::error] = "malformedObjectId";
+        auto const index = parseIndex(pd, jvResult);
         return index;
     }
 
     if (!pd.isObject())
     {
-        jvResult[jss::error] = "malformedObject";
+        jvResult[jss::error] = "malformedRequest";
         return std::nullopt;
     }
 
     if (!pd.isMember(jss::account) || !pd[jss::account].isString())
     {
-        jvResult[jss::error] = "malformedAccount";
+        jvResult[jss::error] = "malformedRequest";
         return std::nullopt;
     }
 
@@ -834,14 +831,14 @@ parsePermissionedDomains(Json::Value const& pd, Json::Value& jvResult)
         (pd[jss::seq].isInt() && pd[jss::seq].asInt() < 0) ||
         (!pd[jss::seq].isInt() && !pd[jss::seq].isUInt()))
     {
-        jvResult[jss::error] = "malformedSequence";
+        jvResult[jss::error] = "malformedRequest";
         return std::nullopt;
     }
 
     auto const account = parseBase58<AccountID>(pd[jss::account].asString());
     if (!account)
     {
-        jvResult[jss::error] = "malformedAccount";
+        jvResult[jss::error] = "malformedAddress";
         return std::nullopt;
     }
 


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->
Update errors for parsing permissioned domains in `LedgerEntry` handler to make them consistent with other parsers.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->
The inconsistency this PR is fixing was introduced here: https://github.com/XRPLF/rippled/pull/5161

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [x] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [x] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

The PR is changing behaviour of the new feature which hasn't got into any release yet.
 
<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
