### PR TITLE
fix issues in `simulate` RPC

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -92,7 +92,7 @@ As of 2025-01-28, version 2.4.0 is in development. You can use a pre-release ver
 - `ledger_entry`: `state` is added an alias for `ripple_state`.
 - `validators`: Added new field `validator_list_threshold` in response.
 - `simulate`: A new RPC that executes a [dry run of a transaction submission](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0069d-simulate#2-rpc-simulate)
-- Signing methods autofill fees better and properly handle transactions that don't have a base fee.
+- Signing methods autofill fees better and properly handle transactions that don't have a base fee, and will also autofill the `NetworkID` field.
 
 ## XRP Ledger server version 2.3.0
 

--- a/src/test/jtx/JTx.h
+++ b/src/test/jtx/JTx.h
@@ -51,6 +51,7 @@ struct JTx
     bool fill_fee = true;
     bool fill_seq = true;
     bool fill_sig = true;
+    bool fill_netid = true;
     std::shared_ptr<STTx const> stx;
     std::function<void(Env&, JTx&)> signer;
 

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -493,9 +493,12 @@ Env::autofill(JTx& jt)
     if (jt.fill_seq)
         jtx::fill_seq(jv, *current());
 
-    uint32_t networkID = app().config().NETWORK_ID;
-    if (!jv.isMember(jss::NetworkID) && networkID > 1024)
-        jv[jss::NetworkID] = std::to_string(networkID);
+    if (jt.fill_netid)
+    {
+        uint32_t networkID = app().config().NETWORK_ID;
+        if (!jv.isMember(jss::NetworkID) && networkID > 1024)
+            jv[jss::NetworkID] = std::to_string(networkID);
+    }
 
     // Must come last
     try

--- a/src/test/rpc/Simulate_test.cpp
+++ b/src/test/rpc/Simulate_test.cpp
@@ -464,7 +464,10 @@ class Simulate_test : public beast::unit_test::suite
         testcase("Successful transaction");
 
         using namespace jtx;
-        Env env(*this);
+        Env env{*this, envconfig([&](std::unique_ptr<Config> cfg) {
+                    cfg->NETWORK_ID = 0;
+                    return cfg;
+                })};
         static auto const newDomain = "123ABC";
 
         {

--- a/src/test/rpc/Simulate_test.cpp
+++ b/src/test/rpc/Simulate_test.cpp
@@ -93,13 +93,17 @@ class Simulate_test : public beast::unit_test::suite
             validate,
         bool testSerialized = true)
     {
+        env.close();
+
         Json::Value params;
         params[jss::tx_json] = tx;
         validate(env.rpc("json", "simulate", to_string(params)), tx);
+
         params[jss::binary] = true;
         validate(env.rpc("json", "simulate", to_string(params)), tx);
         validate(env.rpc("simulate", to_string(tx)), tx);
         validate(env.rpc("simulate", to_string(tx), "binary"), tx);
+
         if (testSerialized)
         {
             // This cannot be tested in the multisign autofill scenario
@@ -119,6 +123,10 @@ class Simulate_test : public beast::unit_test::suite
             validate(env.rpc("simulate", tx_blob), tx);
             validate(env.rpc("simulate", tx_blob, "binary"), tx);
         }
+
+        BEAST_EXPECTS(
+            env.current()->txCount() == 0,
+            std::to_string(env.current()->txCount()));
     }
 
     Json::Value
@@ -528,8 +536,6 @@ class Simulate_test : public beast::unit_test::suite
 
             // test without autofill
             testTx(env, tx, validateOutput);
-
-            // TODO: check that the ledger wasn't affected
         }
     }
 
@@ -578,8 +584,6 @@ class Simulate_test : public beast::unit_test::suite
 
             // test without autofill
             testTx(env, tx, testSimulation);
-
-            // TODO: check that the ledger wasn't affected
         }
     }
 
@@ -659,8 +663,6 @@ class Simulate_test : public beast::unit_test::suite
 
             // test without autofill
             testTx(env, tx, testSimulation);
-
-            // TODO: check that the ledger wasn't affected
         }
     }
 
@@ -680,6 +682,7 @@ class Simulate_test : public beast::unit_test::suite
 
         // set up valid multisign
         env(signers(alice, 1, {{becky, 1}, {carol, 1}}));
+        env.close();
 
         {
             auto validateOutput = [&](Json::Value const& resp,
@@ -717,7 +720,7 @@ class Simulate_test : public beast::unit_test::suite
                             BEAST_EXPECT(finalFields[sfDomain] == newDomain);
                         }
                     }
-                    BEAST_EXPECT(metadata[sfTransactionIndex.jsonName] == 1);
+                    BEAST_EXPECT(metadata[sfTransactionIndex.jsonName] == 0);
                     BEAST_EXPECT(
                         metadata[sfTransactionResult.jsonName] == "tesSUCCESS");
                 }
@@ -752,8 +755,6 @@ class Simulate_test : public beast::unit_test::suite
 
             // test without autofill
             testTx(env, tx, validateOutput);
-
-            // TODO: check that the ledger wasn't affected
         }
     }
 
@@ -809,8 +810,6 @@ class Simulate_test : public beast::unit_test::suite
 
             // test without autofill
             testTx(env, tx, testSimulation);
-
-            // TODO: check that the ledger wasn't affected
         }
     }
 
@@ -880,8 +879,6 @@ class Simulate_test : public beast::unit_test::suite
 
             // test without autofill
             testTx(env, tx, validateOutput);
-
-            // TODO: check that the ledger wasn't affected
         }
     }
 
@@ -1074,8 +1071,6 @@ class Simulate_test : public beast::unit_test::suite
 
             // test without autofill
             testTx(env, tx, validateOutput);
-
-            // TODO: check that the ledger wasn't affected
         }
     }
 

--- a/src/test/rpc/Simulate_test.cpp
+++ b/src/test/rpc/Simulate_test.cpp
@@ -236,6 +236,58 @@ class Simulate_test : public beast::unit_test::suite
                 "Invalid field 'tx_json', not object.");
         }
         {
+            // `seed` field included
+            Json::Value params = Json::objectValue;
+            params[jss::seed] = "doesnt_matter";
+            Json::Value tx_json = Json::objectValue;
+            tx_json[jss::TransactionType] = jss::AccountSet;
+            tx_json[jss::Account] = env.master.human();
+            params[jss::tx_json] = tx_json;
+            auto const resp = env.rpc("json", "simulate", to_string(params));
+            BEAST_EXPECT(
+                resp[jss::result][jss::error_message] ==
+                "Invalid field 'seed'.");
+        }
+        {
+            // `secret` field included
+            Json::Value params = Json::objectValue;
+            params[jss::secret] = "doesnt_matter";
+            Json::Value tx_json = Json::objectValue;
+            tx_json[jss::TransactionType] = jss::AccountSet;
+            tx_json[jss::Account] = env.master.human();
+            params[jss::tx_json] = tx_json;
+            auto const resp = env.rpc("json", "simulate", to_string(params));
+            BEAST_EXPECT(
+                resp[jss::result][jss::error_message] ==
+                "Invalid field 'secret'.");
+        }
+        {
+            // `seed_hex` field included
+            Json::Value params = Json::objectValue;
+            params[jss::seed_hex] = "doesnt_matter";
+            Json::Value tx_json = Json::objectValue;
+            tx_json[jss::TransactionType] = jss::AccountSet;
+            tx_json[jss::Account] = env.master.human();
+            params[jss::tx_json] = tx_json;
+            auto const resp = env.rpc("json", "simulate", to_string(params));
+            BEAST_EXPECT(
+                resp[jss::result][jss::error_message] ==
+                "Invalid field 'seed_hex'.");
+        }
+        {
+            // `passphrase` field included
+            Json::Value params = Json::objectValue;
+            params[jss::passphrase] = "doesnt_matter";
+            Json::Value tx_json = Json::objectValue;
+            tx_json[jss::TransactionType] = jss::AccountSet;
+            tx_json[jss::Account] = env.master.human();
+            params[jss::tx_json] = tx_json;
+            auto const resp = env.rpc("json", "simulate", to_string(params));
+            BEAST_EXPECT(
+                resp[jss::result][jss::error_message] ==
+                "Invalid field 'passphrase'.");
+        }
+        {
             // Invalid transaction
             Json::Value params = Json::objectValue;
             Json::Value tx_json = Json::objectValue;

--- a/src/xrpld/rpc/detail/TransactionSign.cpp
+++ b/src/xrpld/rpc/detail/TransactionSign.cpp
@@ -467,6 +467,13 @@ transactionPreProcessImpl(
 
         if (!tx_json.isMember(jss::Flags))
             tx_json[jss::Flags] = tfFullyCanonicalSig;
+
+        if (!tx_json.isMember(jss::NetworkID))
+        {
+            auto const networkId = app.config().NETWORK_ID;
+            if (networkId > 1024)
+                tx_json[jss::NetworkID] = to_string(networkId);
+        }
     }
 
     {

--- a/src/xrpld/rpc/handlers/Simulate.cpp
+++ b/src/xrpld/rpc/handlers/Simulate.cpp
@@ -144,6 +144,13 @@ autofillTx(Json::Value& tx_json, RPC::JsonContext& context)
         tx_json[sfSequence.jsonName] = *seq;
     }
 
+    if (!tx_json.isMember(jss::NetworkID))
+    {
+        auto const networkId = context.app.config().NETWORK_ID;
+        if (networkId > 1024)
+            tx_json[jss::NetworkID] = to_string(networkId);
+    }
+
     return std::nullopt;
 }
 

--- a/src/xrpld/rpc/handlers/Simulate.cpp
+++ b/src/xrpld/rpc/handlers/Simulate.cpp
@@ -299,6 +299,15 @@ doSimulate(RPC::JsonContext& context)
         return RPC::invalid_field_error(jss::binary);
     }
 
+    for (auto const field :
+         {jss::secret, jss::seed, jss::seed_hex, jss::passphrase})
+    {
+        if (context.params.isMember(field))
+        {
+            return RPC::invalid_field_error(field);
+        }
+    }
+
     // get JSON equivalent of transaction
     tx_json = getTxJsonFromParams(context.params);
     if (tx_json.isMember(jss::error))


### PR DESCRIPTION
## High Level Overview of Change

This PR prevents the use of `seed`, `secret`, `seed_hex`, and `passphrase` fields in the `simulate` RPC, and adds autofilling for `NetworkID`s in simulated transactions.

### Context of Change

The former is to avoid confusion with RPCs like `sign` and `simulate`. Transactions provided in the `simulate` RPC are supposed to be unsigned, so users should also not submit any secrets alongside those transactions.

The latter is to make it easier to work with networks with a larger network ID.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### API Impact

- [x] Public API: Fix

## Test Plan
Tests added.