### PR TITLE
Remove lambda from `rotateWithLock`

### DIFF
--- a/src/test/app/SHAMapStore_test.cpp
+++ b/src/test/app/SHAMapStore_test.cpp
@@ -20,14 +20,10 @@
 #include <test/jtx.h>
 #include <test/jtx/envconfig.h>
 #include <xrpld/app/main/Application.h>
-#include <xrpld/app/main/NodeStoreScheduler.h>
 #include <xrpld/app/misc/SHAMapStore.h>
 #include <xrpld/app/rdb/backend/SQLiteDatabase.h>
 #include <xrpld/core/ConfigSections.h>
-#include <xrpld/nodestore/detail/DatabaseRotatingImp.h>
 #include <xrpl/protocol/jss.h>
-#include <boost/lexical_cast.hpp>
-#include <thread>
 
 namespace ripple {
 namespace test {
@@ -522,144 +518,12 @@ public:
         lastRotated = ledgerSeq - 1;
     }
 
-    std::unique_ptr<NodeStore::Backend>
-    makeBackendRotating(
-        jtx::Env& env,
-        NodeStoreScheduler& scheduler,
-        std::string path)
-    {
-        Section section{
-            env.app().config().section(ConfigSection::nodeDatabase())};
-        boost::filesystem::path newPath;
-
-        if (!BEAST_EXPECT(path.size()))
-            return {};
-        newPath = path;
-        section.set("path", newPath.string());
-
-        auto backend{NodeStore::Manager::instance().make_Backend(
-            section,
-            megabytes(env.app().config().getValueFor(
-                SizedItem::burstSize, std::nullopt)),
-            scheduler,
-            env.app().logs().journal("NodeStoreTest"))};
-        backend->open();
-        return backend;
-    }
-    void
-    testRotateWithLockContention()
-    {
-        // The only purpose of this test is to ensure that if something that
-        // should never happen happens, we don't get a deadlock.
-        testcase("rotate with lock contention");
-
-        using namespace jtx;
-        Env env(*this, envconfig(onlineDelete));
-
-        /////////////////////////////////////////////////////////////
-        // Create the backend. Normally, SHAMapStoreImp handles all these
-        // details
-        auto nscfg = env.app().config().section(ConfigSection::nodeDatabase());
-        nscfg.set(
-            NodeStore::DatabaseRotatingImp::unitTestFlag, std::to_string(true));
-
-        // Provide default values:
-        if (!nscfg.exists("cache_size"))
-            nscfg.set(
-                "cache_size",
-                std::to_string(env.app().config().getValueFor(
-                    SizedItem::treeCacheSize, std::nullopt)));
-
-        if (!nscfg.exists("cache_age"))
-            nscfg.set(
-                "cache_age",
-                std::to_string(env.app().config().getValueFor(
-                    SizedItem::treeCacheAge, std::nullopt)));
-
-        NodeStoreScheduler scheduler(env.app().getJobQueue());
-
-        std::string const writableDb = "write";
-        std::string const archiveDb = "archive";
-        auto writableBackend = makeBackendRotating(env, scheduler, writableDb);
-        auto archiveBackend = makeBackendRotating(env, scheduler, archiveDb);
-
-        // Create NodeStore with two backends to allow online deletion of
-        // data
-        constexpr int readThreads = 4;
-        auto dbr = std::make_unique<NodeStore::DatabaseRotatingImp>(
-            scheduler,
-            readThreads,
-            std::move(writableBackend),
-            std::move(archiveBackend),
-            nscfg,
-            env.app().logs().journal("NodeStoreTest"));
-
-        /////////////////////////////////////////////////////////////
-        // Create the impossible situation. Get several calls to rotateWithLock
-        // going in parallel using a callback that just delays
-        using namespace std::chrono_literals;
-        std::atomic<int> threadNum = 0;
-        auto const cb = [&](std::string const& writableBackendName) {
-            using namespace std::chrono_literals;
-            BEAST_EXPECT(writableBackendName == "write");
-            auto newBackend = makeBackendRotating(
-                env, scheduler, std::to_string(++threadNum));
-            std::this_thread::sleep_for(5s);
-            return newBackend;
-        };
-
-        std::atomic<int> successes = 0;
-        std::atomic<int> failures = 0;
-        std::vector<std::thread> threads;
-        threads.reserve(5);
-        for (int i = 0; i < 5; ++i)
-        {
-            threads.emplace_back([&]() {
-                if (dbr->rotateWithLock(cb))
-                    ++successes;
-                else
-                    ++failures;
-            });
-            // There's no point in trying to time the threads to line up at
-            // exact points, but introduce a little bit of staggering to be more
-            // "realistic".
-            std::this_thread::sleep_for(10ms * i);
-        }
-        for (auto& t : threads)
-        {
-            t.join();
-        }
-        BEAST_EXPECT(successes == 1);
-        BEAST_EXPECT(failures == 4);
-        // Only one thread will invoke the callback to increment threadNum
-        BEAST_EXPECT(threadNum == 1);
-        BEAST_EXPECT(dbr->getName() == "1");
-
-        /////////////////////////////////////////////////////////////
-        // Create another impossible situation. Try to re-enter rotateWithLock
-        // inside the callback.
-        auto const cbReentrant = [&](std::string const& writableBackendName) {
-            BEAST_EXPECT(writableBackendName == "1");
-            auto newBackend = makeBackendRotating(
-                env, scheduler, std::to_string(++threadNum));
-            BEAST_EXPECT(!dbr->rotateWithLock(cb));
-            return newBackend;
-        };
-        BEAST_EXPECT(dbr->rotateWithLock(cbReentrant));
-
-        BEAST_EXPECT(successes == 1);
-        BEAST_EXPECT(failures == 4);
-        BEAST_EXPECT(threadNum == 2);
-        BEAST_EXPECT(dbr->getName() == "2");
-    }
-
     void
     run() override
     {
         testClear();
         testAutomatic();
         testCanDelete();
-        testRotateWithLockContention();
     }
 };
 

--- a/src/xrpld/app/misc/SHAMapStoreImp.cpp
+++ b/src/xrpld/app/misc/SHAMapStoreImp.cpp
@@ -366,27 +366,18 @@ SHAMapStoreImp::run()
 
             lastRotated = validatedSeq;
 
-            if (!dbRotating_->rotateWithLock(
-                    [&](std::string const& writableBackendName) {
-                        SavedState savedState;
-                        savedState.writableDb = newBackend->getName();
-                        savedState.archiveDb = writableBackendName;
-                        savedState.lastRotated = lastRotated;
-                        state_db_.setState(savedState);
+            dbRotating_->rotateWithLock(
+                [&](std::string const& writableBackendName) {
+                    SavedState savedState;
+                    savedState.writableDb = newBackend->getName();
+                    savedState.archiveDb = writableBackendName;
+                    savedState.lastRotated = lastRotated;
+                    state_db_.setState(savedState);
 
-                        clearCaches(validatedSeq);
+                    clearCaches(validatedSeq);
 
-                        return std::move(newBackend);
-                    }))
-            {
-                UNREACHABLE(
-                    "ripple::SHAMapStoreImp::run rotateWithLock failed");
-                JLOG(journal_.error())
-                    << validatedSeq
-                    << " rotation failed. Discard unused new backend.";
-                newBackend->setDeletePath();
-                return;
-            }
+                    return std::move(newBackend);
+                });
 
             JLOG(journal_.warn()) << "finished rotation " << validatedSeq;
         }

--- a/src/xrpld/nodestore/DatabaseRotating.h
+++ b/src/xrpld/nodestore/DatabaseRotating.h
@@ -45,12 +45,8 @@ public:
     /** Rotates the backends.
 
         @param f A function executed before the rotation
-
-        @return bool indicating whether the callback "f" was called, and the new
-                Backend it returned is stored
     */
-    [[nodiscard]]
-    virtual bool
+    virtual void
     rotateWithLock(std::function<std::unique_ptr<NodeStore::Backend>(
                        std::string const& writableBackendName)> const& f) = 0;
 };

--- a/src/xrpld/nodestore/DatabaseRotating.h
+++ b/src/xrpld/nodestore/DatabaseRotating.h
@@ -44,11 +44,11 @@ public:
 
     /** Rotates the backends.
 
-        @param f A function executed before the rotation
+        @param newBackend New backend
+        @return name of the old backend
     */
-    virtual void
-    rotateWithLock(std::function<std::unique_ptr<NodeStore::Backend>(
-                       std::string const& writableBackendName)> const& f) = 0;
+    [[nodiscard]] virtual std::string
+    rotateWithLock(std::unique_ptr<NodeStore::Backend> newBackend) = 0;
 };
 
 }  // namespace NodeStore

--- a/src/xrpld/nodestore/detail/DatabaseRotatingImp.h
+++ b/src/xrpld/nodestore/detail/DatabaseRotatingImp.h
@@ -22,7 +22,7 @@
 
 #include <xrpld/nodestore/DatabaseRotating.h>
 
-#include <boost/thread/shared_mutex.hpp>
+#include <mutex>
 
 namespace ripple {
 namespace NodeStore {
@@ -48,7 +48,7 @@ public:
         stop();
     }
 
-    [[nodiscard]] bool
+    void
     rotateWithLock(
         std::function<std::unique_ptr<NodeStore::Backend>(
             std::string const& writableBackendName)> const& f) override;
@@ -79,21 +79,14 @@ public:
     void
     sweep() override;
 
-    // Include the space in the name to ensure it can't be set in a file
-    static constexpr auto unitTestFlag = " unit_test";
-
 private:
+    // backendMutex_ is only needed when the *Backend_ members are modified.
+    // Reads are protected by the general mutex_.
+    std::mutex backendMutex_;
     std::shared_ptr<Backend> writableBackend_;
     std::shared_ptr<Backend> archiveBackend_;
-    bool const unitTest_;
 
-    // Implements the "UpgradeLockable" concept
-    // https://www.boost.org/doc/libs/release/doc/html/thread/synchronization.html#thread.synchronization.mutex_concepts.upgrade_lockable
-    // In short: Many threads can have shared ownership. One thread can have
-    // upgradable ownership at the same time as others have shared ownership.
-    // The upgradeable ownership can be upgraded to exclusive ownership,
-    // blocking if necessary until no other threads have shared ownership.
-    mutable boost::upgrade_mutex mutex_;
+    mutable std::mutex mutex_;
 
     std::shared_ptr<NodeObject>
     fetchNodeObject(

--- a/src/xrpld/nodestore/detail/DatabaseRotatingImp.h
+++ b/src/xrpld/nodestore/detail/DatabaseRotatingImp.h
@@ -48,10 +48,8 @@ public:
         stop();
     }
 
-    void
-    rotateWithLock(
-        std::function<std::unique_ptr<NodeStore::Backend>(
-            std::string const& writableBackendName)> const& f) override;
+    [[nodiscard]] virtual std::string
+    rotateWithLock(std::unique_ptr<NodeStore::Backend> newBackend) override;
 
     std::string
     getName() const override;
@@ -80,9 +78,6 @@ public:
     sweep() override;
 
 private:
-    // backendMutex_ is only needed when the *Backend_ members are modified.
-    // Reads are protected by the general mutex_.
-    std::mutex backendMutex_;
     std::shared_ptr<Backend> writableBackend_;
     std::shared_ptr<Backend> archiveBackend_;
 


### PR DESCRIPTION
Possible improvement to PR #5276 

This is based on assumption that we do not need to call `clearCaches(validatedSeq)` twice. There should be no reason to call it second time inside the critical section, just like there should be no reason to update `state_db_` inside the critical section, so this change minimises the critical section and also removes the risk that some untested code from outside of `DatabaseRotatingImp` could run inside it.