### PR TITLE
chore: Make a final "success" job for each CI test suite

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -92,3 +92,10 @@ jobs:
           n=$(nproc)
           echo "Using $n test jobs"
           ${build_dir}/rippled --unittest --unittest-jobs $n
+
+  success:
+    name: mac test success
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - run: true

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -163,6 +163,13 @@ jobs:
         run: |
           ${build_dir}/rippled --unittest --unittest-jobs $(nproc)
 
+  success:
+    name: nix test success
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
   coverage:
     strategy:
       fail-fast: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -95,3 +95,10 @@ jobs:
         run: |
           ${build_dir}/${{ matrix.configuration.type }}/rippled --unittest \
               --unittest-jobs $(nproc)
+
+  success:
+    name: windows test success
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - run: true


### PR DESCRIPTION
## High Level Overview of Change

Adds a "success" job that depends on the "test" job(s) in each of the three CI test workflows.

### Context of Change

The "success" job does nothing[^1], but because it depends on the "test" jobs, having it succeed signifies that all the test jobs succeeded. The reason this is significant is that branch protection rules require an exact name match for required jobs, and it's a lot easier to add and maintain a "test success" job for each OS[^2] than to have to add each of the test jobs individually.

[^1]: Ok, technically, it does grab a runner and run `true`, which is unfortunately necessary, but it doesn't do anything _significant_.

[^2]: I created separate jobs for each OS because some of the OS runners have a history of getting flaky and causing spurious failures. It'll be easier to not require those tests per OS when they're split this way. If that happens, though, those jobs will need to be verified another way.

### Type of Change

- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)

## Future Tasks

After this is merged, the branch protection rules for the main branches will need to be updated to remove all the "test" jobs and add the three "* test success" jobs.