### PR TITLE
refactor: Replace static_cast by (un)safe_cast wherever possible.

### DIFF
--- a/include/xrpl/basics/CompressionAlgorithms.h
+++ b/include/xrpl/basics/CompressionAlgorithms.h
@@ -21,6 +21,7 @@
 #define RIPPLED_COMPRESSIONALGORITHMS_H_INCLUDED
 
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <algorithm>
 #include <cstdint>
 #include <lz4.h>
@@ -77,8 +78,8 @@ lz4Decompress(
     std::uint8_t* decompressed,
     std::size_t decompressedSizeUnchecked)
 {
-    int const inSize = static_cast<int>(inSizeUnchecked);
-    int const decompressedSize = static_cast<int>(decompressedSizeUnchecked);
+    int const inSize = unsafe_cast<int>(inSizeUnchecked);
+    int const decompressedSize = unsafe_cast<int>(decompressedSizeUnchecked);
 
     if (inSize <= 0)
         Throw<std::runtime_error>("lz4Decompress: integer overflow (input)");

--- a/include/xrpl/basics/StringUtilities.h
+++ b/include/xrpl/basics/StringUtilities.h
@@ -21,6 +21,7 @@
 #define RIPPLE_BASICS_STRINGUTILITIES_H_INCLUDED
 
 #include <xrpl/basics/Blob.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/basics/strHex.h>
 #include <boost/format.hpp>
 #include <boost/utility/string_view.hpp>
@@ -95,7 +96,7 @@ strUnHex(std::size_t strSize, Iterator begin, Iterator end)
         if (cLow < 0)
             return {};
 
-        out.push_back(static_cast<unsigned char>((cHigh << 4) | cLow));
+        out.push_back(unsafe_cast<unsigned char>((cHigh << 4) | cLow));
     }
 
     return {std::move(out)};

--- a/include/xrpl/basics/TaggedCache.h
+++ b/include/xrpl/basics/TaggedCache.h
@@ -23,6 +23,7 @@
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/UnorderedContainers.h>
 #include <xrpl/basics/hardened_hash.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/clock/abstract_clock.h>
 #include <xrpl/beast/insight/Insight.h>
 #include <atomic>
@@ -111,7 +112,7 @@ public:
         {
             for (auto& partition : m_cache.map())
             {
-                partition.rehash(static_cast<std::size_t>(
+                partition.rehash(safe_cast<std::size_t>(
                     (s + (s >> 2)) /
                         (partition.max_load_factor() * m_cache.partitions()) +
                     1));
@@ -216,7 +217,7 @@ public:
             std::lock_guard lock(m_mutex);
 
             if (m_target_size == 0 ||
-                (static_cast<int>(m_cache.size()) <= m_target_size))
+                (unsafe_cast<int>(m_cache.size()) <= m_target_size))
             {
                 when_expire = now - m_target_age;
             }

--- a/include/xrpl/basics/base_uint.h
+++ b/include/xrpl/basics/base_uint.h
@@ -30,6 +30,7 @@
 #include <xrpl/basics/contract.h>
 #include <xrpl/basics/hardened_hash.h>
 #include <xrpl/basics/partitioned_unordered_map.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/basics/strHex.h>
 #include <xrpl/beast/utility/Zero.h>
 #include <xrpl/beast/utility/instrumentation.h>
@@ -207,11 +208,11 @@ private:
                 return ParseResult::badChar;
 
             if (c >= 'a')
-                nibble = static_cast<std::uint32_t>(c - 'a' + 0xA);
+                nibble = unsafe_cast<std::uint32_t>(c - 'a' + 0xA);
             else if (c >= 'A')
-                nibble = static_cast<std::uint32_t>(c - 'A' + 0xA);
+                nibble = unsafe_cast<std::uint32_t>(c - 'A' + 0xA);
             else if (c <= '9')
-                nibble = static_cast<std::uint32_t>(c - '0');
+                nibble = unsafe_cast<std::uint32_t>(c - '0');
 
             if (nibble > 0xFu)
                 return ParseResult::badChar;
@@ -474,7 +475,7 @@ public:
                 boost::endian::big_to_native(b.data_[i]);
 
             data_[i] =
-                boost::endian::native_to_big(static_cast<std::uint32_t>(n));
+                boost::endian::native_to_big(unsafe_cast<std::uint32_t>(n));
             carry = n >> 32;
         }
 

--- a/include/xrpl/basics/random.h
+++ b/include/xrpl/basics/random.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_BASICS_RANDOM_H_INCLUDED
 #define RIPPLE_BASICS_RANDOM_H_INCLUDED
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/beast/xor_shift_engine.h>
 #include <cstddef>
@@ -171,7 +172,7 @@ std::enable_if_t<
     Byte>
 rand_byte(Engine& engine)
 {
-    return static_cast<Byte>(rand_int<Engine, std::uint32_t>(
+    return unsafe_cast<Byte>(rand_int<Engine, std::uint32_t>(
         engine,
         std::numeric_limits<Byte>::min(),
         std::numeric_limits<Byte>::max()));

--- a/include/xrpl/protocol/AmountConversions.h
+++ b/include/xrpl/protocol/AmountConversions.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_PROTOCOL_AMOUNTCONVERSION_H_INCLUDED
 #define RIPPLE_PROTOCOL_AMOUNTCONVERSION_H_INCLUDED
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/IOUAmount.h>
 #include <xrpl/protocol/STAmount.h>
 #include <xrpl/protocol/XRPAmount.h>
@@ -156,12 +157,12 @@ toMaxAmount(Issue const& issue)
     if constexpr (std::is_same_v<IOUAmount, T>)
         return IOUAmount(STAmount::cMaxValue, STAmount::cMaxOffset);
     else if constexpr (std::is_same_v<XRPAmount, T>)
-        return XRPAmount(static_cast<std::int64_t>(STAmount::cMaxNativeN));
+        return XRPAmount(unsafe_cast<std::int64_t>(STAmount::cMaxNativeN));
     else if constexpr (std::is_same_v<STAmount, T>)
     {
         if (isXRP(issue))
             return STAmount(
-                issue, static_cast<std::int64_t>(STAmount::cMaxNativeN));
+                issue, unsafe_cast<std::int64_t>(STAmount::cMaxNativeN));
         return STAmount(issue, STAmount::cMaxValue, STAmount::cMaxOffset);
     }
     else

--- a/include/xrpl/protocol/HashPrefix.h
+++ b/include/xrpl/protocol/HashPrefix.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_PROTOCOL_HASHPREFIX_H_INCLUDED
 #define RIPPLE_PROTOCOL_HASHPREFIX_H_INCLUDED
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/hash/hash_append.h>
 #include <cstdint>
 
@@ -94,7 +95,7 @@ void
 hash_append(Hasher& h, HashPrefix const& hp) noexcept
 {
     using beast::hash_append;
-    hash_append(h, static_cast<std::uint32_t>(hp));
+    hash_append(h, safe_cast<std::uint32_t>(hp));
 }
 
 }  // namespace ripple

--- a/include/xrpl/protocol/MultiApiJson.h
+++ b/include/xrpl/protocol/MultiApiJson.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_JSON_MULTIAPIJSON_H_INCLUDED
 #define RIPPLE_JSON_MULTIAPIJSON_H_INCLUDED
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/ApiVersion.h>
@@ -64,7 +65,7 @@ struct MultiApiJson
     static constexpr auto
     index(unsigned int v) noexcept -> std::size_t
     {
-        return (v < MinVer) ? 0 : static_cast<std::size_t>(v - MinVer);
+        return (v < MinVer) ? 0 : safe_cast<std::size_t>(v - MinVer);
     }
 
     constexpr static std::size_t size = MaxVer + 1 - MinVer;

--- a/include/xrpl/protocol/Quality.h
+++ b/include/xrpl/protocol/Quality.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_PROTOCOL_QUALITY_H_INCLUDED
 #define RIPPLE_PROTOCOL_QUALITY_H_INCLUDED
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/AmountConversions.h>
 #include <xrpl/protocol/IOUAmount.h>
 #include <xrpl/protocol/STAmount.h>
@@ -310,7 +311,7 @@ public:
             return rate & ~(255ull << (64 - 8));
         };
         auto exponent = [](std::uint64_t rate) {
-            return static_cast<int>(rate >> (64 - 8)) - 100;
+            return unsafe_cast<int>(rate >> (64 - 8)) - 100;
         };
 
         auto const minVMantissa = mantissa(minV);

--- a/include/xrpl/protocol/STBase.h
+++ b/include/xrpl/protocol/STBase.h
@@ -21,6 +21,7 @@
 #define RIPPLE_PROTOCOL_STBASE_H_INCLUDED
 
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/Serializer.h>
 #include <memory>
@@ -29,6 +30,7 @@
 #include <type_traits>
 #include <typeinfo>
 #include <utility>
+
 namespace ripple {
 
 /// Note, should be treated as flags that can be | and &
@@ -86,7 +88,7 @@ struct JsonOptions
     [[nodiscard]] constexpr JsonOptions friend
     operator~(JsonOptions v) noexcept
     {
-        return {~v.value & static_cast<underlying_t>(_all)};
+        return {~v.value & safe_cast<underlying_t>(_all)};
     }
 };
 

--- a/include/xrpl/protocol/Serializer.h
+++ b/include/xrpl/protocol/Serializer.h
@@ -94,10 +94,10 @@ public:
     add32(T i)
     {
         int ret = mData.size();
-        mData.push_back(static_cast<unsigned char>((i >> 24) & 0xff));
-        mData.push_back(static_cast<unsigned char>((i >> 16) & 0xff));
-        mData.push_back(static_cast<unsigned char>((i >> 8) & 0xff));
-        mData.push_back(static_cast<unsigned char>(i & 0xff));
+        mData.push_back(unsafe_cast<unsigned char>((i >> 24) & 0xff));
+        mData.push_back(unsafe_cast<unsigned char>((i >> 16) & 0xff));
+        mData.push_back(unsafe_cast<unsigned char>((i >> 8) & 0xff));
+        mData.push_back(unsafe_cast<unsigned char>(i & 0xff));
         return ret;
     }
 
@@ -112,14 +112,14 @@ public:
     add64(T i)
     {
         int ret = mData.size();
-        mData.push_back(static_cast<unsigned char>((i >> 56) & 0xff));
-        mData.push_back(static_cast<unsigned char>((i >> 48) & 0xff));
-        mData.push_back(static_cast<unsigned char>((i >> 40) & 0xff));
-        mData.push_back(static_cast<unsigned char>((i >> 32) & 0xff));
-        mData.push_back(static_cast<unsigned char>((i >> 24) & 0xff));
-        mData.push_back(static_cast<unsigned char>((i >> 16) & 0xff));
-        mData.push_back(static_cast<unsigned char>((i >> 8) & 0xff));
-        mData.push_back(static_cast<unsigned char>(i & 0xff));
+        mData.push_back(unsafe_cast<unsigned char>((i >> 56) & 0xff));
+        mData.push_back(unsafe_cast<unsigned char>((i >> 48) & 0xff));
+        mData.push_back(unsafe_cast<unsigned char>((i >> 40) & 0xff));
+        mData.push_back(unsafe_cast<unsigned char>((i >> 32) & 0xff));
+        mData.push_back(unsafe_cast<unsigned char>((i >> 24) & 0xff));
+        mData.push_back(unsafe_cast<unsigned char>((i >> 16) & 0xff));
+        mData.push_back(unsafe_cast<unsigned char>((i >> 8) & 0xff));
+        mData.push_back(unsafe_cast<unsigned char>(i & 0xff));
         return ret;
     }
 
@@ -375,7 +375,7 @@ public:
     int
     getBytesLeft() const noexcept
     {
-        return static_cast<int>(remain_);
+        return unsafe_cast<int>(remain_);
     }
 
     // get functions throw on error

--- a/include/xrpl/protocol/XRPAmount.h
+++ b/include/xrpl/protocol/XRPAmount.h
@@ -22,6 +22,7 @@
 
 #include <xrpl/basics/Number.h>
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/Zero.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/FeeUnits.h>
@@ -191,7 +192,7 @@ public:
         {
             return std::nullopt;
         }
-        return static_cast<Dest>(drops_);
+        return unsafe_cast<Dest>(drops_);
     }
 
     template <class Dest>
@@ -226,7 +227,7 @@ public:
             return min;
         if (drops_ > max)
             return max;
-        return static_cast<Json::Int>(drops_);
+        return unsafe_cast<Json::Int>(drops_);
     }
 
     /** Returns the underlying value. Code SHOULD NOT call this

--- a/include/xrpl/protocol/detail/b58_utils.h
+++ b/include/xrpl/protocol/detail/b58_utils.h
@@ -21,6 +21,7 @@
 #define RIPPLE_PROTOCOL_B58_UTILS_H_INCLUDED
 
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/protocol/detail/token_errors.h>
 #include <boost/outcome.hpp>
@@ -154,7 +155,7 @@ inplace_bigint_div_rem(std::span<uint64_t> numerator, std::uint64_t divisor)
             r >> 64 == 0,
             "ripple::b58_fast::detail::inplace_bigint_div_rem::div_rem_64 : "
             "valid remainder");
-        return {static_cast<std::uint64_t>(d), static_cast<std::uint64_t>(r)};
+        return {unsafe_cast<std::uint64_t>(d), unsafe_cast<std::uint64_t>(r)};
     };
 
     std::uint64_t prev_rem = 0;

--- a/include/xrpl/protocol/detail/token_errors.h
+++ b/include/xrpl/protocol/detail/token_errors.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_PROTOCOL_TOKEN_ERRORS_H_INCLUDED
 #define RIPPLE_PROTOCOL_TOKEN_ERRORS_H_INCLUDED
 
+#include <xrpl/basics/safe_cast.h>
 #include <system_error>
 
 namespace ripple {
@@ -59,7 +60,7 @@ public:
     virtual std::string
     message(int c) const override final
     {
-        switch (static_cast<TokenCodecErrc>(c))
+        switch (safe_cast<TokenCodecErrc>(c))
         {
             case TokenCodecErrc::success:
                 return "conversion successful";
@@ -96,7 +97,7 @@ TokenCodecErrcCategory()
 inline std::error_code
 make_error_code(ripple::TokenCodecErrc e)
 {
-    return {static_cast<int>(e), TokenCodecErrcCategory()};
+    return {safe_cast<int>(e), TokenCodecErrcCategory()};
 }
 }  // namespace ripple
 #endif  // TOKEN_ERRORS_H_

--- a/src/libxrpl/basics/FileUtilities.cpp
+++ b/src/libxrpl/basics/FileUtilities.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <xrpl/basics/FileUtilities.h>
+#include <xrpl/basics/safe_cast.h>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
@@ -57,7 +58,7 @@ getFileContents(
 
     if (!fileStream)
     {
-        ec = make_error_code(static_cast<errc_t>(errno));
+        ec = make_error_code(unsafe_cast<errc_t>(errno));
         return {};
     }
 
@@ -67,7 +68,7 @@ getFileContents(
 
     if (fileStream.bad())
     {
-        ec = make_error_code(static_cast<errc_t>(errno));
+        ec = make_error_code(unsafe_cast<errc_t>(errno));
         return {};
     }
 
@@ -87,7 +88,7 @@ writeFileContents(
 
     if (!fileStream)
     {
-        ec = make_error_code(static_cast<errc_t>(errno));
+        ec = make_error_code(unsafe_cast<errc_t>(errno));
         return;
     }
 
@@ -95,7 +96,7 @@ writeFileContents(
 
     if (fileStream.bad())
     {
-        ec = make_error_code(static_cast<errc_t>(errno));
+        ec = make_error_code(unsafe_cast<errc_t>(errno));
         return;
     }
 }

--- a/src/libxrpl/basics/Number.cpp
+++ b/src/libxrpl/basics/Number.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <xrpl/basics/Number.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <algorithm>
 #include <cstddef>
@@ -181,7 +182,7 @@ Number::normalize()
         return;
     }
     bool const negative = (mantissa_ < 0);
-    auto m = static_cast<std::make_unsigned_t<rep>>(mantissa_);
+    auto m = unsafe_cast<std::make_unsigned_t<rep>>(mantissa_);
     if (negative)
         m = -m;
     while ((m < minMantissa) && (exponent_ > minExponent))
@@ -343,7 +344,7 @@ Number::operator+=(Number const& y)
 }
 
 // Optimization equivalent to:
-// auto r = static_cast<unsigned>(u % 10);
+// auto r = safe_cast<unsigned>(u % 10);
 // u /= 10;
 // return r;
 // Derived from Hacker's Delight Second Edition Chapter 10
@@ -408,7 +409,7 @@ Number::operator*=(Number const& y)
     while (zm > maxMantissa)
     {
         // The following is optimization for:
-        // g.push(static_cast<unsigned>(zm % 10));
+        // g.push(safe_cast<unsigned>(zm % 10));
         // zm /= 10;
         g.push(divu10(zm));
         ++ze;
@@ -650,7 +651,7 @@ root(Number f, unsigned d)
 
     // Scale f into the range (0, 1) such that f's exponent is a multiple of d
     auto e = f.exponent() + 16;
-    auto const di = static_cast<int>(d);
+    auto const di = unsafe_cast<int>(d);
     auto ex = [e = e, di = di]()  // Euclidean remainder of e/d
     {
         int k = (e >= 0 ? e : e - (di - 1)) / di;

--- a/src/libxrpl/basics/ResolverAsio.cpp
+++ b/src/libxrpl/basics/ResolverAsio.cpp
@@ -20,6 +20,7 @@
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/Resolver.h>
 #include <xrpl/basics/ResolverAsio.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/net/IPAddressConversion.h>
 #include <xrpl/beast/net/IPEndpoint.h>
 #include <xrpl/beast/utility/Journal.h>
@@ -336,7 +337,7 @@ public:
 
         // Attempt to find the first and last valid port separators
         auto const find_port_separator = [](char const c) -> bool {
-            if (std::isspace(static_cast<unsigned char>(c)))
+            if (std::isspace(unsafe_cast<unsigned char>(c)))
                 return true;
 
             if (c == ':')

--- a/src/libxrpl/crypto/RFC1751.cpp
+++ b/src/libxrpl/crypto/RFC1751.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/crypto/RFC1751.h>
 #include <boost/algorithm/string/classification.hpp>
@@ -289,9 +290,9 @@ RFC1751::extract(char const* s, int start, int length)
     cc = (shiftR < 16) ? s[start / 8 + 1] : 0;
     cr = (shiftR < 8) ? s[start / 8 + 2] : 0;
 
-    x = (static_cast<long>(cl << 8 | cc) << 8 | cr);  // Put bits together
-    x = x >> shiftR;                                  // Right justify number
-    x = (x & (0xffff >> (16 - length)));              // Trim extra bits.
+    x = (safe_cast<long>(cl << 8 | cc) << 8 | cr);  // Put bits together
+    x = x >> shiftR;                                // Right justify number
+    x = (x & (0xffff >> (16 - length)));            // Trim extra bits.
 
     return x;
 }
@@ -310,7 +311,7 @@ RFC1751::btoe(std::string& strHuman, std::string const& strData)
     for (p = 0, i = 0; i < 64; i += 2)
         p += extract(caBuffer, i, 2);
 
-    caBuffer[8] = static_cast<char>(p) << 6;
+    caBuffer[8] = unsafe_cast<char>(p) << 6;
 
     strHuman = std::string() + s_dictionary[extract(caBuffer, 0, 11)] + " " +
         s_dictionary[extract(caBuffer, 11, 11)] + " " +
@@ -337,7 +338,7 @@ RFC1751::insert(char* s, int x, int start, int length)
         "ripple::RFC1751::insert : maximum start + length");
 
     shift = ((8 - ((start + length) % 8)) % 8);
-    y = static_cast<long>(x) << shift;
+    y = safe_cast<long>(x) << shift;
     cl = (y >> 16) & 0xff;
     cc = (y >> 8) & 0xff;
     cr = y & 0xff;
@@ -364,8 +365,8 @@ RFC1751::standard(std::string& strWord)
 {
     for (auto& letter : strWord)
     {
-        if (islower(static_cast<unsigned char>(letter)))
-            letter = toupper(static_cast<unsigned char>(letter));
+        if (islower(unsafe_cast<unsigned char>(letter)))
+            letter = toupper(unsafe_cast<unsigned char>(letter));
         else if (letter == '1')
             letter = 'L';
         else if (letter == '0')

--- a/src/libxrpl/json/JsonPropertyStream.cpp
+++ b/src/libxrpl/json/JsonPropertyStream.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/json/JsonPropertyStream.h>
 #include <xrpl/json/json_value.h>
 #include <string>
@@ -86,7 +87,7 @@ JsonPropertyStream::add(std::string const& key, unsigned int v)
 void
 JsonPropertyStream::add(std::string const& key, long v)
 {
-    (*m_stack.back())[key] = static_cast<int>(v);
+    (*m_stack.back())[key] = unsafe_cast<int>(v);
 }
 
 void
@@ -158,7 +159,7 @@ JsonPropertyStream::add(unsigned int v)
 void
 JsonPropertyStream::add(long v)
 {
-    m_stack.back()->append(static_cast<int>(v));
+    m_stack.back()->append(unsafe_cast<int>(v));
 }
 
 void

--- a/src/libxrpl/json/json_reader.cpp
+++ b/src/libxrpl/json/json_reader.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/json/json_reader.h>
 #include <xrpl/json/json_value.h>
 #include <algorithm>
@@ -43,28 +44,28 @@ codePointToUTF8(unsigned int cp)
     if (cp <= 0x7f)
     {
         result.resize(1);
-        result[0] = static_cast<char>(cp);
+        result[0] = ripple::unsafe_cast<char>(cp);
     }
     else if (cp <= 0x7FF)
     {
         result.resize(2);
-        result[1] = static_cast<char>(0x80 | (0x3f & cp));
-        result[0] = static_cast<char>(0xC0 | (0x1f & (cp >> 6)));
+        result[1] = ripple::unsafe_cast<char>(0x80 | (0x3f & cp));
+        result[0] = ripple::unsafe_cast<char>(0xC0 | (0x1f & (cp >> 6)));
     }
     else if (cp <= 0xFFFF)
     {
         result.resize(3);
-        result[2] = static_cast<char>(0x80 | (0x3f & cp));
-        result[1] = 0x80 | static_cast<char>((0x3f & (cp >> 6)));
-        result[0] = 0xE0 | static_cast<char>((0xf & (cp >> 12)));
+        result[2] = ripple::unsafe_cast<char>(0x80 | (0x3f & cp));
+        result[1] = 0x80 | ripple::unsafe_cast<char>((0x3f & (cp >> 6)));
+        result[0] = 0xE0 | ripple::unsafe_cast<char>((0xf & (cp >> 12)));
     }
     else if (cp <= 0x10FFFF)
     {
         result.resize(4);
-        result[3] = static_cast<char>(0x80 | (0x3f & cp));
-        result[2] = static_cast<char>(0x80 | (0x3f & (cp >> 6)));
-        result[1] = static_cast<char>(0x80 | (0x3f & (cp >> 12)));
-        result[0] = static_cast<char>(0xF0 | (0x7 & (cp >> 18)));
+        result[3] = ripple::unsafe_cast<char>(0x80 | (0x3f & cp));
+        result[2] = ripple::unsafe_cast<char>(0x80 | (0x3f & (cp >> 6)));
+        result[1] = ripple::unsafe_cast<char>(0x80 | (0x3f & (cp >> 12)));
+        result[0] = ripple::unsafe_cast<char>(0xF0 | (0x7 & (cp >> 18)));
     }
 
     return result;
@@ -93,7 +94,7 @@ Reader::parse(std::istream& sin, Value& root)
     // Since std::string is reference-counted, this at least does not
     // create an extra copy.
     std::string doc;
-    std::getline(sin, doc, static_cast<char>(EOF));
+    std::getline(sin, doc, ripple::unsafe_cast<char>(EOF));
     return parse(doc, root);
 }
 
@@ -377,7 +378,7 @@ Reader::readNumber()
 
         while (current_ != end_)
         {
-            if (!std::isdigit(static_cast<unsigned char>(*current_)))
+            if (!std::isdigit(ripple::unsafe_cast<unsigned char>(*current_)))
             {
                 auto ret = std::ranges::find(extended_tokens, *current_);
 
@@ -599,7 +600,7 @@ Reader::decodeNumber(Token& token)
                 token);
         }
 
-        currentValue() = static_cast<Value::Int>(value);
+        currentValue() = ripple::unsafe_cast<Value::Int>(value);
     }
     else
     {
@@ -613,9 +614,9 @@ Reader::decodeNumber(Token& token)
 
         // If it's representable as a signed integer, construct it as one.
         if (value <= Value::maxInt)
-            currentValue() = static_cast<Value::Int>(value);
+            currentValue() = ripple::unsafe_cast<Value::Int>(value);
         else
-            currentValue() = static_cast<Value::UInt>(value);
+            currentValue() = ripple::unsafe_cast<Value::UInt>(value);
     }
 
     return true;
@@ -627,7 +628,7 @@ Reader::decodeDouble(Token& token)
     double value = 0;
     const int bufferSize = 32;
     int count;
-    int length = static_cast<int>(token.end_ - token.start_);
+    int length = ripple::unsafe_cast<int>(token.end_ - token.start_);
     // Sanity check to avoid buffer overflow exploits.
     if (length < 0)
     {
@@ -844,7 +845,7 @@ Reader::addError(std::string const& message, Token& token, Location extra)
 bool
 Reader::recoverFromError(TokenType skipUntilToken)
 {
-    int errorCount = static_cast<int>(errors_.size());
+    int errorCount = ripple::unsafe_cast<int>(errors_.size());
     Token skip;
 
     while (true)
@@ -913,7 +914,7 @@ Reader::getLocationLineAndColumn(Location location, int& line, int& column)
     }
 
     // column & line start at 1
-    column = static_cast<int>(location - lastLineStart) + 1;
+    column = ripple::unsafe_cast<int>(location - lastLineStart) + 1;
     ++line;
 }
 

--- a/src/libxrpl/json/json_value.cpp
+++ b/src/libxrpl/json/json_value.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/core/LexicalCast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/json/detail/json_assert.h>
@@ -31,9 +32,11 @@
 namespace Json {
 
 const Value Value::null;
-const Int Value::minInt = static_cast<Int>(~(static_cast<UInt>(-1) / 2));
-const Int Value::maxInt = static_cast<Int>(static_cast<UInt>(-1) / 2);
-const UInt Value::maxUInt = static_cast<UInt>(-1);
+const Int Value::minInt =
+    ripple::unsafe_cast<Int>(~(ripple::unsafe_cast<UInt>(-1) / 2));
+const Int Value::maxInt =
+    ripple::unsafe_cast<Int>(ripple::unsafe_cast<UInt>(-1) / 2);
+const UInt Value::maxUInt = ripple::unsafe_cast<UInt>(-1);
 
 class DefaultValueAllocator : public ValueAllocator
 {
@@ -61,7 +64,8 @@ public:
         //   return 0;
 
         if (length == unknown)
-            length = value ? static_cast<unsigned int>(strlen(value)) : 0;
+            length =
+                value ? ripple::unsafe_cast<unsigned int>(strlen(value)) : 0;
 
         char* newString = static_cast<char*>(malloc(length + 1));
         if (value)
@@ -239,7 +243,7 @@ Value::Value(const char* value) : type_(stringValue), allocated_(true)
 Value::Value(std::string const& value) : type_(stringValue), allocated_(true)
 {
     value_.string_ = valueAllocator()->duplicateStringValue(
-        value.c_str(), static_cast<unsigned int>(value.length()));
+        value.c_str(), ripple::unsafe_cast<unsigned int>(value.length()));
 }
 
 Value::Value(const StaticString& value) : type_(stringValue), allocated_(false)
@@ -404,7 +408,7 @@ operator<(const Value& x, const Value& y)
 
         case arrayValue:
         case objectValue: {
-            if (int signum = static_cast<int>(x.value_.map_->size()) -
+            if (int signum = ripple::unsafe_cast<int>(x.value_.map_->size()) -
                     y.value_.map_->size())
                 return signum < 0;
 
@@ -518,7 +522,7 @@ Value::asInt() const
 
         case uintValue:
             JSON_ASSERT_MESSAGE(
-                value_.uint_ < static_cast<unsigned>(maxInt),
+                value_.uint_ < ripple::unsafe_cast<unsigned>(maxInt),
                 "integer out of signed integer range");
             return value_.uint_;
 
@@ -670,7 +674,7 @@ Value::isConvertibleTo(ValueType other) const
         case uintValue:
             return (other == nullValue && value_.uint_ == 0) ||
                 (other == intValue &&
-                 value_.uint_ <= static_cast<unsigned int>(maxInt)) ||
+                 value_.uint_ <= ripple::unsafe_cast<unsigned int>(maxInt)) ||
                 other == uintValue || other == realValue ||
                 other == stringValue || other == booleanValue;
 
@@ -733,7 +737,7 @@ Value::size() const
             return 0;
 
         case objectValue:
-            return static_cast<Int>(value_.map_->size());
+            return ripple::unsafe_cast<Int>(value_.map_->size());
 
         default:
             UNREACHABLE("Json::Value::size : invalid type");

--- a/src/libxrpl/json/json_valueiterator.cpp
+++ b/src/libxrpl/json/json_valueiterator.cpp
@@ -19,6 +19,7 @@
 
 // included by json_value.cpp
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/json/json_forwards.h>
 #include <xrpl/json/json_value.h>
 
@@ -129,7 +130,7 @@ ValueIteratorBase::index() const
     if (!czstring.c_str())
         return czstring.index();
 
-    return static_cast<Value::UInt>(-1);
+    return ripple::unsafe_cast<Value::UInt>(-1);
 }
 
 const char*

--- a/src/libxrpl/json/json_writer.cpp
+++ b/src/libxrpl/json/json_writer.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/json/json_forwards.h>
 #include <xrpl/json/json_value.h>
@@ -71,7 +72,7 @@ valueToString(Int value)
     if (isNegative)
         value = -value;
 
-    uintToString(static_cast<UInt>(value), current);
+    uintToString(ripple::unsafe_cast<UInt>(value), current);
 
     if (isNegative)
         *--current = '-';
@@ -176,7 +177,7 @@ valueToQuotedString(const char* value)
                     std::ostringstream oss;
                     oss << "\\u" << std::hex << std::uppercase
                         << std::setfill('0') << std::setw(4)
-                        << static_cast<int>(*c);
+                        << ripple::safe_cast<int>(*c);
                     result += oss.str();
                 }
                 else
@@ -439,7 +440,8 @@ StyledWriter::isMultineArray(const Value& value)
         for (int index = 0; index < size; ++index)
         {
             writeValue(value[index]);
-            lineLength += static_cast<int>(childValues_[index].length());
+            lineLength +=
+                ripple::unsafe_cast<int>(childValues_[index].length());
         }
 
         addChildValues_ = false;
@@ -665,7 +667,8 @@ StyledStreamWriter::isMultineArray(const Value& value)
         for (int index = 0; index < size; ++index)
         {
             writeValue(value[index]);
-            lineLength += static_cast<int>(childValues_[index].length());
+            lineLength +=
+                ripple::unsafe_cast<int>(childValues_[index].length());
         }
 
         addChildValues_ = false;

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/core/LexicalCast.h>
 #include <xrpl/beast/core/SemanticVersion.h>
 #include <xrpl/protocol/BuildInfo.h>
@@ -143,7 +144,7 @@ encodeSoftwareVersion(char const* const versionStr)
 
                 if (x & 0xC0)
                 {
-                    c |= static_cast<std::uint64_t>(x) << 16;
+                    c |= safe_cast<std::uint64_t>(x) << 16;
                     break;
                 }
             }

--- a/src/libxrpl/protocol/IOUAmount.cpp
+++ b/src/libxrpl/protocol/IOUAmount.cpp
@@ -20,6 +20,7 @@
 #include <xrpl/basics/LocalValue.h>
 #include <xrpl/basics/Number.h>
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/Zero.h>
 #include <xrpl/protocol/IOUAmount.h>
 #include <boost/multiprecision/cpp_int.hpp>
@@ -229,7 +230,7 @@ mulRatio(
         // Find the index of the first element >= the requested element, the
         // index is the log of the element in the log table.
         auto const l = std::ranges::lower_bound(powerTable, v);
-        return static_cast<int>(std::distance(powerTable.begin(), l));
+        return unsafe_cast<int>(std::distance(powerTable.begin(), l));
     };
 
     static auto const fl64 =

--- a/src/libxrpl/protocol/Rate2.cpp
+++ b/src/libxrpl/protocol/Rate2.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/protocol/Asset.h>
 #include <xrpl/protocol/Issue.h>
@@ -43,7 +44,7 @@ namespace nft {
 Rate
 transferFeeAsRate(std::uint16_t fee)
 {
-    return Rate{static_cast<std::uint32_t>(fee) * 10000};
+    return Rate{safe_cast<std::uint32_t>(fee) * 10000};
 }
 
 }  // namespace nft

--- a/src/libxrpl/protocol/STAmount.cpp
+++ b/src/libxrpl/protocol/STAmount.cpp
@@ -101,10 +101,10 @@ getInt64Value(STAmount const& amount, bool valid, const char* error)
     XRPL_ASSERT(
         amount.exponent() == 0, "ripple::getInt64Value : exponent is zero");
 
-    auto ret = static_cast<std::int64_t>(amount.mantissa());
+    auto ret = unsafe_cast<std::int64_t>(amount.mantissa());
 
     XRPL_ASSERT(
-        static_cast<std::uint64_t>(ret) == amount.mantissa(),
+        unsafe_cast<std::uint64_t>(ret) == amount.mantissa(),
         "ripple::getInt64Value : mantissa must roundtrip");
 
     if (amount.negative())
@@ -186,7 +186,7 @@ STAmount::STAmount(SerialIter& sit, SField const& name) : STBase(name)
         Throw<std::runtime_error>("invalid native account");
 
     // 10 bits for the offset, sign and "not native" flag
-    int offset = static_cast<int>(value >> (64 - 10));
+    int offset = unsafe_cast<int>(value >> (64 - 10));
 
     value &= ~(1023ull << (64 - 10));
 
@@ -306,7 +306,7 @@ STAmount::xrp() const
         Throw<std::logic_error>(
             "Cannot return non-native STAmount as XRPAmount");
 
-    auto drops = static_cast<XRPAmount::value_type>(mValue);
+    auto drops = unsafe_cast<XRPAmount::value_type>(mValue);
 
     if (mIsNegative)
         drops = -drops;
@@ -320,7 +320,7 @@ STAmount::iou() const
     if (native() || !holds<Issue>())
         Throw<std::logic_error>("Cannot return non-IOU STAmount as IOUAmount");
 
-    auto mantissa = static_cast<std::int64_t>(mValue);
+    auto mantissa = unsafe_cast<std::int64_t>(mValue);
     auto exponent = mOffset;
 
     if (mIsNegative)
@@ -335,7 +335,7 @@ STAmount::mpt() const
     if (!holds<MPTIssue>())
         Throw<std::logic_error>("Cannot return STAmount as MPTAmount");
 
-    auto value = static_cast<MPTAmount::value_type>(mValue);
+    auto value = unsafe_cast<MPTAmount::value_type>(mValue);
 
     if (mIsNegative)
         value = -value;
@@ -352,9 +352,9 @@ STAmount::operator=(IOUAmount const& iou)
     mOffset = iou.exponent();
     mIsNegative = iou < beast::zero;
     if (mIsNegative)
-        mValue = static_cast<std::uint64_t>(-iou.mantissa());
+        mValue = unsafe_cast<std::uint64_t>(-iou.mantissa());
     else
-        mValue = static_cast<std::uint64_t>(iou.mantissa());
+        mValue = unsafe_cast<std::uint64_t>(iou.mantissa());
     return *this;
 }
 
@@ -411,8 +411,8 @@ operator+(STAmount const& v1, STAmount const& v2)
     }
 
     int ov1 = v1.exponent(), ov2 = v2.exponent();
-    std::int64_t vv1 = static_cast<std::int64_t>(v1.mantissa());
-    std::int64_t vv2 = static_cast<std::int64_t>(v2.mantissa());
+    std::int64_t vv1 = unsafe_cast<std::int64_t>(v1.mantissa());
+    std::int64_t vv2 = unsafe_cast<std::int64_t>(v2.mantissa());
 
     if (v1.negative())
         vv1 = -vv1;
@@ -444,12 +444,12 @@ operator+(STAmount const& v1, STAmount const& v2)
         return STAmount{
             v1.getFName(),
             v1.asset(),
-            static_cast<std::uint64_t>(fv),
+            unsafe_cast<std::uint64_t>(fv),
             ov1,
             false};
 
     return STAmount{
-        v1.getFName(), v1.asset(), static_cast<std::uint64_t>(-fv), ov1, true};
+        v1.getFName(), v1.asset(), unsafe_cast<std::uint64_t>(-fv), ov1, true};
 }
 
 STAmount
@@ -652,9 +652,9 @@ STAmount::add(Serializer& s) const
     }
     else if (mAsset.holds<MPTIssue>())
     {
-        auto u8 = static_cast<unsigned char>(cMPToken >> 56);
+        auto u8 = unsafe_cast<unsigned char>(cMPToken >> 56);
         if (!mIsNegative)
-            u8 |= static_cast<unsigned char>(cPositive >> 56);
+            u8 |= unsafe_cast<unsigned char>(cPositive >> 56);
         s.add8(u8);
         s.add64(mValue);
         s.addBitString(mAsset.get<MPTIssue>().getMptID());
@@ -837,12 +837,12 @@ STAmount::set(std::int64_t v)
     if (v < 0)
     {
         mIsNegative = true;
-        mValue = static_cast<std::uint64_t>(-v);
+        mValue = unsafe_cast<std::uint64_t>(-v);
     }
     else
     {
         mIsNegative = false;
-        mValue = static_cast<std::uint64_t>(v);
+        mValue = unsafe_cast<std::uint64_t>(v);
     }
 }
 
@@ -855,7 +855,7 @@ amountFromQuality(std::uint64_t rate)
         return STAmount(noIssue());
 
     std::uint64_t mantissa = rate & ~(255ull << (64 - 8));
-    int exponent = static_cast<int>(rate >> (64 - 8)) - 100;
+    int exponent = unsafe_cast<int>(rate >> (64 - 8)) - 100;
 
     return STAmount(noIssue(), mantissa, exponent);
 }
@@ -963,9 +963,9 @@ amountFromJson(SField const& name, Json::Value const& v)
     }
     else if (v.isArray())
     {
-        value = v.get(static_cast<Json::UInt>(0), 0);
-        currencyOrMPTID = v.get(static_cast<Json::UInt>(1), Json::nullValue);
-        issuer = v.get(static_cast<Json::UInt>(2), Json::nullValue);
+        value = v.get(unsafe_cast<Json::UInt>(0), 0);
+        currencyOrMPTID = v.get(unsafe_cast<Json::UInt>(1), Json::nullValue);
+        issuer = v.get(unsafe_cast<Json::UInt>(2), Json::nullValue);
     }
     else if (v.isString())
     {

--- a/src/libxrpl/protocol/STLedgerEntry.cpp
+++ b/src/libxrpl/protocol/STLedgerEntry.cpp
@@ -57,7 +57,7 @@ STLedgerEntry::STLedgerEntry(Keylet const& k)
 
     set(format->getSOTemplate());
 
-    setFieldU16(sfLedgerEntryType, static_cast<std::uint16_t>(type_));
+    setFieldU16(sfLedgerEntryType, safe_cast<std::uint16_t>(type_));
 }
 
 STLedgerEntry::STLedgerEntry(SerialIter& sit, uint256 const& index)

--- a/src/libxrpl/protocol/STParsedJSON.cpp
+++ b/src/libxrpl/protocol/STParsedJSON.cpp
@@ -75,7 +75,7 @@ to_unsigned(U2 value)
 {
     if (std::numeric_limits<U1>::max() < value)
         Throw<std::runtime_error>("Value out of range");
-    return static_cast<U1>(value);
+    return unsafe_cast<U1>(value);
 }
 
 static std::string
@@ -246,7 +246,7 @@ parseLeaf(
 
                             ret = detail::make_stvar<STUInt8>(
                                 field,
-                                static_cast<std::uint8_t>(TERtoInt(*ter)));
+                                unsafe_cast<std::uint8_t>(TERtoInt(*ter)));
                         }
                         else
                         {
@@ -270,7 +270,7 @@ parseLeaf(
                     }
 
                     ret = detail::make_stvar<STUInt8>(
-                        field, static_cast<std::uint8_t>(value.asInt()));
+                        field, unsafe_cast<std::uint8_t>(value.asInt()));
                 }
                 else if (value.isUInt())
                 {
@@ -281,7 +281,7 @@ parseLeaf(
                     }
 
                     ret = detail::make_stvar<STUInt8>(
-                        field, static_cast<std::uint8_t>(value.asUInt()));
+                        field, unsafe_cast<std::uint8_t>(value.asUInt()));
                 }
                 else
                 {
@@ -310,7 +310,7 @@ parseLeaf(
                         {
                             ret = detail::make_stvar<STUInt16>(
                                 field,
-                                static_cast<std::uint16_t>(
+                                safe_cast<std::uint16_t>(
                                     TxFormats::getInstance().findTypeByName(
                                         strValue)));
 
@@ -321,7 +321,7 @@ parseLeaf(
                         {
                             ret = detail::make_stvar<STUInt16>(
                                 field,
-                                static_cast<std::uint16_t>(
+                                safe_cast<std::uint16_t>(
                                     LedgerFormats::getInstance().findTypeByName(
                                         strValue)));
 

--- a/src/libxrpl/protocol/Serializer.cpp
+++ b/src/libxrpl/protocol/Serializer.cpp
@@ -41,8 +41,8 @@ int
 Serializer::add16(std::uint16_t i)
 {
     int ret = mData.size();
-    mData.push_back(static_cast<unsigned char>(i >> 8));
-    mData.push_back(static_cast<unsigned char>(i & 0xff));
+    mData.push_back(unsafe_cast<unsigned char>(i >> 8));
+    mData.push_back(unsafe_cast<unsigned char>(i & 0xff));
     return ret;
 }
 
@@ -128,26 +128,26 @@ Serializer::addFieldID(int type, int name)
     if (type < 16)
     {
         if (name < 16)  // common type, common name
-            mData.push_back(static_cast<unsigned char>((type << 4) | name));
+            mData.push_back(unsafe_cast<unsigned char>((type << 4) | name));
         else
         {
             // common type, uncommon name
-            mData.push_back(static_cast<unsigned char>(type << 4));
-            mData.push_back(static_cast<unsigned char>(name));
+            mData.push_back(unsafe_cast<unsigned char>(type << 4));
+            mData.push_back(unsafe_cast<unsigned char>(name));
         }
     }
     else if (name < 16)
     {
         // uncommon type, common name
-        mData.push_back(static_cast<unsigned char>(name));
-        mData.push_back(static_cast<unsigned char>(type));
+        mData.push_back(unsafe_cast<unsigned char>(name));
+        mData.push_back(unsafe_cast<unsigned char>(type));
     }
     else
     {
         // uncommon type, uncommon name
-        mData.push_back(static_cast<unsigned char>(0));
-        mData.push_back(static_cast<unsigned char>(type));
-        mData.push_back(static_cast<unsigned char>(name));
+        mData.push_back(unsafe_cast<unsigned char>(0));
+        mData.push_back(unsafe_cast<unsigned char>(type));
+        mData.push_back(unsafe_cast<unsigned char>(name));
     }
 
     return ret;
@@ -227,22 +227,22 @@ Serializer::addEncoded(int length)
 
     if (length <= 192)
     {
-        bytes[0] = static_cast<unsigned char>(length);
+        bytes[0] = unsafe_cast<unsigned char>(length);
         numBytes = 1;
     }
     else if (length <= 12480)
     {
         length -= 193;
-        bytes[0] = 193 + static_cast<unsigned char>(length >> 8);
-        bytes[1] = static_cast<unsigned char>(length & 0xff);
+        bytes[0] = 193 + unsafe_cast<unsigned char>(length >> 8);
+        bytes[1] = unsafe_cast<unsigned char>(length & 0xff);
         numBytes = 2;
     }
     else if (length <= 918744)
     {
         length -= 12481;
-        bytes[0] = 241 + static_cast<unsigned char>(length >> 16);
-        bytes[1] = static_cast<unsigned char>((length >> 8) & 0xff);
-        bytes[2] = static_cast<unsigned char>(length & 0xff);
+        bytes[0] = 241 + unsafe_cast<unsigned char>(length >> 16);
+        bytes[1] = unsafe_cast<unsigned char>((length >> 8) & 0xff);
+        bytes[2] = unsafe_cast<unsigned char>(length & 0xff);
         numBytes = 3;
     }
     else
@@ -371,8 +371,8 @@ SerialIter::get16()
     p_ += 2;
     used_ += 2;
     remain_ -= 2;
-    return (static_cast<std::uint64_t>(t[0]) << 8) +
-        static_cast<std::uint64_t>(t[1]);
+    return (safe_cast<std::uint64_t>(t[0]) << 8) +
+        safe_cast<std::uint64_t>(t[1]);
 }
 
 std::uint32_t
@@ -384,10 +384,9 @@ SerialIter::get32()
     p_ += 4;
     used_ += 4;
     remain_ -= 4;
-    return (static_cast<std::uint64_t>(t[0]) << 24) +
-        (static_cast<std::uint64_t>(t[1]) << 16) +
-        (static_cast<std::uint64_t>(t[2]) << 8) +
-        static_cast<std::uint64_t>(t[3]);
+    return (safe_cast<std::uint64_t>(t[0]) << 24) +
+        (safe_cast<std::uint64_t>(t[1]) << 16) +
+        (safe_cast<std::uint64_t>(t[2]) << 8) + safe_cast<std::uint64_t>(t[3]);
 }
 
 std::uint64_t
@@ -399,14 +398,13 @@ SerialIter::get64()
     p_ += 8;
     used_ += 8;
     remain_ -= 8;
-    return (static_cast<std::uint64_t>(t[0]) << 56) +
-        (static_cast<std::uint64_t>(t[1]) << 48) +
-        (static_cast<std::uint64_t>(t[2]) << 40) +
-        (static_cast<std::uint64_t>(t[3]) << 32) +
-        (static_cast<std::uint64_t>(t[4]) << 24) +
-        (static_cast<std::uint64_t>(t[5]) << 16) +
-        (static_cast<std::uint64_t>(t[6]) << 8) +
-        static_cast<std::uint64_t>(t[7]);
+    return (safe_cast<std::uint64_t>(t[0]) << 56) +
+        (safe_cast<std::uint64_t>(t[1]) << 48) +
+        (safe_cast<std::uint64_t>(t[2]) << 40) +
+        (safe_cast<std::uint64_t>(t[3]) << 32) +
+        (safe_cast<std::uint64_t>(t[4]) << 24) +
+        (safe_cast<std::uint64_t>(t[5]) << 16) +
+        (safe_cast<std::uint64_t>(t[6]) << 8) + safe_cast<std::uint64_t>(t[7]);
 }
 
 std::int32_t

--- a/src/libxrpl/protocol/TxMeta.cpp
+++ b/src/libxrpl/protocol/TxMeta.cpp
@@ -20,6 +20,7 @@
 #include <xrpl/basics/Blob.h>
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/SField.h>
@@ -92,7 +93,7 @@ TxMeta::TxMeta(
 TxMeta::TxMeta(uint256 const& transactionID, std::uint32_t ledger)
     : mTransactionID(transactionID)
     , mLedger(ledger)
-    , mIndex(static_cast<std::uint32_t>(-1))
+    , mIndex(unsafe_cast<std::uint32_t>(-1))
     , mResult(255)
     , mNodes(sfAffectedNodes)
 {

--- a/src/libxrpl/protocol/XChainAttestations.cpp
+++ b/src/libxrpl/protocol/XChainAttestations.cpp
@@ -20,6 +20,7 @@
 #include <xrpl/basics/Buffer.h>
 #include <xrpl/basics/Slice.h>
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/PublicKey.h>
@@ -111,7 +112,7 @@ AttestationBase::AttestationBase(STObject const& o)
     , sendingAccount{o[sfAccount]}
     , sendingAmount{o[sfAmount]}
     , rewardAccount{o[sfAttestationRewardAccount]}
-    , wasLockingChainSend{static_cast<bool>(o[sfWasLockingChainSend])}
+    , wasLockingChainSend{safe_cast<bool>(o[sfWasLockingChainSend])}
 {
 }
 

--- a/src/libxrpl/protocol/tokens.cpp
+++ b/src/libxrpl/protocol/tokens.cpp
@@ -145,7 +145,7 @@ static constexpr std::array<int, 256> const alphabetReverse = []() {
     for (auto& m : map)
         m = -1;
     for (int i = 0, j = 0; alphabetForward[i] != 0; ++i)
-        map[static_cast<unsigned char>(alphabetForward[i])] = j++;
+        map[unsafe_cast<unsigned char>(alphabetForward[i])] = j++;
     return map;
 }();
 
@@ -353,7 +353,7 @@ decodeBase58Token(std::string const& s, TokenType type)
         return {};
 
     // The type must match.
-    if (type != safe_cast<TokenType>(static_cast<std::uint8_t>(ret[0])))
+    if (type != safe_cast<TokenType>(unsafe_cast<std::uint8_t>(ret[0])))
         return {};
 
     // And the checksum must as well.
@@ -654,7 +654,7 @@ encodeBase58Token(
         return Unexpected(TokenCodecErrc::inputTooSmall);
     }
     // <type (1 byte)><token (input len)><checksum (4 bytes)>
-    buf[0] = static_cast<std::uint8_t>(token_type);
+    buf[0] = safe_cast<std::uint8_t>(token_type);
     // buf[1..=input.len()] = input;
     memcpy(&buf[1], input.data(), input.size());
     size_t const checksum_i = input.size() + 1;
@@ -688,7 +688,7 @@ decodeBase58Token(
         return Unexpected(TokenCodecErrc::inputTooSmall);
 
     // The type must match.
-    if (type != static_cast<TokenType>(static_cast<std::uint8_t>(ret[0])))
+    if (type != safe_cast<TokenType>(safe_cast<std::uint8_t>(ret[0])))
         return Unexpected(TokenCodecErrc::mismatchedTokenType);
 
     // And the checksum must as well.

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -16,6 +16,7 @@
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 //==============================================================================
+
 #include <test/jtx.h>
 #include <test/jtx/AMM.h>
 #include <test/jtx/AMMTest.h>
@@ -25,6 +26,7 @@
 #include <xrpld/app/misc/AMMUtils.h>
 #include <xrpld/app/tx/detail/AMMBid.h>
 #include <xrpl/basics/Number.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/AMMCore.h>
 #include <xrpl/protocol/Feature.h>
 #include <boost/regex.hpp>
@@ -6367,33 +6369,33 @@ private:
                      .sendMaxUsdBIT{usdBIT(50)},             //
                      .sendUsdGH{
                          usdGH,
-                         static_cast<uint64_t>(272'455089820359),
+                         unsafe_cast<uint64_t>(272'455089820359),
                          -12},                   //
                      .failUsdGH = STAmount{0},   //
                      .failUsdGHr = STAmount{0},  //
                      .failUsdBIT{
                          usdBIT,
-                         static_cast<uint64_t>(46'47826086956522),
+                         unsafe_cast<uint64_t>(46'47826086956522),
                          -14},  //
                      .failUsdBITr{
                          usdBIT,
-                         static_cast<uint64_t>(46'47826086956521),
+                         unsafe_cast<uint64_t>(46'47826086956521),
                          -14},  //
                      .goodUsdGH{
                          usdGH,
-                         static_cast<uint64_t>(96'7543114220382),
+                         unsafe_cast<uint64_t>(96'7543114220382),
                          -13},  //
                      .goodUsdGHr{
                          usdGH,
-                         static_cast<uint64_t>(96'7543114222965),
+                         unsafe_cast<uint64_t>(96'7543114222965),
                          -13},  //
                      .goodUsdBIT{
                          usdBIT,
-                         static_cast<uint64_t>(8'464739069120721),
+                         unsafe_cast<uint64_t>(8'464739069120721),
                          -15},  //
                      .goodUsdBITr{
                          usdBIT,
-                         static_cast<uint64_t>(8'464739069098152),
+                         unsafe_cast<uint64_t>(8'464739069098152),
                          -15},                                    //
                      .lpTokenBalance = {28'61817604250837, -14},  //
                      .offer1BtcGH = 0.1,                          //
@@ -6414,11 +6416,11 @@ private:
                      .failUsdBITr{usdBIT, static_cast<uint64_t>(1'111), -3},  //
                      .goodUsdGH{
                          usdGH,
-                         static_cast<uint64_t>(90'04347888284115),
+                         unsafe_cast<uint64_t>(90'04347888284115),
                          -14},  //
                      .goodUsdGHr{
                          usdGH,
-                         static_cast<uint64_t>(90'04347888284201),
+                         unsafe_cast<uint64_t>(90'04347888284201),
                          -14},                                                //
                      .goodUsdBIT{usdBIT, static_cast<uint64_t>(1'111), -3},   //
                      .goodUsdBITr{usdBIT, static_cast<uint64_t>(1'111), -3},  //
@@ -6441,11 +6443,11 @@ private:
                      .failUsdBITr{usdBIT, static_cast<uint64_t>(2), 0},  //
                      .goodUsdGH{
                          usdGH,
-                         static_cast<uint64_t>(52'94379354424079),
+                         unsafe_cast<uint64_t>(52'94379354424079),
                          -14},  //
                      .goodUsdGHr{
                          usdGH,
-                         static_cast<uint64_t>(52'94379354424135),
+                         unsafe_cast<uint64_t>(52'94379354424135),
                          -14},                                           //
                      .goodUsdBIT{usdBIT, static_cast<uint64_t>(2), 0},   //
                      .goodUsdBITr{usdBIT, static_cast<uint64_t>(2), 0},  //
@@ -6469,19 +6471,19 @@ private:
                          usdBIT, static_cast<uint64_t>(5'6432), -4},  //
                      .goodUsdGH{
                          usdGH,
-                         static_cast<uint64_t>(35'44113971506987),
+                         unsafe_cast<uint64_t>(35'44113971506987),
                          -14},  //
                      .goodUsdGHr{
                          usdGH,
-                         static_cast<uint64_t>(35'44113971506987),
+                         unsafe_cast<uint64_t>(35'44113971506987),
                          -14},  //
                      .goodUsdBIT{
                          usdBIT,
-                         static_cast<uint64_t>(2'821579689703915),
+                         unsafe_cast<uint64_t>(2'821579689703915),
                          -15},  //
                      .goodUsdBITr{
                          usdBIT,
-                         static_cast<uint64_t>(2'821579689703954),
+                         unsafe_cast<uint64_t>(2'821579689703954),
                          -15},                //
                      .lpTokenBalance{10, 0},  //
                      .offer1BtcGH = 1e-5,     //
@@ -6502,19 +6504,19 @@ private:
                      .failUsdBITr{usdBIT, static_cast<uint64_t>(11), 0},  //
                      .goodUsdGH{
                          usdGH,
-                         static_cast<uint64_t>(35'44113971506987),
+                         unsafe_cast<uint64_t>(35'44113971506987),
                          -14},  //
                      .goodUsdGHr{
                          usdGH,
-                         static_cast<uint64_t>(35'44113971506987),
+                         unsafe_cast<uint64_t>(35'44113971506987),
                          -14},  //
                      .goodUsdBIT{
                          usdBIT,
-                         static_cast<uint64_t>(2'821579689703915),
+                         unsafe_cast<uint64_t>(2'821579689703915),
                          -15},  //
                      .goodUsdBITr{
                          usdBIT,
-                         static_cast<uint64_t>(2'821579689703954),
+                         unsafe_cast<uint64_t>(2'821579689703954),
                          -15},                //
                      .lpTokenBalance{10, 0},  //
                      .offer1BtcGH = 1e-5,     //
@@ -6535,16 +6537,16 @@ private:
                      .failUsdBITr{usdBIT, static_cast<uint64_t>(55'55), -2},  //
                      .goodUsdGH{
                          usdGH,
-                         static_cast<uint64_t>(90'04347888284113),
+                         unsafe_cast<uint64_t>(90'04347888284113),
                          -14},  //
                      .goodUsdGHr{
                          usdGH,
-                         static_cast<uint64_t>(90'0434788828413),
+                         unsafe_cast<uint64_t>(90'0434788828413),
                          -13},                                                //
                      .goodUsdBIT{usdBIT, static_cast<uint64_t>(55'55), -2},   //
                      .goodUsdBITr{usdBIT, static_cast<uint64_t>(55'55), -2},  //
                      .lpTokenBalance{
-                         static_cast<uint64_t>(70'71067811865475), -14},  //
+                         unsafe_cast<uint64_t>(70'71067811865475), -14},  //
                      .offer1BtcGH = 1e-5,                                 //
                      .offer2BtcGH = 1,                                    //
                      .offer2UsdGH = 1e-5,                                 //
@@ -6559,26 +6561,26 @@ private:
                      .sendUsdGH{usdGH, 100},                        //
                      .failUsdGH{
                          usdGH,
-                         static_cast<uint64_t>(52'94379354424081),
+                         unsafe_cast<uint64_t>(52'94379354424081),
                          -14},  //
                      .failUsdGHr{
                          usdGH,
-                         static_cast<uint64_t>(52'94379354424092),
+                         unsafe_cast<uint64_t>(52'94379354424092),
                          -14},                                             //
                      .failUsdBIT{usdBIT, static_cast<uint64_t>(100), 0},   //
                      .failUsdBITr{usdBIT, static_cast<uint64_t>(100), 0},  //
                      .goodUsdGH{
                          usdGH,
-                         static_cast<uint64_t>(52'94379354424081),
+                         unsafe_cast<uint64_t>(52'94379354424081),
                          -14},  //
                      .goodUsdGHr{
                          usdGH,
-                         static_cast<uint64_t>(52'94379354424092),
+                         unsafe_cast<uint64_t>(52'94379354424092),
                          -14},                                             //
                      .goodUsdBIT{usdBIT, static_cast<uint64_t>(100), 0},   //
                      .goodUsdBITr{usdBIT, static_cast<uint64_t>(100), 0},  //
                      .lpTokenBalance{
-                         static_cast<uint64_t>(70'71067811865475), -14},  //
+                         unsafe_cast<uint64_t>(70'71067811865475), -14},  //
                      .offer1BtcGH = 1e-5,                                 //
                      .offer2BtcGH = 1,                                    //
                      .offer2UsdGH = 1e-5,                                 //
@@ -6598,19 +6600,19 @@ private:
                          usdBIT, static_cast<uint64_t>(282'16), -2},  //
                      .goodUsdGH{
                          usdGH,
-                         static_cast<uint64_t>(35'44113971506987),
+                         unsafe_cast<uint64_t>(35'44113971506987),
                          -14},  //
                      .goodUsdGHr{
                          usdGH,
-                         static_cast<uint64_t>(35'44113971506987),
+                         unsafe_cast<uint64_t>(35'44113971506987),
                          -14},  //
                      .goodUsdBIT{
                          usdBIT,
-                         static_cast<uint64_t>(141'0789844851958),
+                         unsafe_cast<uint64_t>(141'0789844851958),
                          -13},  //
                      .goodUsdBITr{
                          usdBIT,
-                         static_cast<uint64_t>(141'0789844851962),
+                         unsafe_cast<uint64_t>(141'0789844851962),
                          -13},                                 //
                      .lpTokenBalance{70'71067811865475, -14},  //
                      .offer1BtcGH = 1e-5,                      //
@@ -6631,19 +6633,19 @@ private:
                      .failUsdBITr{usdBIT, static_cast<uint64_t>(550), 0},  //
                      .goodUsdGH{
                          usdGH,
-                         static_cast<uint64_t>(35'44113971506987),
+                         unsafe_cast<uint64_t>(35'44113971506987),
                          -14},  //
                      .goodUsdGHr{
                          usdGH,
-                         static_cast<uint64_t>(35'44113971506987),
+                         unsafe_cast<uint64_t>(35'44113971506987),
                          -14},  //
                      .goodUsdBIT{
                          usdBIT,
-                         static_cast<uint64_t>(141'0789844851958),
+                         unsafe_cast<uint64_t>(141'0789844851958),
                          -13},  //
                      .goodUsdBITr{
                          usdBIT,
-                         static_cast<uint64_t>(141'0789844851962),
+                         unsafe_cast<uint64_t>(141'0789844851962),
                          -13},                                 //
                      .lpTokenBalance{70'71067811865475, -14},  //
                      .offer1BtcGH = 1e-5,                      //
@@ -6732,9 +6734,9 @@ private:
 
                     // Include a tiny tolerance for the test cases using
                     //   .goodUsdGH{usdGH,
-                    //   static_cast<uint64_t>(35'44113971506987), -14},
+                    //   unsafe_cast<uint64_t>(35'44113971506987), -14},
                     //   .goodUsdBIT{usdBIT,
-                    //   static_cast<uint64_t>(2'821579689703915), -15},
+                    //   unsafe_cast<uint64_t>(2'821579689703915), -15},
                     // These two values multiply
                     // to 99.99999999999994227040383754105 which gets
                     // internally rounded to 100, due to representation

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -20,6 +20,7 @@
 #include <test/jtx.h>
 #include <xrpld/app/tx/applySteps.h>
 #include <xrpld/ledger/Dir.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/TxFlags.h>
@@ -1154,7 +1155,7 @@ struct Escrow_test : public beast::unit_test::suite
                 cancel_time(env.now() + 500s));
             BEAST_EXPECT(
                 (*env.meta())[sfTransactionResult] ==
-                static_cast<std::uint8_t>(tesSUCCESS));
+                unsafe_cast<std::uint8_t>(tesSUCCESS));
             env.close(5s);
             auto const aa = env.le(keylet::escrow(alice.id(), aseq));
             BEAST_EXPECT(aa);
@@ -1171,7 +1172,7 @@ struct Escrow_test : public beast::unit_test::suite
                 cancel_time(env.now() + 2s));
             BEAST_EXPECT(
                 (*env.meta())[sfTransactionResult] ==
-                static_cast<std::uint8_t>(tesSUCCESS));
+                unsafe_cast<std::uint8_t>(tesSUCCESS));
             env.close(5s);
             auto const bb = env.le(keylet::escrow(bruce.id(), bseq));
             BEAST_EXPECT(bb);
@@ -1189,7 +1190,7 @@ struct Escrow_test : public beast::unit_test::suite
                 BEAST_EXPECT(!env.le(keylet::escrow(alice.id(), aseq)));
                 BEAST_EXPECT(
                     (*env.meta())[sfTransactionResult] ==
-                    static_cast<std::uint8_t>(tesSUCCESS));
+                    unsafe_cast<std::uint8_t>(tesSUCCESS));
 
                 ripple::Dir aod(*env.current(), keylet::ownerDir(alice.id()));
                 BEAST_EXPECT(std::distance(aod.begin(), aod.end()) == 0);
@@ -1208,7 +1209,7 @@ struct Escrow_test : public beast::unit_test::suite
                 BEAST_EXPECT(!env.le(keylet::escrow(bruce.id(), bseq)));
                 BEAST_EXPECT(
                     (*env.meta())[sfTransactionResult] ==
-                    static_cast<std::uint8_t>(tesSUCCESS));
+                    unsafe_cast<std::uint8_t>(tesSUCCESS));
 
                 ripple::Dir bod(*env.current(), keylet::ownerDir(bruce.id()));
                 BEAST_EXPECT(std::distance(bod.begin(), bod.end()) == 0);
@@ -1227,14 +1228,14 @@ struct Escrow_test : public beast::unit_test::suite
             env(escrow(alice, bruce, XRP(1000)), finish_time(env.now() + 1s));
             BEAST_EXPECT(
                 (*env.meta())[sfTransactionResult] ==
-                static_cast<std::uint8_t>(tesSUCCESS));
+                unsafe_cast<std::uint8_t>(tesSUCCESS));
             env.close(5s);
             env(escrow(bruce, carol, XRP(1000)),
                 finish_time(env.now() + 1s),
                 cancel_time(env.now() + 2s));
             BEAST_EXPECT(
                 (*env.meta())[sfTransactionResult] ==
-                static_cast<std::uint8_t>(tesSUCCESS));
+                unsafe_cast<std::uint8_t>(tesSUCCESS));
             env.close(5s);
 
             auto const ab = env.le(keylet::escrow(alice.id(), aseq));

--- a/src/test/app/FeeVote_test.cpp
+++ b/src/test/app/FeeVote_test.cpp
@@ -19,6 +19,7 @@
 
 #include <test/jtx.h>
 #include <xrpl/basics/BasicConfig.h>
+#include <xrpl/basics/safe_cast.h>
 
 namespace ripple {
 namespace test {
@@ -70,13 +71,13 @@ class FeeVote_test : public beast::unit_test::suite
             auto setup = setup_FeeVote(config);
             BEAST_EXPECT(setup.reference_fee == defaultSetup.reference_fee);
             BEAST_EXPECT(
-                setup.account_reserve == static_cast<std::uint32_t>(-1234567));
+                setup.account_reserve == unsafe_cast<std::uint32_t>(-1234567));
             BEAST_EXPECT(
-                setup.owner_reserve == static_cast<std::uint32_t>(-1234));
+                setup.owner_reserve == unsafe_cast<std::uint32_t>(-1234));
         }
         {
             const auto big64 = std::to_string(
-                static_cast<std::uint64_t>(
+                unsafe_cast<std::uint64_t>(
                     std::numeric_limits<XRPAmount::value_type>::max()) +
                 1);
             Section config;

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -25,6 +25,7 @@
 #include <xrpld/ledger/PaymentSandbox.h>
 #include <xrpld/ledger/Sandbox.h>
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/Feature.h>
 
 namespace ripple {
@@ -1103,7 +1104,7 @@ struct Flow_test : public beast::unit_test::suite
                 // 12.55....
                 STAmount{
                     USD.issue(),
-                    static_cast<std::uint64_t>(1255555555555555ull),
+                    safe_cast<std::uint64_t>(1255555555555555ull),
                     -14,
                     false}));
 
@@ -1112,7 +1113,7 @@ struct Flow_test : public beast::unit_test::suite
             // 5.0...
             STAmount{
                 USD.issue(),
-                static_cast<std::uint64_t>(5000000000000000ull),
+                safe_cast<std::uint64_t>(5000000000000000ull),
                 -15,
                 false},
             XRP(1000)));
@@ -1122,7 +1123,7 @@ struct Flow_test : public beast::unit_test::suite
             // .555...
             STAmount{
                 USD.issue(),
-                static_cast<std::uint64_t>(5555555555555555ull),
+                safe_cast<std::uint64_t>(5555555555555555ull),
                 -16,
                 false},
             XRP(10)));
@@ -1132,7 +1133,7 @@ struct Flow_test : public beast::unit_test::suite
             // 4.44....
             STAmount{
                 USD.issue(),
-                static_cast<std::uint64_t>(4444444444444444ull),
+                safe_cast<std::uint64_t>(4444444444444444ull),
                 -15,
                 false},
             XRP(.1)));
@@ -1142,7 +1143,7 @@ struct Flow_test : public beast::unit_test::suite
             // 17
             STAmount{
                 USD.issue(),
-                static_cast<std::uint64_t>(1700000000000000ull),
+                safe_cast<std::uint64_t>(1700000000000000ull),
                 -14,
                 false},
             XRP(.001)));

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -20,6 +20,7 @@
 #include <test/jtx.h>
 #include <test/jtx/PathSet.h>
 #include <test/jtx/WSClient.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Quality.h>
 #include <xrpl/protocol/jss.h>
@@ -1108,7 +1109,7 @@ public:
         // Offer with a bad expiration
         {
             env(offer(alice, USD(1000), XRP(1000)),
-                json(sfExpiration.fieldName, static_cast<std::uint32_t>(0)),
+                json(sfExpiration.fieldName, unsafe_cast<std::uint32_t>(0)),
                 ter(temBAD_EXPIRATION));
             env.require(owners(alice, 1), offers(alice, 0));
         }
@@ -1116,7 +1117,7 @@ public:
         // Offer with a bad offer sequence
         {
             env(offer(alice, USD(1000), XRP(1000)),
-                json(jss::OfferSequence, static_cast<std::uint32_t>(0)),
+                json(jss::OfferSequence, unsafe_cast<std::uint32_t>(0)),
                 ter(temBAD_SEQUENCE));
             env.require(owners(alice, 1), offers(alice, 0));
         }
@@ -3850,7 +3851,7 @@ public:
             BEAST_EXPECT(offer[sfLedgerEntryType] == ltOFFER);
             BEAST_EXPECT(
                 offer[sfTakerGets] ==
-                STAmount(JPY.issue(), static_cast<std::uint64_t>(2230682446713524ul), -12));
+                STAmount(JPY.issue(), safe_cast<std::uint64_t>(2230682446713524ul), -12));
             BEAST_EXPECT(offer[sfTakerPays] == BTC(0.035378));
         }
     }
@@ -3887,24 +3888,24 @@ public:
         env(
             pay(gw1,
                 alice,
-                STAmount{USD.issue(), static_cast<std::uint64_t>(2185410179555600), -14}));
+                STAmount{USD.issue(), unsafe_cast<std::uint64_t>(2185410179555600), -14}));
         env(
             pay(gw2,
                 bob,
-                STAmount{JPY.issue(), static_cast<std::uint64_t>(6351823459548956), -12}));
+                STAmount{JPY.issue(), unsafe_cast<std::uint64_t>(6351823459548956), -12}));
         env.close();
 
         env(offer(
             bob,
-            STAmount{USD.issue(), static_cast<std::uint64_t>(4371257532306000), -17},
-            STAmount{JPY.issue(), static_cast<std::uint64_t>(4573216636606000), -15}));
+            STAmount{USD.issue(), unsafe_cast<std::uint64_t>(4371257532306000), -17},
+            STAmount{JPY.issue(), unsafe_cast<std::uint64_t>(4573216636606000), -15}));
         env.close();
 
         // This offer did not partially cross correctly.
         env(offer(
             alice,
-            STAmount{JPY.issue(), static_cast<std::uint64_t>(2291181510070762), -12},
-            STAmount{USD.issue(), static_cast<std::uint64_t>(2190218999914694), -14}));
+            STAmount{JPY.issue(), unsafe_cast<std::uint64_t>(2291181510070762), -12},
+            STAmount{USD.issue(), unsafe_cast<std::uint64_t>(2190218999914694), -14}));
         env.close();
 
         auto const aliceOffers = offersOnAccount(env, alice);
@@ -3915,10 +3916,10 @@ public:
             BEAST_EXPECT(offer[sfLedgerEntryType] == ltOFFER);
             BEAST_EXPECT(
                 offer[sfTakerGets] ==
-                STAmount(USD.issue(), static_cast<std::uint64_t>(2185847305256635), -14));
+                STAmount(USD.issue(), unsafe_cast<std::uint64_t>(2185847305256635), -14));
             BEAST_EXPECT(
                 offer[sfTakerPays] ==
-                STAmount(JPY.issue(), static_cast<std::uint64_t>(2286608293434156), -12));
+                STAmount(JPY.issue(), unsafe_cast<std::uint64_t>(2286608293434156), -12));
         }
     }
 
@@ -3947,21 +3948,21 @@ public:
         // Place alice's tiny offer in the book first.  Let's see what happens
         // when a reasonable offer crosses it.
         STAmount const alicesCnyOffer{
-            CNY.issue(), static_cast<std::uint64_t>(4926000000000000), -23};
+            CNY.issue(), unsafe_cast<std::uint64_t>(4926000000000000), -23};
 
         env(offer(alice, alicesCnyOffer, drops(1), tfPassive));
         env.close();
 
         // bob places an ordinary offer
         STAmount const bobsCnyStartBalance{
-            CNY.issue(), static_cast<std::uint64_t>(3767479960090235), -15};
+            CNY.issue(), unsafe_cast<std::uint64_t>(3767479960090235), -15};
         env(pay(gw, bob, bobsCnyStartBalance));
         env.close();
 
         env(offer(
             bob,
             drops(203),
-            STAmount{CNY.issue(), static_cast<std::uint64_t>(1000000000000000), -20}));
+            STAmount{CNY.issue(), unsafe_cast<std::uint64_t>(1000000000000000), -20}));
         env.close();
 
         env.require(balance(alice, alicesCnyOffer));

--- a/src/test/app/Oracle_test.cpp
+++ b/src/test/app/Oracle_test.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <test/jtx/Oracle.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/jss.h>
 
 namespace ripple {
@@ -234,25 +235,25 @@ private:
             // Less than the last close time - 300s
             oracle.set(UpdateArg{
                 .series = {{"XRP", "USD", 740, 1}},
-                .lastUpdateTime = static_cast<std::uint32_t>(closeTime() - 301),
+                .lastUpdateTime = unsafe_cast<std::uint32_t>(closeTime() - 301),
                 .err = ter(tecINVALID_UPDATE_TIME)});
             // Greater than last close time + 300s
             oracle.set(UpdateArg{
                 .series = {{"XRP", "USD", 740, 1}},
-                .lastUpdateTime = static_cast<std::uint32_t>(closeTime() + 311),
+                .lastUpdateTime = unsafe_cast<std::uint32_t>(closeTime() + 311),
                 .err = ter(tecINVALID_UPDATE_TIME)});
             oracle.set(UpdateArg{.series = {{"XRP", "USD", 740, 1}}});
             BEAST_EXPECT(oracle.expectLastUpdateTime(
-                static_cast<std::uint32_t>(testStartTime.count() + 450)));
+                unsafe_cast<std::uint32_t>(testStartTime.count() + 450)));
             // Less than the previous lastUpdateTime
             oracle.set(UpdateArg{
                 .series = {{"XRP", "USD", 740, 1}},
-                .lastUpdateTime = static_cast<std::uint32_t>(449),
+                .lastUpdateTime = unsafe_cast<std::uint32_t>(449),
                 .err = ter(tecINVALID_UPDATE_TIME)});
             // Less than the epoch time
             oracle.set(UpdateArg{
                 .series = {{"XRP", "USD", 740, 1}},
-                .lastUpdateTime = static_cast<int>(epoch_offset.count() - 1),
+                .lastUpdateTime = unsafe_cast<int>(epoch_offset.count() - 1),
                 .err = ter(tecINVALID_UPDATE_TIME)});
         }
 

--- a/src/test/app/SetTrust_test.cpp
+++ b/src/test/app/SetTrust_test.cpp
@@ -16,7 +16,9 @@
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 //==============================================================================
+
 #include <test/jtx.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/jss.h>
 
@@ -315,7 +317,7 @@ public:
                 env(trust(
                         alice,
                         gw["USD"](100),
-                        static_cast<std::uint32_t>(badFlag)),
+                        unsafe_cast<std::uint32_t>(badFlag)),
                     ter(temINVALID_FLAG));
         }
 

--- a/src/test/basics/XRPAmount_test.cpp
+++ b/src/test/basics/XRPAmount_test.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/unit_test.h>
 #include <xrpl/protocol/XRPAmount.h>
 
@@ -164,9 +165,9 @@ public:
         BEAST_EXPECT(test < XRPAmount{1000});
         BEAST_EXPECT(test > XRPAmount{100});
 
-        test = static_cast<std::int64_t>(200);
+        test = safe_cast<std::int64_t>(200);
         BEAST_EXPECT(test.drops() == 200);
-        test = static_cast<std::uint32_t>(300);
+        test = unsafe_cast<std::uint32_t>(300);
         BEAST_EXPECT(test.drops() == 300);
 
         test = targetSame;

--- a/src/test/beast/IPEndpointCommon.h
+++ b/src/test/beast/IPEndpointCommon.h
@@ -17,7 +17,11 @@
 */
 //==============================================================================
 
+#ifndef RIPPLE_TEST_BEST_IPENDPOINTCOMMON_H_INCLUDED
+#define RIPPLE_TEST_BEST_IPENDPOINTCOMMON_H_INCLUDED
+
 #include <xrpl/basics/random.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/net/IPEndpoint.h>
 
 namespace beast {
@@ -29,29 +33,29 @@ randomEP(bool v4 = true)
     using namespace ripple;
     auto dv4 = []() -> AddressV4::bytes_type {
         return {
-            {static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX))}};
+            {unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX))}};
     };
     auto dv6 = []() -> AddressV6::bytes_type {
         return {
-            {static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
-             static_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX))}};
+            {unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX)),
+             unsafe_cast<std::uint8_t>(rand_int<int>(1, UINT8_MAX))}};
     };
     return Endpoint{
         v4 ? Address{AddressV4{dv4()}} : Address{AddressV6{dv6()}},
@@ -60,3 +64,5 @@ randomEP(bool v4 = true)
 
 }  // namespace IP
 }  // namespace beast
+
+#endif

--- a/src/test/beast/LexicalCast_test.cpp
+++ b/src/test/beast/LexicalCast_test.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/core/LexicalCast.h>
 #include <xrpl/beast/unit_test.h>
 #include <xrpl/beast/xor_shift_engine.h>
@@ -243,7 +244,7 @@ public:
 
         while (i <= std::numeric_limits<std::int16_t>::max())
         {
-            std::int16_t j = static_cast<std::int16_t>(i);
+            std::int16_t j = ripple::unsafe_cast<std::int16_t>(i);
 
             auto actual = std::to_string(j);
 

--- a/src/test/beast/beast_io_latency_probe_test.cpp
+++ b/src/test/beast/beast_io_latency_probe_test.cpp
@@ -191,9 +191,9 @@ class io_latency_probe_test : public beast::unit_test::suite,
         log << "measured max for timers: " << tt.getMax<milliseconds>()
             << "ms\n";
         expected_probe_count_min =
-            static_cast<size_t>(
+            safe_cast<size_t>(
                 duration_cast<milliseconds>(probe_duration).count()) /
-            static_cast<size_t>(tt.getMean<milliseconds>());
+            safe_cast<size_t>(tt.getMean<milliseconds>());
 #endif
         test_sampler io_probe{interval, get_io_service()};
         io_probe.start();

--- a/src/test/consensus/Consensus_test.cpp
+++ b/src/test/consensus/Consensus_test.cpp
@@ -16,6 +16,7 @@
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 //==============================================================================
+
 #include <test/csf.h>
 #include <test/unit_test/SuiteJournal.h>
 #include <xrpld/consensus/Consensus.h>

--- a/src/test/consensus/DistributedValidatorsSim_test.cpp
+++ b/src/test/consensus/DistributedValidatorsSim_test.cpp
@@ -16,6 +16,7 @@
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 //==============================================================================
+
 #include <test/csf.h>
 #include <xrpl/beast/unit_test.h>
 #include <boost/algorithm/string/classification.hpp>

--- a/src/test/core/SociDB_test.cpp
+++ b/src/test/core/SociDB_test.cpp
@@ -21,6 +21,7 @@
 #include <xrpld/core/SociDB.h>
 #include <xrpl/basics/BasicConfig.h>
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 
@@ -179,7 +180,7 @@ public:
         setupSQLiteConfig(c, getDatabasePath());
         DBConfig sc(c, "SociTestDB");
         std::vector<std::uint64_t> const ubid(
-            {static_cast<std::uint64_t>(
+            {unsafe_cast<std::uint64_t>(
                  std::numeric_limits<std::int64_t>::max()),
              20,
              30});

--- a/src/test/csf/README.md
+++ b/src/test/csf/README.md
@@ -76,7 +76,7 @@ sim.run(1);
 
 // everyone submits their own ID as a TX and relay it to peers
 for (Peer * p : validators)
-    p->submit(Tx(static_cast<std::uint32_t>(p->id)));
+    p->submit(Tx(safe_cast<std::uint32_t>(p->id)));
 
 sim.run(1);
 
@@ -167,7 +167,7 @@ std::cout << (simDur.stop - simDur.start).count() << std::endl;
 ```c++
 // everyone submits their own ID as a TX and relay it to peers
 for (Peer * p : validators)
-    p->submit(Tx(static_cast<std::uint32_t>(p->id)));
+    p->submit(Tx(safe_cast<std::uint32_t>(p->id)));
 ```
 
 In this basic example, we explicitly submit a single transaction to each

--- a/src/test/csf/Sim.h
+++ b/src/test/csf/Sim.h
@@ -28,6 +28,7 @@
 #include <test/csf/Scheduler.h>
 #include <test/csf/SimTime.h>
 #include <test/csf/TrustGraph.h>
+#include <xrpl/basics/safe_cast.h>
 #include <deque>
 #include <iostream>
 #include <random>
@@ -104,7 +105,7 @@ public:
         for (std::size_t i = 0; i < numPeers; ++i)
         {
             peers.emplace_back(
-                PeerID{static_cast<std::uint32_t>(peers.size())},
+                PeerID{unsafe_cast<std::uint32_t>(peers.size())},
                 scheduler,
                 oracle,
                 net,

--- a/src/test/csf/impl/ledgers.cpp
+++ b/src/test/csf/impl/ledgers.cpp
@@ -16,7 +16,9 @@
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 //==============================================================================
+
 #include <test/csf/ledgers.h>
+#include <xrpl/basics/safe_cast.h>
 #include <algorithm>
 
 namespace ripple {
@@ -88,7 +90,7 @@ LedgerOracle::LedgerOracle()
 Ledger::ID
 LedgerOracle::nextID() const
 {
-    return Ledger::ID{static_cast<Ledger::ID::value_type>(instances_.size())};
+    return Ledger::ID{unsafe_cast<Ledger::ID::value_type>(instances_.size())};
 }
 
 Ledger

--- a/src/test/json/json_value_test.cpp
+++ b/src/test/json/json_value_test.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/core/LexicalCast.h>
 #include <xrpl/beast/unit_test.h>
 #include <xrpl/json/json_reader.h>
@@ -640,7 +641,7 @@ struct json_value_test : beast::unit_test::suite
         BEAST_EXPECT(j1["a_small_int"] < a_uint);
 
         json = "{\"overflow\":";
-        json += std::to_string(static_cast<std::uint64_t>(max_uint) + 1);
+        json += std::to_string(safe_cast<std::uint64_t>(max_uint) + 1);
         json += "}";
 
         Json::Value j2;
@@ -649,7 +650,7 @@ struct json_value_test : beast::unit_test::suite
         BEAST_EXPECT(!r2.parse(json, j2));
 
         json = "{\"underflow\":";
-        json += std::to_string(static_cast<std::int64_t>(min_int) - 1);
+        json += std::to_string(safe_cast<std::int64_t>(min_int) - 1);
         json += "}";
 
         Json::Value j3;

--- a/src/test/jtx/TrustedPublisherServer.h
+++ b/src/test/jtx/TrustedPublisherServer.h
@@ -22,6 +22,7 @@
 #include <test/jtx/envconfig.h>
 #include <xrpl/basics/base64.h>
 #include <xrpl/basics/random.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/basics/strHex.h>
 #include <xrpl/protocol/PublicKey.h>
 #include <xrpl/protocol/SecretKey.h>
@@ -630,7 +631,7 @@ private:
                     {
                         std::stringstream body;
                         for (auto i = 0; i < 1024; ++i)
-                            body << static_cast<char>(rand_int<short>(32, 126)),
+                            body << unsafe_cast<char>(rand_int<short>(32, 126)),
                                 res.body() = body.str();
                     }
                 }

--- a/src/test/overlay/compression_test.cpp
+++ b/src/test/overlay/compression_test.cpp
@@ -31,6 +31,7 @@
 #include <xrpld/overlay/detail/ZeroCopyStream.h>
 #include <xrpld/shamap/SHAMapNodeID.h>
 #include <xrpl/basics/random.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/unit_test.h>
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/protocol/HashPrefix.h>
@@ -58,14 +59,14 @@ ledgerHash(LedgerInfo const& info)
     return ripple::sha512Half(
         HashPrefix::ledgerMaster,
         info.seq,
-        static_cast<std::uint64_t>(info.drops.drops()),
+        unsafe_cast<std::uint64_t>(info.drops.drops()),
         info.parentHash,
         info.txHash,
         info.accountHash,
         info.parentCloseTime.time_since_epoch().count(),
         info.closeTime.time_since_epoch().count(),
-        static_cast<std::uint8_t>(info.closeTimeResolution.count()),
-        static_cast<std::uint8_t>(info.closeFlags));
+        unsafe_cast<std::uint8_t>(info.closeTimeResolution.count()),
+        unsafe_cast<std::uint8_t>(info.closeFlags));
 }
 
 class compression_test : public beast::unit_test::suite

--- a/src/test/overlay/reduce_relay_test.cpp
+++ b/src/test/overlay/reduce_relay_test.cpp
@@ -24,6 +24,7 @@
 #include <xrpld/overlay/Squelch.h>
 #include <xrpld/overlay/detail/Handshake.h>
 #include <xrpl/basics/random.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/unit_test.h>
 #include <xrpl/protocol/SecretKey.h>
 #include <xrpl/protocol/messages.h>
@@ -886,11 +887,11 @@ protected:
     {
         auto peers = network_.overlay().getPeers(network_.validator(validator));
         std::cout << msg << " " << "num peers "
-                  << static_cast<int>(network_.overlay().getNumPeers())
+                  << safe_cast<int>(network_.overlay().getNumPeers())
                   << std::endl;
         for (auto& [k, v] : peers)
             std::cout << k << ":"
-                      << static_cast<int>(std::get<reduce_relay::PeerState>(v))
+                      << safe_cast<int>(std::get<reduce_relay::PeerState>(v))
                       << " ";
         std::cout << std::endl;
     }
@@ -1006,10 +1007,10 @@ protected:
                             network_.isSelected(link.peerId());
                 };
                 auto r = rand_int(0, 1000);
-                if (r == static_cast<int>(EventType::LinkDown) ||
-                    r == static_cast<int>(EventType::PeerDisconnected))
+                if (r == unsafe_cast<int>(EventType::LinkDown) ||
+                    r == unsafe_cast<int>(EventType::PeerDisconnected))
                 {
-                    update(static_cast<EventType>(r));
+                    update(unsafe_cast<EventType>(r));
                 }
             }
 

--- a/src/test/overlay/tx_reduce_relay_test.cpp
+++ b/src/test/overlay/tx_reduce_relay_test.cpp
@@ -16,12 +16,14 @@
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 //==============================================================================
+
 #include <test/jtx.h>
 #include <test/jtx/Env.h>
 #include <xrpld/overlay/detail/OverlayImpl.h>
 #include <xrpld/overlay/detail/PeerImp.h>
 #include <xrpld/peerfinder/detail/SlotImp.h>
 #include <xrpl/basics/make_SSLContext.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/unit_test.h>
 
 namespace ripple {
@@ -55,8 +57,8 @@ private:
                             bool success = true) {
                 std::stringstream str("[reduce_relay]");
                 str << "[reduce_relay]\n"
-                    << "tx_enable=" << static_cast<int>(enable) << "\n"
-                    << "tx_metrics=" << static_cast<int>(metrics) << "\n"
+                    << "tx_enable=" << safe_cast<int>(enable) << "\n"
+                    << "tx_metrics=" << safe_cast<int>(metrics) << "\n"
                     << "tx_min_peers=" << min << "\n"
                     << "tx_relay_percentage=" << pct << "\n";
                 Config c;

--- a/src/test/protocol/STObject_test.cpp
+++ b/src/test/protocol/STObject_test.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <test/jtx.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/unit_test.h>
 #include <xrpl/json/json_reader.h>
 #include <xrpl/json/to_string.h>
@@ -135,7 +136,7 @@ public:
             {
                 // Integer values are always parsed as int,
                 // unless they're too big. We want a small uint.
-                jv["CloseResolution"] = static_cast<Json::UInt>(19);
+                jv["CloseResolution"] = unsafe_cast<Json::UInt>(19);
                 STParsedJSONObject parsed("test", jv);
                 if (BEAST_EXPECT(parsed.object))
                 {

--- a/src/test/resource/Logic_test.cpp
+++ b/src/test/resource/Logic_test.cpp
@@ -72,7 +72,7 @@ public:
             Gossip::Item item;
             item.balance = 100 + rand_int(499);
             beast::IP::AddressV4::bytes_type d = {
-                {192, 0, 2, static_cast<std::uint8_t>(v + i)}};
+                {192, 0, 2, unsafe_cast<std::uint8_t>(v + i)}};
             item.address = beast::IP::Endpoint{beast::IP::AddressV4{d}};
             gossip.items.push_back(item);
         }

--- a/src/test/rpc/AccountLines_test.cpp
+++ b/src/test/rpc/AccountLines_test.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <test/jtx.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/unit_test.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/TxFlags.h>
@@ -131,7 +132,7 @@ public:
         {
             // gw1 currencies have names "YAA" -> "YAZ".
             gw1Currencies.push_back(
-                gw1[std::string("YA") + static_cast<char>('A' + c)]);
+                gw1[std::string("YA") + unsafe_cast<char>('A' + c)]);
             IOU const& gw1Currency = gw1Currencies.back();
 
             // Establish trust lines.
@@ -156,7 +157,7 @@ public:
         {
             // gw2 currencies have names "ZAA" -> "ZAZ".
             gw2Currencies.push_back(
-                gw2[std::string("ZA") + static_cast<char>('A' + c)]);
+                gw2[std::string("ZA") + unsafe_cast<char>('A' + c)]);
             IOU const& gw2Currency = gw2Currencies.back();
 
             // Establish trust lines.
@@ -951,7 +952,7 @@ public:
         {
             // gw1 currencies have names "YAA" -> "YAZ".
             gw1Currencies.push_back(
-                gw1[std::string("YA") + static_cast<char>('A' + c)]);
+                gw1[std::string("YA") + unsafe_cast<char>('A' + c)]);
             IOU const& gw1Currency = gw1Currencies.back();
 
             // Establish trust lines.
@@ -976,7 +977,7 @@ public:
         {
             // gw2 currencies have names "ZAA" -> "ZAZ".
             gw2Currencies.push_back(
-                gw2[std::string("ZA") + static_cast<char>('A' + c)]);
+                gw2[std::string("ZA") + unsafe_cast<char>('A' + c)]);
             IOU const& gw2Currency = gw2Currencies.back();
 
             // Establish trust lines.

--- a/src/test/rpc/AccountObjects_test.cpp
+++ b/src/test/rpc/AccountObjects_test.cpp
@@ -21,6 +21,7 @@
 #include <test/jtx/AMM.h>
 #include <test/jtx/xchain_bridge.h>
 #include <xrpld/app/tx/detail/NFTokenMint.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/json/json_reader.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
@@ -1002,7 +1003,7 @@ public:
             }();
 
             std::uint32_t const expectedAccountObjects{
-                static_cast<std::uint32_t>(std::size(expectedLedgerTypes))};
+                unsafe_cast<std::uint32_t>(std::size(expectedLedgerTypes))};
 
             if (BEAST_EXPECT(acctObjsIsSize(resp, expectedAccountObjects)))
             {

--- a/src/test/rpc/AccountSet_test.cpp
+++ b/src/test/rpc/AccountSet_test.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <test/jtx.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/AmountConversions.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Quality.h>

--- a/src/test/rpc/Handler_test.cpp
+++ b/src/test/rpc/Handler_test.cpp
@@ -19,6 +19,7 @@
 
 #include <test/jtx.h>
 #include <xrpld/rpc/detail/Handler.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/unit_test.h>
 #include <chrono>
 #include <iostream>
@@ -107,7 +108,7 @@ class Handler_test : public beast::unit_test::suite
             1'000'000,
             [&](std::size_t i) {
                 auto const d = RPC::getHandler(1, false, names[i]);
-                dummy = dummy + i + static_cast<int>(d->role_);
+                dummy = dummy + i + safe_cast<int>(d->role_);
             },
             [&]() -> std::size_t { return distr(prng); });
 

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -23,6 +23,7 @@
 #include <test/jtx/multisign.h>
 #include <test/jtx/xchain_bridge.h>
 #include <xrpld/app/misc/TxQ.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/unit_test.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/AccountID.h>
@@ -275,12 +276,12 @@ class LedgerRPC_XChain_test : public beast::unit_test::suite,
             auto attest = r[sfXChainCreateAccountAttestations.jsonName];
             BEAST_EXPECT(attest.isArray());
             BEAST_EXPECT(attest.size() == 3);
-            BEAST_EXPECT(attest[static_cast<Json::Value::UInt>(0)].isMember(
+            BEAST_EXPECT(attest[unsafe_cast<Json::Value::UInt>(0)].isMember(
                 sfXChainCreateAccountProofSig.jsonName));
             Json::Value a[num_attest];
             for (size_t i = 0; i < num_attest; ++i)
             {
-                a[i] = attest[static_cast<Json::Value::UInt>(0)]
+                a[i] = attest[unsafe_cast<Json::Value::UInt>(0)]
                              [sfXChainCreateAccountProofSig.jsonName];
                 BEAST_EXPECT(
                     a[i].isMember(jss::Amount) &&

--- a/src/test/rpc/Transaction_test.cpp
+++ b/src/test/rpc/Transaction_test.cpp
@@ -22,6 +22,7 @@
 #include <test/jtx/envconfig.h>
 #include <xrpld/app/rdb/backend/SQLiteDatabase.h>
 #include <xrpld/rpc/CTID.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/STBase.h>
 #include <xrpl/protocol/jss.h>
@@ -572,7 +573,7 @@ class Transaction_test : public beast::unit_test::suite
         auto const expected3 = std::optional<std::string>("CFFFFFFF0000FFFF");
         BEAST_EXPECT(
             RPC::encodeCTID(
-                0x0FFF'FFFF, static_cast<uint16_t>(0x10000), 0xFFFF) ==
+                0x0FFF'FFFF, unsafe_cast<uint16_t>(0x10000), 0xFFFF) ==
             expected3);
 
         // Test case 4: network_id greater than 0xFFFF
@@ -581,7 +582,7 @@ class Transaction_test : public beast::unit_test::suite
         auto const expected4 = std::optional<std::string>("CFFFFFFFFFFF0000");
         BEAST_EXPECT(
             RPC::encodeCTID(
-                0x0FFF'FFFFUL, 0xFFFFU, static_cast<uint16_t>(0x1000'0U)) ==
+                0x0FFF'FFFFUL, 0xFFFFU, unsafe_cast<uint16_t>(0x1000'0U)) ==
             expected4);
 
         // Test case 5: Valid input values

--- a/src/test/shamap/SHAMap_test.cpp
+++ b/src/test/shamap/SHAMap_test.cpp
@@ -22,6 +22,7 @@
 #include <xrpld/shamap/SHAMap.h>
 #include <xrpl/basics/Blob.h>
 #include <xrpl/basics/Buffer.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/unit_test.h>
 #include <xrpl/beast/utility/Journal.h>
 
@@ -110,7 +111,7 @@ public:
     IntToVUC(int v)
     {
         Buffer vuc(32);
-        std::fill_n(vuc.data(), vuc.size(), static_cast<std::uint8_t>(v));
+        std::fill_n(vuc.data(), vuc.size(), unsafe_cast<std::uint8_t>(v));
         return vuc;
     }
 

--- a/src/xrpld/app/consensus/RCLValidations.cpp
+++ b/src/xrpld/app/consensus/RCLValidations.cpp
@@ -28,6 +28,7 @@
 #include <xrpld/perflog/PerfLog.h>
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/chrono.h>
+#include <xrpl/basics/safe_cast.h>
 #include <memory>
 
 namespace ripple {
@@ -59,7 +60,7 @@ RCLValidatedLedger::RCLValidatedLedger(
 auto
 RCLValidatedLedger::minSeq() const -> Seq
 {
-    return seq() - std::min(seq(), static_cast<Seq>(ancestors_.size()));
+    return seq() - std::min(seq(), unsafe_cast<Seq>(ancestors_.size()));
 }
 
 auto

--- a/src/xrpld/app/ledger/Ledger.cpp
+++ b/src/xrpld/app/ledger/Ledger.cpp
@@ -32,6 +32,7 @@
 #include <xrpld/nodestore/detail/DatabaseNodeImp.h>
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/json/to_string.h>
 #include <xrpl/protocol/Feature.h>
@@ -55,14 +56,14 @@ calculateLedgerHash(LedgerInfo const& info)
     return sha512Half(
         HashPrefix::ledgerMaster,
         info.seq,
-        static_cast<std::uint64_t>(info.drops.drops()),
+        unsafe_cast<std::uint64_t>(info.drops.drops()),
         info.parentHash,
         info.txHash,
         info.accountHash,
         info.parentCloseTime.time_since_epoch().count(),
         info.closeTime.time_since_epoch().count(),
-        static_cast<std::uint8_t>(info.closeTimeResolution.count()),
-        static_cast<std::uint8_t>(info.closeFlags));
+        unsafe_cast<std::uint8_t>(info.closeTimeResolution.count()),
+        unsafe_cast<std::uint8_t>(info.closeFlags));
 }
 
 //------------------------------------------------------------------------------

--- a/src/xrpld/app/ledger/OrderBookDB.cpp
+++ b/src/xrpld/app/ledger/OrderBookDB.cpp
@@ -25,6 +25,7 @@
 #include <xrpld/core/Config.h>
 #include <xrpld/core/JobQueue.h>
 #include <xrpl/basics/Log.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/Indexes.h>
 
 namespace ripple {
@@ -203,7 +204,7 @@ OrderBookDB::getBookSize(Issue const& issue)
 {
     std::lock_guard sl(mLock);
     if (auto it = allBooks_.find(issue); it != allBooks_.end())
-        return static_cast<int>(it->second.size());
+        return unsafe_cast<int>(it->second.size());
     return 0;
 }
 

--- a/src/xrpld/app/ledger/detail/InboundLedger.cpp
+++ b/src/xrpld/app/ledger/detail/InboundLedger.cpp
@@ -1308,7 +1308,7 @@ InboundLedger::getJson(int)
         ret[jss::failed] = true;
 
     if (!complete_ && !failed_)
-        ret[jss::peers] = static_cast<int>(mPeerSet->getPeerIds().size());
+        ret[jss::peers] = unsafe_cast<int>(mPeerSet->getPeerIds().size());
 
     ret[jss::have_header] = mHaveHeader;
 

--- a/src/xrpld/app/main/Application.cpp
+++ b/src/xrpld/app/main/Application.cpp
@@ -59,6 +59,7 @@
 #include <xrpl/basics/ByteUtilities.h>
 #include <xrpl/basics/ResolverAsio.h>
 #include <xrpl/basics/random.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/asio/io_latency_probe.h>
 #include <xrpl/beast/core/LexicalCast.h>
 #include <xrpl/crypto/csprng.h>
@@ -298,7 +299,7 @@ public:
                       return config->WORKERS;
 
                   auto count =
-                      static_cast<int>(std::thread::hardware_concurrency());
+                      unsafe_cast<int>(std::thread::hardware_concurrency());
 
                   // Be more aggressive about the number of threads to use
                   // for the job queue if the server is configured as "large"

--- a/src/xrpld/app/main/GRPCServer.cpp
+++ b/src/xrpld/app/main/GRPCServer.cpp
@@ -19,6 +19,7 @@
 
 #include <xrpld/app/main/GRPCServer.h>
 #include <xrpld/core/ConfigSections.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/core/CurrentThreadName.h>
 #include <xrpl/beast/net/IPAddressConversion.h>
 #include <xrpl/resource/Fees.h>
@@ -158,7 +159,7 @@ GRPCServerImpl::CallData<Request, Response>::process(
 
             {
                 std::stringstream toLog;
-                toLog << "role = " << static_cast<int>(role);
+                toLog << "role = " << safe_cast<int>(role);
 
                 toLog << " address = ";
                 if (auto clientIp = getClientIpAddress())
@@ -575,9 +576,9 @@ GRPCServerImpl::start()
     cq_ = builder.AddCompletionQueue();
     // Finally assemble the server.
     server_ = builder.BuildAndStart();
-    serverPort_ = static_cast<std::uint16_t>(port);
+    serverPort_ = unsafe_cast<std::uint16_t>(port);
 
-    return static_cast<bool>(serverPort_);
+    return unsafe_cast<bool>(serverPort_);
 }
 
 boost::asio::ip::tcp::endpoint

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -1983,7 +1983,7 @@ NetworkOPsImp::pubManifest(Manifest const& mo)
         if (mo.signingKey)
             jvObj[jss::signing_key] =
                 toBase58(TokenType::NodePublic, *mo.signingKey);
-        jvObj[jss::seq] = static_cast<Json::UInt>(mo.sequence);
+        jvObj[jss::seq] = safe_cast<Json::UInt>(mo.sequence);
         if (auto sig = mo.getSignature())
             jvObj[jss::signature] = strHex(*sig);
         jvObj[jss::master_signature] = strHex(mo.getMasterSignature());
@@ -2440,7 +2440,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
         info[jss::network_ledger] = "waiting";
 
     info[jss::validation_quorum] =
-        static_cast<Json::UInt>(app_.validators().quorum());
+        unsafe_cast<Json::UInt>(app_.validators().quorum());
 
     if (admin)
     {
@@ -2469,7 +2469,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
         {
             if (when)
                 info[jss::validator_list_expires] =
-                    safe_cast<Json::UInt>(when->time_since_epoch().count());
+                    static_cast<Json::UInt>(when->time_since_epoch().count());
             else
                 info[jss::validator_list_expires] = 0;
         }
@@ -2553,13 +2553,13 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
     auto const fp = m_ledgerMaster.getFetchPackCacheSize();
 
     if (fp != 0)
-        info[jss::fetch_pack] = static_cast<Json::UInt>(fp);
+        info[jss::fetch_pack] = unsafe_cast<Json::UInt>(fp);
 
-    info[jss::peers] = static_cast<Json::UInt>(app_.overlay().size());
+    info[jss::peers] = unsafe_cast<Json::UInt>(app_.overlay().size());
 
     Json::Value lastClose = Json::objectValue;
     lastClose[jss::proposers] =
-        static_cast<Json::UInt>(mConsensus.prevProposers());
+        unsafe_cast<Json::UInt>(mConsensus.prevProposers());
 
     if (human)
     {
@@ -2569,7 +2569,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
     else
     {
         lastClose[jss::converge_time] =
-            static_cast<Json::Int>(mConsensus.prevRoundTime().count());
+            unsafe_cast<Json::Int>(mConsensus.prevRoundTime().count());
     }
 
     info[jss::last_close] = lastClose;
@@ -2580,7 +2580,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
         info[jss::load] = m_job_queue.getJson();
 
     if (auto const netid = app_.overlay().networkID())
-        info[jss::network_id] = static_cast<Json::UInt>(*netid);
+        info[jss::network_id] = safe_cast<Json::UInt>(*netid);
 
     auto const escalationMetrics =
         app_.getTxQ().getMetrics(*app_.openLedger().current());
@@ -2667,7 +2667,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
     {
         XRPAmount const baseFee = lpClosed->fees().base;
         Json::Value l(Json::objectValue);
-        l[jss::seq] = static_cast<Json::UInt>(lpClosed->info().seq);
+        l[jss::seq] = safe_cast<Json::UInt>(lpClosed->info().seq);
         l[jss::hash] = to_string(lpClosed->info().hash);
 
         if (!human)
@@ -2676,7 +2676,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
             l[jss::reserve_base] =
                 lpClosed->fees().accountReserve(0).jsonClipped();
             l[jss::reserve_inc] = lpClosed->fees().increment.jsonClipped();
-            l[jss::close_time] = static_cast<Json::Value::UInt>(
+            l[jss::close_time] = safe_cast<Json::Value::UInt>(
                 lpClosed->info().closeTime.time_since_epoch().count());
         }
         else
@@ -2689,13 +2689,13 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
             if (auto const closeOffset = app_.timeKeeper().closeOffset();
                 std::abs(closeOffset.count()) >= 60)
                 l[jss::close_time_offset] =
-                    static_cast<std::uint32_t>(closeOffset.count());
+                    unsafe_cast<std::uint32_t>(closeOffset.count());
 
             constexpr std::chrono::seconds highAgeThreshold{1000000};
             if (m_ledgerMaster.haveValidated())
             {
                 auto const age = m_ledgerMaster.getValidatedLedgerAge();
-                l[jss::age] = static_cast<Json::UInt>(
+                l[jss::age] = unsafe_cast<Json::UInt>(
                     age < highAgeThreshold ? age.count() : 0);
             }
             else
@@ -2706,7 +2706,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
                 {
                     using namespace std::chrono_literals;
                     auto age = closeTime - lCloseTime;
-                    l[jss::age] = static_cast<Json::UInt>(
+                    l[jss::age] = safe_cast<Json::UInt>(
                         age < highAgeThreshold ? age.count() : 0);
                 }
             }
@@ -2860,7 +2860,7 @@ NetworkOPsImp::pubLedger(std::shared_ptr<ReadView const> const& lpAccepted)
             jvObj[jss::type] = "ledgerClosed";
             jvObj[jss::ledger_index] = lpAccepted->info().seq;
             jvObj[jss::ledger_hash] = to_string(lpAccepted->info().hash);
-            jvObj[jss::ledger_time] = static_cast<Json::Value::UInt>(
+            jvObj[jss::ledger_time] = safe_cast<Json::Value::UInt>(
                 lpAccepted->info().closeTime.time_since_epoch().count());
 
             if (!lpAccepted->rules().enabled(featureXRPFees))
@@ -2872,7 +2872,7 @@ NetworkOPsImp::pubLedger(std::shared_ptr<ReadView const> const& lpAccepted)
                 lpAccepted->fees().increment.jsonClipped();
 
             jvObj[jss::txn_count] =
-                static_cast<Json::UInt>(alpAccepted->size());
+                unsafe_cast<Json::UInt>(alpAccepted->size());
 
             if (mMode >= OperatingMode::SYNCING)
             {
@@ -3899,7 +3899,7 @@ NetworkOPsImp::subLedger(InfoSub::ref isrListener, Json::Value& jvResult)
     {
         jvResult[jss::ledger_index] = lpClosed->info().seq;
         jvResult[jss::ledger_hash] = to_string(lpClosed->info().hash);
-        jvResult[jss::ledger_time] = static_cast<Json::Value::UInt>(
+        jvResult[jss::ledger_time] = safe_cast<Json::Value::UInt>(
             lpClosed->info().closeTime.time_since_epoch().count());
         if (!lpClosed->rules().enabled(featureXRPFees))
             jvResult[jss::fee_ref] = Config::FEE_UNITS_DEPRECATED;

--- a/src/xrpld/app/misc/detail/AmendmentTable.cpp
+++ b/src/xrpld/app/misc/detail/AmendmentTable.cpp
@@ -318,13 +318,13 @@ private:
         threshold_ = !rules_.enabled(fixAmendmentMajorityCalc)
             ? std::max(
                   1L,
-                  static_cast<long>(
+                  safe_cast<long>(
                       (trustedValidations_ *
                        preFixAmendmentMajorityCalcThreshold.num) /
                       preFixAmendmentMajorityCalcThreshold.den))
             : std::max(
                   1L,
-                  static_cast<long>(
+                  safe_cast<long>(
                       (trustedValidations_ *
                        postFixAmendmentMajorityCalcThreshold.num) /
                       postFixAmendmentMajorityCalcThreshold.den));

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -25,6 +25,7 @@
 #include <xrpl/basics/Slice.h>
 #include <xrpl/basics/StringUtilities.h>
 #include <xrpl/basics/base64.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/json/json_reader.h>
 #include <xrpl/protocol/PublicKey.h>
 #include <xrpl/protocol/STValidation.h>
@@ -1619,7 +1620,7 @@ ValidatorList::getJson() const
     {
         auto& x = (res[jss::validator_list] = Json::objectValue);
 
-        x[jss::count] = static_cast<Json::UInt>(count(read_lock));
+        x[jss::count] = unsafe_cast<Json::UInt>(count(read_lock));
 
         if (auto when = expires(read_lock))
         {
@@ -1645,7 +1646,7 @@ ValidatorList::getJson() const
         }
 
         x[jss::validator_list_threshold] =
-            static_cast<Json::UInt>(listThreshold_);
+            unsafe_cast<Json::UInt>(listThreshold_);
     }
 
     // Validator keys listed in the local config file
@@ -1671,7 +1672,7 @@ ValidatorList::getJson() const
             if (publisherList.validUntil != TimeKeeper::time_point{})
             {
                 target[jss::seq] =
-                    static_cast<Json::UInt>(publisherList.sequence);
+                    unsafe_cast<Json::UInt>(publisherList.sequence);
                 target[jss::expiration] = to_string(publisherList.validUntil);
             }
             if (publisherList.validFrom != TimeKeeper::time_point{})

--- a/src/xrpld/app/misc/detail/ValidatorSite.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorSite.cpp
@@ -22,6 +22,7 @@
 #include <xrpld/app/misc/detail/WorkFile.h>
 #include <xrpld/app/misc/detail/WorkPlain.h>
 #include <xrpld/app/misc/detail/WorkSSL.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/json/json_reader.h>
 #include <xrpl/protocol/digest.h>
 #include <xrpl/protocol/jss.h>
@@ -696,7 +697,7 @@ ValidatorSite::getJson() const
                         site.lastRefreshStatus->message;
             }
             v[jss::refresh_interval_min] =
-                static_cast<Int>(site.refreshInterval.count());
+                unsafe_cast<Int>(site.refreshInterval.count());
         }
     }
     return jrr;

--- a/src/xrpld/app/rdb/RelationalDatabase.h
+++ b/src/xrpld/app/rdb/RelationalDatabase.h
@@ -26,6 +26,7 @@
 #include <xrpld/core/Config.h>
 #include <xrpld/core/DatabaseCon.h>
 #include <xrpld/rpc/detail/RPCHelpers.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <boost/filesystem.hpp>
 #include <boost/variant.hpp>
@@ -241,7 +242,7 @@ rangeCheckedCast(C c)
             << " max: " << std::numeric_limits<T>::max();
     }
 
-    return static_cast<T>(c);
+    return unsafe_cast<T>(c);
 }
 
 }  // namespace ripple

--- a/src/xrpld/app/rdb/detail/Wallet.cpp
+++ b/src/xrpld/app/rdb/detail/Wallet.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <xrpld/app/rdb/Wallet.h>
+#include <xrpl/basics/safe_cast.h>
 #include <boost/format.hpp>
 
 namespace ripple {
@@ -234,7 +235,7 @@ createFeatureVotes(soci::session& session)
     // SOCI requires boost::optional (not std::optional) as the parameter.
     boost::optional<int> featureVotesCount;
     session << sql, soci::into(featureVotesCount);
-    bool exists = static_cast<bool>(*featureVotesCount);
+    bool exists = unsafe_cast<bool>(*featureVotesCount);
 
     // Create FeatureVotes table in WalletDB if it doesn't exist
     if (!exists)

--- a/src/xrpld/app/tx/detail/Change.cpp
+++ b/src/xrpld/app/tx/detail/Change.cpp
@@ -24,6 +24,7 @@
 #include <xrpld/app/tx/detail/Change.h>
 #include <xrpld/ledger/Sandbox.h>
 #include <xrpl/basics/Log.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/TxFlags.h>
@@ -178,7 +179,7 @@ Change::activateTrustLinesToSelfFix()
         if (tl->getType() != ltRIPPLE_STATE)
         {
             JLOG(j_.warn()) << id << ": Unexpected type "
-                            << static_cast<std::uint16_t>(tl->getType());
+                            << safe_cast<std::uint16_t>(tl->getType());
             return true;
         }
 

--- a/src/xrpld/app/tx/detail/DepositPreauth.cpp
+++ b/src/xrpld/app/tx/detail/DepositPreauth.cpp
@@ -21,6 +21,7 @@
 #include <xrpld/app/tx/detail/DepositPreauth.h>
 #include <xrpld/ledger/View.h>
 #include <xrpl/basics/Log.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/TxFlags.h>
@@ -38,7 +39,7 @@ DepositPreauth::preflight(PreflightContext const& ctx)
     bool const unauthArrPresent =
         ctx.tx.isFieldPresent(sfUnauthorizeCredentials);
     int const authCredPresent =
-        static_cast<int>(authArrPresent) + static_cast<int>(unauthArrPresent);
+        safe_cast<int>(authArrPresent) + safe_cast<int>(unauthArrPresent);
 
     if (authCredPresent && !ctx.rules.enabled(featureCredentials))
         return temDISABLED;
@@ -56,8 +57,8 @@ DepositPreauth::preflight(PreflightContext const& ctx)
 
     auto const optAuth = ctx.tx[~sfAuthorize];
     auto const optUnauth = ctx.tx[~sfUnauthorize];
-    int const authPresent = static_cast<int>(optAuth.has_value()) +
-        static_cast<int>(optUnauth.has_value());
+    int const authPresent = safe_cast<int>(optAuth.has_value()) +
+        safe_cast<int>(optUnauth.has_value());
 
     if (authPresent + authCredPresent != 1)
     {

--- a/src/xrpld/app/tx/detail/NFTokenMint.cpp
+++ b/src/xrpld/app/tx/detail/NFTokenMint.cpp
@@ -20,6 +20,7 @@
 #include <xrpld/app/tx/detail/NFTokenMint.h>
 #include <xrpld/ledger/View.h>
 #include <xrpl/basics/Expected.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/InnerObjectFormats.h>
 #include <xrpl/protocol/Rate.h>
@@ -32,7 +33,7 @@ namespace ripple {
 static std::uint16_t
 extractNFTokenFlagsFromTxFlags(std::uint32_t txFlags)
 {
-    return static_cast<std::uint16_t>(txFlags & 0x0000FFFF);
+    return unsafe_cast<std::uint16_t>(txFlags & 0x0000FFFF);
 }
 
 NotTEC

--- a/src/xrpld/app/tx/detail/SetSignerList.cpp
+++ b/src/xrpld/app/tx/detail/SetSignerList.cpp
@@ -21,6 +21,7 @@
 #include <xrpld/app/tx/detail/SetSignerList.h>
 #include <xrpld/ledger/ApplyView.h>
 #include <xrpl/basics/Log.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/STArray.h>
@@ -179,7 +180,7 @@ signerCountBasedOwnerCountDelta(std::size_t entryCount, Rules const& rules)
     // So, at a minimum, adding a SignerList with 1 entry costs 3 OwnerCount
     // units.  A SignerList with 8 entries would cost 10 OwnerCount units.
     //
-    // The static_cast should always be safe since entryCount should always
+    // The safe_cast should always be safe since entryCount should always
     // be in the range from 1 to 8 (or 32 if ExpandedSignerList is enabled).
     // We've got a lot of room to grow.
     XRPL_ASSERT(
@@ -188,7 +189,7 @@ signerCountBasedOwnerCountDelta(std::size_t entryCount, Rules const& rules)
     XRPL_ASSERT(
         entryCount <= STTx::maxMultiSigners(&rules),
         "ripple::signerCountBasedOwnerCountDelta : maximum signers");
-    return 2 + static_cast<int>(entryCount);
+    return 2 + unsafe_cast<int>(entryCount);
 }
 
 static TER

--- a/src/xrpld/conditions/detail/PreimageSha256.h
+++ b/src/xrpld/conditions/detail/PreimageSha256.h
@@ -25,6 +25,7 @@
 #include <xrpld/conditions/detail/error.h>
 #include <xrpl/basics/Buffer.h>
 #include <xrpl/basics/Slice.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/digest.h>
 #include <memory>
 
@@ -128,7 +129,7 @@ public:
     std::uint32_t
     cost() const override
     {
-        return static_cast<std::uint32_t>(payload_.size());
+        return unsafe_cast<std::uint32_t>(payload_.size());
     }
 
     Condition

--- a/src/xrpld/consensus/Consensus.h
+++ b/src/xrpld/consensus/Consensus.h
@@ -27,6 +27,7 @@
 #include <xrpld/consensus/LedgerTiming.h>
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/chrono.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/json/json_writer.h>
 #include <chrono>
@@ -917,14 +918,14 @@ Consensus<Adaptor>::getJson(bool full) const
     Json::Value ret(Json::objectValue);
 
     ret["proposing"] = (mode_.get() == ConsensusMode::proposing);
-    ret["proposers"] = static_cast<int>(currPeerPositions_.size());
+    ret["proposers"] = unsafe_cast<int>(currPeerPositions_.size());
 
     if (mode_.get() != ConsensusMode::wrongLedger)
     {
         ret["synched"] = true;
         ret["ledger_seq"] =
             static_cast<std::uint32_t>(previousLedger_.seq()) + 1;
-        ret["close_granularity"] = static_cast<Int>(closeResolution_.count());
+        ret["close_granularity"] = unsafe_cast<Int>(closeResolution_.count());
     }
     else
         ret["synched"] = false;
@@ -932,7 +933,7 @@ Consensus<Adaptor>::getJson(bool full) const
     ret["phase"] = to_string(phase_);
 
     if (result_ && !result_->disputes.empty() && !full)
-        ret["disputes"] = static_cast<Int>(result_->disputes.size());
+        ret["disputes"] = unsafe_cast<Int>(result_->disputes.size());
 
     if (result_)
         ret["our_position"] = result_->position.getJson();
@@ -941,12 +942,12 @@ Consensus<Adaptor>::getJson(bool full) const
     {
         if (result_)
             ret["current_ms"] =
-                static_cast<Int>(result_->roundTime.read().count());
+                unsafe_cast<Int>(result_->roundTime.read().count());
         ret["converge_percent"] = convergePercent_;
-        ret["close_resolution"] = static_cast<Int>(closeResolution_.count());
+        ret["close_resolution"] = unsafe_cast<Int>(closeResolution_.count());
         ret["have_time_consensus"] = haveCloseTimeConsensus_;
-        ret["previous_proposers"] = static_cast<Int>(prevProposers_);
-        ret["previous_mseconds"] = static_cast<Int>(prevRoundTime_.count());
+        ret["previous_proposers"] = unsafe_cast<Int>(prevProposers_);
+        ret["previous_mseconds"] = unsafe_cast<Int>(prevRoundTime_.count());
 
         if (!currPeerPositions_.empty())
         {

--- a/src/xrpld/core/detail/Config.cpp
+++ b/src/xrpld/core/detail/Config.cpp
@@ -24,6 +24,7 @@
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/StringUtilities.h>
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/core/LexicalCast.h>
 #include <xrpl/json/json_reader.h>
 #include <xrpl/protocol/Feature.h>
@@ -49,7 +50,7 @@ namespace detail {
 getMemorySize()
 {
     if (MEMORYSTATUSEX msx{sizeof(MEMORYSTATUSEX)}; GlobalMemoryStatusEx(&msx))
-        return static_cast<std::uint64_t>(msx.ullTotalPhys);
+        return safe_cast<std::uint64_t>(msx.ullTotalPhys);
 
     return 0;
 }
@@ -68,7 +69,7 @@ namespace detail {
 getMemorySize()
 {
     if (struct sysinfo si; sysinfo(&si) == 0)
-        return static_cast<std::uint64_t>(si.totalram) * si.mem_unit;
+        return safe_cast<std::uint64_t>(si.totalram) * si.mem_unit;
 
     return 0;
 }
@@ -93,7 +94,7 @@ getMemorySize()
     size_t size = sizeof(ram);
 
     if (sysctl(mib, 2, &ram, &size, NULL, 0) == 0)
-        return static_cast<std::uint64_t>(ram);
+        return unsafe_cast<std::uint64_t>(ram);
 
     return 0;
 }
@@ -137,7 +138,7 @@ static_assert(
 
         for (auto const& i : sizedItems)
         {
-            if (static_cast<std::underlying_type_t<SizedItem>>(i.first) != idx)
+            if (safe_cast<std::underlying_type_t<SizedItem>>(i.first) != idx)
                 return false;
 
             ++idx;
@@ -278,7 +279,7 @@ Config::setupControl(bool bQuiet, bool bSilent, bool bStandalone)
     {
         // First, check against 'minimum' RAM requirements per node size:
         auto const& threshold =
-            sizedItems[static_cast<std::underlying_type_t<SizedItem>>(
+            sizedItems[safe_cast<std::underlying_type_t<SizedItem>>(
                 SizedItem::ramSizeGB)];
 
         auto ns =
@@ -1074,7 +1075,7 @@ Config::getDebugLogFile() const
 int
 Config::getValueFor(SizedItem item, std::optional<std::size_t> node) const
 {
-    auto const index = static_cast<std::underlying_type_t<SizedItem>>(item);
+    auto const index = safe_cast<std::underlying_type_t<SizedItem>>(item);
     XRPL_ASSERT(
         index < sizedItems.size(),
         "ripple::Config::getValueFor : valid index input");

--- a/src/xrpld/core/detail/JobQueue.cpp
+++ b/src/xrpld/core/detail/JobQueue.cpp
@@ -20,6 +20,7 @@
 #include <xrpld/core/JobQueue.h>
 #include <xrpld/perflog/PerfLog.h>
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <mutex>
 
 namespace ripple {
@@ -248,13 +249,13 @@ JobQueue::getJson(int c)
                 pri["waiting"] = waiting;
 
             if (stats.count != 0)
-                pri["per_second"] = static_cast<int>(stats.count);
+                pri["per_second"] = unsafe_cast<int>(stats.count);
 
             if (stats.latencyPeak != 0ms)
-                pri["peak_time"] = static_cast<int>(stats.latencyPeak.count());
+                pri["peak_time"] = unsafe_cast<int>(stats.latencyPeak.count());
 
             if (stats.latencyAvg != 0ms)
-                pri["avg_time"] = static_cast<int>(stats.latencyAvg.count());
+                pri["avg_time"] = unsafe_cast<int>(stats.latencyAvg.count());
 
             if (running != 0)
                 pri["in_progress"] = running;

--- a/src/xrpld/core/detail/SociDB.cpp
+++ b/src/xrpld/core/detail/SociDB.cpp
@@ -27,6 +27,7 @@
 #include <xrpld/core/SociDB.h>
 #include <xrpl/basics/ByteUtilities.h>
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <boost/filesystem.hpp>
 #include <memory>
 #include <soci/sqlite3/soci-sqlite3.h>
@@ -130,7 +131,7 @@ getKBUsedAll(soci::session& s)
 {
     if (!getConnection(s))
         Throw<std::logic_error>("No connection found.");
-    return static_cast<size_t>(
+    return unsafe_cast<size_t>(
         sqlite_api::sqlite3_memory_used() / kilobytes(1));
 }
 

--- a/src/xrpld/core/detail/Workers.h
+++ b/src/xrpld/core/detail/Workers.h
@@ -21,6 +21,7 @@
 #define RIPPLE_CORE_WORKERS_H_INCLUDED
 
 #include <xrpld/core/detail/semaphore.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/core/LockFreeStack.h>
 #include <atomic>
 #include <condition_variable>
@@ -114,7 +115,7 @@ public:
         perf::PerfLog* perfLog,
         std::string const& threadNames = "Worker",
         int numberOfThreads =
-            static_cast<int>(std::thread::hardware_concurrency()));
+            unsafe_cast<int>(std::thread::hardware_concurrency()));
 
     ~Workers();
 

--- a/src/xrpld/ledger/detail/View.cpp
+++ b/src/xrpld/ledger/detail/View.cpp
@@ -21,6 +21,7 @@
 #include <xrpld/ledger/View.h>
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/chrono.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Protocol.h>
@@ -1191,9 +1192,9 @@ rippleCreditIOU(
             && (uFlags & (!bSenderHigh ? lsfLowReserve : lsfHighReserve))
             // Sender reserve is set.
             &&
-            static_cast<bool>(
+            unsafe_cast<bool>(
                 uFlags & (!bSenderHigh ? lsfLowNoRipple : lsfHighNoRipple)) !=
-                static_cast<bool>(
+                unsafe_cast<bool>(
                     view.read(keylet::account(uSenderID))->getFlags() &
                     lsfDefaultRipple) &&
             !(uFlags & (!bSenderHigh ? lsfLowFreeze : lsfHighFreeze)) &&
@@ -1649,9 +1650,9 @@ updateTrustLine(
         // Sender is zero or negative.
         && (flags & (!bSenderHigh ? lsfLowReserve : lsfHighReserve))
         // Sender reserve is set.
-        && static_cast<bool>(
+        && unsafe_cast<bool>(
                flags & (!bSenderHigh ? lsfLowNoRipple : lsfHighNoRipple)) !=
-            static_cast<bool>(sle->getFlags() & lsfDefaultRipple) &&
+            unsafe_cast<bool>(sle->getFlags() & lsfDefaultRipple) &&
         !(flags & (!bSenderHigh ? lsfLowFreeze : lsfHighFreeze)) &&
         !state->getFieldAmount(!bSenderHigh ? sfLowLimit : sfHighLimit)
         // Sender trust limit is 0.

--- a/src/xrpld/net/HTTPClientSSLContext.h
+++ b/src/xrpld/net/HTTPClientSSLContext.h
@@ -24,6 +24,7 @@
 #include <xrpld/net/RegisterSSLCerts.h>
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 #include <boost/asio.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl.hpp>
@@ -110,7 +111,7 @@ public:
         if (!SSL_set_tlsext_host_name(strm.native_handle(), host.c_str()))
         {
             ec.assign(
-                static_cast<int>(::ERR_get_error()),
+                unsafe_cast<int>(::ERR_get_error()),
                 boost::asio::error::get_ssl_category());
         }
         else if (!sslVerify())

--- a/src/xrpld/net/detail/RegisterSSLCerts.cpp
+++ b/src/xrpld/net/detail/RegisterSSLCerts.cpp
@@ -16,7 +16,9 @@
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 //==============================================================================
+
 #include <xrpld/net/RegisterSSLCerts.h>
+#include <xrpl/basics/safe_cast.h>
 
 #if BOOST_OS_WINDOWS
 #include <boost/asio/ssl/error.hpp>
@@ -59,7 +61,7 @@ registerSSLCerts(
     if (!store)
     {
         ec = boost::system::error_code(
-            static_cast<int>(::ERR_get_error()),
+            safe_cast<int>(::ERR_get_error()),
             boost::asio::error::get_ssl_category());
         return;
     }

--- a/src/xrpld/nodestore/backend/RocksDBFactory.cpp
+++ b/src/xrpld/nodestore/backend/RocksDBFactory.cpp
@@ -315,7 +315,7 @@ public:
             }
             else
             {
-                status = static_cast<Status>(
+                status = unsafe_cast<Status>(
                     customCode + unsafe_cast<int>(getStatus.code()));
 
                 JLOG(m_journal.error()) << getStatus.ToString();

--- a/src/xrpld/nodestore/detail/BatchWriter.cpp
+++ b/src/xrpld/nodestore/detail/BatchWriter.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <xrpld/nodestore/detail/BatchWriter.h>
+#include <xrpl/basics/safe_cast.h>
 
 namespace ripple {
 namespace NodeStore {
@@ -61,7 +62,7 @@ BatchWriter::getWriteLoad()
 {
     std::lock_guard sl(mWriteMutex);
 
-    return std::max(mWriteLoad, static_cast<int>(mWriteSet.size()));
+    return std::max(mWriteLoad, unsafe_cast<int>(mWriteSet.size()));
 }
 
 void

--- a/src/xrpld/nodestore/detail/Database.cpp
+++ b/src/xrpld/nodestore/detail/Database.cpp
@@ -19,6 +19,7 @@
 
 #include <xrpld/nodestore/Database.h>
 #include <xrpl/basics/chrono.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/core/CurrentThreadName.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/HashPrefix.h>
@@ -271,7 +272,7 @@ Database::getCountsJson(Json::Value& obj)
 
     {
         std::unique_lock<std::mutex> lock(readLock_);
-        obj["read_queue"] = static_cast<Json::UInt>(read_.size());
+        obj["read_queue"] = unsafe_cast<Json::UInt>(read_.size());
     }
 
     obj["read_threads_total"] = readThreads_.load();

--- a/src/xrpld/nodestore/detail/EncodedBlob.h
+++ b/src/xrpld/nodestore/detail/EncodedBlob.h
@@ -21,6 +21,7 @@
 #define RIPPLE_NODESTORE_ENCODEDBLOB_H_INCLUDED
 
 #include <xrpld/nodestore/NodeObject.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <boost/align/align_up.hpp>
 #include <algorithm>
@@ -94,7 +95,7 @@ public:
                                          : new std::uint8_t[size_])
     {
         std::fill_n(ptr_, 8, std::uint8_t{0});
-        ptr_[8] = static_cast<std::uint8_t>(obj->getType());
+        ptr_[8] = unsafe_cast<std::uint8_t>(obj->getType());
         std::copy_n(obj->getData().data(), obj->getData().size(), ptr_ + 9);
         std::copy_n(obj->getHash().data(), obj->getHash().size(), key_.data());
     }

--- a/src/xrpld/nodestore/detail/codec.h
+++ b/src/xrpld/nodestore/detail/codec.h
@@ -41,7 +41,7 @@ template <class BufferFactory>
 std::pair<void const*, std::size_t>
 lz4_decompress(void const* in, std::size_t in_size, BufferFactory&& bf)
 {
-    if (static_cast<int>(in_size) < 0)
+    if (unsafe_cast<int>(in_size) < 0)
         Throw<std::runtime_error>("lz4_decompress: integer overflow (input)");
 
     std::size_t outSize = 0;
@@ -52,16 +52,16 @@ lz4_decompress(void const* in, std::size_t in_size, BufferFactory&& bf)
     if (n == 0 || n >= in_size)
         Throw<std::runtime_error>("lz4_decompress: invalid blob");
 
-    if (static_cast<int>(outSize) <= 0)
+    if (unsafe_cast<int>(outSize) <= 0)
         Throw<std::runtime_error>("lz4_decompress: integer overflow (output)");
 
     void* const out = bf(outSize);
 
     if (LZ4_decompress_safe(
-            reinterpret_cast<char const*>(in) + n,
-            reinterpret_cast<char*>(out),
-            static_cast<int>(in_size - n),
-            static_cast<int>(outSize)) != static_cast<int>(outSize))
+            static_cast<char const*>(in) + n,
+            static_cast<char*>(out),
+            unsafe_cast<int>(in_size - n),
+            unsafe_cast<int>(outSize)) != unsafe_cast<int>(outSize))
         Throw<std::runtime_error>("lz4_decompress: LZ4_decompress_safe");
 
     return {out, outSize};
@@ -150,7 +150,7 @@ nodeobject_decompress(void const* in, std::size_t in_size, BufferFactory&& bf)
             write<std::uint32_t>(os, 0);
             write<std::uint8_t>(os, hotUNKNOWN);
             write<std::uint32_t>(
-                os, static_cast<std::uint32_t>(HashPrefix::innerNode));
+                os, safe_cast<std::uint32_t>(HashPrefix::innerNode));
             if (mask == 0)
                 Throw<std::runtime_error>(
                     "nodeobject codec v1: empty inner node");
@@ -194,7 +194,7 @@ nodeobject_decompress(void const* in, std::size_t in_size, BufferFactory&& bf)
             write<std::uint32_t>(os, 0);
             write<std::uint8_t>(os, hotUNKNOWN);
             write<std::uint32_t>(
-                os, static_cast<std::uint32_t>(HashPrefix::innerNode));
+                os, safe_cast<std::uint32_t>(HashPrefix::innerNode));
             write(os, is(512), 512);
             break;
         }

--- a/src/xrpld/overlay/Compression.h
+++ b/src/xrpld/overlay/Compression.h
@@ -22,6 +22,7 @@
 
 #include <xrpl/basics/CompressionAlgorithms.h>
 #include <xrpl/basics/Log.h>
+#include <xrpl/basics/safe_cast.h>
 
 namespace ripple {
 
@@ -62,7 +63,7 @@ decompress(
         {
             JLOG(debugLog().warn())
                 << "decompress: invalid compression algorithm "
-                << static_cast<int>(algorithm);
+                << safe_cast<int>(algorithm);
             UNREACHABLE(
                 "ripple::compression::decompress : invalid compression "
                 "algorithm");
@@ -99,7 +100,7 @@ compress(
         else
         {
             JLOG(debugLog().warn()) << "compress: invalid compression algorithm"
-                                    << static_cast<int>(algorithm);
+                                    << safe_cast<int>(algorithm);
             UNREACHABLE(
                 "ripple::compression::compress : invalid compression "
                 "algorithm");

--- a/src/xrpld/overlay/Slot.h
+++ b/src/xrpld/overlay/Slot.h
@@ -25,6 +25,7 @@
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/chrono.h>
 #include <xrpl/basics/random.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/container/aged_unordered_map.h>
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/protocol/PublicKey.h>
@@ -292,8 +293,8 @@ Slot<clock_type>::update(
 
     JLOG(journal_.trace())
         << "update: existing peer " << Slice(validator) << " " << id
-        << " slot state " << static_cast<int>(state_) << " peer state "
-        << static_cast<int>(peer.state) << " count " << peer.count << " last "
+        << " slot state " << safe_cast<int>(state_) << " peer state "
+        << safe_cast<int>(peer.state) << " count " << peer.count << " last "
         << duration_cast<milliseconds>(now - peer.lastMessage).count()
         << " pool " << considered_.size() << " threshold " << reachedThreshold_
         << " " << (type == protocol::mtVALIDATION ? "validation" : "proposal");

--- a/src/xrpld/overlay/detail/Message.cpp
+++ b/src/xrpld/overlay/detail/Message.cpp
@@ -19,6 +19,7 @@
 
 #include <xrpld/overlay/Message.h>
 #include <xrpld/overlay/detail/TrafficCount.h>
+#include <xrpl/basics/safe_cast.h>
 #include <cstdint>
 
 namespace ripple {
@@ -180,17 +181,17 @@ Message::setHeader(
     auto h = in;
 
     auto pack = [](std::uint8_t*& in, std::uint32_t size) {
-        *in++ = static_cast<std::uint8_t>(
+        *in++ = unsafe_cast<std::uint8_t>(
             (size >> 24) & 0x0F);  // leftmost 4 are compression bits
-        *in++ = static_cast<std::uint8_t>((size >> 16) & 0xFF);
-        *in++ = static_cast<std::uint8_t>((size >> 8) & 0xFF);
-        *in++ = static_cast<std::uint8_t>(size & 0xFF);
+        *in++ = unsafe_cast<std::uint8_t>((size >> 16) & 0xFF);
+        *in++ = unsafe_cast<std::uint8_t>((size >> 8) & 0xFF);
+        *in++ = unsafe_cast<std::uint8_t>(size & 0xFF);
     };
 
     pack(in, payloadBytes);
 
-    *in++ = static_cast<std::uint8_t>((type >> 8) & 0xFF);
-    *in++ = static_cast<std::uint8_t>(type & 0xFF);
+    *in++ = unsafe_cast<std::uint8_t>((type >> 8) & 0xFF);
+    *in++ = unsafe_cast<std::uint8_t>(type & 0xFF);
 
     if (compression != Algorithm::None)
     {
@@ -222,7 +223,7 @@ Message::getBuffer(Compressed tryCompressed)
 int
 Message::getType(std::uint8_t const* in) const
 {
-    int type = (static_cast<int>(*(in + 4)) << 8) + *(in + 5);
+    int type = (safe_cast<int>(*(in + 4)) << 8) + *(in + 5);
     return type;
 }
 

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -34,6 +34,7 @@
 #include <xrpl/basics/base64.h>
 #include <xrpl/basics/make_SSLContext.h>
 #include <xrpl/basics/random.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/core/LexicalCast.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/server/SimpleWriter.h>
@@ -722,7 +723,7 @@ OverlayImpl::getOverlayInfo()
         pv[jss::public_key] = base64_encode(
             sp->getNodePublic().data(), sp->getNodePublic().size());
         pv[jss::type] = sp->slot()->inbound() ? "in" : "out";
-        pv[jss::uptime] = static_cast<std::uint32_t>(
+        pv[jss::uptime] = unsafe_cast<std::uint32_t>(
             duration_cast<seconds>(sp->uptime()).count());
         if (sp->crawl())
         {

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -251,7 +251,7 @@ PeerImp::send(std::shared_ptr<Message> const& m)
     overlay_.reportTraffic(
         safe_cast<TrafficCount::category>(m->getCategory()),
         false,
-        static_cast<int>(m->getBuffer(compressionEnabled_).size()));
+        unsafe_cast<int>(m->getBuffer(compressionEnabled_).size()));
 
     auto sendq_size = send_queue_.size();
 
@@ -409,10 +409,10 @@ PeerImp::json()
     {
         std::lock_guard sl(recentLock_);
         if (latency_)
-            ret[jss::latency] = static_cast<Json::UInt>(latency_->count());
+            ret[jss::latency] = unsafe_cast<Json::UInt>(latency_->count());
     }
 
-    ret[jss::uptime] = static_cast<Json::UInt>(
+    ret[jss::uptime] = unsafe_cast<Json::UInt>(
         std::chrono::duration_cast<std::chrono::seconds>(uptime()).count());
 
     std::uint32_t minSeq, maxSeq;
@@ -1010,7 +1010,7 @@ PeerImp::onMessageBegin(
     load_event_ = app_.getJobQueue().makeLoadEvent(jtPEER, name);
     fee_ = {Resource::feeTrivialPeer, name};
     auto const category = TrafficCount::categorize(*m, type, true);
-    overlay_.reportTraffic(category, true, static_cast<int>(size));
+    overlay_.reportTraffic(category, true, unsafe_cast<int>(size));
     using namespace protocol;
     if ((type == MessageType::mtTRANSACTION ||
          type == MessageType::mtHAVE_TRANSACTIONS ||
@@ -1026,7 +1026,7 @@ PeerImp::onMessageBegin(
         (txReduceRelayEnabled() || app_.config().TX_REDUCE_RELAY_METRICS))
     {
         overlay_.addTxMetrics(
-            static_cast<MessageType>(type), static_cast<std::uint64_t>(size));
+            safe_cast<MessageType>(type), static_cast<std::uint64_t>(size));
     }
     JLOG(journal_.trace()) << "onMessageBegin: " << type << " " << size << " "
                            << uncompressed_size << " " << isCompressed;
@@ -1898,13 +1898,13 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMStatusChange> const& m)
 
         if (m->has_networktime())
         {
-            j[jss::date] = static_cast<Json::UInt>(m->networktime());
+            j[jss::date] = unsafe_cast<Json::UInt>(m->networktime());
         }
 
         if (m->has_firstseq() && m->has_lastseq())
         {
-            j[jss::ledger_index_min] = static_cast<Json::UInt>(m->firstseq());
-            j[jss::ledger_index_max] = static_cast<Json::UInt>(m->lastseq());
+            j[jss::ledger_index_min] = safe_cast<Json::UInt>(m->firstseq());
+            j[jss::ledger_index_max] = safe_cast<Json::UInt>(m->lastseq());
         }
 
         return j;

--- a/src/xrpld/overlay/detail/ProtocolMessage.h
+++ b/src/xrpld/overlay/detail/ProtocolMessage.h
@@ -23,6 +23,7 @@
 #include <xrpld/overlay/Compression.h>
 #include <xrpld/overlay/Message.h>
 #include <xrpld/overlay/detail/ZeroCopyStream.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/protocol/messages.h>
 #include <boost/asio/buffer.hpp>
@@ -198,7 +199,7 @@ parseMessageHeader(
             return std::nullopt;
         }
 
-        hdr.algorithm = static_cast<compression::Algorithm>(*iter & 0xF0);
+        hdr.algorithm = unsafe_cast<compression::Algorithm>(*iter & 0xF0);
 
         if (hdr.algorithm != compression::Algorithm::LZ4)
         {

--- a/src/xrpld/peerfinder/detail/PeerfinderConfig.cpp
+++ b/src/xrpld/peerfinder/detail/PeerfinderConfig.cpp
@@ -19,6 +19,7 @@
 
 #include <xrpld/peerfinder/PeerfinderManager.h>
 #include <xrpld/peerfinder/detail/Tuning.h>
+#include <xrpl/basics/safe_cast.h>
 
 namespace ripple {
 namespace PeerFinder {
@@ -39,7 +40,7 @@ Config::calcOutPeers() const
 {
     return std::max(
         (maxPeers * Tuning::outPercent + 50) / 100,
-        static_cast<std::size_t>(Tuning::minOutCount));
+        safe_cast<std::size_t>(Tuning::minOutCount));
 }
 
 void
@@ -54,12 +55,12 @@ Config::applyTuning()
 
         if (inPeers > Tuning::defaultMaxPeers)
             ipLimit += std::min(
-                5, static_cast<int>(inPeers / Tuning::defaultMaxPeers));
+                5, unsafe_cast<int>(inPeers / Tuning::defaultMaxPeers));
     }
 
     // We don't allow a single IP to consume all incoming slots,
     // unless we only have one incoming slot available.
-    ipLimit = std::max(1, std::min(ipLimit, static_cast<int>(inPeers / 2)));
+    ipLimit = std::max(1, std::min(ipLimit, unsafe_cast<int>(inPeers / 2)));
 }
 
 void

--- a/src/xrpld/perflog/detail/PerfLogImp.cpp
+++ b/src/xrpld/perflog/detail/PerfLogImp.cpp
@@ -20,6 +20,7 @@
 #include <xrpld/core/JobTypes.h>
 #include <xrpld/perflog/detail/PerfLogImp.h>
 #include <xrpl/basics/BasicConfig.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/core/CurrentThreadName.h>
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/json/json_writer.h>
@@ -294,7 +295,7 @@ PerfLogImp::report()
     {
         std::lock_guard lock{counters_.jobsMutex_};
         report[jss::workers] =
-            static_cast<unsigned int>(counters_.jobs_.size());
+            unsafe_cast<unsigned int>(counters_.jobs_.size());
     }
     report[jss::hostid] = hostname_;
     report[jss::counters] = counters_.countersJson();

--- a/src/xrpld/rpc/CTID.h
+++ b/src/xrpld/rpc/CTID.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_RPC_CTID_H_INCLUDED
 #define RIPPLE_RPC_CTID_H_INCLUDED
 
+#include <xrpl/basics/safe_cast.h>
 #include <boost/regex.hpp>
 #include <optional>
 #include <regex>
@@ -39,8 +40,8 @@ encodeCTID(
         return {};
 
     uint64_t ctidValue =
-        ((0xC000'0000ULL + static_cast<uint64_t>(ledger_seq)) << 32) +
-        (static_cast<uint64_t>(txn_index) << 16) + network_id;
+        ((0xC000'0000ULL + safe_cast<uint64_t>(ledger_seq)) << 32) +
+        (safe_cast<uint64_t>(txn_index) << 16) + network_id;
 
     std::stringstream buffer;
     buffer << std::hex << std::uppercase << std::setfill('0') << std::setw(16)

--- a/src/xrpld/rpc/detail/RPCHelpers.cpp
+++ b/src/xrpld/rpc/detail/RPCHelpers.cpp
@@ -28,6 +28,7 @@
 #include <xrpld/rpc/Context.h>
 #include <xrpld/rpc/DeliveredAmount.h>
 #include <xrpld/rpc/detail/RPCHelpers.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/RPCErr.h>
 #include <xrpl/protocol/nftPageMask.h>
@@ -723,9 +724,9 @@ parseRippleLibSeed(Json::Value const& value)
     auto const result = decodeBase58Token(value.asString(), TokenType::None);
 
     if (result.size() == 18 &&
-        static_cast<std::uint8_t>(result[0]) ==
-            static_cast<std::uint8_t>(0xE1) &&
-        static_cast<std::uint8_t>(result[1]) == static_cast<std::uint8_t>(0x4B))
+        unsafe_cast<std::uint8_t>(result[0]) ==
+            unsafe_cast<std::uint8_t>(0xE1) &&
+        unsafe_cast<std::uint8_t>(result[1]) == unsafe_cast<std::uint8_t>(0x4B))
         return Seed(makeSlice(result.substr(2)));
 
     return std::nullopt;

--- a/src/xrpld/rpc/detail/ServerHandler.cpp
+++ b/src/xrpld/rpc/detail/ServerHandler.cpp
@@ -31,6 +31,7 @@
 #include <xrpl/basics/base64.h>
 #include <xrpl/basics/contract.h>
 #include <xrpl/basics/make_SSLContext.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/net/IPAddressConversion.h>
 #include <xrpl/beast/rfc2616.h>
 #include <xrpl/json/json_reader.h>
@@ -268,7 +269,7 @@ build_map(boost::beast::http::fields const& h)
         // map and along with iterators
         std::string key(e.name_string());
         std::ranges::transform(key, key.begin(), [](auto kc) {
-            return std::tolower(static_cast<unsigned char>(kc));
+            return std::tolower(unsafe_cast<unsigned char>(kc));
         });
         c[key] = e.value();
     }
@@ -668,7 +669,7 @@ ServerHandler::processRequest(
             jsonRPC[jss::params][0u].isObject())
         {
             apiVersion = RPC::getAPIVersionNumber(
-                jsonRPC[jss::params][static_cast<Json::UInt>(0)],
+                jsonRPC[jss::params][unsafe_cast<Json::UInt>(0)],
                 app_.config().BETA_RPC_API);
         }
 
@@ -705,12 +706,12 @@ ServerHandler::processRequest(
 
         if (jsonRPC.isMember(jss::params) && jsonRPC[jss::params].isArray() &&
             jsonRPC[jss::params].size() > 0 &&
-            jsonRPC[jss::params][static_cast<Json::UInt>(0)].isObjectOrNull())
+            jsonRPC[jss::params][unsafe_cast<Json::UInt>(0)].isObjectOrNull())
         {
             role = requestRole(
                 required,
                 port,
-                jsonRPC[jss::params][static_cast<Json::UInt>(0)],
+                jsonRPC[jss::params][unsafe_cast<Json::UInt>(0)],
                 remoteIPAddress,
                 user);
         }
@@ -1006,7 +1007,7 @@ ServerHandler::processRequest(
             {
                 int const errCode = reply[jss::error][jss::error_code].asInt();
                 return RPC::error_code_http_status(
-                    static_cast<error_code_i>(errCode));
+                    safe_cast<error_code_i>(errCode));
             }
         }
         // Return OK.

--- a/src/xrpld/rpc/handlers/AccountInfo.cpp
+++ b/src/xrpld/rpc/handlers/AccountInfo.cpp
@@ -23,6 +23,7 @@
 #include <xrpld/rpc/Context.h>
 #include <xrpld/rpc/GRPCHandlers.h>
 #include <xrpld/rpc/detail/RPCHelpers.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/Indexes.h>
@@ -189,7 +190,7 @@ doAccountInfo(RPC::JsonContext& context)
             if (!txs.empty())
             {
                 jvQueueData[jss::txn_count] =
-                    static_cast<Json::UInt>(txs.size());
+                    unsafe_cast<Json::UInt>(txs.size());
 
                 auto& jvQueueTx = jvQueueData[jss::transactions];
                 jvQueueTx = Json::arrayValue;

--- a/src/xrpld/rpc/handlers/GetAggregatePrice.cpp
+++ b/src/xrpld/rpc/handlers/GetAggregatePrice.cpp
@@ -22,6 +22,7 @@
 #include <xrpld/ledger/ReadView.h>
 #include <xrpld/rpc/Context.h>
 #include <xrpld/rpc/detail/RPCHelpers.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/jss.h>
@@ -290,7 +291,7 @@ doGetAggregatePrice(RPC::JsonContext& context)
             {
                 auto const price = iter->getFieldU64(sfAssetPrice);
                 auto const scale = iter->isFieldPresent(sfScale)
-                    ? -static_cast<int>(iter->getFieldU8(sfScale))
+                    ? -safe_cast<int>(iter->getFieldU8(sfScale))
                     : 0;
                 prices.insert(Prices::value_type(
                     node.getFieldU32(sfLastUpdateTime),

--- a/src/xrpld/rpc/handlers/GetCounts.cpp
+++ b/src/xrpld/rpc/handlers/GetCounts.cpp
@@ -26,6 +26,7 @@
 #include <xrpld/nodestore/Database.h>
 #include <xrpld/rpc/Context.h>
 #include <xrpl/basics/UptimeClock.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/jss.h>
@@ -95,22 +96,22 @@ getCountsJson(Application& app, int minObjectCount)
         {
             std::size_t c = app.getOPs().getLocalTxCount();
             if (c > 0)
-                ret[jss::local_txs] = static_cast<Json::UInt>(c);
+                ret[jss::local_txs] = unsafe_cast<Json::UInt>(c);
         }
     }
 
     ret[jss::write_load] = app.getNodeStore().getWriteLoad();
 
     ret[jss::historical_perminute] =
-        static_cast<int>(app.getInboundLedgers().fetchRate());
+        unsafe_cast<int>(app.getInboundLedgers().fetchRate());
     ret[jss::SLE_hit_rate] = app.cachedSLEs().rate();
     ret[jss::ledger_hit_rate] = app.getLedgerMaster().getCacheHitRate();
     ret[jss::AL_size] =
-        static_cast<Json::UInt>(app.getAcceptedLedgerCache().size());
+        unsafe_cast<Json::UInt>(app.getAcceptedLedgerCache().size());
     ret[jss::AL_hit_rate] = app.getAcceptedLedgerCache().getHitRate();
 
     ret[jss::fullbelow_size] =
-        static_cast<int>(app.getNodeFamily().getFullBelowCache()->size());
+        unsafe_cast<int>(app.getNodeFamily().getFullBelowCache()->size());
     ret[jss::treenode_cache_size] =
         app.getNodeFamily().getTreeNodeCache()->getCacheSize();
     ret[jss::treenode_track_size] =

--- a/src/xrpld/rpc/handlers/LedgerHandler.cpp
+++ b/src/xrpld/rpc/handlers/LedgerHandler.cpp
@@ -23,6 +23,7 @@
 #include <xrpld/rpc/GRPCHandlers.h>
 #include <xrpld/rpc/Role.h>
 #include <xrpld/rpc/handlers/LedgerHandler.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/jss.h>
 #include <xrpl/resource/Fees.h>
@@ -225,7 +226,7 @@ doLedgerGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetLedgerRequest>& context)
                 obj->set_mod_type(org::xrpl::rpc::v1::RawLedgerObject::CREATED);
             auto const blob = inDesired ? inDesired->slice() : inBase->slice();
             auto const objectType =
-                static_cast<LedgerEntryType>(blob[1] << 8 | blob[2]);
+                unsafe_cast<LedgerEntryType>(blob[1] << 8 | blob[2]);
 
             if (request.get_object_neighbors())
             {

--- a/src/xrpld/rpc/handlers/NoRippleCheck.cpp
+++ b/src/xrpld/rpc/handlers/NoRippleCheck.cpp
@@ -24,6 +24,7 @@
 #include <xrpld/rpc/Context.h>
 #include <xrpld/rpc/detail/RPCHelpers.h>
 #include <xrpld/rpc/detail/Tuning.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/RPCErr.h>
 #include <xrpl/protocol/TxFlags.h>
@@ -39,7 +40,7 @@ fillTransaction(
     std::uint32_t& sequence,
     ReadView const& ledger)
 {
-    txArray["Sequence"] = static_cast<Json::UInt>(sequence++);
+    txArray["Sequence"] = safe_cast<Json::UInt>(sequence++);
     txArray["Account"] = toBase58(accountID);
     auto& fees = ledger.fees();
     // Convert the reference transaction cost in fee units to drops

--- a/src/xrpld/rpc/handlers/Tx.cpp
+++ b/src/xrpld/rpc/handlers/Tx.cpp
@@ -30,6 +30,7 @@
 #include <xrpld/rpc/MPTokenIssuanceID.h>
 #include <xrpld/rpc/detail/RPCHelpers.h>
 #include <xrpl/basics/ToString.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/NFTSyntheticSerializer.h>
 #include <xrpl/protocol/RPCErr.h>
@@ -174,8 +175,8 @@ doTxHelp(RPC::Context& context, TxArgs args)
         if (txnIdx <= 0xFFFFU && netID < 0xFFFFU && lgrSeq < 0x0FFF'FFFFUL)
             result.ctid = RPC::encodeCTID(
                 lgrSeq,
-                static_cast<uint16_t>(txnIdx),
-                static_cast<uint16_t>(netID));
+                unsafe_cast<uint16_t>(txnIdx),
+                unsafe_cast<uint16_t>(netID));
     }
 
     return {result, rpcSUCCESS};

--- a/src/xrpld/shamap/SHAMapItem.h
+++ b/src/xrpld/shamap/SHAMapItem.h
@@ -25,6 +25,7 @@
 #include <xrpl/basics/SlabAllocator.h>
 #include <xrpl/basics/Slice.h>
 #include <xrpl/basics/base_uint.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 
@@ -62,7 +63,7 @@ private:
     // so we limit this constructor to codepaths that do this right and limit
     // arbitrary construction.
     SHAMapItem(uint256 const& tag, Slice data)
-        : tag_(tag), size_(static_cast<std::uint32_t>(data.size()))
+        : tag_(tag), size_(unsafe_cast<std::uint32_t>(data.size()))
     {
         std::memcpy(
             reinterpret_cast<std::uint8_t*>(this) + sizeof(*this),

--- a/src/xrpld/shamap/detail/SHAMap.cpp
+++ b/src/xrpld/shamap/detail/SHAMap.cpp
@@ -24,6 +24,7 @@
 #include <xrpld/shamap/SHAMapTxLeafNode.h>
 #include <xrpld/shamap/SHAMapTxPlusMetaLeafNode.h>
 #include <xrpl/basics/contract.h>
+#include <xrpl/basics/safe_cast.h>
 
 namespace ripple {
 
@@ -47,7 +48,7 @@ makeTypedLeaf(
     LogicError(
         "Attempt to create leaf node of unknown type " +
         std::to_string(
-            static_cast<std::underlying_type_t<SHAMapNodeType>>(type)));
+            safe_cast<std::underlying_type_t<SHAMapNodeType>>(type)));
 }
 
 SHAMap::SHAMap(SHAMapType t, Family& f)

--- a/src/xrpld/shamap/detail/SHAMapNodeID.cpp
+++ b/src/xrpld/shamap/detail/SHAMapNodeID.cpp
@@ -19,6 +19,7 @@
 
 #include <xrpld/shamap/SHAMap.h>
 #include <xrpld/shamap/SHAMapNodeID.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/core/LexicalCast.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/protocol/Serializer.h>
@@ -128,7 +129,7 @@ deserializeSHAMapNodeID(void const* data, std::size_t size)
 selectBranch(SHAMapNodeID const& id, uint256 const& hash)
 {
     auto const depth = id.getDepth();
-    auto branch = static_cast<unsigned int>(*(hash.begin() + (depth / 2)));
+    auto branch = safe_cast<unsigned int>(*(hash.begin() + (depth / 2)));
 
     if (depth & 1)
         branch &= 0xf;


### PR DESCRIPTION
## High Level Overview of Change

This change replaces all `static_cast` by `safe_cast` or `unsafe_cast` wherever possible.

### Context of Change

The intention of the `safe_cast` and `unsafe_cast` functions is mainly for developers. It allows you to see at a glance if you have to worry about overflows and similar issues. They are also a great shortcut for casting enums. The functions are only for integral types for now, but they could be extended to cover other types in the future.

The change in this PR:
1. Replaced all `static_cast` calls by `safe_cast` calls.
2. Repeatedly compiled, and changed `safe_cast` to `unsafe_cast` or otherwise to `static_cast` if building failed.
3. Added the safe_cast.h include if needed.

### Type of Change

- [X] Refactor (non-breaking change that only restructures code)