### PR TITLE
docs: Revert peer port to 51235

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1425,7 +1425,10 @@ admin = 127.0.0.1
 protocol = http
 
 [port_peer]
-port = 2459
+# Many servers still use the legacy port of 51235, so for backward-compatibility
+# we maintain that port number here. However, for new servers we recommend
+# changing this to the default port of 2459.
+port = 51235
 ip = 0.0.0.0
 # alternatively, to accept connections on IPv4 + IPv6, use:
 #ip = ::


### PR DESCRIPTION
## High Level Overview of Change

Following up on https://github.com/XRPLF/rippled/pull/5290, this change sets the `[port_peer]` back to the legacy port 51235 rather than to the default port 2459.

### Context of Change

The config is part of the binary and, unless an explicit config is passed, the behavior of the binary will unexpectedly be different when the port changes. As the binary would then use a different port, it would possibly make the server inaccessible depending on how routes and firewalls are configured. To err on the safe side, this change restores the port to the legacy value as it was, but still recommends using the default port for new deployments.

### Type of Change

- [X] Documentation update