### PR TITLE
Fix to correct memory ordering for compare_exchange_weak and wait in the intrusive reference counting logic

### DIFF
--- a/include/xrpl/basics/IntrusiveRefCounts.h
+++ b/include/xrpl/basics/IntrusiveRefCounts.h
@@ -250,13 +250,13 @@ private:
 inline void
 IntrusiveRefCounts::addStrongRef() const noexcept
 {
-    refCounts.fetch_add(strongDelta, std::memory_order_seq_cst);
+    refCounts.fetch_add(strongDelta, std::memory_order_acq_rel);
 }
 
 inline void
 IntrusiveRefCounts::addWeakRef() const noexcept
 {
-    refCounts.fetch_add(weakDelta, std::memory_order_seq_cst);
+    refCounts.fetch_add(weakDelta, std::memory_order_acq_rel);
 }
 
 inline ReleaseStrongRefAction
@@ -270,7 +270,7 @@ IntrusiveRefCounts::releaseStrongRef() const
     // conditional `fetch_or`. This loop will almost always run once.
 
     using enum ReleaseStrongRefAction;
-    auto prevIntVal = refCounts.load(std::memory_order_seq_cst);
+    auto prevIntVal = refCounts.load(std::memory_order_acquire);
     while (1)
     {
         RefCountPair const prevVal{prevIntVal};
@@ -294,7 +294,7 @@ IntrusiveRefCounts::releaseStrongRef() const
         }
 
         if (refCounts.compare_exchange_weak(
-                prevIntVal, nextIntVal, std::memory_order_seq_cst))
+                prevIntVal, nextIntVal, std::memory_order_acq_rel))
         {
             // Can't be in partial destroy because only decrementing the strong
             // count to zero can start a partial destroy, and that can't happen
@@ -315,7 +315,7 @@ IntrusiveRefCounts::addWeakReleaseStrongRef() const
 
     static_assert(weakDelta > strongDelta);
     auto constexpr delta = weakDelta - strongDelta;
-    auto prevIntVal = refCounts.load(std::memory_order_seq_cst);
+    auto prevIntVal = refCounts.load(std::memory_order_acquire);
     // This loop will almost always run once. The loop is needed to atomically
     // change the counts and flags (the count could be atomically changed, but
     // the flags depend on the current value of the counts).
@@ -351,7 +351,7 @@ IntrusiveRefCounts::addWeakReleaseStrongRef() const
             }
         }
         if (refCounts.compare_exchange_weak(
-                prevIntVal, nextIntVal, std::memory_order_seq_cst))
+                prevIntVal, nextIntVal, std::memory_order_acq_rel))
         {
             XRPL_ASSERT(
                 (!(prevIntVal & partialDestroyStartedMask)),
@@ -365,7 +365,7 @@ IntrusiveRefCounts::addWeakReleaseStrongRef() const
 inline ReleaseWeakRefAction
 IntrusiveRefCounts::releaseWeakRef() const
 {
-    auto prevIntVal = refCounts.fetch_sub(weakDelta, std::memory_order_seq_cst);
+    auto prevIntVal = refCounts.fetch_sub(weakDelta, std::memory_order_acq_rel);
     RefCountPair prev = prevIntVal;
     if (prev.weak == 1 && prev.strong == 0)
     {
@@ -374,15 +374,15 @@ IntrusiveRefCounts::releaseWeakRef() const
             // This case should only be hit if the partialDestroyStartedBit is
             // set non-atomically (and even then very rarely). The code is kept
             // in case we need to set the flag non-atomically for perf reasons.
-            refCounts.wait(prevIntVal, std::memory_order_seq_cst);
-            prevIntVal = refCounts.load(std::memory_order_seq_cst);
+            refCounts.wait(prevIntVal, std::memory_order_acquire);
+            prevIntVal = refCounts.load(std::memory_order_acquire);
             prev = RefCountPair{prevIntVal};
         }
         if (!prev.partialDestroyFinishedBit)
         {
             // partial destroy MUST finish before running a full destroy (when
             // using weak pointers)
-            refCounts.wait(prevIntVal - weakDelta, std::memory_order_seq_cst);
+            refCounts.wait(prevIntVal - weakDelta, std::memory_order_acquire);
         }
         return ReleaseWeakRefAction::destroy;
     }
@@ -396,7 +396,7 @@ IntrusiveRefCounts::checkoutStrongRefFromWeak() const noexcept
     auto desiredValue = RefCountPair{2, 1}.combinedValue();
 
     while (!refCounts.compare_exchange_weak(
-        curValue, desiredValue, std::memory_order_seq_cst))
+        curValue, desiredValue, std::memory_order_acq_rel))
     {
         RefCountPair const prev{curValue};
         if (!prev.strong)
@@ -410,21 +410,21 @@ IntrusiveRefCounts::checkoutStrongRefFromWeak() const noexcept
 inline bool
 IntrusiveRefCounts::expired() const noexcept
 {
-    RefCountPair const val = refCounts.load(std::memory_order_seq_cst);
+    RefCountPair const val = refCounts.load(std::memory_order_acquire);
     return val.strong == 0;
 }
 
 inline std::size_t
 IntrusiveRefCounts::use_count() const noexcept
 {
-    RefCountPair const val = refCounts.load(std::memory_order_seq_cst);
+    RefCountPair const val = refCounts.load(std::memory_order_acquire);
     return val.strong;
 }
 
 inline IntrusiveRefCounts::~IntrusiveRefCounts() noexcept
 {
 #ifndef NDEBUG
-    auto v = refCounts.load(std::memory_order_seq_cst);
+    auto v = refCounts.load(std::memory_order_acquire);
     XRPL_ASSERT(
         (!(v & valueMask)),
         "ripple::IntrusiveRefCounts::~IntrusiveRefCounts : count must be zero");

--- a/src/test/basics/IntrusiveShared_test.cpp
+++ b/src/test/basics/IntrusiveShared_test.cpp
@@ -39,7 +39,7 @@ public:
     getState(int id)
     {
         assert(id < state.size());
-        return state[id].load(std::memory_order_seq_cst);
+        return state[id].load(std::memory_order_acquire);
     }
     static void
     resetStates(bool resetCallback)
@@ -47,9 +47,9 @@ public:
         for (int i = 0; i < maxStates; ++i)
         {
             state[i].store(
-                TrackedState::uninitialized, std::memory_order_seq_cst);
+                TrackedState::uninitialized, std::memory_order_release);
         }
-        nextId.store(0, std::memory_order_seq_cst);
+        nextId.store(0, std::memory_order_release);
         if (resetCallback)
             TIBase::tracingCallback_ = [](TrackedState,
                                           std::optional<TrackedState>) {};
@@ -72,7 +72,7 @@ public:
     TIBase() : id_{checkoutID()}
     {
         assert(state.size() > id_);
-        state[id_].store(TrackedState::alive, std::memory_order_seq_cst);
+        state[id_].store(TrackedState::alive, std::memory_order_relaxed);
     }
     ~TIBase()
     {
@@ -80,18 +80,18 @@ public:
 
         assert(state.size() > id_);
         tracingCallback_(
-            state[id_].load(std::memory_order_seq_cst), deletedStarted);
+            state[id_].load(std::memory_order_relaxed), deletedStarted);
 
         assert(state.size() > id_);
         // Use relaxed memory order to try to avoid atomic operations from
         // adding additional memory synchronizations that may hide threading
         // errors in the underlying shared pointer class.
-        state[id_].store(deletedStarted, std::memory_order_seq_cst);
+        state[id_].store(deletedStarted, std::memory_order_relaxed);
 
         tracingCallback_(deletedStarted, deleted);
 
         assert(state.size() > id_);
-        state[id_].store(TrackedState::deleted, std::memory_order_seq_cst);
+        state[id_].store(TrackedState::deleted, std::memory_order_relaxed);
 
         tracingCallback_(TrackedState::deleted, std::nullopt);
     }
@@ -103,16 +103,16 @@ public:
 
         assert(state.size() > id_);
         tracingCallback_(
-            state[id_].load(std::memory_order_seq_cst),
+            state[id_].load(std::memory_order_relaxed),
             partiallyDeletedStarted);
 
         assert(state.size() > id_);
-        state[id_].store(partiallyDeletedStarted, std::memory_order_seq_cst);
+        state[id_].store(partiallyDeletedStarted, std::memory_order_relaxed);
 
         tracingCallback_(partiallyDeletedStarted, partiallyDeleted);
 
         assert(state.size() > id_);
-        state[id_].store(partiallyDeleted, std::memory_order_seq_cst);
+        state[id_].store(partiallyDeleted, std::memory_order_relaxed);
 
         tracingCallback_(partiallyDeleted, std::nullopt);
     }
@@ -126,7 +126,7 @@ private:
     static int
     checkoutID()
     {
-        return nextId.fetch_add(1, std::memory_order_seq_cst);
+        return nextId.fetch_add(1, std::memory_order_acq_rel);
     }
 };
 
@@ -449,14 +449,14 @@ public:
         std::atomic<int> destructionState{0};
         // returns destructorRan and partialDestructorRan (in that order)
         auto getDestructorState = [&]() -> std::pair<bool, bool> {
-            int s = destructionState.load(std::memory_order_seq_cst);
+            int s = destructionState.load(std::memory_order_relaxed);
             return {(s & 1) != 0, (s & 2) != 0};
         };
         auto setDestructorRan = [&]() -> void {
-            destructionState.fetch_or(1, std::memory_order_seq_cst);
+            destructionState.fetch_or(1, std::memory_order_acq_rel);
         };
         auto setPartialDeleteRan = [&]() -> void {
-            destructionState.fetch_or(2, std::memory_order_seq_cst);
+            destructionState.fetch_or(2, std::memory_order_acq_rel);
         };
         auto tracingCallback = [&](TrackedState cur,
                                    std::optional<TrackedState> next) {
@@ -534,7 +534,7 @@ public:
                     auto [destructorRan, partialDeleteRan] =
                         getDestructorState();
                     BEAST_EXPECT(!i || destructorRan);
-                    destructionState.store(0, std::memory_order_seq_cst);
+                    destructionState.store(0, std::memory_order_release);
 
                     toClone.clear();
                     toClone.resize(numThreads);
@@ -589,14 +589,14 @@ public:
         std::atomic<int> destructionState{0};
         // returns destructorRan and partialDestructorRan (in that order)
         auto getDestructorState = [&]() -> std::pair<bool, bool> {
-            int s = destructionState.load(std::memory_order_seq_cst);
+            int s = destructionState.load(std::memory_order_relaxed);
             return {(s & 1) != 0, (s & 2) != 0};
         };
         auto setDestructorRan = [&]() -> void {
-            destructionState.fetch_or(1, std::memory_order_seq_cst);
+            destructionState.fetch_or(1, std::memory_order_acq_rel);
         };
         auto setPartialDeleteRan = [&]() -> void {
-            destructionState.fetch_or(2, std::memory_order_seq_cst);
+            destructionState.fetch_or(2, std::memory_order_acq_rel);
         };
         auto tracingCallback = [&](TrackedState cur,
                                    std::optional<TrackedState> next) {
@@ -663,7 +663,7 @@ public:
                     auto [destructorRan, partialDeleteRan] =
                         getDestructorState();
                     BEAST_EXPECT(!i || destructorRan);
-                    destructionState.store(0, std::memory_order_seq_cst);
+                    destructionState.store(0, std::memory_order_release);
 
                     toClone.clear();
                     toClone.resize(numThreads);
@@ -732,14 +732,14 @@ public:
         std::atomic<int> destructionState{0};
         // returns destructorRan and partialDestructorRan (in that order)
         auto getDestructorState = [&]() -> std::pair<bool, bool> {
-            int s = destructionState.load(std::memory_order_seq_cst);
+            int s = destructionState.load(std::memory_order_relaxed);
             return {(s & 1) != 0, (s & 2) != 0};
         };
         auto setDestructorRan = [&]() -> void {
-            destructionState.fetch_or(1, std::memory_order_seq_cst);
+            destructionState.fetch_or(1, std::memory_order_acq_rel);
         };
         auto setPartialDeleteRan = [&]() -> void {
-            destructionState.fetch_or(2, std::memory_order_seq_cst);
+            destructionState.fetch_or(2, std::memory_order_acq_rel);
         };
         auto tracingCallback = [&](TrackedState cur,
                                    std::optional<TrackedState> next) {
@@ -786,7 +786,7 @@ public:
                     auto [destructorRan, partialDeleteRan] =
                         getDestructorState();
                     BEAST_EXPECT(!i || destructorRan);
-                    destructionState.store(0, std::memory_order_seq_cst);
+                    destructionState.store(0, std::memory_order_release);
 
                     toLock.clear();
                     toLock.resize(numThreads);
@@ -828,12 +828,12 @@ public:
     void
     run() override
     {
-        testBasics();
+        // testBasics();
         testPartialDelete();
-        testDestructor();
-        testMultithreadedClearMixedVariant();
-        testMultithreadedClearMixedUnion();
-        testMultithreadedLockingWeak();
+        // testDestructor();
+        // testMultithreadedClearMixedVariant();
+        // testMultithreadedClearMixedUnion();
+        // testMultithreadedLockingWeak();
     }
 };  // namespace tests
 

--- a/src/test/basics/IntrusiveShared_test.cpp
+++ b/src/test/basics/IntrusiveShared_test.cpp
@@ -828,12 +828,12 @@ public:
     void
     run() override
     {
-        // testBasics();
+        testBasics();
         testPartialDelete();
-        // testDestructor();
-        // testMultithreadedClearMixedVariant();
-        // testMultithreadedClearMixedUnion();
-        // testMultithreadedLockingWeak();
+        testDestructor();
+        testMultithreadedClearMixedVariant();
+        testMultithreadedClearMixedUnion();
+        testMultithreadedLockingWeak();
     }
 };  // namespace tests
 


### PR DESCRIPTION
## High Level Overview of Change

This change addresses a memory ordering assertion failure observed on one of the Windows test machines during the `IntrusiveShared_test suite`.

### Context of Change

The key fix involves two parts:

1. Updating uses of `compare_exchange_weak` to specify `std::memory_order_acq_rel`. This is necessary because `compare_exchange_weak` must do two things:
a) Update the shared `refCounts` state.
b) Synchronize with other threads that may be waiting on that state.

Using only `memory_order_release` can fail to fully enforce these requirements, leading to potential race conditions.

2. In contrast, `wait()` operations are only used to observe state changes, not modify them. Therefore, `memory_order_acquire` is sufficient for these calls since the thread only acquires visibility of the updated state. Using` acq_rel` here would be an overkill and is a UB according to [cppreference](https://en.cppreference.com/w/cpp/atomic/atomic/wait).

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
