### PR TITLE
Fix `PriceDataSeries` order on `PriceOracle` creation

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -32,6 +32,7 @@
 // If you add an amendment here, then do not forget to increment `numFeatures`
 // in include/xrpl/protocol/Feature.h.
 
+XRPL_FIX    (PriceOracleOrder,           Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(TokenEscrow,                Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (EnforceNFTokenTrustlineV2,  Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (AMMv1_3,                    Supported::yes, VoteBehavior::DefaultNo)

--- a/src/test/app/Oracle_test.cpp
+++ b/src/test/app/Oracle_test.cpp
@@ -678,6 +678,58 @@ private:
             oracle.set(
                 UpdateArg{.series = {{"XRP", "USD", 742, 2}}, .fee = baseFee});
         }
+
+        for (bool const withFixOrder : {false, true})
+        {
+            // Should be same order as creation
+            Env env(
+                *this,
+                withFixOrder ? supported_amendments()
+                             : supported_amendments() - fixPriceOracleOrder);
+
+            auto test = [&](Env& env, DataSeries const& series) {
+                env.fund(XRP(1'000), owner);
+                Oracle oracle(env, {.owner = owner, .series = series});
+                BEAST_EXPECT(oracle.exists());
+                auto sle = env.le(keylet::oracle(owner, oracle.documentID()));
+                BEAST_EXPECT(
+                    sle->getFieldArray(sfPriceDataSeries).size() ==
+                    series.size());
+
+                auto const beforeQuoteAssetName1 =
+                    sle->getFieldArray(sfPriceDataSeries)[0]
+                        .getFieldCurrency(sfQuoteAsset)
+                        .getText();
+                auto const beforeQuoteAssetName2 =
+                    sle->getFieldArray(sfPriceDataSeries)[1]
+                        .getFieldCurrency(sfQuoteAsset)
+                        .getText();
+
+                oracle.set(UpdateArg{.series = series});
+                sle = env.le(keylet::oracle(owner, oracle.documentID()));
+
+                auto const afterQuoteAssetName1 =
+                    sle->getFieldArray(sfPriceDataSeries)[0]
+                        .getFieldCurrency(sfQuoteAsset)
+                        .getText();
+                auto const afterQuoteAssetName2 =
+                    sle->getFieldArray(sfPriceDataSeries)[1]
+                        .getFieldCurrency(sfQuoteAsset)
+                        .getText();
+
+                if (env.current()->rules().enabled(fixPriceOracleOrder))
+                {
+                    BEAST_EXPECT(afterQuoteAssetName1 == beforeQuoteAssetName1);
+                    BEAST_EXPECT(afterQuoteAssetName2 == beforeQuoteAssetName2);
+                }
+                else
+                {
+                    BEAST_EXPECT(afterQuoteAssetName1 != beforeQuoteAssetName1);
+                    BEAST_EXPECT(afterQuoteAssetName2 != beforeQuoteAssetName2);
+                }
+            };
+            test(env, {{"XRP", "USD", 742, 2}, {"XRP", "EUR", 711, 2}});
+        }
     }
 
     void

--- a/src/xrpld/app/tx/detail/SetOracle.cpp
+++ b/src/xrpld/app/tx/detail/SetOracle.cpp
@@ -285,7 +285,34 @@ SetOracle::doApply()
         sle->setFieldVL(sfProvider, ctx_.tx[sfProvider]);
         if (ctx_.tx.isFieldPresent(sfURI))
             sle->setFieldVL(sfURI, ctx_.tx[sfURI]);
-        auto const& series = ctx_.tx.getFieldArray(sfPriceDataSeries);
+
+        STArray series;
+        if (!ctx_.view().rules().enabled(fixPriceOracleOrder))
+        {
+            series = ctx_.tx.getFieldArray(sfPriceDataSeries);
+        }
+        else
+        {
+            std::map<std::pair<Currency, Currency>, STObject> pairs;
+            for (auto const& entry : ctx_.tx.getFieldArray(sfPriceDataSeries))
+            {
+                auto const key = tokenPairKey(entry);
+                STObject priceData{sfPriceData};
+                setPriceDataInnerObjTemplate(priceData);
+                priceData.setFieldCurrency(
+                    sfBaseAsset, entry.getFieldCurrency(sfBaseAsset));
+                priceData.setFieldCurrency(
+                    sfQuoteAsset, entry.getFieldCurrency(sfQuoteAsset));
+                priceData.setFieldU64(
+                    sfAssetPrice, entry.getFieldU64(sfAssetPrice));
+                if (entry.isFieldPresent(sfScale))
+                    priceData.setFieldU8(sfScale, entry.getFieldU8(sfScale));
+                pairs.emplace(key, std::move(priceData));
+            }
+            for (auto const& iter : pairs)
+                series.push_back(std::move(iter.second));
+        }
+
         sle->setFieldArray(sfPriceDataSeries, series);
         sle->setFieldVL(sfAssetClass, ctx_.tx[sfAssetClass]);
         sle->setFieldU32(sfLastUpdateTime, ctx_.tx[sfLastUpdateTime]);


### PR DESCRIPTION

## High Level Overview of Change

Fixed an issue where the order of PriceDataSeries was out of sync between when PriceOracle was created and when it was updated.

### Context of Change

Although they are registered in the canonical order when updated, they are created using the order specified in the transaction, so change so that they are also registered in the canonical order when created.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### API Impact
 no

### Examples of data with issues

```json
{
   "AffectedNodes" : [
      {
         "ModifiedNode" : {
            "FinalFields" : {
               "Account" : "rwhaYGnJMexktjhxAKzRwoCcQ2g6hvBDWu",
               "Balance" : "999999980",
               "Flags" : 8388608,
               "OwnerCount" : 1,
               "Sequence" : 6
            },
            "LedgerEntryType" : "AccountRoot",
            "LedgerIndex" : "2D6FE275B8B62F3B2C743090152CA05B8A28D5D20BEBED3A4B26745881180462",
            "PreviousFields" : {
               "Balance" : "999999990",
               "Sequence" : 5
            },
            "PreviousTxnID" : "18F8010465F8ABBE5A6DDF05E2AC5E9F28F7BA2B574FD1112B7B57C188E79F87",
            "PreviousTxnLgrSeq" : 4
         }
      },
      {
         "ModifiedNode" : {
            "FinalFields" : {
               "AssetClass" : "63757272656E6379",
               "Flags" : 0,
               "LastUpdateTime" : 946694820,
               "Owner" : "rwhaYGnJMexktjhxAKzRwoCcQ2g6hvBDWu",
               "OwnerNode" : "0",
               "PriceDataSeries" : [
                  {
                     "PriceData" : {
                        "AssetPrice" : "2c7",
                        "BaseAsset" : "XRP",
                        "QuoteAsset" : "EUR",
                        "Scale" : 2
                     }
                  },
                  {
                     "PriceData" : {
                        "AssetPrice" : "2e6",
                        "BaseAsset" : "XRP",
                        "QuoteAsset" : "USD",
                        "Scale" : 2
                     }
                  }
               ],
               "Provider" : "70726F7669646572",
               "URI" : "555249"
            },
            "LedgerEntryType" : "Oracle",
            "LedgerIndex" : "72CD5C8AE42E0A993C1234E95B0F8A3BC7CADBD7097ACB23CC7B6DBFB06AA101",
            "PreviousFields" : {
               "LastUpdateTime" : 946694810,
               "PriceDataSeries" : [
                  {
                     "PriceData" : {
                        "AssetPrice" : "2e6",
                        "BaseAsset" : "XRP",
                        "QuoteAsset" : "USD",
                        "Scale" : 2
                     }
                  },
                  {
                     "PriceData" : {
                        "AssetPrice" : "2c7",
                        "BaseAsset" : "XRP",
                        "QuoteAsset" : "EUR",
                        "Scale" : 2
                     }
                  }
               ]
            },
            "PreviousTxnID" : "18F8010465F8ABBE5A6DDF05E2AC5E9F28F7BA2B574FD1112B7B57C188E79F87",
            "PreviousTxnLgrSeq" : 4
         }
      }
   ],
   "TransactionIndex" : 0,
   "TransactionResult" : "tesSUCCESS"
}
```
