### PR TITLE
Replace `assert` with `XRPL_ASSERT`

### DIFF
--- a/src/xrpld/app/misc/detail/AmendmentTable.cpp
+++ b/src/xrpld/app/misc/detail/AmendmentTable.cpp
@@ -226,7 +226,10 @@ public:
                     toBase58(TokenType::NodePublic, votes.first);
                 if (!votes.second.timeout)
                 {
-                    assert(votes.second.upVotes.empty());
+                    XRPL_ASSERT(
+                        votes.second.upVotes.empty(),
+                        "ripple::TrustedVotes::recordVotes : received no "
+                        "upvotes");
                     JLOG(j.debug())
                         << "recordVotes: Have not received any "
                            "amendment votes from "
@@ -242,7 +245,10 @@ public:
                 }
                 else if (votes.second.timeout != newTimeout)
                 {
-                    assert(votes.second.timeout < newTimeout);
+                    XRPL_ASSERT(
+                        votes.second.timeout < newTimeout,
+                        "ripple::TrustedVotes::recordVotes : votes not "
+                        "expired");
                     using namespace std::chrono;
                     auto const age = duration_cast<minutes>(
                         newTimeout - *votes.second.timeout);
@@ -262,9 +268,10 @@ public:
         int available = 0;
         for (auto& validatorVotes : recordedVotes_)
         {
-            assert(
+            XRPL_ASSERT(
                 validatorVotes.second.timeout ||
-                validatorVotes.second.upVotes.empty());
+                    validatorVotes.second.upVotes.empty(),
+                "ripple::TrustedVotes::getVotes : valid votes");
             if (validatorVotes.second.timeout)
                 ++available;
             for (uint256 const& amendment : validatorVotes.second.upVotes)

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -1245,7 +1245,7 @@ PeerImp::handleTransaction(
 {
     XRPL_ASSERT(
         eraseTxQueue != batch,
-        ("ripple::PeerImp::handleTransaction correct function params"));
+        ("ripple::PeerImp::handleTransaction : valid inputs"));
     if (tracking_.load() == Tracking::diverged)
         return;
 

--- a/src/xrpld/overlay/detail/PeerImp.h
+++ b/src/xrpld/overlay/detail/PeerImp.h
@@ -154,7 +154,8 @@ private:
         update(Resource::Charge f, std::string const& add)
         {
             XRPL_ASSERT(
-                f >= fee, "ripple::PeerImp::ChargeWithContext fee increases");
+                f >= fee,
+                "ripple::PeerImp::ChargeWithContext::update : fee increases");
             fee = f;
             if (!context.empty())
             {


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Replace `assert` with `XRPL_ASSERT` in `AmendmentTable.cpp` 

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

`assert` was added in #5173 ; during a merge from `develop` it should have been replaced by `XRPL_ASSERT` in that PR but it did not happen.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
