### PR TITLE
Changed XRPL Foundation public key to new one

### DIFF
--- a/cfg/validators-example.txt
+++ b/cfg/validators-example.txt
@@ -60,7 +60,7 @@ https://vl.xrplf.org
 #vl.ripple.com
 ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
 # vl.xrplf.org
-ED45D1840EE724BE327ABE9146503D5848EFD5F38B6D5FEDE71E80ACCE5E6E738B
+ED42AEC58B701EEBB77356FFFEC26F83C1F0407263530F068C7C73D392C7E06FD1
 
 # To use the test network (see https://xrpl.org/connect-your-rippled-to-the-xrp-test-net.html),
 # use the following configuration instead:


### PR DESCRIPTION
Following XRPL Foundation UNL migration, new set of keys were generated. This pull requests updates old key with new one.