### PR TITLE
chore: Move "assert" and "werr" flags from "actions/build"

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -20,8 +20,6 @@ runs:
           ${{ inputs.generator && format('-G "{0}"', inputs.generator) || '' }} \
           -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake \
           -DCMAKE_BUILD_TYPE=${{ inputs.configuration }} \
-          -Dassert=TRUE \
-          -Dwerr=TRUE \
           -Dtests=TRUE \
           -Dxrpld=TRUE \
           ${{ inputs.cmake-args }} \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           generator: ${{ matrix.generator }}
           configuration: ${{ matrix.configuration }}
-          cmake-args: ${{ matrix.cmake-args }}
+          cmake-args: "-Dassert=TRUE -Dwerr=TRUE ${{ matrix.cmake-args }}"
       - name: test
         run: |
           n=$(nproc)

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -158,7 +158,7 @@ jobs:
         with:
           generator: Ninja
           configuration: ${{ matrix.configuration }}
-          cmake-args: ${{ matrix.cmake-args }}
+          cmake-args: "-Dassert=TRUE -Dwerr=TRUE ${{ matrix.cmake-args }}"
       - name: test
         run: |
           ${build_dir}/rippled --unittest --unittest-jobs $(nproc)
@@ -214,6 +214,8 @@ jobs:
           generator: Ninja
           configuration: ${{ matrix.configuration }}
           cmake-args: >-
+            -Dassert=TRUE
+            -Dwerr=TRUE
             -Dcoverage=ON
             -Dcoverage_format=xml
             -DCODE_COVERAGE_VERBOSE=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,7 +87,7 @@ jobs:
           generator: '${{ matrix.version.generator }}'
           configuration: ${{ matrix.configuration.type }}
           # Hard code for now. Move to the matrix if varied options are needed
-          cmake-args: '-Dassert=ON -Dreporting=OFF -Dunity=ON'
+          cmake-args: '-Dassert=TRUE -Dwerr=TRUE -Dreporting=OFF -Dunity=ON'
           cmake-target: install
       - name: test
         shell: bash


### PR DESCRIPTION
## High Level Overview of Change

PR #5228 added assert=TRUE and werr=TRUE CMake flags to the build/action.yml script which is used by all CI jobs to build rippled, ensuring those flags were always set. The assumption was that only the CI jobs used that script, so any extra time cost was offset by the benefit of the extra checks. That assumption was incorrect. That script is used by other downstream projects. Therefore, those flags have been moved into the individual CI jobs' "cmake-args" parameter passed to build/action.yml. This will have the same effect for CI jobs without any side effects.

### Context of Change

Internal performance testing detected a regression introduced by #5228. The regression was caused by the introduction of the `assert` flag in build/action.yml (which it used to build the `rippled` executable), which has a lot of processing overhead in performance-critical situations / testing.

No changes were made to the running code, only the build flags.

### Type of Change

- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)

I am categorizing this as a chore because there is no change to the binary for anyone building directly.
