### PR TITLE
docs: Clarifies default port of hosts

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -410,9 +410,11 @@
 #   starter list is included in the code and used if no other hostnames are
 #   available.
 #
-#   One address or domain name per line is allowed. A port may must be
-#   specified after adding a space to the address.  The ordering of entries
-#   does not generally matter.
+#   One address or domain name per line is allowed. A port may be specified
+#   after adding a space to the address. If a port is not specified, the default
+#   port of 2459 will be used. Many servers still use the legacy port of 51235.
+#   To connect to such servers, you must specify the port number. The ordering
+#   of entries does not generally matter.
 #
 #   The default list of entries is:
 #     - r.ripple.com 51235

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1425,7 +1425,7 @@ admin = 127.0.0.1
 protocol = http
 
 [port_peer]
-port = 51235
+port = 2459
 ip = 0.0.0.0
 # alternatively, to accept connections on IPv4 + IPv6, use:
 #ip = ::


### PR DESCRIPTION
## High Level Overview of Change

The current comment in the example cfg file incorrectly mentions both "may" and "must". This change fixes this comment to clarify that the default port of hosts is 2459 and that specifying it is therefore optional. It further sets the default port to 2459 instead of the legacy 51235.

### Type of Change

- [X] Documentation update