### PR TITLE
fix: improve multisign usage of `simulate`

### DIFF
--- a/src/test/rpc/Simulate_test.cpp
+++ b/src/test/rpc/Simulate_test.cpp
@@ -838,11 +838,12 @@ class Simulate_test : public beast::unit_test::suite
             tx[jss::Account] = env.master.human();
             tx[jss::TransactionType] = jss::AccountSet;
             tx[sfDomain] = newDomain;
+            // master key is disabled, so this is invalid
+            tx[jss::SigningPubKey] = strHex(env.master.pk().slice());
 
             // test with autofill
             testTx(env, tx, testSimulation);
 
-            tx[sfSigningPubKey] = "";
             tx[sfTxnSignature] = "";
             tx[sfSequence] = env.seq(env.master);
             tx[sfFee] = env.current()->fees().base.jsonClipped().asString();

--- a/src/test/rpc/Simulate_test.cpp
+++ b/src/test/rpc/Simulate_test.cpp
@@ -720,7 +720,11 @@ class Simulate_test : public beast::unit_test::suite
                                       Json::Value const& tx) {
                 auto result = resp[jss::result];
                 checkBasicReturnValidity(
-                    result, tx, env.seq(alice), env.current()->fees().base * 2);
+                    result,
+                    tx,
+                    env.seq(alice),
+                    tx.isMember(jss::Signers) ? env.current()->fees().base * 2
+                                              : env.current()->fees().base);
 
                 BEAST_EXPECT(result[jss::engine_result] == "tesSUCCESS");
                 BEAST_EXPECT(result[jss::engine_result_code] == 0);
@@ -762,6 +766,10 @@ class Simulate_test : public beast::unit_test::suite
             tx[jss::Account] = alice.human();
             tx[jss::TransactionType] = jss::AccountSet;
             tx[sfDomain] = newDomain;
+
+            // test with autofill
+            testTx(env, tx, validateOutput, false);
+
             tx[sfSigners] = Json::arrayValue;
             {
                 Json::Value signer;
@@ -771,7 +779,7 @@ class Simulate_test : public beast::unit_test::suite
                 tx[sfSigners].append(signerOuter);
             }
 
-            // test with autofill
+            // test with just signer accounts
             testTx(env, tx, validateOutput, false);
 
             tx[sfSigningPubKey] = "";

--- a/src/test/rpc/Simulate_test.cpp
+++ b/src/test/rpc/Simulate_test.cpp
@@ -854,7 +854,7 @@ class Simulate_test : public beast::unit_test::suite
     }
 
     void
-    testTransactionSingleAndMultiSigning()
+    testInvalidSingleAndMultiSigningTransaction()
     {
         testcase(
             "Transaction with both single-signing SigningPubKey and "
@@ -1199,7 +1199,7 @@ public:
         testTransactionTecFailure();
         testSuccessfulTransactionMultisigned();
         testTransactionSigningFailure();
-        testTransactionSingleAndMultiSigning();
+        testInvalidSingleAndMultiSigningTransaction();
         testMultisignedBadPubKey();
         testDeleteExpiredCredentials();
         testSuccessfulTransactionNetworkID();

--- a/src/test/rpc/Simulate_test.cpp
+++ b/src/test/rpc/Simulate_test.cpp
@@ -788,8 +788,7 @@ class Simulate_test : public beast::unit_test::suite
             // transaction requires a non-base fee
             tx[sfFee] =
                 (env.current()->fees().base * 2).jsonClipped().asString();
-            tx[sfSigners][0u][sfSigner][jss::SigningPubKey] =
-                strHex(becky.pk().slice());
+            tx[sfSigners][0u][sfSigner][jss::SigningPubKey] = "";
             tx[sfSigners][0u][sfSigner][jss::TxnSignature] = "";
 
             // test without autofill

--- a/src/xrpld/app/tx/detail/Transactor.cpp
+++ b/src/xrpld/app/tx/detail/Transactor.cpp
@@ -297,9 +297,9 @@ Transactor::checkFee(PreclaimContext const& ctx, XRPAmount baseFee)
 
     if (balance < feePaid)
     {
-        JLOG(ctx.j.trace()) << "Insufficient balance:"
-                            << " balance=" << to_string(balance)
-                            << " paid=" << to_string(feePaid);
+        JLOG(ctx.j.trace())
+            << "Insufficient balance:" << " balance=" << to_string(balance)
+            << " paid=" << to_string(feePaid);
 
         if ((balance > beast::zero) && !ctx.view.open())
         {
@@ -615,6 +615,12 @@ Transactor::checkSign(PreclaimContext const& ctx)
     auto const sleAccount = ctx.view.read(keylet::account(idAccount));
     if (!sleAccount)
         return terNO_ACCOUNT;
+
+    if ((ctx.flags & tapDRY_RUN) && !ctx.tx.isFieldPresent(sfSigningPubKey))
+    {
+        // simulate, no SigningPubKey/signature situation to check
+        return tesSUCCESS;
+    }
 
     return checkSingleSign(
         idSigner, idAccount, sleAccount, ctx.view.rules(), ctx.j);

--- a/src/xrpld/app/tx/detail/Transactor.cpp
+++ b/src/xrpld/app/tx/detail/Transactor.cpp
@@ -603,8 +603,7 @@ Transactor::checkSign(PreclaimContext const& ctx)
 
     // If the pk is empty and not simulate or simulate and signers,
     // then we must be multi-signing.
-    if ((ctx.flags & tapDRY_RUN && ctx.tx.isFieldPresent(sfSigners)) ||
-        (!(ctx.flags & tapDRY_RUN) && ctx.tx.getSigningPubKey().empty()))
+    if (ctx.tx.isFieldPresent(sfSigners))
     {
         STArray const& txSigners(ctx.tx.getFieldArray(sfSigners));
         return checkMultiSign(ctx.view, idAccount, txSigners, ctx.flags, ctx.j);

--- a/src/xrpld/app/tx/detail/Transactor.cpp
+++ b/src/xrpld/app/tx/detail/Transactor.cpp
@@ -603,7 +603,7 @@ Transactor::checkSign(PreclaimContext const& ctx)
 
     // If the pk is empty and not simulate or simulate and signers,
     // then we must be multi-signing.
-    if (ctx.tx.isFieldPresent(sfSigners))
+    if (ctx.tx.getSigningPubKey().empty())
     {
         STArray const& txSigners(ctx.tx.getFieldArray(sfSigners));
         return checkMultiSign(ctx.view, idAccount, txSigners, ctx.flags, ctx.j);

--- a/src/xrpld/app/tx/detail/Transactor.cpp
+++ b/src/xrpld/app/tx/detail/Transactor.cpp
@@ -809,7 +809,9 @@ Transactor::checkMultiSign(
         // public key.
         auto const spk = txSigner.getFieldVL(sfSigningPubKey);
 
-        if (!(flags & tapDRY_RUN) && !publicKeyType(makeSlice(spk)))
+        // spk being non-empty in non-simulate is checked in
+        // STTx::checkMultiSign
+        if (!spk.empty() && !publicKeyType(makeSlice(spk)))
         {
             JLOG(j.trace())
                 << "checkMultiSign: signing public key type is unknown";

--- a/src/xrpld/app/tx/detail/Transactor.cpp
+++ b/src/xrpld/app/tx/detail/Transactor.cpp
@@ -594,7 +594,8 @@ Transactor::checkSign(PreclaimContext const& ctx)
     if ((ctx.flags & tapDRY_RUN) && pkSigner.empty() &&
         !ctx.tx.isFieldPresent(sfSigners))
     {
-        // simulate, no SigningPubKey/signature situation to check
+        // simulate: skip signature validation when neither SigningPubKey nor
+        // Signers are provided
         return tesSUCCESS;
     }
 

--- a/src/xrpld/app/tx/detail/Transactor.cpp
+++ b/src/xrpld/app/tx/detail/Transactor.cpp
@@ -616,7 +616,7 @@ Transactor::checkSign(PreclaimContext const& ctx)
     if (!sleAccount)
         return terNO_ACCOUNT;
 
-    if ((ctx.flags & tapDRY_RUN) && !ctx.tx.isFieldPresent(sfSigningPubKey))
+    if ((ctx.flags & tapDRY_RUN) && ctx.tx[sfSigningPubKey].empty())
     {
         // simulate, no SigningPubKey/signature situation to check
         return tesSUCCESS;


### PR DESCRIPTION
## High Level Overview of Change

This PR allows users to submit `simulate` requests from a multisign account without needing to specify the accounts that are doing the multisigning, and fixes an error with `simulate` that allowed double-"signed" (both single-sign and multi-sign public keys are provided) transactions.

### Context of Change

There was some confusion about how to use `simulate` with a multisign account. Receiving `tefMASTER_DISABLED` was unexpected. This change makes it more intuitive.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### API Impact

- [x] Public API: Non-breaking change

## Before / After

**Before:** 
Submitting a `simulate` request for a transaction from an account with the master key disabled and a multisig setup would result in `tefMASTER_DISABLED`. 
You can submit a `simulate` request with both `SigningPubKey` and `Signers`.

**After:**
Submitting a `simulate` request for a transaction from an account with the master key disabled and a multisig setup ignores signature checking completely (unless `Signers` is provided in any way, shape, or form).
Submitting a `simulate` request with both `SigningPubKey` and `Signers` results in `temINVALID`.

## Test Plan

Tests were adjusted and CI passes.
