### PR TITLE
Updates Conan dependencies

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -63,6 +63,9 @@ jobs:
     env:
       build_dir: .build
     steps:
+      - name: upgrade conan
+        run: |
+          pip install --upgrade "conan<2"
       - name: checkout
         uses: actions/checkout@v4
       - name: check environment
@@ -122,6 +125,9 @@ jobs:
     env:
       build_dir: .build
     steps:
+      - name: upgrade conan
+        run: |
+          pip install --upgrade "conan<2"
       - name: download cache
         uses: actions/download-artifact@v4
         with:
@@ -170,6 +176,9 @@ jobs:
     env:
       build_dir: .build
     steps:
+      - name: upgrade conan
+        run: |
+          pip install --upgrade "conan<2"
       - name: download cache
         uses: actions/download-artifact@v4
         with:
@@ -240,6 +249,9 @@ jobs:
       build_dir: .build
       configuration: Release
     steps:
+      - name: upgrade conan
+        run: |
+          pip install --upgrade "conan<2"
       - name: download cache
         uses: actions/download-artifact@v4
         with:

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,10 +25,10 @@ class Xrpl(ConanFile):
 
     requires = [
         'date/3.0.3',
-        'grpc/1.67.1',
-        'libarchive/3.6.2',
+        'grpc/1.50.1',
+        'libarchive/3.7.6',
         'nudb/2.0.8',
-        'openssl/1.1.1u',
+        'openssl/1.1.1v',
         'soci/4.0.3',
         'xxhash/0.8.2',
         'zlib/1.3.1',
@@ -99,10 +99,10 @@ class Xrpl(ConanFile):
             self.options['boost'].visibility = 'global'
 
     def requirements(self):
-        self.requires('boost/1.82.0', force=True)
+        self.requires('boost/1.83.0', force=True)
         self.requires('lz4/1.10.0', force=True)
         self.requires('protobuf/3.21.9', force=True)
-        self.requires('sqlite3/3.42.0', force=True)
+        self.requires('sqlite3/3.47.0', force=True)
         if self.options.jemalloc:
             self.requires('jemalloc/5.3.0')
         if self.options.rocksdb:

--- a/conanfile.py
+++ b/conanfile.py
@@ -24,14 +24,14 @@ class Xrpl(ConanFile):
     }
 
     requires = [
-        'date/3.0.1',
-        'grpc/1.50.1',
+        'date/3.0.3',
+        'grpc/1.67.1',
         'libarchive/3.6.2',
         'nudb/2.0.8',
         'openssl/1.1.1u',
         'soci/4.0.3',
         'xxhash/0.8.2',
-        'zlib/1.2.13',
+        'zlib/1.3.1',
     ]
 
     tool_requires = [
@@ -100,7 +100,7 @@ class Xrpl(ConanFile):
 
     def requirements(self):
         self.requires('boost/1.82.0', force=True)
-        self.requires('lz4/1.9.3', force=True)
+        self.requires('lz4/1.10.0', force=True)
         self.requires('protobuf/3.21.9', force=True)
         self.requires('sqlite3/3.42.0', force=True)
         if self.options.jemalloc:

--- a/external/rocksdb/conanfile.py
+++ b/external/rocksdb/conanfile.py
@@ -89,13 +89,13 @@ class RocksDBConan(ConanFile):
         if self.options.with_snappy:
             self.requires("snappy/1.1.10")
         if self.options.with_lz4:
-            self.requires("lz4/1.9.4")
+            self.requires("lz4/1.10.0")
         if self.options.with_zlib:
-            self.requires("zlib/[>=1.2.11 <2]")
+            self.requires("zlib/[>=1.3.1 <2]")
         if self.options.with_zstd:
-            self.requires("zstd/1.5.5")
+            self.requires("zstd/1.5.6")
         if self.options.get_safe("with_tbb"):
-            self.requires("onetbb/2021.10.0")
+            self.requires("onetbb/2021.12.0")
         if self.options.with_jemalloc:
             self.requires("jemalloc/5.3.0")
 

--- a/external/rocksdb/conanfile.py
+++ b/external/rocksdb/conanfile.py
@@ -91,7 +91,7 @@ class RocksDBConan(ConanFile):
         if self.options.with_lz4:
             self.requires("lz4/1.10.0")
         if self.options.with_zlib:
-            self.requires("zlib/[>=1.3.1 <2]")
+            self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_zstd:
             self.requires("zstd/1.5.6")
         if self.options.get_safe("with_tbb"):

--- a/external/soci/conanfile.py
+++ b/external/soci/conanfile.py
@@ -62,15 +62,15 @@ class SociConan(ConanFile):
 
     def requirements(self):
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.41.1")
+            self.requires("sqlite3/3.47.0")
         if self.options.with_odbc and self.settings.os != "Windows":
             self.requires("odbc/2.3.11")
         if self.options.with_mysql:
             self.requires("libmysqlclient/8.1.0")
         if self.options.with_postgresql:
-            self.requires("libpq/14.7")
+            self.requires("libpq/15.5")
         if self.options.with_boost:
-            self.requires("boost/1.81.0")
+            self.requires("boost/1.83.0")
 
     @property
     def _minimum_compilers_version(self):

--- a/external/soci/conanfile.py
+++ b/external/soci/conanfile.py
@@ -66,7 +66,7 @@ class SociConan(ConanFile):
         if self.options.with_odbc and self.settings.os != "Windows":
             self.requires("odbc/2.3.11")
         if self.options.with_mysql:
-            self.requires("libmysqlclient/8.0.31")
+            self.requires("libmysqlclient/8.1.0")
         if self.options.with_postgresql:
             self.requires("libpq/14.7")
         if self.options.with_boost:


### PR DESCRIPTION
## High Level Overview of Change

This PR updates several Conan dependencies, namely:
* boost
* date
* libarchive
* libmysqlclient
* libpq
* lz4
* onetbb
* openssl
* sqlite3
* zlib
* zstd

### Context of Change

Dependency scanning revealed that current dependencies are out of date. Updating dependencies allows us to take advantage of bug fixes, new features, and/or security improvements.

### Type of Change

- [X] Refactor (non-breaking change that only restructures code)

## Future Tasks

Not all dependencies could be updated to their latest published versions without resulting in compilation errors, particularly grpc, protobuf, boost (>= 1.84), and rocksdb. These will be addressed in additional PRs.