### PR TITLE
Fix undefined uint128_t type on Windows non-unity builds

### DIFF
--- a/src/libxrpl/basics/Number.cpp
+++ b/src/libxrpl/basics/Number.cpp
@@ -20,6 +20,8 @@
 #include <xrpl/basics/Number.h>
 #include <xrpl/beast/utility/instrumentation.h>
 
+#include <boost/predef.h>
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -31,12 +33,12 @@
 #include <type_traits>
 #include <utility>
 
-#ifdef BOOST_COMP_MSVC
+#ifndef BOOST_COMP_MSVC
 #include <boost/multiprecision/cpp_int.hpp>
 using uint128_t = boost::multiprecision::uint128_t;
-#else   // !defined(_MSVC_LANG)
+#else   // !defined(BOOST_COMP_MSVC)
 using uint128_t = __uint128_t;
-#endif  // !defined(_MSVC_LANG)
+#endif  // !defined(BOOST_COMP_MSVC)
 
 namespace ripple {
 

--- a/src/libxrpl/basics/Number.cpp
+++ b/src/libxrpl/basics/Number.cpp
@@ -20,7 +20,7 @@
 #include <xrpl/basics/Number.h>
 #include <xrpl/beast/utility/instrumentation.h>
 
-#include <boost/predef.h>
+#include <boost/predef/compiler/visualc.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -33,7 +33,7 @@
 #include <type_traits>
 #include <utility>
 
-#ifndef BOOST_COMP_MSVC
+#ifdef BOOST_COMP_MSVC
 #include <boost/multiprecision/cpp_int.hpp>
 using uint128_t = boost::multiprecision::uint128_t;
 #else   // !defined(BOOST_COMP_MSVC)

--- a/src/libxrpl/basics/Number.cpp
+++ b/src/libxrpl/basics/Number.cpp
@@ -20,8 +20,6 @@
 #include <xrpl/basics/Number.h>
 #include <xrpl/beast/utility/instrumentation.h>
 
-#include <boost/predef/compiler/visualc.h>
-
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -33,12 +31,13 @@
 #include <type_traits>
 #include <utility>
 
-#ifdef BOOST_COMP_MSVC
+#ifdef _MSC_VER
+#pragma message("Using boost::multiprecision::uint128_t")
 #include <boost/multiprecision/cpp_int.hpp>
 using uint128_t = boost::multiprecision::uint128_t;
-#else   // !defined(BOOST_COMP_MSVC)
+#else   // !defined(_MSC_VER)
 using uint128_t = __uint128_t;
-#endif  // !defined(BOOST_COMP_MSVC)
+#endif  // !defined(_MSC_VER)
 
 namespace ripple {
 

--- a/src/libxrpl/basics/Number.cpp
+++ b/src/libxrpl/basics/Number.cpp
@@ -20,7 +20,7 @@
 #include <xrpl/basics/Number.h>
 #include <xrpl/beast/utility/instrumentation.h>
 
-#include <boost/predef/compiler/visualc.h>
+#include <boost/predef.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/src/libxrpl/basics/Number.cpp
+++ b/src/libxrpl/basics/Number.cpp
@@ -20,7 +20,7 @@
 #include <xrpl/basics/Number.h>
 #include <xrpl/beast/utility/instrumentation.h>
 
-#include <boost/predef.h>
+#include <boost/predef/compiler/visualc.h>
 
 #include <algorithm>
 #include <cstddef>


### PR DESCRIPTION
## High Level Overview of Change

Updates the `#ifdef` statements in Number.cpp to use Boost's `uint128_t` type on Windows.

### Context of Change

In https://github.com/XRPLF/rippled/pull/5293 the includes were optimized to more closely align with "include what you use". However, as Windows non-unity builds are rarely performed, and not done as part of the CI pipeline due to taking an excessive amount of time, it was not discovered until today that it does not compile using that configuration, as `__uint128_t` is not defined.

As part of the optimized imports, a transitive include had been removed that defined `BOOST_COMP_MSVC` on Windows. In unity builds, this definition was pulled in, but in non-unity builds it was not - causing the compilation error. An inspection of the Boost code revealed that we can just gate the statements by `_MS_VER` instead. A `#pragma message` is added to verify that the statement is only printed on Windows builds. 

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)