### PR TITLE
fix: disable `channel_authorize` when `signing_support` is disabled

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -83,9 +83,17 @@ The [commandline](https://xrpl.org/docs/references/http-websocket-apis/api-conve
 
 The `network_id` field was added in the `server_info` response in version 1.5.0 (2019), but it is not returned in [reporting mode](https://xrpl.org/rippled-server-modes.html#reporting-mode). However, use of reporting mode is now discouraged, in favor of using [Clio](https://github.com/XRPLF/clio) instead.
 
+## XRP Ledger server version 2.5.0
+
+As of 2025-04-04, version 2.5.0 is in development. You can use a pre-release version by building from source or [using the `nightly` package](https://xrpl.org/docs/infrastructure/installation/install-rippled-on-ubuntu).
+
+### Additions and bugfixes in 2.5.0
+
+- `channel_authorize`: If `signing_support` is not enabled in the config, the RPC is disabled.
+
 ## XRP Ledger server version 2.4.0
 
-As of 2025-01-28, version 2.4.0 is in development. You can use a pre-release version by building from source or [using the `nightly` package](https://xrpl.org/docs/infrastructure/installation/install-rippled-on-ubuntu).
+[Version 2.4.0](https://github.com/XRPLF/rippled/releases/tag/2.4.0) was released on March 4, 2025.
 
 ### Additions and bugfixes in 2.4.0
 

--- a/src/xrpld/rpc/handlers/PayChanClaim.cpp
+++ b/src/xrpld/rpc/handlers/PayChanClaim.cpp
@@ -40,6 +40,12 @@ namespace ripple {
 Json::Value
 doChannelAuthorize(RPC::JsonContext& context)
 {
+    if (context.role != Role::ADMIN && !context.app.config().canSign())
+    {
+        return RPC::make_error(
+            rpcNOT_SUPPORTED, "Signing is not supported by this server.");
+    }
+
     auto const& params(context.params);
     for (auto const& p : {jss::channel_id, jss::amount})
         if (!params.isMember(p))

--- a/src/xrpld/rpc/handlers/PayChanClaim.cpp
+++ b/src/xrpld/rpc/handlers/PayChanClaim.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <xrpld/app/main/Application.h>
 #include <xrpld/ledger/ReadView.h>
 #include <xrpld/rpc/Context.h>
 #include <xrpld/rpc/detail/RPCHelpers.h>


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

Every other method that takes a seed/secret is disabled if `signing_support` is disabled - that's the point of the config method.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### API Impact

Not sure how to log a bugfix change.

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
