### PR TITLE
[DRAFT] Decouple ledger from xrpld/app

### DIFF
--- a/src/xrpld/app/misc/CredentialHelpers.cpp
+++ b/src/xrpld/app/misc/CredentialHelpers.cpp
@@ -150,7 +150,11 @@ checkFields(STTx const& tx, beast::Journal j)
 }
 
 TER
-valid(STTx const& tx, ReadView const& view, AccountID const& src, beast::Journal j)
+valid(
+    STTx const& tx,
+    ReadView const& view,
+    AccountID const& src,
+    beast::Journal j)
 {
     if (!tx.isFieldPresent(sfCredentialIDs))
         return tesSUCCESS;
@@ -368,8 +372,7 @@ verifyDepositPreauth(
     bool const credentialsPresent = tx.isFieldPresent(sfCredentialIDs);
 
     if (credentialsPresent &&
-        credentials::removeExpired(
-            view, tx.getFieldV256(sfCredentialIDs), j))
+        credentials::removeExpired(view, tx.getFieldV256(sfCredentialIDs), j))
         return tecEXPIRED;
 
     if (sleDst && (sleDst->getFlags() & lsfDepositAuth))
@@ -380,9 +383,7 @@ verifyDepositPreauth(
                 return !credentialsPresent
                     ? tecNO_PERMISSION
                     : credentials::authorizedDepositPreauth(
-                          view,
-                          tx.getFieldV256(sfCredentialIDs),
-                          dst);
+                          view, tx.getFieldV256(sfCredentialIDs), dst);
         }
     }
 

--- a/src/xrpld/app/misc/CredentialHelpers.cpp
+++ b/src/xrpld/app/misc/CredentialHelpers.cpp
@@ -120,15 +120,15 @@ deleteSLE(
 }
 
 NotTEC
-checkFields(PreflightContext const& ctx)
+checkFields(STTx const& tx, beast::Journal j)
 {
-    if (!ctx.tx.isFieldPresent(sfCredentialIDs))
+    if (!tx.isFieldPresent(sfCredentialIDs))
         return tesSUCCESS;
 
-    auto const& credentials = ctx.tx.getFieldV256(sfCredentialIDs);
+    auto const& credentials = tx.getFieldV256(sfCredentialIDs);
     if (credentials.empty() || (credentials.size() > maxCredentialsArraySize))
     {
-        JLOG(ctx.j.trace())
+        JLOG(j.trace())
             << "Malformed transaction: Credentials array size is invalid: "
             << credentials.size();
         return temMALFORMED;
@@ -140,7 +140,7 @@ checkFields(PreflightContext const& ctx)
         auto [it, ins] = duplicates.insert(cred);
         if (!ins)
         {
-            JLOG(ctx.j.trace())
+            JLOG(j.trace())
                 << "Malformed transaction: duplicates in credentials.";
             return temMALFORMED;
         }
@@ -150,24 +150,24 @@ checkFields(PreflightContext const& ctx)
 }
 
 TER
-valid(PreclaimContext const& ctx, AccountID const& src)
+valid(STTx const& tx, ReadView const& view, AccountID const& src, beast::Journal j)
 {
-    if (!ctx.tx.isFieldPresent(sfCredentialIDs))
+    if (!tx.isFieldPresent(sfCredentialIDs))
         return tesSUCCESS;
 
-    auto const& credIDs(ctx.tx.getFieldV256(sfCredentialIDs));
+    auto const& credIDs(tx.getFieldV256(sfCredentialIDs));
     for (auto const& h : credIDs)
     {
-        auto const sleCred = ctx.view.read(keylet::credential(h));
+        auto const sleCred = view.read(keylet::credential(h));
         if (!sleCred)
         {
-            JLOG(ctx.j.trace()) << "Credential doesn't exist. Cred: " << h;
+            JLOG(j.trace()) << "Credential doesn't exist. Cred: " << h;
             return tecBAD_CREDENTIALS;
         }
 
         if (sleCred->getAccountID(sfSubject) != src)
         {
-            JLOG(ctx.j.trace())
+            JLOG(j.trace())
                 << "Credential doesn't belong to the source account. Cred: "
                 << h;
             return tecBAD_CREDENTIALS;
@@ -175,7 +175,7 @@ valid(PreclaimContext const& ctx, AccountID const& src)
 
         if (!(sleCred->getFlags() & lsfAccepted))
         {
-            JLOG(ctx.j.trace()) << "Credential isn't accepted. Cred: " << h;
+            JLOG(j.trace()) << "Credential isn't accepted. Cred: " << h;
             return tecBAD_CREDENTIALS;
         }
 
@@ -352,10 +352,12 @@ verifyValidDomain(
 
 TER
 verifyDepositPreauth(
-    ApplyContext& ctx,
+    STTx const& tx,
+    ApplyView& view,
     AccountID const& src,
     AccountID const& dst,
-    std::shared_ptr<SLE> const& sleDst)
+    std::shared_ptr<SLE> const& sleDst,
+    beast::Journal j)
 {
     // If depositPreauth is enabled, then an account that requires
     // authorization has at least two ways to get a payment in:
@@ -363,23 +365,23 @@ verifyDepositPreauth(
     //  2. If src is deposit preauthorized by dst (either by account or by
     //  credentials).
 
-    bool const credentialsPresent = ctx.tx.isFieldPresent(sfCredentialIDs);
+    bool const credentialsPresent = tx.isFieldPresent(sfCredentialIDs);
 
     if (credentialsPresent &&
         credentials::removeExpired(
-            ctx.view(), ctx.tx.getFieldV256(sfCredentialIDs), ctx.journal))
+            view, tx.getFieldV256(sfCredentialIDs), j))
         return tecEXPIRED;
 
     if (sleDst && (sleDst->getFlags() & lsfDepositAuth))
     {
         if (src != dst)
         {
-            if (!ctx.view().exists(keylet::depositPreauth(dst, src)))
+            if (!view.exists(keylet::depositPreauth(dst, src)))
                 return !credentialsPresent
                     ? tecNO_PERMISSION
                     : credentials::authorizedDepositPreauth(
-                          ctx.view(),
-                          ctx.tx.getFieldV256(sfCredentialIDs),
+                          view,
+                          tx.getFieldV256(sfCredentialIDs),
                           dst);
         }
     }

--- a/src/xrpld/app/misc/CredentialHelpers.h
+++ b/src/xrpld/app/misc/CredentialHelpers.h
@@ -20,16 +20,16 @@
 #ifndef RIPPLE_APP_MISC_CREDENTIALHELPERS_H_INCLUDED
 #define RIPPLE_APP_MISC_CREDENTIALHELPERS_H_INCLUDED
 
-#include <xrpld/ledger/ReadView.h>
 #include <xrpld/ledger/ApplyView.h>
+#include <xrpld/ledger/ReadView.h>
 
-#include <xrpl/protocol/AccountID.h>
-#include <xrpl/protocol/STTx.h>
-#include <xrpl/protocol/STArray.h>
-#include <xrpl/protocol/TER.h>
-#include <xrpl/beast/utility/Journal.h>
-#include <xrpl/basics/base_uint.h>
 #include <xrpl/basics/Log.h>
+#include <xrpl/basics/base_uint.h>
+#include <xrpl/beast/utility/Journal.h>
+#include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/STArray.h>
+#include <xrpl/protocol/STTx.h>
+#include <xrpl/protocol/TER.h>
 
 namespace ripple {
 namespace credentials {
@@ -63,7 +63,11 @@ checkFields(STTx const& tx, beast::Journal j);
 // in doApply (only in preclaim) since it does not remove expired credentials.
 // If you call it in prelaim, you also must call verifyDepositPreauth in doApply
 TER
-valid(STTx const& tx, ReadView const& view, AccountID const& src, beast::Journal j);
+valid(
+    STTx const& tx,
+    ReadView const& view,
+    AccountID const& src,
+    beast::Journal j);
 
 // Check if subject has any credential maching the given domain. If you call it
 // in preclaim and it returns tecEXPIRED, you should call verifyValidDomain in

--- a/src/xrpld/app/misc/CredentialHelpers.h
+++ b/src/xrpld/app/misc/CredentialHelpers.h
@@ -20,7 +20,16 @@
 #ifndef RIPPLE_APP_MISC_CREDENTIALHELPERS_H_INCLUDED
 #define RIPPLE_APP_MISC_CREDENTIALHELPERS_H_INCLUDED
 
-#include <xrpld/app/tx/detail/Transactor.h>
+#include <xrpld/ledger/ReadView.h>
+#include <xrpld/ledger/ApplyView.h>
+
+#include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/STTx.h>
+#include <xrpl/protocol/STArray.h>
+#include <xrpl/protocol/TER.h>
+#include <xrpl/beast/utility/Journal.h>
+#include <xrpl/basics/base_uint.h>
+#include <xrpl/basics/Log.h>
 
 namespace ripple {
 namespace credentials {
@@ -48,13 +57,13 @@ deleteSLE(
 
 // Amendment and parameters checks for sfCredentialIDs field
 NotTEC
-checkFields(PreflightContext const& ctx);
+checkFields(STTx const& tx, beast::Journal j);
 
 // Accessing the ledger to check if provided credentials are valid. Do not use
 // in doApply (only in preclaim) since it does not remove expired credentials.
 // If you call it in prelaim, you also must call verifyDepositPreauth in doApply
 TER
-valid(PreclaimContext const& ctx, AccountID const& src);
+valid(STTx const& tx, ReadView const& view, AccountID const& src, beast::Journal j);
 
 // Check if subject has any credential maching the given domain. If you call it
 // in preclaim and it returns tecEXPIRED, you should call verifyValidDomain in
@@ -93,10 +102,12 @@ verifyValidDomain(
 // Check expired credentials and for existing DepositPreauth ledger object
 TER
 verifyDepositPreauth(
-    ApplyContext& ctx,
+    STTx const& tx,
+    ApplyView& view,
     AccountID const& src,
     AccountID const& dst,
-    std::shared_ptr<SLE> const& sleDst);
+    std::shared_ptr<SLE> const& sleDst,
+    beast::Journal j);
 
 }  // namespace ripple
 

--- a/src/xrpld/app/tx/detail/DeleteAccount.cpp
+++ b/src/xrpld/app/tx/detail/DeleteAccount.cpp
@@ -58,7 +58,8 @@ DeleteAccount::preflight(PreflightContext const& ctx)
         // An account cannot be deleted and give itself the resulting XRP.
         return temDST_IS_SRC;
 
-    if (auto const err = credentials::checkFields(ctx.tx, ctx.j); !isTesSuccess(err))
+    if (auto const err = credentials::checkFields(ctx.tx, ctx.j);
+        !isTesSuccess(err))
         return err;
 
     return preflight2(ctx);
@@ -241,7 +242,8 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
         return tecDST_TAG_NEEDED;
 
     // If credentials are provided - check them anyway
-    if (auto const err = credentials::valid(ctx.tx, ctx.view, account, ctx.j); !isTesSuccess(err))
+    if (auto const err = credentials::valid(ctx.tx, ctx.view, account, ctx.j);
+        !isTesSuccess(err))
         return err;
 
     // if credentials then postpone auth check to doApply, to check for expired
@@ -376,7 +378,8 @@ DeleteAccount::doApply()
     if (ctx_.view().rules().enabled(featureDepositAuth) &&
         ctx_.tx.isFieldPresent(sfCredentialIDs))
     {
-        if (auto err = verifyDepositPreauth(ctx_.tx, ctx_.view(), account_, dstID, dst, ctx_.journal);
+        if (auto err = verifyDepositPreauth(
+                ctx_.tx, ctx_.view(), account_, dstID, dst, ctx_.journal);
             !isTesSuccess(err))
             return err;
     }

--- a/src/xrpld/app/tx/detail/DeleteAccount.cpp
+++ b/src/xrpld/app/tx/detail/DeleteAccount.cpp
@@ -58,7 +58,7 @@ DeleteAccount::preflight(PreflightContext const& ctx)
         // An account cannot be deleted and give itself the resulting XRP.
         return temDST_IS_SRC;
 
-    if (auto const err = credentials::checkFields(ctx); !isTesSuccess(err))
+    if (auto const err = credentials::checkFields(ctx.tx, ctx.j); !isTesSuccess(err))
         return err;
 
     return preflight2(ctx);
@@ -241,7 +241,7 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
         return tecDST_TAG_NEEDED;
 
     // If credentials are provided - check them anyway
-    if (auto const err = credentials::valid(ctx, account); !isTesSuccess(err))
+    if (auto const err = credentials::valid(ctx.tx, ctx.view, account, ctx.j); !isTesSuccess(err))
         return err;
 
     // if credentials then postpone auth check to doApply, to check for expired
@@ -376,7 +376,7 @@ DeleteAccount::doApply()
     if (ctx_.view().rules().enabled(featureDepositAuth) &&
         ctx_.tx.isFieldPresent(sfCredentialIDs))
     {
-        if (auto err = verifyDepositPreauth(ctx_, account_, dstID, dst);
+        if (auto err = verifyDepositPreauth(ctx_.tx, ctx_.view(), account_, dstID, dst, ctx_.journal);
             !isTesSuccess(err))
             return err;
     }

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -672,7 +672,7 @@ EscrowFinish::preflight(PreflightContext const& ctx)
         }
     }
 
-    if (auto const err = credentials::checkFields(ctx); !isTesSuccess(err))
+    if (auto const err = credentials::checkFields(ctx.tx, ctx.j); !isTesSuccess(err))
         return err;
 
     return tesSUCCESS;
@@ -761,7 +761,7 @@ EscrowFinish::preclaim(PreclaimContext const& ctx)
 {
     if (ctx.view.rules().enabled(featureCredentials))
     {
-        if (auto const err = credentials::valid(ctx, ctx.tx[sfAccount]);
+        if (auto const err = credentials::valid(ctx.tx, ctx.view, ctx.tx[sfAccount], ctx.j);
             !isTesSuccess(err))
             return err;
     }
@@ -1107,7 +1107,7 @@ EscrowFinish::doApply()
 
     if (ctx_.view().rules().enabled(featureDepositAuth))
     {
-        if (auto err = verifyDepositPreauth(ctx_, account_, destID, sled);
+        if (auto err = verifyDepositPreauth(ctx_.tx, ctx_.view(), account_, destID, sled, ctx_.journal);
             !isTesSuccess(err))
             return err;
     }

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -672,7 +672,8 @@ EscrowFinish::preflight(PreflightContext const& ctx)
         }
     }
 
-    if (auto const err = credentials::checkFields(ctx.tx, ctx.j); !isTesSuccess(err))
+    if (auto const err = credentials::checkFields(ctx.tx, ctx.j);
+        !isTesSuccess(err))
         return err;
 
     return tesSUCCESS;
@@ -761,7 +762,8 @@ EscrowFinish::preclaim(PreclaimContext const& ctx)
 {
     if (ctx.view.rules().enabled(featureCredentials))
     {
-        if (auto const err = credentials::valid(ctx.tx, ctx.view, ctx.tx[sfAccount], ctx.j);
+        if (auto const err =
+                credentials::valid(ctx.tx, ctx.view, ctx.tx[sfAccount], ctx.j);
             !isTesSuccess(err))
             return err;
     }
@@ -1107,7 +1109,8 @@ EscrowFinish::doApply()
 
     if (ctx_.view().rules().enabled(featureDepositAuth))
     {
-        if (auto err = verifyDepositPreauth(ctx_.tx, ctx_.view(), account_, destID, sled, ctx_.journal);
+        if (auto err = verifyDepositPreauth(
+                ctx_.tx, ctx_.view(), account_, destID, sled, ctx_.journal);
             !isTesSuccess(err))
             return err;
     }

--- a/src/xrpld/app/tx/detail/MPTokenAuthorize.cpp
+++ b/src/xrpld/app/tx/detail/MPTokenAuthorize.cpp
@@ -176,125 +176,17 @@ MPTokenAuthorize::createMPToken(
 }
 
 TER
-MPTokenAuthorize::authorize(
-    ApplyView& view,
-    beast::Journal journal,
-    MPTAuthorizeArgs const& args)
-{
-    auto const sleAcct = view.peek(keylet::account(args.account));
-    if (!sleAcct)
-        return tecINTERNAL;
-
-    // If the account that submitted the tx is a holder
-    // Note: `account_` is holder's account
-    //       `holderID` is NOT used
-    if (!args.holderID)
-    {
-        // When a holder wants to unauthorize/delete a MPT, the ledger must
-        //      - delete mptokenKey from owner directory
-        //      - delete the MPToken
-        if (args.flags & tfMPTUnauthorize)
-        {
-            auto const mptokenKey =
-                keylet::mptoken(args.mptIssuanceID, args.account);
-            auto const sleMpt = view.peek(mptokenKey);
-            if (!sleMpt || (*sleMpt)[sfMPTAmount] != 0)
-                return tecINTERNAL;  // LCOV_EXCL_LINE
-
-            if (!view.dirRemove(
-                    keylet::ownerDir(args.account),
-                    (*sleMpt)[sfOwnerNode],
-                    sleMpt->key(),
-                    false))
-                return tecINTERNAL;  // LCOV_EXCL_LINE
-
-            adjustOwnerCount(view, sleAcct, -1, journal);
-
-            view.erase(sleMpt);
-            return tesSUCCESS;
-        }
-
-        // A potential holder wants to authorize/hold a mpt, the ledger must:
-        //      - add the new mptokenKey to the owner directory
-        //      - create the MPToken object for the holder
-
-        // The reserve that is required to create the MPToken. Note
-        // that although the reserve increases with every item
-        // an account owns, in the case of MPTokens we only
-        // *enforce* a reserve if the user owns more than two
-        // items. This is similar to the reserve requirements of trust lines.
-        std::uint32_t const uOwnerCount = sleAcct->getFieldU32(sfOwnerCount);
-        XRPAmount const reserveCreate(
-            (uOwnerCount < 2) ? XRPAmount(beast::zero)
-                              : view.fees().accountReserve(uOwnerCount + 1));
-
-        if (args.priorBalance < reserveCreate)
-            return tecINSUFFICIENT_RESERVE;
-
-        auto const mptokenKey =
-            keylet::mptoken(args.mptIssuanceID, args.account);
-        auto mptoken = std::make_shared<SLE>(mptokenKey);
-        if (auto ter = dirLink(view, args.account, mptoken))
-            return ter;  // LCOV_EXCL_LINE
-
-        (*mptoken)[sfAccount] = args.account;
-        (*mptoken)[sfMPTokenIssuanceID] = args.mptIssuanceID;
-        (*mptoken)[sfFlags] = 0;
-        view.insert(mptoken);
-
-        // Update owner count.
-        adjustOwnerCount(view, sleAcct, 1, journal);
-
-        return tesSUCCESS;
-    }
-
-    auto const sleMptIssuance =
-        view.read(keylet::mptIssuance(args.mptIssuanceID));
-    if (!sleMptIssuance)
-        return tecINTERNAL;
-
-    // If the account that submitted this tx is the issuer of the MPT
-    // Note: `account_` is issuer's account
-    //       `holderID` is holder's account
-    if (args.account != (*sleMptIssuance)[sfIssuer])
-        return tecINTERNAL;
-
-    auto const sleMpt =
-        view.peek(keylet::mptoken(args.mptIssuanceID, *args.holderID));
-    if (!sleMpt)
-        return tecINTERNAL;
-
-    std::uint32_t const flagsIn = sleMpt->getFieldU32(sfFlags);
-    std::uint32_t flagsOut = flagsIn;
-
-    // Issuer wants to unauthorize the holder, unset lsfMPTAuthorized on
-    // their MPToken
-    if (args.flags & tfMPTUnauthorize)
-        flagsOut &= ~lsfMPTAuthorized;
-    // Issuer wants to authorize a holder, set lsfMPTAuthorized on their
-    // MPToken
-    else
-        flagsOut |= lsfMPTAuthorized;
-
-    if (flagsIn != flagsOut)
-        sleMpt->setFieldU32(sfFlags, flagsOut);
-
-    view.update(sleMpt);
-    return tesSUCCESS;
-}
-
-TER
 MPTokenAuthorize::doApply()
 {
     auto const& tx = ctx_.tx;
-    return authorize(
+    return authorizeMPToken(
         ctx_.view(),
-        ctx_.journal,
-        {.priorBalance = mPriorBalance,
-         .mptIssuanceID = tx[sfMPTokenIssuanceID],
-         .account = account_,
-         .flags = tx.getFlags(),
-         .holderID = tx[~sfHolder]});
+        mPriorBalance,
+        tx[sfMPTokenIssuanceID],
+        account_,
+        tx.getFlags(),
+        tx[~sfHolder],
+        ctx_.journal);
 }
 
 }  // namespace ripple

--- a/src/xrpld/app/tx/detail/MPTokenAuthorize.h
+++ b/src/xrpld/app/tx/detail/MPTokenAuthorize.h
@@ -49,12 +49,6 @@ public:
     preclaim(PreclaimContext const& ctx);
 
     static TER
-    authorize(
-        ApplyView& view,
-        beast::Journal journal,
-        MPTAuthorizeArgs const& args);
-
-    static TER
     createMPToken(
         ApplyView& view,
         MPTID const& mptIssuanceID,

--- a/src/xrpld/app/tx/detail/PayChan.cpp
+++ b/src/xrpld/app/tx/detail/PayChan.cpp
@@ -473,7 +473,7 @@ PayChanClaim::preflight(PreflightContext const& ctx)
             return temBAD_SIGNATURE;
     }
 
-    if (auto const err = credentials::checkFields(ctx); !isTesSuccess(err))
+    if (auto const err = credentials::checkFields(ctx.tx, ctx.j); !isTesSuccess(err))
         return err;
 
     return preflight2(ctx);
@@ -485,7 +485,7 @@ PayChanClaim::preclaim(PreclaimContext const& ctx)
     if (!ctx.view.rules().enabled(featureCredentials))
         return Transactor::preclaim(ctx);
 
-    if (auto const err = credentials::valid(ctx, ctx.tx[sfAccount]);
+    if (auto const err = credentials::valid(ctx.tx, ctx.view, ctx.tx[sfAccount], ctx.j);
         !isTesSuccess(err))
         return err;
 
@@ -554,7 +554,7 @@ PayChanClaim::doApply()
 
         if (depositAuth)
         {
-            if (auto err = verifyDepositPreauth(ctx_, txAccount, dst, sled);
+            if (auto err = verifyDepositPreauth(ctx_.tx, ctx_.view(), txAccount, dst, sled, ctx_.journal);
                 !isTesSuccess(err))
                 return err;
         }

--- a/src/xrpld/app/tx/detail/PayChan.cpp
+++ b/src/xrpld/app/tx/detail/PayChan.cpp
@@ -473,7 +473,8 @@ PayChanClaim::preflight(PreflightContext const& ctx)
             return temBAD_SIGNATURE;
     }
 
-    if (auto const err = credentials::checkFields(ctx.tx, ctx.j); !isTesSuccess(err))
+    if (auto const err = credentials::checkFields(ctx.tx, ctx.j);
+        !isTesSuccess(err))
         return err;
 
     return preflight2(ctx);
@@ -485,7 +486,8 @@ PayChanClaim::preclaim(PreclaimContext const& ctx)
     if (!ctx.view.rules().enabled(featureCredentials))
         return Transactor::preclaim(ctx);
 
-    if (auto const err = credentials::valid(ctx.tx, ctx.view, ctx.tx[sfAccount], ctx.j);
+    if (auto const err =
+            credentials::valid(ctx.tx, ctx.view, ctx.tx[sfAccount], ctx.j);
         !isTesSuccess(err))
         return err;
 
@@ -554,7 +556,8 @@ PayChanClaim::doApply()
 
         if (depositAuth)
         {
-            if (auto err = verifyDepositPreauth(ctx_.tx, ctx_.view(), txAccount, dst, sled, ctx_.journal);
+            if (auto err = verifyDepositPreauth(
+                    ctx_.tx, ctx_.view(), txAccount, dst, sled, ctx_.journal);
                 !isTesSuccess(err))
                 return err;
         }

--- a/src/xrpld/app/tx/detail/Payment.cpp
+++ b/src/xrpld/app/tx/detail/Payment.cpp
@@ -238,7 +238,8 @@ Payment::preflight(PreflightContext const& ctx)
         }
     }
 
-    if (auto const err = credentials::checkFields(ctx.tx, ctx.j); !isTesSuccess(err))
+    if (auto const err = credentials::checkFields(ctx.tx, ctx.j);
+        !isTesSuccess(err))
         return err;
 
     return preflight2(ctx);
@@ -358,7 +359,8 @@ Payment::preclaim(PreclaimContext const& ctx)
         }
     }
 
-    if (auto const err = credentials::valid(ctx.tx, ctx.view, ctx.tx[sfAccount], ctx.j);
+    if (auto const err =
+            credentials::valid(ctx.tx, ctx.view, ctx.tx[sfAccount], ctx.j);
         !isTesSuccess(err))
         return err;
 
@@ -450,8 +452,13 @@ Payment::doApply()
             //  1. If Account == Destination, or
             //  2. If Account is deposit preauthorized by destination.
 
-            if (auto err =
-                    verifyDepositPreauth(ctx_.tx, ctx_.view(), account_, dstAccountID, sleDst, ctx_.journal);
+            if (auto err = verifyDepositPreauth(
+                    ctx_.tx,
+                    ctx_.view(),
+                    account_,
+                    dstAccountID,
+                    sleDst,
+                    ctx_.journal);
                 !isTesSuccess(err))
                 return err;
         }
@@ -521,8 +528,13 @@ Payment::doApply()
             ter != tesSUCCESS)
             return ter;
 
-        if (auto err =
-                verifyDepositPreauth(ctx_.tx, ctx_.view(), account_, dstAccountID, sleDst, ctx_.journal);
+        if (auto err = verifyDepositPreauth(
+                ctx_.tx,
+                ctx_.view(),
+                account_,
+                dstAccountID,
+                sleDst,
+                ctx_.journal);
             !isTesSuccess(err))
             return err;
 
@@ -644,8 +656,13 @@ Payment::doApply()
         if (dstAmount > dstReserve ||
             sleDst->getFieldAmount(sfBalance) > dstReserve)
         {
-            if (auto err =
-                    verifyDepositPreauth(ctx_.tx, ctx_.view(), account_, dstAccountID, sleDst, ctx_.journal);
+            if (auto err = verifyDepositPreauth(
+                    ctx_.tx,
+                    ctx_.view(),
+                    account_,
+                    dstAccountID,
+                    sleDst,
+                    ctx_.journal);
                 !isTesSuccess(err))
                 return err;
         }

--- a/src/xrpld/app/tx/detail/Payment.cpp
+++ b/src/xrpld/app/tx/detail/Payment.cpp
@@ -238,7 +238,7 @@ Payment::preflight(PreflightContext const& ctx)
         }
     }
 
-    if (auto const err = credentials::checkFields(ctx); !isTesSuccess(err))
+    if (auto const err = credentials::checkFields(ctx.tx, ctx.j); !isTesSuccess(err))
         return err;
 
     return preflight2(ctx);
@@ -358,7 +358,7 @@ Payment::preclaim(PreclaimContext const& ctx)
         }
     }
 
-    if (auto const err = credentials::valid(ctx, ctx.tx[sfAccount]);
+    if (auto const err = credentials::valid(ctx.tx, ctx.view, ctx.tx[sfAccount], ctx.j);
         !isTesSuccess(err))
         return err;
 
@@ -451,7 +451,7 @@ Payment::doApply()
             //  2. If Account is deposit preauthorized by destination.
 
             if (auto err =
-                    verifyDepositPreauth(ctx_, account_, dstAccountID, sleDst);
+                    verifyDepositPreauth(ctx_.tx, ctx_.view(), account_, dstAccountID, sleDst, ctx_.journal);
                 !isTesSuccess(err))
                 return err;
         }
@@ -522,7 +522,7 @@ Payment::doApply()
             return ter;
 
         if (auto err =
-                verifyDepositPreauth(ctx_, account_, dstAccountID, sleDst);
+                verifyDepositPreauth(ctx_.tx, ctx_.view(), account_, dstAccountID, sleDst, ctx_.journal);
             !isTesSuccess(err))
             return err;
 
@@ -645,7 +645,7 @@ Payment::doApply()
             sleDst->getFieldAmount(sfBalance) > dstReserve)
         {
             if (auto err =
-                    verifyDepositPreauth(ctx_, account_, dstAccountID, sleDst);
+                    verifyDepositPreauth(ctx_.tx, ctx_.view(), account_, dstAccountID, sleDst, ctx_.journal);
                 !isTesSuccess(err))
                 return err;
         }

--- a/src/xrpld/app/tx/detail/VaultDeposit.cpp
+++ b/src/xrpld/app/tx/detail/VaultDeposit.cpp
@@ -210,12 +210,14 @@ VaultDeposit::doApply()
         auto sleMpt = view().read(keylet::mptoken(mptIssuanceID, account_));
         if (!sleMpt)
         {
-            if (auto const err = MPTokenAuthorize::authorize(
+            if (auto const err = authorizeMPToken(
                     view(),
-                    ctx_.journal,
-                    {.priorBalance = mPriorBalance,
-                     .mptIssuanceID = mptIssuanceID->value(),
-                     .account = account_});
+                    mPriorBalance,
+                    mptIssuanceID->value(),
+                    account_,
+                    {},  // flags
+                    {},  // holderID
+                    ctx_.journal);
                 !isTesSuccess(err))
                 return err;
         }
@@ -223,15 +225,14 @@ VaultDeposit::doApply()
         // If the vault is private, set the authorized flag for the vault owner
         if (vault->isFlag(tfVaultPrivate))
         {
-            if (auto const err = MPTokenAuthorize::authorize(
+            if (auto const err = authorizeMPToken(
                     view(),
-                    ctx_.journal,
-                    {
-                        .priorBalance = mPriorBalance,
-                        .mptIssuanceID = mptIssuanceID->value(),
-                        .account = sleIssuance->at(sfIssuer),
-                        .holderID = account_,
-                    });
+                    mPriorBalance,              // priorBalance
+                    mptIssuanceID->value(),     // mptIssuanceID
+                    sleIssuance->at(sfIssuer),  // account
+                    {},                         // flags
+                    account_,                   // holderID
+                    ctx_.journal);
                 !isTesSuccess(err))
                 return err;
         }

--- a/src/xrpld/ledger/View.h
+++ b/src/xrpld/ledger/View.h
@@ -577,6 +577,16 @@ addEmptyHolding(
         asset.value());
 }
 
+[[nodiscard]] TER
+authorizeMPToken(
+    ApplyView& view,
+    XRPAmount const& priorBalance,
+    MPTID const& mptIssuanceID,
+    AccountID const& account,
+    std::uint32_t flags,
+    std::optional<AccountID> holderID,
+    beast::Journal journal);
+
 // VFALCO NOTE Both STAmount parameters should just
 //             be "Amount", a unit-less number.
 //

--- a/src/xrpld/ledger/detail/View.cpp
+++ b/src/xrpld/ledger/detail/View.cpp
@@ -18,7 +18,6 @@
 //==============================================================================
 
 #include <xrpld/app/misc/CredentialHelpers.h>
-#include <xrpld/app/tx/detail/MPTokenAuthorize.h>
 #include <xrpld/ledger/ReadView.h>
 #include <xrpld/ledger/View.h>
 
@@ -1215,12 +1214,122 @@ addEmptyHolding(
     if (view.peek(keylet::mptoken(mptID, accountID)))
         return tecDUPLICATE;
 
-    return MPTokenAuthorize::authorize(
+    return authorizeMPToken(
         view,
-        journal,
-        {.priorBalance = priorBalance,
-         .mptIssuanceID = mptID,
-         .account = accountID});
+        priorBalance,
+        mptID,
+        accountID,
+        {},  // flags
+        {},  // holderID
+        journal);
+}
+
+[[nodiscard]] TER
+authorizeMPToken(
+    ApplyView& view,
+    XRPAmount const& priorBalance,
+    MPTID const& mptIssuanceID,
+    AccountID const& account,
+    std::uint32_t flags,
+    std::optional<AccountID> holderID,
+    beast::Journal journal)
+{
+    auto const sleAcct = view.peek(keylet::account(account));
+    if (!sleAcct)
+        return tecINTERNAL;
+
+    // If the account that submitted the tx is a holder
+    // Note: `account_` is holder's account
+    //       `holderID` is NOT used
+    if (!holderID)
+    {
+        // When a holder wants to unauthorize/delete a MPT, the ledger must
+        //      - delete mptokenKey from owner directory
+        //      - delete the MPToken
+        if (flags & tfMPTUnauthorize)
+        {
+            auto const mptokenKey = keylet::mptoken(mptIssuanceID, account);
+            auto const sleMpt = view.peek(mptokenKey);
+            if (!sleMpt || (*sleMpt)[sfMPTAmount] != 0)
+                return tecINTERNAL;  // LCOV_EXCL_LINE
+
+            if (!view.dirRemove(
+                    keylet::ownerDir(account),
+                    (*sleMpt)[sfOwnerNode],
+                    sleMpt->key(),
+                    false))
+                return tecINTERNAL;  // LCOV_EXCL_LINE
+
+            adjustOwnerCount(view, sleAcct, -1, journal);
+
+            view.erase(sleMpt);
+            return tesSUCCESS;
+        }
+
+        // A potential holder wants to authorize/hold a mpt, the ledger must:
+        //      - add the new mptokenKey to the owner directory
+        //      - create the MPToken object for the holder
+
+        // The reserve that is required to create the MPToken. Note
+        // that although the reserve increases with every item
+        // an account owns, in the case of MPTokens we only
+        // *enforce* a reserve if the user owns more than two
+        // items. This is similar to the reserve requirements of trust lines.
+        std::uint32_t const uOwnerCount = sleAcct->getFieldU32(sfOwnerCount);
+        XRPAmount const reserveCreate(
+            (uOwnerCount < 2) ? XRPAmount(beast::zero)
+                              : view.fees().accountReserve(uOwnerCount + 1));
+
+        if (priorBalance < reserveCreate)
+            return tecINSUFFICIENT_RESERVE;
+
+        auto const mptokenKey = keylet::mptoken(mptIssuanceID, account);
+        auto mptoken = std::make_shared<SLE>(mptokenKey);
+        if (auto ter = dirLink(view, account, mptoken))
+            return ter;  // LCOV_EXCL_LINE
+
+        (*mptoken)[sfAccount] = account;
+        (*mptoken)[sfMPTokenIssuanceID] = mptIssuanceID;
+        (*mptoken)[sfFlags] = 0;
+        view.insert(mptoken);
+
+        // Update owner count.
+        adjustOwnerCount(view, sleAcct, 1, journal);
+
+        return tesSUCCESS;
+    }
+
+    auto const sleMptIssuance = view.read(keylet::mptIssuance(mptIssuanceID));
+    if (!sleMptIssuance)
+        return tecINTERNAL;
+
+    // If the account that submitted this tx is the issuer of the MPT
+    // Note: `account_` is issuer's account
+    //       `holderID` is holder's account
+    if (account != (*sleMptIssuance)[sfIssuer])
+        return tecINTERNAL;
+
+    auto const sleMpt = view.peek(keylet::mptoken(mptIssuanceID, *holderID));
+    if (!sleMpt)
+        return tecINTERNAL;
+
+    std::uint32_t const flagsIn = sleMpt->getFieldU32(sfFlags);
+    std::uint32_t flagsOut = flagsIn;
+
+    // Issuer wants to unauthorize the holder, unset lsfMPTAuthorized on
+    // their MPToken
+    if (flags & tfMPTUnauthorize)
+        flagsOut &= ~lsfMPTAuthorized;
+    // Issuer wants to authorize a holder, set lsfMPTAuthorized on their
+    // MPToken
+    else
+        flagsOut |= lsfMPTAuthorized;
+
+    if (flagsIn != flagsOut)
+        sleMpt->setFieldU32(sfFlags, flagsOut);
+
+    view.update(sleMpt);
+    return tesSUCCESS;
 }
 
 TER
@@ -1418,13 +1527,14 @@ removeEmptyHolding(
     if (mptoken->at(sfMPTAmount) != 0)
         return tecHAS_OBLIGATIONS;
 
-    return MPTokenAuthorize::authorize(
+    return authorizeMPToken(
         view,
-        journal,
-        {.priorBalance = {},
-         .mptIssuanceID = mptID,
-         .account = accountID,
-         .flags = tfMPTUnauthorize});
+        {},  // priorBalance
+        mptID,
+        accountID,
+        tfMPTUnauthorize,  // flags
+        {},                // holderID
+        journal);
 }
 
 TER
@@ -2484,15 +2594,14 @@ enforceMPTokenAuthorization(
         XRPL_ASSERT(
             maybeDomainID.has_value() && sleToken == nullptr,
             "ripple::enforceMPTokenAuthorization : new MPToken for domain");
-        if (auto const err = MPTokenAuthorize::authorize(
+        if (auto const err = authorizeMPToken(
                 view,
-                j,
-                {
-                    .priorBalance = priorBalance,
-                    .mptIssuanceID = mptIssuanceID,
-                    .account = account,
-                    .flags = 0,
-                });
+                priorBalance,   // priorBalance
+                mptIssuanceID,  // mptIssuanceID
+                account,        // account
+                0,              // flags,
+                {},             // holderID
+                j);
             !isTesSuccess(err))
             return err;
 


### PR DESCRIPTION
## High Level Overview of Change

This PR decouples ledger from xrpld/app, and therefore fully clears the path to the modularisation of the ledger component.

### Context of Change

Before this change, `View.cpp` relies on `MPTokenAuthorize::authorize`, and this change moves `MPTokenAuthorize::authorize` to `View.cpp` to invert the dependency, making `ledger` a standalone module. 

### Type of Change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

This change doesn't affect any API

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

## Test Plan

As usual, regression test just for our sanity

## Future Tasks

Modularise `ledger`