### PR TITLE
draft: refactor squelching 

### DIFF
--- a/src/xrpld/overlay/Slot.h
+++ b/src/xrpld/overlay/Slot.h
@@ -142,7 +142,7 @@ private:
     // number of peers that reached MAX_MESSAGE_THRESHOLD
     std::uint16_t reachedThreshold_;
     // last time peers were selected, used to age the slot
-    typename clock_type::time_point lastSelected_;
+    time_point lastSelected_;
     SlotState state_;                // slot's state
     SquelchHandler const& handler_;  // squelch/unsquelch handler
     beast::Journal const journal_;   // logging
@@ -542,7 +542,7 @@ Slot<clock_type>::inState(PeerState state) const
 }
 
 template <typename clock_type>
-std::set<typename Peer::id_t>
+std::set<id_t>
 Slot<clock_type>::getSelected() const
 {
     std::set<id_t> r;
@@ -553,9 +553,7 @@ Slot<clock_type>::getSelected() const
 }
 
 template <typename clock_type>
-std::unordered_map<
-    typename Peer::id_t,
-    std::tuple<PeerState, uint16_t, uint32_t, uint32_t>>
+std::unordered_map<id_t, std::tuple<PeerState, uint16_t, uint32_t, uint32_t>>
 Slot<clock_type>::getPeers() const
 {
     using namespace std::chrono;
@@ -586,7 +584,7 @@ class Slots final
     using id_t = typename Peer::id_t;
     using messages = beast::aged_unordered_map<
         uint256,
-        std::unordered_set<Peer::id_t>,
+        std::unordered_set<id_t>,
         clock_type,
         hardened_hash<strong_hash>>;
 
@@ -653,7 +651,7 @@ public:
      * expiration milliseconds.
      */
     std::unordered_map<
-        typename Peer::id_t,
+        id_t,
         std::tuple<PeerState, uint16_t, uint32_t, std::uint32_t>>
     getPeers(PublicKey const& validator)
     {

--- a/src/xrpld/overlay/Slot.h
+++ b/src/xrpld/overlay/Slot.h
@@ -167,10 +167,6 @@ private:
     std::uint16_t
     inState(PeerState state) const;
 
-    /** Return number of peers not in state */
-    std::uint16_t
-    notInState(PeerState state) const;
-
     /** Return Slot's state */
     SlotState
     getState() const
@@ -485,15 +481,6 @@ Slot<clock_type>::inState(PeerState state) const
 }
 
 template <typename clock_type>
-std::uint16_t
-Slot<clock_type>::notInState(PeerState state) const
-{
-    return std::count_if(peers_.begin(), peers_.end(), [&](auto const& it) {
-        return (it.second.state != state);
-    });
-}
-
-template <typename clock_type>
 std::set<typename Peer::id_t>
 Slot<clock_type>::getSelected() const
 {
@@ -578,16 +565,6 @@ public:
         auto const& it = slots_.find(validator);
         if (it != slots_.end())
             return it->second.inState(state);
-        return {};
-    }
-
-    /** Return number of peers not in state */
-    std::optional<std::uint16_t>
-    notInState(PublicKey const& validator, PeerState state) const
-    {
-        auto const& it = slots_.find(validator);
-        if (it != slots_.end())
-            return it->second.notInState(state);
         return {};
     }
 

--- a/src/xrpld/overlay/Slot.h
+++ b/src/xrpld/overlay/Slot.h
@@ -167,13 +167,6 @@ private:
     std::uint16_t
     inState(PeerState state) const;
 
-    /** Return Slot's state */
-    SlotState
-    getState() const
-    {
-        return state_;
-    }
-
     /** Return selected peers */
     std::set<id_t>
     getSelected() const;
@@ -599,16 +592,6 @@ public:
         auto const& it = slots_.find(validator);
         if (it != slots_.end())
             return it->second.getPeers();
-        return {};
-    }
-
-    /** Get Slot's state */
-    std::optional<SlotState>
-    getState(PublicKey const& validator)
-    {
-        auto const& it = slots_.find(validator);
-        if (it != slots_.end())
-            return it->second.getState();
         return {};
     }
 

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -1661,9 +1661,6 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMProposeSet> const& m)
         return;
     }
 
-    // RH TODO: when isTrusted = false we should probably also cache a key
-    // suppression for 30 seconds to avoid doing a relatively expensive lookup
-    // every time a spam packet is received
     PublicKey const publicKey{makeSlice(set.nodepubkey())};
     auto const isTrusted = app_.validators().trusted(publicKey);
 


### PR DESCRIPTION
This PR makes the following changes to squelching implementation
- Improves the logic of `deleteIdlePeers` by first selecting a list of peers to delete, and then deleting them at once, not one at a time.
- Removes unused methods: `getState` and `notInState`
- Improves general code readability 

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
