### PR TITLE
Set up fees for WASM processing

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1271,8 +1271,17 @@
 #       default. Don't change this without understanding the consequences.
 #
 #       Example:
-#           extension_compute_limit = 2000000      # 2 million gas
+#           extension_size_limit = 2000000      # 2 mb
 #
+#   gas_price = <bytes>
+#
+#       The gas price is the conversion between WASM gas and its price in drops.
+#
+#       If this parameter is unspecified, rippled will use an internal
+#       default. Don't change this without understanding the consequences.
+#
+#       Example:
+#           gas_price = 2000000      # 2 drops per gas
 #-------------------------------------------------------------------------------
 #
 # 9. Misc Settings

--- a/include/xrpl/protocol/Fees.h
+++ b/include/xrpl/protocol/Fees.h
@@ -37,6 +37,7 @@ struct Fees
     std::uint32_t extensionComputeLimit{
         0};  // Extension compute limit (instructions)
     std::uint32_t extensionSizeLimit{0};  // Extension size limit (bytes)
+    std::uint32_t gasPrice{0};            // price of WASM gas (nano-drops)
 
     explicit Fees() = default;
     Fees(Fees const&) = default;

--- a/include/xrpl/protocol/Fees.h
+++ b/include/xrpl/protocol/Fees.h
@@ -37,7 +37,7 @@ struct Fees
     std::uint32_t extensionComputeLimit{
         0};  // Extension compute limit (instructions)
     std::uint32_t extensionSizeLimit{0};  // Extension size limit (bytes)
-    std::uint32_t gasPrice{0};            // price of WASM gas (nano-drops)
+    std::uint32_t gasPrice{0};            // price of WASM gas (micro-drops)
 
     explicit Fees() = default;
     Fees(Fees const&) = default;

--- a/include/xrpl/protocol/Fees.h
+++ b/include/xrpl/protocol/Fees.h
@@ -24,6 +24,8 @@
 
 namespace ripple {
 
+constexpr std::uint32_t MICRO_DROPS_PER_DROP{1'000'000};
+
 /** Reflects the fee settings for a particular ledger.
 
     The fees are always the same for any transactions applied

--- a/include/xrpl/protocol/TER.h
+++ b/include/xrpl/protocol/TER.h
@@ -185,6 +185,8 @@ enum TEFcodes : TERUnderlyingType {
     tefNO_TICKET,
     tefNFTOKEN_IS_NOT_TRANSFERABLE,
     tefINVALID_LEDGER_FIX_TYPE,
+    tefNO_WASM,
+    tefWASM_FIELD_NOT_INCLUDED,
 };
 
 //------------------------------------------------------------------------------

--- a/include/xrpl/protocol/detail/ledger_entries.macro
+++ b/include/xrpl/protocol/detail/ledger_entries.macro
@@ -319,6 +319,7 @@ LEDGER_ENTRY(ltFEE_SETTINGS, 0x0073, FeeSettings, fee, ({
     // New fields
     {sfExtensionComputeLimit,  soeOPTIONAL},
     {sfExtensionSizeLimit,     soeOPTIONAL},
+    {sfGasPrice,               soeOPTIONAL},
 
     {sfPreviousTxnID,          soeOPTIONAL},
     {sfPreviousTxnLgrSeq,      soeOPTIONAL},

--- a/include/xrpl/protocol/detail/sfields.macro
+++ b/include/xrpl/protocol/detail/sfields.macro
@@ -114,6 +114,8 @@ TYPED_SFIELD(sfFirstNFTokenSequence,     UINT32,    50)
 TYPED_SFIELD(sfOracleDocumentID,         UINT32,    51)
 TYPED_SFIELD(sfExtensionComputeLimit,    UINT32,    52)
 TYPED_SFIELD(sfExtensionSizeLimit,       UINT32,    53)
+TYPED_SFIELD(sfGasPrice,                 UINT32,    54)
+TYPED_SFIELD(sfComputationAllowance,     UINT32,    55)
 
 // 64-bit integers (common)
 TYPED_SFIELD(sfIndexNext,                UINT64,     1)

--- a/include/xrpl/protocol/detail/transactions.macro
+++ b/include/xrpl/protocol/detail/transactions.macro
@@ -59,6 +59,7 @@ TRANSACTION(ttESCROW_FINISH, 2, EscrowFinish, ({
     {sfFulfillment, soeOPTIONAL},
     {sfCondition, soeOPTIONAL},
     {sfCredentialIDs, soeOPTIONAL},
+    {sfComputationAllowance, soeOPTIONAL},
 }))
 
 

--- a/include/xrpl/protocol/detail/transactions.macro
+++ b/include/xrpl/protocol/detail/transactions.macro
@@ -491,8 +491,9 @@ TRANSACTION(ttFEE, 101, SetFee, ({
     {sfBaseFeeDrops, soeOPTIONAL},
     {sfReserveBaseDrops, soeOPTIONAL},
     {sfReserveIncrementDrops, soeOPTIONAL},
-    {sfExtensionComputeLimit,  soeOPTIONAL},
-    {sfExtensionSizeLimit,     soeOPTIONAL},
+    {sfExtensionComputeLimit, soeOPTIONAL},
+    {sfExtensionSizeLimit, soeOPTIONAL},
+    {sfGasPrice, soeOPTIONAL},
 }))
 
 /** This system-generated transaction type is used to update the network's negative UNL

--- a/include/xrpl/protocol/jss.h
+++ b/include/xrpl/protocol/jss.h
@@ -267,6 +267,7 @@ JSS(expiration);              // out: AccountOffers, AccountChannels,
                               //      ValidatorList, amm_info
 JSS(extension_compute);       // out: NetworkOps
 JSS(extension_size);          // out: NetworkOps
+JSS(gas_price);               // out: NetworkOps
 JSS(fail_hard);               // in: Sign, Submit
 JSS(failed);                  // out: InboundLedger
 JSS(feature);                 // in: Feature

--- a/src/libxrpl/protocol/STValidation.cpp
+++ b/src/libxrpl/protocol/STValidation.cpp
@@ -81,6 +81,7 @@ STValidation::validationFormat()
         // featureSmartEscrow
         {sfExtensionComputeLimit,  soeOPTIONAL},
         {sfExtensionSizeLimit,     soeOPTIONAL},
+        {sfGasPrice,               soeOPTIONAL},
     };
     // clang-format on
 

--- a/src/libxrpl/protocol/TER.cpp
+++ b/src/libxrpl/protocol/TER.cpp
@@ -147,6 +147,8 @@ transResults()
         MAKE_ERROR(tefNO_TICKET,                   "Ticket is not in ledger."),
         MAKE_ERROR(tefNFTOKEN_IS_NOT_TRANSFERABLE, "The specified NFToken is not transferable."),
         MAKE_ERROR(tefINVALID_LEDGER_FIX_TYPE,     "The LedgerFixType field has an invalid value."),
+        MAKE_ERROR(tefNO_WASM,                     "There is no WASM code to run, but a WASM-specific field was included."),
+        MAKE_ERROR(tefWASM_FIELD_NOT_INCLUDED,     "WASM code requires a field to be included that was not included."),
 
         MAKE_ERROR(telLOCAL_ERROR,            "Local failure."),
         MAKE_ERROR(telBAD_DOMAIN,             "Domain too long."),

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -3378,22 +3378,22 @@ struct Escrow_test : public beast::unit_test::suite
     void
     run() override
     {
-        // testEnablement();
-        // testTiming();
-        // testTags();
-        // testDisallowXRP();
-        // test1571();
-        // testFails();
-        // testLockup();
-        // testEscrowConditions();
-        // testMetaAndOwnership();
-        // testConsequences();
-        // testEscrowWithTickets();
-        // testCredentials();
-        // testCreateFinishFunctionPreflight();
+        testEnablement();
+        testTiming();
+        testTags();
+        testDisallowXRP();
+        test1571();
+        testFails();
+        testLockup();
+        testEscrowConditions();
+        testMetaAndOwnership();
+        testConsequences();
+        testEscrowWithTickets();
+        testCredentials();
+        testCreateFinishFunctionPreflight();
         testFinishWasmFailures();
-        // testFinishFunction();
-        // testAllHostFunctions();
+        testFinishFunction();
+        testAllHostFunctions();
     }
 };
 

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -1864,18 +1864,18 @@ struct Escrow_test : public beast::unit_test::suite
             env.close();
         }
 
-        Env env(*this, envconfig([](std::unique_ptr<Config> cfg) {
-            cfg->FEES.extension_compute_limit = 100'000;
-            cfg->FEES.gas_price = 1'000'000;  // 1 drop = 1 gas
-            return cfg;
-        }));
+        Env env(*this);
+
+        // Run past the flag ledger so that a Fee change vote occurs and
+        // lowers the reserve fee. (It also activates all supported
+        // amendments.)
         for (auto i = env.current()->seq(); i <= 257; ++i)
             env.close();
+
         XRPAmount const txnFees = env.current()->fees().base + 1000;
-        // create escrow
         env.fund(XRP(5000), alice, carol);
 
-        // EscrowFinish
+        // create escrow
         auto const seq = env.seq(alice);
         env(escrow(alice, carol, XRP(500)),
             finish_function(wasmHex),

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -1869,6 +1869,8 @@ struct Escrow_test : public beast::unit_test::suite
             cfg->FEES.gas_price = 1'000'000;  // 1 drop = 1 gas
             return cfg;
         }));
+        for (auto i = env.current()->seq(); i <= 257; ++i)
+            env.close();
         XRPAmount const txnFees = env.current()->fees().base + 1000;
         // create escrow
         env.fund(XRP(5000), alice, carol);
@@ -1889,7 +1891,7 @@ struct Escrow_test : public beast::unit_test::suite
             env(finish(carol, alice, seq),
                 fee(finishFee),
                 comp_allowance(110),
-                ter(telCAN_NOT_QUEUE_FEE));
+                ter(telINSUF_FEE_P));
         }
 
         {

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -1950,22 +1950,30 @@ struct Escrow_test : public beast::unit_test::suite
                 env.require(balance(carol, XRP(5000)));
 
                 env(finish(carol, alice, seq),
+                    comp_allowance(110),
                     fee(txnFees),
                     ter(tecWASM_REJECTED));
                 env(finish(alice, alice, seq),
+                    comp_allowance(110),
                     fee(txnFees),
                     ter(tecWASM_REJECTED));
                 env(finish(alice, alice, seq),
+                    comp_allowance(110),
                     fee(txnFees),
                     ter(tecWASM_REJECTED));
                 env(finish(carol, alice, seq),
+                    comp_allowance(110),
                     fee(txnFees),
                     ter(tecWASM_REJECTED));
                 env(finish(carol, alice, seq),
+                    comp_allowance(110),
                     fee(txnFees),
                     ter(tecWASM_REJECTED));
                 env.close();
-                env(finish(alice, alice, seq), fee(txnFees), ter(tesSUCCESS));
+                env(finish(alice, alice, seq),
+                    fee(txnFees),
+                    comp_allowance(110),
+                    ter(tesSUCCESS));
                 env.close();
 
                 BEAST_EXPECT((*env.le(alice))[sfOwnerCount] == 0);
@@ -1995,29 +2003,34 @@ struct Escrow_test : public beast::unit_test::suite
 
                 // no fulfillment provided, function fails
                 env(finish(carol, alice, seq),
+                    comp_allowance(110),
                     fee(txnFees),
                     ter(tecCRYPTOCONDITION_ERROR));
                 // fulfillment provided, function fails
                 env(finish(carol, alice, seq),
                     condition(cb1),
                     fulfillment(fb1),
+                    comp_allowance(110),
                     fee(txnFees),
                     ter(tecWASM_REJECTED));
                 env.close();
                 // no fulfillment provided, function succeeds
                 env(finish(alice, alice, seq),
+                    comp_allowance(110),
                     fee(txnFees),
                     ter(tecCRYPTOCONDITION_ERROR));
                 // wrong fulfillment provided, function succeeds
                 env(finish(alice, alice, seq),
                     condition(cb1),
                     fulfillment(fb2),
+                    comp_allowance(110),
                     fee(txnFees),
                     ter(tecCRYPTOCONDITION_ERROR));
                 // fulfillment provided, function succeeds, tx succeeds
                 env(finish(alice, alice, seq),
                     condition(cb1),
                     fulfillment(fb1),
+                    comp_allowance(110),
                     fee(txnFees),
                     ter(tesSUCCESS));
                 env.close();
@@ -2050,16 +2063,19 @@ struct Escrow_test : public beast::unit_test::suite
 
                 // finish time hasn't passed, function fails
                 env(finish(carol, alice, seq),
+                    comp_allowance(110),
                     fee(txnFees + 1),
                     ter(tecNO_PERMISSION));
                 env.close();
                 // finish time hasn't passed, function succeeds
                 for (; env.now() < ts; env.close())
                     env(finish(carol, alice, seq),
+                        comp_allowance(110),
                         fee(txnFees + 2),
                         ter(tecNO_PERMISSION));
 
                 env(finish(carol, alice, seq),
+                    comp_allowance(110),
                     fee(txnFees + 1),
                     ter(tesSUCCESS));
                 BEAST_EXPECT((*env.le(alice))[sfOwnerCount] == 0);
@@ -2089,17 +2105,22 @@ struct Escrow_test : public beast::unit_test::suite
 
                 // finish time hasn't passed, function fails
                 env(finish(carol, alice, seq),
+                    comp_allowance(110),
                     fee(txnFees),
                     ter(tecNO_PERMISSION));
                 env.close();
 
                 // finish time has passed, function fails
                 env(finish(carol, alice, seq),
+                    comp_allowance(110),
                     fee(txnFees),
                     ter(tecWASM_REJECTED));
                 env.close();
                 // finish time has passed, function succeeds, tx succeeds
-                env(finish(carol, alice, seq), fee(txnFees), ter(tesSUCCESS));
+                env(finish(carol, alice, seq),
+                    comp_allowance(110),
+                    fee(txnFees),
+                    ter(tesSUCCESS));
                 env.close();
 
                 BEAST_EXPECT((*env.le(alice))[sfOwnerCount] == 0);
@@ -3260,19 +3281,24 @@ struct Escrow_test : public beast::unit_test::suite
                 env.require(balance(alice, XRP(4000) - txnFees));
                 env.require(balance(carol, XRP(5000)));
 
+                auto const allowance = 40'000;
+
                 // FinishAfter time hasn't passed
                 env(finish(carol, alice, seq),
+                    comp_allowance(allowance),
                     fee(txnFees),
                     ter(tecNO_PERMISSION));
                 env.close();
 
                 // tx sender not escrow creator (alice)
                 env(finish(carol, alice, seq),
+                    comp_allowance(allowance),
                     fee(txnFees),
                     ter(tecWASM_REJECTED));
 
                 // destination balance is too high
                 env(finish(carol, alice, seq),
+                    comp_allowance(allowance),
                     fee(txnFees),
                     ter(tecWASM_REJECTED));
 
@@ -3284,11 +3310,15 @@ struct Escrow_test : public beast::unit_test::suite
 
                 // tx sender not escrow creator (alice)
                 env(finish(carol, alice, seq),
+                    comp_allowance(allowance),
                     fee(txnFees),
                     ter(tecWASM_REJECTED));
                 env.close();
 
-                env(finish(alice, alice, seq), fee(txnFees), ter(tesSUCCESS));
+                env(finish(alice, alice, seq),
+                    comp_allowance(allowance),
+                    fee(txnFees),
+                    ter(tesSUCCESS));
                 env.close();
 
                 BEAST_EXPECT((*env.le(alice))[sfOwnerCount] == 0);
@@ -3299,22 +3329,22 @@ struct Escrow_test : public beast::unit_test::suite
     void
     run() override
     {
-        // testEnablement();
-        // testTiming();
-        // testTags();
-        // testDisallowXRP();
-        // test1571();
-        // testFails();
-        // testLockup();
-        // testEscrowConditions();
-        // testMetaAndOwnership();
-        // testConsequences();
-        // testEscrowWithTickets();
-        // testCredentials();
+        testEnablement();
+        testTiming();
+        testTags();
+        testDisallowXRP();
+        test1571();
+        testFails();
+        testLockup();
+        testEscrowConditions();
+        testMetaAndOwnership();
+        testConsequences();
+        testEscrowWithTickets();
+        testCredentials();
         testCreateFinishFunctionPreflight();
         testFinishWasmFailures();
-        // testFinishFunction();
-        // testAllHostFunctions();
+        testFinishFunction();
+        testAllHostFunctions();
     }
 };
 

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -1703,6 +1703,28 @@ struct Escrow_test : public beast::unit_test::suite
             env.close();
         }
 
+        {
+            // FinishFunction > max length
+            Env env(*this, envconfig([](std::unique_ptr<Config> cfg) {
+                cfg->FEES.extension_size_limit = 10;  // 10 bytes
+                return cfg;
+            }));
+            XRPAmount const txnFees = env.current()->fees().base + 1000;
+            // create escrow
+            env.fund(XRP(5000), alice, carol);
+
+            auto escrowCreate = escrow(alice, carol, XRP(500));
+
+            // 11-byte string
+            std::string longWasmHex = "00112233445566778899AA";
+            env(escrowCreate,
+                finish_function(longWasmHex),
+                cancel_time(env.now() + 100s),
+                fee(txnFees),
+                ter(temMALFORMED));
+            env.close();
+        }
+
         Env env(*this, envconfig([](std::unique_ptr<Config> cfg) {
             cfg->START_UP = Config::FRESH;
             return cfg;
@@ -1797,23 +1819,6 @@ struct Escrow_test : public beast::unit_test::suite
                 ter(temMALFORMED));
             env.close();
         }
-        // {
-        //     // FinishFunction > max length
-        //     std::string longWasmHex = "00";
-        //     // TODO: fix to use the config setting
-        //     // TODO: make this test more efficient
-        //     // uncomment when that's done
-        //     for (int i = 0; i < 4294967295; i++)
-        //     {
-        //         longWasmHex += "11";
-        //     }
-        //     env(escrowCreate,
-        //         finish_function(longWasmHex),
-        //         cancel_time(env.now() + 100s),
-        //         fee(txnFees),
-        //         ter(temMALFORMED));
-        //     env.close();
-        // }
     }
 
     void
@@ -1860,7 +1865,8 @@ struct Escrow_test : public beast::unit_test::suite
         }
 
         Env env(*this, envconfig([](std::unique_ptr<Config> cfg) {
-            cfg->START_UP = Config::FRESH;
+            cfg->FEES.extension_compute_limit = 100'000;
+            cfg->FEES.gas_price = 1'000'000;  // 1 drop = 1 gas
             return cfg;
         }));
         XRPAmount const txnFees = env.current()->fees().base + 1000;
@@ -3329,22 +3335,22 @@ struct Escrow_test : public beast::unit_test::suite
     void
     run() override
     {
-        testEnablement();
-        testTiming();
-        testTags();
-        testDisallowXRP();
-        test1571();
-        testFails();
-        testLockup();
-        testEscrowConditions();
-        testMetaAndOwnership();
-        testConsequences();
-        testEscrowWithTickets();
-        testCredentials();
-        testCreateFinishFunctionPreflight();
+        // testEnablement();
+        // testTiming();
+        // testTags();
+        // testDisallowXRP();
+        // test1571();
+        // testFails();
+        // testLockup();
+        // testEscrowConditions();
+        // testMetaAndOwnership();
+        // testConsequences();
+        // testEscrowWithTickets();
+        // testCredentials();
+        // testCreateFinishFunctionPreflight();
         testFinishWasmFailures();
-        testFinishFunction();
-        testAllHostFunctions();
+        // testFinishFunction();
+        // testAllHostFunctions();
     }
 };
 

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -1890,10 +1890,10 @@ struct Escrow_test : public beast::unit_test::suite
             // not enough gas
             // This function takes 110 gas
             // In testing, 1 gas costs 1 drop
-            auto const finishFee = env.current()->fees().base + 109;
+            auto const finishFee = env.current()->fees().base + 108;
             env(finish(carol, alice, seq),
                 fee(finishFee),
-                comp_allowance(109),
+                comp_allowance(108),
                 ter(tecFAILED_PROCESSING));
         }
     }

--- a/src/test/app/FeeVote_test.cpp
+++ b/src/test/app/FeeVote_test.cpp
@@ -43,6 +43,7 @@ class FeeVote_test : public beast::unit_test::suite
             BEAST_EXPECT(
                 setup.extension_size_limit ==
                 defaultSetup.extension_size_limit);
+            BEAST_EXPECT(setup.gas_price == defaultSetup.gas_price);
         }
         {
             Section config;
@@ -51,13 +52,15 @@ class FeeVote_test : public beast::unit_test::suite
                  "account_reserve = 1234567",
                  "owner_reserve = 1234",
                  "extension_compute_limit = 100",
-                 "extension_size_limit = 200"});
+                 "extension_size_limit = 200",
+                 " gas_price = 300"});
             auto setup = setup_FeeVote(config);
             BEAST_EXPECT(setup.reference_fee == 50);
             BEAST_EXPECT(setup.account_reserve == 1234567);
             BEAST_EXPECT(setup.owner_reserve == 1234);
             BEAST_EXPECT(setup.extension_compute_limit == 100);
             BEAST_EXPECT(setup.extension_size_limit == 200);
+            BEAST_EXPECT(setup.gas_price == 300);
         }
         {
             Section config;
@@ -66,7 +69,8 @@ class FeeVote_test : public beast::unit_test::suite
                  "account_reserve = yada",
                  "owner_reserve = foo",
                  "extension_compute_limit = bar",
-                 "extension_size_limit = baz"});
+                 "extension_size_limit = baz",
+                 "gas_price = qux"});
             // Illegal values are ignored, and the defaults left unchanged
             auto setup = setup_FeeVote(config);
             BEAST_EXPECT(setup.reference_fee == defaultSetup.reference_fee);
@@ -78,6 +82,7 @@ class FeeVote_test : public beast::unit_test::suite
             BEAST_EXPECT(
                 setup.extension_size_limit ==
                 defaultSetup.extension_size_limit);
+            BEAST_EXPECT(setup.gas_price == defaultSetup.gas_price);
         }
         {
             Section config;
@@ -86,7 +91,8 @@ class FeeVote_test : public beast::unit_test::suite
                  "account_reserve = -1234567",
                  "owner_reserve = -1234",
                  "extension_compute_limit = -100",
-                 "extension_size_limit = -200"});
+                 "extension_size_limit = -200",
+                 "gas_price = -300"});
             // Illegal values are ignored, and the defaults left unchanged
             auto setup = setup_FeeVote(config);
             BEAST_EXPECT(setup.reference_fee == defaultSetup.reference_fee);
@@ -99,6 +105,7 @@ class FeeVote_test : public beast::unit_test::suite
                 static_cast<std::uint32_t>(-100));
             BEAST_EXPECT(
                 setup.extension_size_limit == static_cast<std::uint32_t>(-200));
+            BEAST_EXPECT(setup.gas_price == static_cast<std::uint32_t>(-300));
         }
         {
             const auto big64 = std::to_string(
@@ -111,7 +118,8 @@ class FeeVote_test : public beast::unit_test::suite
                  "account_reserve = " + big64,
                  "owner_reserve = " + big64,
                  "extension_compute_limit = " + big64,
-                 "extension_size_limit = " + big64});
+                 "extension_size_limit = " + big64,
+                 "gas_price = " + big64});
             // Illegal values are ignored, and the defaults left unchanged
             auto setup = setup_FeeVote(config);
             BEAST_EXPECT(setup.reference_fee == defaultSetup.reference_fee);
@@ -123,6 +131,7 @@ class FeeVote_test : public beast::unit_test::suite
             BEAST_EXPECT(
                 setup.extension_size_limit ==
                 defaultSetup.extension_size_limit);
+            BEAST_EXPECT(setup.gas_price == defaultSetup.gas_price);
         }
     }
 

--- a/src/test/app/PseudoTx_test.cpp
+++ b/src/test/app/PseudoTx_test.cpp
@@ -54,6 +54,7 @@ struct PseudoTx_test : public beast::unit_test::suite
             {
                 obj[sfExtensionComputeLimit] = 0;
                 obj[sfExtensionSizeLimit] = 0;
+                obj[sfGasPrice] = 0;
             }
         }));
 

--- a/src/test/jtx/TestHelpers.h
+++ b/src/test/jtx/TestHelpers.h
@@ -398,6 +398,23 @@ public:
     }
 };
 
+struct comp_allowance
+{
+private:
+    std::uint32_t value_;
+
+public:
+    explicit comp_allowance(std::uint32_t const& value) : value_(value)
+    {
+    }
+
+    void
+    operator()(Env&, JTx& jt) const
+    {
+        jt.jv[sfComputationAllowance.jsonName] = value_;
+    }
+};
+
 /* Payment Channel */
 /******************************************************************************/
 

--- a/src/test/jtx/impl/envconfig.cpp
+++ b/src/test/jtx/impl/envconfig.cpp
@@ -33,6 +33,8 @@ setupConfigForUnitTests(Config& cfg)
     using namespace jtx;
     // Default fees to old values, so tests don't have to worry about changes in
     // Config.h
+    // NOTE: For new `FEES` fields, you need to wait for the first flag ledger
+    // to close for the values to be activated.
     cfg.FEES.reference_fee = 10;
     cfg.FEES.account_reserve = XRP(200).value().xrp().drops();
     cfg.FEES.owner_reserve = XRP(50).value().xrp().drops();

--- a/src/test/jtx/impl/envconfig.cpp
+++ b/src/test/jtx/impl/envconfig.cpp
@@ -38,6 +38,7 @@ setupConfigForUnitTests(Config& cfg)
     cfg.FEES.owner_reserve = XRP(50).value().xrp().drops();
     cfg.FEES.extension_compute_limit = 4294967295;
     cfg.FEES.extension_size_limit = 4294967295;
+    cfg.FEES.gas_price = 1000000;
 
     // The Beta API (currently v2) is always available to tests
     cfg.BETA_RPC_API = true;

--- a/src/xrpld/app/ledger/Ledger.cpp
+++ b/src/xrpld/app/ledger/Ledger.cpp
@@ -228,6 +228,7 @@ Ledger::Ledger(
             sle->at(sfExtensionComputeLimit) =
                 config.FEES.extension_compute_limit;
             sle->at(sfExtensionSizeLimit) = config.FEES.extension_size_limit;
+            sle->at(sfGasPrice) = config.FEES.gas_price;
         }
         rawInsert(sle);
     }
@@ -659,6 +660,7 @@ Ledger::setup()
                 auto const extensionComputeLimit =
                     sle->at(~sfExtensionComputeLimit);
                 auto const extensionSizeLimit = sle->at(~sfExtensionSizeLimit);
+                auto const gasPrice = sle->at(~sfGasPrice);
 
                 auto assign = [](std::uint32_t& dest,
                                  std::optional<std::uint32_t> const& src) {
@@ -669,7 +671,9 @@ Ledger::setup()
                 };
                 assign(fees_.extensionComputeLimit, extensionComputeLimit);
                 assign(fees_.extensionSizeLimit, extensionSizeLimit);
-                extensionFees = extensionComputeLimit || extensionSizeLimit;
+                assign(fees_.gasPrice, gasPrice);
+                extensionFees =
+                    extensionComputeLimit || extensionSizeLimit || gasPrice;
             }
             if (oldFees && newFees)
                 // Should be all of one or the other, but not both
@@ -701,7 +705,8 @@ Ledger::defaultFees(Config const& config)
 {
     assert(
         fees_.base == 0 && fees_.reserve == 0 && fees_.increment == 0 &&
-        fees_.extensionComputeLimit == 0 && fees_.extensionSizeLimit == 0);
+        fees_.extensionComputeLimit == 0 && fees_.extensionSizeLimit == 0 &&
+        fees_.gasPrice == 0);
     if (fees_.base == 0)
         fees_.base = config.FEES.reference_fee;
     if (fees_.reserve == 0)
@@ -710,6 +715,8 @@ Ledger::defaultFees(Config const& config)
         fees_.extensionComputeLimit = config.FEES.extension_compute_limit;
     if (fees_.extensionSizeLimit == 0)
         fees_.extensionSizeLimit = config.FEES.extension_size_limit;
+    if (fees_.gasPrice == 0)
+        fees_.gasPrice = config.FEES.gas_price;
 }
 
 std::shared_ptr<SLE>

--- a/src/xrpld/app/misc/FeeVoteImpl.cpp
+++ b/src/xrpld/app/misc/FeeVoteImpl.cpp
@@ -216,6 +216,7 @@ FeeVoteImpl::doValidation(
             target_.extension_size_limit,
             "extension size limit",
             sfExtensionSizeLimit);
+        vote(lastFees.gasPrice, target_.gas_price, "gas price", sfGasPrice);
     }
 }
 
@@ -246,6 +247,9 @@ FeeVoteImpl::doVoting(
     detail::VotableValue extensionSizeVote(
         lastClosedLedger->fees().extensionSizeLimit,
         target_.extension_size_limit);
+
+    detail::VotableValue gasPriceVote(
+        lastClosedLedger->fees().gasPrice, target_.gas_price);
 
     auto const& rules = lastClosedLedger->rules();
     if (rules.enabled(featureXRPFees))
@@ -332,6 +336,7 @@ FeeVoteImpl::doVoting(
                 continue;
             doVote(val, extensionComputeVote, sfExtensionComputeLimit);
             doVote(val, extensionSizeVote, sfExtensionSizeLimit);
+            doVote(val, gasPriceVote, sfGasPrice);
         }
     }
 
@@ -344,12 +349,13 @@ FeeVoteImpl::doVoting(
     auto const incReserve = incReserveVote.getVotes();
     auto const extensionCompute = extensionComputeVote.getVotes();
     auto const extensionSize = extensionSizeVote.getVotes();
+    auto const gasPrice = gasPriceVote.getVotes();
 
     auto const seq = lastClosedLedger->info().seq + 1;
 
     // add transactions to our position
     if (baseFee.second || baseReserve.second || incReserve.second ||
-        extensionCompute.second || extensionSize.second)
+        extensionCompute.second || extensionSize.second || gasPrice.second)
     {
         JLOG(journal_.warn())
             << "We are voting for a fee change: " << baseFee.first << "/"
@@ -381,6 +387,7 @@ FeeVoteImpl::doVoting(
             {
                 obj[sfExtensionComputeLimit] = extensionCompute.first;
                 obj[sfExtensionSizeLimit] = extensionSize.first;
+                obj[sfGasPrice] = gasPrice.first;
             }
         });
 

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -2296,7 +2296,7 @@ NetworkOPsImp::pubValidation(std::shared_ptr<STValidation> const& val)
             jvObj[jss::extension_size] = *extensionSizeLimit;
 
         if (auto const gasPrice = ~val->at(~sfGasPrice); gasPrice)
-            jvObj[jss::extension_size] = *gasPrice;
+            jvObj[jss::gas_price] = *gasPrice;
 
         // NOTE Use MultiApiJson to publish two slightly different JSON objects
         // for consumers supporting different API versions

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -2295,6 +2295,9 @@ NetworkOPsImp::pubValidation(std::shared_ptr<STValidation> const& val)
             extensionSizeLimit)
             jvObj[jss::extension_size] = *extensionSizeLimit;
 
+        if (auto const gasPrice = ~val->at(~sfGasPrice); gasPrice)
+            jvObj[jss::extension_size] = *gasPrice;
+
         // NOTE Use MultiApiJson to publish two slightly different JSON objects
         // for consumers supporting different API versions
         MultiApiJson multiObj{jvObj};
@@ -2758,6 +2761,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
                 l[jss::extension_compute] =
                     lpClosed->fees().extensionComputeLimit;
                 l[jss::extension_size] = lpClosed->fees().extensionSizeLimit;
+                l[jss::gas_price] = lpClosed->fees().gasPrice;
             }
             l[jss::close_time] = Json::Value::UInt(
                 lpClosed->info().closeTime.time_since_epoch().count());
@@ -2773,6 +2777,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
                 l[jss::extension_compute] =
                     lpClosed->fees().extensionComputeLimit;
                 l[jss::extension_size] = lpClosed->fees().extensionSizeLimit;
+                l[jss::gas_price] = lpClosed->fees().gasPrice;
             }
 
             if (auto const closeOffset = app_.timeKeeper().closeOffset();
@@ -2965,6 +2970,7 @@ NetworkOPsImp::pubLedger(std::shared_ptr<ReadView const> const& lpAccepted)
                     lpAccepted->fees().extensionComputeLimit;
                 jvObj[jss::extension_size] =
                     lpAccepted->fees().extensionSizeLimit;
+                jvObj[jss::gas_price] = lpAccepted->fees().gasPrice;
             }
 
             jvObj[jss::txn_count] = Json::UInt(alpAccepted->size());
@@ -4007,6 +4013,7 @@ NetworkOPsImp::subLedger(InfoSub::ref isrListener, Json::Value& jvResult)
             jvResult[jss::extension_compute] =
                 lpClosed->fees().extensionComputeLimit;
             jvResult[jss::extension_size] = lpClosed->fees().extensionSizeLimit;
+            jvResult[jss::gas_price] = lpClosed->fees().gasPrice;
         }
     }
 

--- a/src/xrpld/app/tx/detail/Change.cpp
+++ b/src/xrpld/app/tx/detail/Change.cpp
@@ -133,13 +133,15 @@ Change::preclaim(PreclaimContext const& ctx)
             if (ctx.view.rules().enabled(featureSmartEscrow))
             {
                 if (!ctx.tx.isFieldPresent(sfExtensionComputeLimit) ||
-                    !ctx.tx.isFieldPresent(sfExtensionSizeLimit))
+                    !ctx.tx.isFieldPresent(sfExtensionSizeLimit) ||
+                    !ctx.tx.isFieldPresent(sfGasPrice))
                     return temMALFORMED;
             }
             else
             {
                 if (ctx.tx.isFieldPresent(sfExtensionComputeLimit) ||
-                    ctx.tx.isFieldPresent(sfExtensionSizeLimit))
+                    ctx.tx.isFieldPresent(sfExtensionSizeLimit) ||
+                    ctx.tx.isFieldPresent(sfGasPrice))
                     return temDISABLED;
             }
             return tesSUCCESS;
@@ -393,6 +395,7 @@ Change::applyFee()
     {
         set(feeObject, ctx_.tx, sfExtensionComputeLimit);
         set(feeObject, ctx_.tx, sfExtensionSizeLimit);
+        set(feeObject, ctx_.tx, sfGasPrice);
     }
 
     view().update(feeObject);

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -402,6 +402,16 @@ EscrowFinish::preflight(PreflightContext const& ctx)
         }
     }
 
+    if (auto const allowance = ctx.tx[~sfComputationAllowance]; allowance)
+    {
+        if (*allowance > ctx.app.config().FEES.extension_compute_limit)
+        {
+            JLOG(ctx.j.debug())
+                << "ComputationAllowance too large: " << *allowance;
+            return temBAD_LIMIT;
+        }
+    }
+
     if (auto const err = credentials::checkFields(ctx); !isTesSuccess(err))
         return err;
 

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -620,9 +620,12 @@ EscrowFinish::doApply()
 
         WasmHostFunctionsImpl ledgerDataProvider(ctx_, k);
 
-        std::uint32_t allowance = std::min(
-            ctx_.tx[sfComputationAllowance],
-            ctx_.app.config().FEES.extension_compute_limit);
+        if (!ctx.tx.isFieldPresent(sfComputationAllowance))
+        {
+            // already checked above, this check is just in case
+            return tecINTERNAL;
+        }
+        std::uint32_t allowance = ctx_.tx[sfComputationAllowance];
         auto re = runEscrowWasm(wasm, funcName, &ledgerDataProvider, allowance);
         JLOG(j_.trace()) << "Escrow WASM ran";
         if (re.has_value())

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -620,7 +620,7 @@ EscrowFinish::doApply()
 
         WasmHostFunctionsImpl ledgerDataProvider(ctx_, k);
 
-        if (!ctx.tx.isFieldPresent(sfComputationAllowance))
+        if (!ctx_.tx.isFieldPresent(sfComputationAllowance))
         {
             // already checked above, this check is just in case
             return tecINTERNAL;

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -429,8 +429,7 @@ EscrowFinish::calculateBaseFee(ReadView const& view, STTx const& tx)
     }
     if (auto const allowance = tx[~sfComputationAllowance])
     {
-        // TODO: get gas-drops conversion
-        extraFee += (1000 / 1000000) * (*allowance);
+        extraFee += (view.fees().gasPrice / 1000000) * (*allowance);
     }
 
     return Transactor::calculateBaseFee(view, tx) + extraFee;

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -417,7 +417,11 @@ EscrowFinish::calculateBaseFee(ReadView const& view, STTx const& tx)
     {
         extraFee += view.fees().base * (32 + (fb->size() / 16));
     }
-    // TODO: make this fee increase based on the extra compute run
+    if (auto const allowance = tx[~sfComputationAllowance])
+    {
+        // TODO: get gas-drops conversion
+        extraFee += (1000 / 1000000) * (*allowance);
+    }
 
     return Transactor::calculateBaseFee(view, tx) + extraFee;
 }

--- a/src/xrpld/core/Config.h
+++ b/src/xrpld/core/Config.h
@@ -79,7 +79,7 @@ struct FeeSetup
     /** The WASM size limit for Feature Extensions. */
     std::uint32_t extension_size_limit{4294967295};
 
-    /** The price of 1 WASM gas, in nano-drops. */
+    /** The price of 1 WASM gas, in micro-drops. */
     std::uint32_t gas_price{1000000};
 
     /* (Remember to update the example cfg files when changing any of these

--- a/src/xrpld/core/Config.h
+++ b/src/xrpld/core/Config.h
@@ -79,6 +79,9 @@ struct FeeSetup
     /** The WASM size limit for Feature Extensions. */
     std::uint32_t extension_size_limit{4294967295};
 
+    /** The price of 1 WASM gas, in nano-drops. */
+    std::uint32_t gas_price{1000000};
+
     /* (Remember to update the example cfg files when changing any of these
      * values.) */
 };

--- a/src/xrpld/core/detail/Config.cpp
+++ b/src/xrpld/core/detail/Config.cpp
@@ -1108,6 +1108,8 @@ setup_FeeVote(Section const& section)
             setup.extension_compute_limit = temp;
         if (set(temp, "extension_size_limit", section))
             setup.extension_size_limit = temp;
+        if (set(temp, "gas_price", section))
+            setup.gas_price = temp;
     }
     return setup;
 }


### PR DESCRIPTION
## High Level Overview of Change

This PR:
* Adds a new fee parameter, `gasPrice` - this is the price of 1 gas in micro-drops (i.e. 1,000,000 of this unit = 1 drop/gas)
* Adds a new `EscrowFinish` parameter, `ComputationAllowance` - this is how much gas the transaction submitter is willing to pay
* Adds `ComputationAllowance * gasPrice / 100000` to the `EscrowFinish` transaction fee
* Adds tests for everything

### Context of Change

Setting up proper fees for WASM usage

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan
Tests were added and work properly.

<!--
## Future Tasks
For future tasks related to PR.
-->
