### PR TITLE
 Introduced new XRPLF UNL subdomain as an intermediate step for migration

### DIFF
--- a/cfg/validators-example.txt
+++ b/cfg/validators-example.txt
@@ -54,15 +54,12 @@
 
 [validator_list_sites]
 https://vl.ripple.com
-https://vl.xrplf.org
 https://unl.xrplf.org
 
 [validator_list_keys]
 #vl.ripple.com
 ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
-# vl.xrplf.org
-ED45D1840EE724BE327ABE9146503D5848EFD5F38B6D5FEDE71E80ACCE5E6E738B
-# unl.xrplf.org
+#unl.xrplf.org
 ED42AEC58B701EEBB77356FFFEC26F83C1F0407263530F068C7C73D392C7E06FD1
 
 # To use the test network (see https://xrpl.org/connect-your-rippled-to-the-xrp-test-net.html),

--- a/cfg/validators-example.txt
+++ b/cfg/validators-example.txt
@@ -55,11 +55,14 @@
 [validator_list_sites]
 https://vl.ripple.com
 https://vl.xrplf.org
+https://unl.xrplf.org
 
 [validator_list_keys]
 #vl.ripple.com
 ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
 # vl.xrplf.org
+ED45D1840EE724BE327ABE9146503D5848EFD5F38B6D5FEDE71E80ACCE5E6E738B
+# unl.xrplf.org
 ED42AEC58B701EEBB77356FFFEC26F83C1F0407263530F068C7C73D392C7E06FD1
 
 # To use the test network (see https://xrpl.org/connect-your-rippled-to-the-xrp-test-net.html),


### PR DESCRIPTION
To facilitate a smooth transition, a new subdomain (unl.xrplf.org) is introduced alongside the existing vl.xrplf.org. This allows for a staged migration without modifying the key for the current UNL list. Eventually, vl.xrplf.org will be fully deprecated and replaced by unl.xrplf.org.