### PR TITLE
chore: Renames docs job and runs on shared runner

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  job:
-    runs-on: ubuntu-latest
+  documentation:
+    runs-on: [self-hosted, heavy]
     permissions:
       contents: write
     container: ghcr.io/xrplf/rippled-build-ubuntu:aaf5e3e


### PR DESCRIPTION
## High Level Overview of Change

Renames the docs job from `job` to `documentation` for better readability, and makes it run on the shared runner.

### Context of Change

We were pulling our Docker images from DockerHub without logging in, causing us to run into rate limits. To solve this, the images were pushed to our GitHub registry, but the documentation pipeline cannot access them as it runs on the GitHub runner instead of our own runner. This change makes the pipeline run on our shared runner.

As the documentation job name `job` is meaningless, this PR renames it to `documentation`.

### Type of Change

- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)