### PR TITLE
Removes unnecessary dependency step in nix jobs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -147,12 +147,6 @@ jobs:
           cmake --version
       - name: checkout
         uses: actions/checkout@v4
-      - name: dependencies
-        uses: ./.github/actions/dependencies
-        env:
-          CONAN_URL: http://18.143.149.228:8081/artifactory/api/conan/conan-non-prod
-        with:
-          configuration: ${{ matrix.configuration }}
       - name: build
         uses: ./.github/actions/build
         with:
@@ -202,12 +196,6 @@ jobs:
           ls ~/.conan
       - name: checkout
         uses: actions/checkout@v4
-      - name: dependencies
-        uses: ./.github/actions/dependencies
-        env:
-          CONAN_URL: http://18.143.149.228:8081/artifactory/api/conan/conan-non-prod
-        with:
-          configuration: ${{ matrix.configuration }}
       - name: build
         uses: ./.github/actions/build
         with:
@@ -273,12 +261,6 @@ jobs:
           cmake --version
       - name: checkout
         uses: actions/checkout@v4
-      - name: dependencies
-        uses: ./.github/actions/dependencies
-        env:
-          CONAN_URL: http://18.143.149.228:8081/artifactory/api/conan/conan-non-prod
-        with:
-          configuration: ${{ env.configuration }}
       - name: export
         run: |
           version=$(conan inspect --raw version .)


### PR DESCRIPTION
## High Level Overview of Change

The Linux jobs perform a step to configure the dependencies, which is unnecessary as they already obtained them from the cache. This change removes this unnecessary step.

### Context of Change

The Linux CI pipeline, unlike Windows and MacOS, has a separate job for configuring the dependencies and uploading them to the GitHub cache. The other jobs, i.e. build+test, coverage, and conan, then pull down the dependencies from the cache so they don't all needlessly do the same work. However, each of these jobs also has a step that configures the dependencies anyway. As the dependencies already were pulled down, this is mostly a no-op, but it's still a waste of compute.

### Type of Change

- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
