### PR TITLE
Ensure that coverage file generation is atomic.

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -247,7 +247,7 @@ jobs:
           mkdir -p ~/.conan
           tar -xzf conan.tar -C ~/.conan
       - name: install gcovr
-        run: pip install "gcovr>=8,<9"
+        run: pip install "gcovr>=7,<9"
       - name: check environment
         run: |
           echo ${PATH} | tr ':' '\n'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -247,7 +247,7 @@ jobs:
           mkdir -p ~/.conan
           tar -xzf conan.tar -C ~/.conan
       - name: install gcovr
-        run: pip install "gcovr>=7,<8"
+        run: pip install "gcovr>=8,<9"
       - name: check environment
         run: |
           echo ${PATH} | tr ':' '\n'

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -209,6 +209,16 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     if(HAVE_c_fprofile_abs_path)
         set(COVERAGE_C_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-abs-path")
     endif()
+
+    check_cxx_compiler_flag(-fprofile-update HAVE_cxx_fprofile_update)
+    if(HAVE_cxx_fprofile_update)
+        set(COVERAGE_CXX_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS}  -fprofile-update=atomic")
+    endif()
+    include(CheckCCompilerFlag)
+    check_c_compiler_flag(-fprofile-update HAVE_c_fprofile_update)
+    if(HAVE_c_fprofile_update)
+        set(COVERAGE_C_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-update=atomic")
+    endif()
 endif()
 
 set(CMAKE_Fortran_FLAGS_COVERAGE

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -203,11 +203,13 @@ set(COVERAGE_COMPILER_FLAGS "-g --coverage"
     CACHE INTERNAL "")
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     include(CheckCXXCompilerFlag)
+    include(CheckCCompilerFlag)
+
     check_cxx_compiler_flag(-fprofile-abs-path HAVE_cxx_fprofile_abs_path)
     if(HAVE_cxx_fprofile_abs_path)
         set(COVERAGE_CXX_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-abs-path")
     endif()
-    include(CheckCCompilerFlag)
+
     check_c_compiler_flag(-fprofile-abs-path HAVE_c_fprofile_abs_path)
     if(HAVE_c_fprofile_abs_path)
         set(COVERAGE_C_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-abs-path")
@@ -217,7 +219,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     if(HAVE_cxx_fprofile_update)
         set(COVERAGE_CXX_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS}  -fprofile-update=atomic")
     endif()
-    include(CheckCCompilerFlag)
+
     check_c_compiler_flag(-fprofile-update HAVE_c_fprofile_update)
     if(HAVE_c_fprofile_update)
         set(COVERAGE_C_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-update=atomic")

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -98,6 +98,9 @@
 # 2024-04-03, Bronek Kozicki
 #     - add support for output formats: jacoco, clover, lcov
 #
+# 2025-05-12, Jingchen Wu
+#     - add -fprofile-update=atomic to ensure atomic profile generation
+#
 # USAGE:
 #
 # 1. Copy this file into your cmake modules path.


### PR DESCRIPTION
## High Level Overview of Change

Added `-fprofile-update=atomic` as instructed by https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. We were getting errors like the following when running with the latest gconvr version.

```
(WARNING) - Thread-12 (worker) - Unrecognized GCOV output for /Users/a/rippled/.build/modules/xrpl.libxrpl.basics/xrpl/basics/base_uint.h
	  4491647027:  130:    data() const
	  4491647027:  132:        return reinterpret_cast<const_pointer>(data_.data());
	  4485690555:  132-block  0
	This is indicative of a gcov output parse error.
	Please report this to the gcovr developers
	at <https://github.com/gcovr/gcovr/issues>.
(WARNING) - Thread-12 (worker) - Exception during parsing:
	SuspiciousHits: Got suspicious hit value in gcov line '4491647027:  130:    data() const' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.
(WARNING) - Thread-12 (worker) - Exception during parsing:
	SuspiciousHits: Got suspicious hit value in gcov line '4491647027:  132:        return reinterpret_cast<const_pointer>(data_.data());' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.
(WARNING) - Thread-12 (worker) - Exception during parsing:
	SuspiciousHits: Got suspicious hit value in gcov line '4485690555:  132-block  0' caused by a
bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-suspicious-hits-threshold.
``` 

The issue was that we're running unit tests in parallel and multiple threads can write into one file, which can corrupt output files, and then gcovr won't be able to parse the corrupted file. The error message suggested ignoring the wrong lines but it only hides the underlying issue, which is not ideal. We should make sure file writes are locked and avoid corrupting files.


### Context of Change

The bug was introduced when we started running unit tests in parallel, and older gconvr doesn't complain about this issue.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

This fix only affects unit tests and doesn't affect any API.
