### PR TITLE
Switch Permissioned Domain to Supported::yes

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -33,7 +33,7 @@
 XRPL_FIX    (InvalidTxFlags,             Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (FrozenLPTokenTransfer,      Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(DeepFreeze,                 Supported::yes, VoteBehavior::DefaultNo)
-XRPL_FEATURE(PermissionedDomains,        Supported::no,  VoteBehavior::DefaultNo)
+XRPL_FEATURE(PermissionedDomains,        Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(DynamicNFT,                 Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(Credentials,                Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(AMMClawback,                Supported::yes, VoteBehavior::DefaultNo)

--- a/src/test/app/PermissionedDomains_test.cpp
+++ b/src/test/app/PermissionedDomains_test.cpp
@@ -54,7 +54,8 @@ exceptionExpected(Env& env, Json::Value const& jv)
 
 class PermissionedDomains_test : public beast::unit_test::suite
 {
-    FeatureBitset withoutFeature_{supported_amendments()};
+    FeatureBitset withoutFeature_{
+        supported_amendments() - featurePermissionedDomains};
     FeatureBitset withFeature_{
         supported_amendments()  //
         | featurePermissionedDomains | featureCredentials};


### PR DESCRIPTION
## High Level Overview of Change

Switch Permissioned Domain to Supported::yes

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

Switch Permissioned Domain feature's `supported` flag from `Supported::no`  to `Supported::yes`

