### PR TITLE
Do not allow creating PDs if credentials are not enabled

### DIFF
--- a/src/test/app/PermissionedDomains_test.cpp
+++ b/src/test/app/PermissionedDomains_test.cpp
@@ -91,7 +91,6 @@ class PermissionedDomains_test : public beast::unit_test::suite
         env.fund(XRP(1000), alice);
         pdomain::Credentials credentials{{alice, "first credential"}};
         env(pdomain::setTx(alice, credentials), ter(temDISABLED));
-        env(pdomain::deleteTx(alice, uint256(75)), ter(tecNO_ENTRY));
     }
 
     // Verify that each tx does not execute if feature is disabled

--- a/src/xrpld/app/tx/detail/PermissionedDomainSet.cpp
+++ b/src/xrpld/app/tx/detail/PermissionedDomainSet.cpp
@@ -30,8 +30,10 @@ namespace ripple {
 NotTEC
 PermissionedDomainSet::preflight(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featurePermissionedDomains))
+    if (!ctx.rules.enabled(featurePermissionedDomains) ||
+        !ctx.rules.enabled(featureCredentials))
         return temDISABLED;
+
     if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
         return ret;
 


### PR DESCRIPTION
## High Level Overview of Change

This solves the problem of permissioned domains dependency on credentials.

### Context of Change

If the permissioned domains amendment XLS-80 were enabled before credentials XLS-70, then the permissioned domain users will not be able to match any credentials, i.e. the amendment will be useless. The simplest solution, proposed in this PR, is to prevent creation of any PD objects if credentials are not enabled.

Similarly, amendments which depend on permissioned domains (e.g.  single asset vault) will have to check if permissioned domain amendment XLS-80 is enabled, and act accordingly. This is similar in spirit to how we handle addition of new optional fields to existing transactions, returning `temDISABLED` if the newly added features wanted by the transaction are not enabled. 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
