### PR TITLE
Discussion: TokenEscrowV1

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -35,6 +35,7 @@
 // If you add an amendment here, then do not forget to increment `numFeatures`
 // in include/xrpl/protocol/Feature.h.
 
+XRPL_FIX    (TokenEscrowV1,              Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(TokenEscrow,                Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (EnforceNFTokenTrustlineV2,  Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (AMMv1_3,                    Supported::yes, VoteBehavior::DefaultNo)

--- a/include/xrpl/protocol/detail/ledger_entries.macro
+++ b/include/xrpl/protocol/detail/ledger_entries.macro
@@ -301,6 +301,7 @@ LEDGER_ENTRY(ltRIPPLE_STATE, 0x0072, RippleState, state, ({
     {sfHighNode,             soeOPTIONAL},
     {sfHighQualityIn,        soeOPTIONAL},
     {sfHighQualityOut,       soeOPTIONAL},
+    {sfLockedCount,          soeOPTIONAL},
 }))
 
 /** The ledger object which lists the network's fee settings.

--- a/include/xrpl/protocol/detail/sfields.macro
+++ b/include/xrpl/protocol/detail/sfields.macro
@@ -114,6 +114,7 @@ TYPED_SFIELD(sfVoteWeight,               UINT32,    48)
 TYPED_SFIELD(sfFirstNFTokenSequence,     UINT32,    50)
 TYPED_SFIELD(sfOracleDocumentID,         UINT32,    51)
 TYPED_SFIELD(sfPermissionValue,          UINT32,    52)
+TYPED_SFIELD(sfLockedCount,              UINT32,    53)
 
 // 64-bit integers (common)
 TYPED_SFIELD(sfIndexNext,                UINT64,     1)

--- a/src/test/app/EscrowToken_test.cpp
+++ b/src/test/app/EscrowToken_test.cpp
@@ -129,6 +129,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1'000)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150),
                 createResult);
             env.close();
@@ -181,6 +182,36 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::cancel(bob, alice, seq1), ter(tecNO_TARGET));
             env.close();
         }
+
+        {
+            Env env{*this, features};
+            auto const baseFee = env.current()->fees().base;
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+            auto const gw = Account{"gateway"};
+            auto const USD = gw["USD"];
+            env.fund(XRP(5000), alice, bob, gw);
+            env(fset(gw, asfAllowTrustLineLocking));
+            env.close();
+            env.trust(USD(10'000), alice, bob);
+            env.close();
+            env(pay(gw, alice, USD(5000)));
+            env(pay(gw, bob, USD(5000)));
+            env.close();
+
+            bool const withTokenFix =
+                env.current()->rules().enabled(fixTokenEscrowV1);
+            auto const createResult =
+                withTokenFix ? ter(temMALFORMED) : ter(tesSUCCESS);
+
+            env(escrow::create(alice, bob, USD(1'000)),
+                escrow::condition(escrow::cb1),
+                escrow::finish_time(env.now() + 1s),
+                // no cancel_time
+                fee(baseFee * 150),
+                createResult);
+            env.close();
+        }
     }
 
     void
@@ -211,6 +242,7 @@ struct EscrowToken_test : public beast::unit_test::suite
         env(escrow::create(alice, bob, USD(1'000)),
             escrow::condition(escrow::cb1),
             escrow::finish_time(env.now() + 1s),
+            escrow::cancel_time(env.now() + 60s),
             fee(baseFee * 150),
             ter(tesSUCCESS));
         env.close();
@@ -232,6 +264,7 @@ struct EscrowToken_test : public beast::unit_test::suite
         env(escrow::create(alice, bob, USD(1'000)),
             escrow::condition(escrow::cb1),
             escrow::finish_time(env.now() + 1s),
+            escrow::cancel_time(env.now() + 2s),
             fee(baseFee * 150),
             ter(tecNO_PERMISSION));
         env.close();
@@ -267,6 +300,7 @@ struct EscrowToken_test : public beast::unit_test::suite
 
             env(escrow::create(alice, bob, USD(1)),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(XRP(-1)),
                 ter(temBAD_FEE));
             env.close();
@@ -285,6 +319,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(-1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(temBAD_AMOUNT));
             env.close();
@@ -303,6 +338,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, BAD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(temBAD_CURRENCY));
             env.close();
@@ -329,6 +365,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(gw, alice, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecNO_PERMISSION));
             env.close();
@@ -349,6 +386,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecNO_ISSUER));
             env.close();
@@ -373,6 +411,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(gw, alice, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecNO_PERMISSION));
             env.close();
@@ -392,6 +431,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecNO_LINE));
             env.close();
@@ -417,6 +457,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecNO_AUTH));
             env.close();
@@ -442,6 +483,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecNO_AUTH));
             env.close();
@@ -473,6 +515,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecFROZEN));
             env.close();
@@ -504,6 +547,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecFROZEN));
             env.close();
@@ -528,6 +572,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecINSUFFICIENT_FUNDS));
             env.close();
@@ -555,6 +600,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(10'001)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecINSUFFICIENT_FUNDS));
             env.close();
@@ -582,6 +628,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecPRECISION_LOSS));
             env.close();
@@ -621,6 +668,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -663,6 +711,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -711,6 +760,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -745,6 +795,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -779,6 +830,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(5)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 20s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -816,6 +868,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(5)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 20s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -875,18 +928,24 @@ struct EscrowToken_test : public beast::unit_test::suite
                 ter(tesSUCCESS));
             env.close();
 
+            auto const trustResult =
+                env.current()->rules().enabled(fixTokenEscrowV1)
+                ? ter(tecHAS_OBLIGATIONS)
+                : ter(tesSUCCESS);
             env(pay(alice, gw, USD(9'999)));
             env(trust(gw, aliceUSD(0)), txflags(tfSetfAuth));
-            env(trust(alice, USD(0)));
+            env(trust(alice, USD(0)), trustResult);
             env.close();
 
             env.trust(USD(10'000), alice);
             env.close();
 
             // alice cannot cancel because she is not authorized
-            env(escrow::cancel(bob, alice, seq1),
-                fee(baseFee),
-                ter(tecNO_AUTH));
+            auto const cancelResult =
+                env.current()->rules().enabled(fixTokenEscrowV1)
+                ? ter(tesSUCCESS)
+                : ter(tecNO_AUTH);
+            env(escrow::cancel(bob, alice, seq1), fee(baseFee), cancelResult);
             env.close();
         }
     }
@@ -924,6 +983,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1'000)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -1116,7 +1176,8 @@ struct EscrowToken_test : public beast::unit_test::suite
             auto const bseq = env.seq(bob);
 
             env(escrow::create(alice, bob, USD(1'000)),
-                escrow::finish_time(env.now() + 1s));
+                escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 500s));
             BEAST_EXPECT(
                 (*env.meta())[sfTransactionResult] ==
                 static_cast<std::uint8_t>(tesSUCCESS));
@@ -1235,7 +1296,8 @@ struct EscrowToken_test : public beast::unit_test::suite
             auto const aseq = env.seq(alice);
 
             env(escrow::create(alice, gw, USD(1'000)),
-                escrow::finish_time(env.now() + 1s));
+                escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 500s));
 
             BEAST_EXPECT(
                 (*env.meta())[sfTransactionResult] ==
@@ -1347,6 +1409,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(t.src, t.dst, delta),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150));
             env.close();
 
@@ -1399,6 +1462,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(gw, alice, USD(1'000)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 20s),
                 fee(baseFee * 150),
                 ter(tecNO_PERMISSION));
             env.close();
@@ -1437,6 +1501,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(t.src, t.dst, USD(1'000)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 20s),
                 fee(baseFee * 150));
             env.close();
 
@@ -1467,6 +1532,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(gw, gw, USD(1'000)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecNO_PERMISSION));
             env.close();
@@ -1508,6 +1574,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, delta),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150));
             env.close();
             auto const transferRate = escrow::rate(env, alice, seq1);
@@ -1546,6 +1613,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, delta),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 20s),
                 fee(baseFee * 150));
             env.close();
             auto transferRate = escrow::rate(env, alice, seq1);
@@ -1589,6 +1657,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, delta),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 20s),
                 fee(baseFee * 150));
             env.close();
             auto transferRate = escrow::rate(env, alice, seq1);
@@ -1682,6 +1751,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, delta),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150));
             env.close();
 
@@ -1733,6 +1803,7 @@ struct EscrowToken_test : public beast::unit_test::suite
         env(escrow::create(alice, bob, delta),
             escrow::condition(escrow::cb1),
             escrow::finish_time(env.now() + 1s),
+            escrow::cancel_time(env.now() + 2s),
             fee(baseFee * 150),
             ter(tecNO_AUTH));
         env.close();
@@ -1749,6 +1820,7 @@ struct EscrowToken_test : public beast::unit_test::suite
         env(escrow::create(alice, bob, delta),
             escrow::condition(escrow::cb1),
             escrow::finish_time(env.now() + 1s),
+            escrow::cancel_time(env.now() + 10s),
             fee(baseFee * 150));
         env.close();
 
@@ -1797,6 +1869,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, delta),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecFROZEN));
             env.close();
@@ -1810,6 +1883,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, delta),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 20s),
                 fee(baseFee * 150));
             env.close();
 
@@ -1872,6 +1946,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, delta),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecFROZEN));
             env.close();
@@ -1885,6 +1960,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, delta),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 20s),
                 fee(baseFee * 150));
             env.close();
 
@@ -1948,6 +2024,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, delta),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecFROZEN));
             env.close();
@@ -1962,6 +2039,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, delta),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150));
             env.close();
 
@@ -2034,6 +2112,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, delta),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150));
             env.close();
             env(pay(alice, gw, USD(10'000)), ter(tecPATH_PARTIAL));
@@ -2057,12 +2136,14 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, delta),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150));
             env.close();
 
             env(escrow::create(alice, bob, USD(10'000)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecINSUFFICIENT_FUNDS));
             env.close();
@@ -2099,6 +2180,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecPRECISION_LOSS));
             env.close();
@@ -2108,6 +2190,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, USD(1'000)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150));
             env.close();
 
@@ -2158,6 +2241,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(1'000)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150),
                 createResult);
             env.close();
@@ -2208,6 +2292,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(jv,
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 result);
             env.close();
@@ -2236,6 +2321,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(-1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(temBAD_AMOUNT));
             env.close();
@@ -2269,6 +2355,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(gw, alice, MPT(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecNO_PERMISSION));
             env.close();
@@ -2292,6 +2379,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(jv,
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecOBJECT_NOT_FOUND));
             env.close();
@@ -2318,6 +2406,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(3)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecNO_PERMISSION));
             env.close();
@@ -2341,6 +2430,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(4)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecOBJECT_NOT_FOUND));
             env.close();
@@ -2373,6 +2463,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(5)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecNO_AUTH));
             env.close();
@@ -2408,6 +2499,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(6)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecNO_AUTH));
             env.close();
@@ -2439,6 +2531,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(7)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecLOCKED));
             env.close();
@@ -2470,6 +2563,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(8)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecLOCKED));
             env.close();
@@ -2496,6 +2590,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(9)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecNO_AUTH));
             env.close();
@@ -2523,6 +2618,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(11)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecINSUFFICIENT_FUNDS));
             env.close();
@@ -2551,6 +2647,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(11)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tecINSUFFICIENT_FUNDS));
             env.close();
@@ -2591,6 +2688,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(10)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -2664,6 +2762,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(8)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -2714,6 +2813,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(10)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -2750,6 +2850,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(10)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -2787,6 +2888,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(10)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -2842,7 +2944,10 @@ struct EscrowToken_test : public beast::unit_test::suite
             mptGw.authorize(
                 {.account = gw, .holder = alice, .flags = tfMPTUnauthorize});
 
-            env(escrow::cancel(bob, alice, seq1), ter(tecNO_AUTH));
+            auto const result = env.current()->rules().enabled(fixTokenEscrowV1)
+                ? ter(tesSUCCESS)
+                : ter(tecNO_AUTH);
+            env(escrow::cancel(bob, alice, seq1), result);
             env.close();
         }
 
@@ -2915,6 +3020,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(1'000)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 30s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -2985,6 +3091,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, alice, MPT(1'000)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 30s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -3041,6 +3148,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(1'000)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -3048,6 +3156,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(carol, bob, MPT(1'000)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 2s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -3089,6 +3198,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(1)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 30s),
                 fee(baseFee * 150));
             env.close();
 
@@ -3146,6 +3256,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(maxMPTokenAmount - 10)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 30s),
                 fee(baseFee * 150));
             env.close();
 
@@ -3154,6 +3265,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(10)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 30s),
                 fee(baseFee * 150));
             env.close();
 
@@ -3313,7 +3425,8 @@ struct EscrowToken_test : public beast::unit_test::suite
             auto const bseq = env.seq(bob);
 
             env(escrow::create(alice, bob, MPT(1'000)),
-                escrow::finish_time(env.now() + 1s));
+                escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 500s));
             BEAST_EXPECT(
                 (*env.meta())[sfTransactionResult] ==
                 static_cast<std::uint8_t>(tesSUCCESS));
@@ -3432,6 +3545,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, gw, MPT(1'000)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150));
             env.close();
 
@@ -3495,6 +3609,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(125)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150));
             env.close();
             auto const transferRate = escrow::rate(env, alice, seq1);
@@ -3589,8 +3704,12 @@ struct EscrowToken_test : public beast::unit_test::suite
         env(escrow::create(alice, bob, MPT(100)),
             escrow::condition(escrow::cb1),
             escrow::finish_time(env.now() + 1s),
+            escrow::cancel_time(env.now() + 30s),
             fee(baseFee * 150));
         env.close();
+
+        mptGw.authorize(
+            {.account = gw, .holder = alice, .flags = tfMPTUnauthorize});
 
         // bob can finish escrow - is authorized
         env(escrow::finish(bob, alice, seq),
@@ -3690,6 +3809,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, gw, MPT(100)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 10s),
                 fee(baseFee * 150));
             env.close();
 
@@ -3749,6 +3869,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(10)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 30s),
                 fee(baseFee * 150));
             env.close();
 
@@ -3801,6 +3922,7 @@ struct EscrowToken_test : public beast::unit_test::suite
             env(escrow::create(alice, bob, MPT(10)),
                 escrow::condition(escrow::cb1),
                 escrow::finish_time(env.now() + 1s),
+                escrow::cancel_time(env.now() + 30s),
                 fee(baseFee * 150),
                 ter(tesSUCCESS));
             env.close();
@@ -3877,7 +3999,9 @@ public:
         using namespace test::jtx;
         FeatureBitset const all{supported_amendments()};
         testIOUWithFeats(all);
+        testIOUWithFeats(all - fixTokenEscrowV1);
         testMPTWithFeats(all);
+        testMPTWithFeats(all - fixTokenEscrowV1);
     }
 };
 

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -403,6 +403,7 @@ struct Escrow_test : public beast::unit_test::suite
                 withTokenEscrow ? ter(tecNO_PERMISSION) : ter(temBAD_AMOUNT);
             env(escrow::create("alice", "carol", Account("alice")["USD"](500)),
                 escrow::finish_time(env.now() + 5s),
+                escrow::cancel_time(env.now() + 10s),
                 txResult);
         }
 

--- a/src/xrpld/ledger/detail/View.cpp
+++ b/src/xrpld/ledger/detail/View.cpp
@@ -1439,6 +1439,14 @@ trustDelete(
     std::uint64_t uLowNode = sleRippleState->getFieldU64(sfLowNode);
     std::uint64_t uHighNode = sleRippleState->getFieldU64(sfHighNode);
 
+    if (view.rules().enabled(fixTokenEscrowV1) &&
+        (*sleRippleState)[~sfLockedCount].value_or(0) != 0)
+    {
+        JLOG(j.warn()) << "trustDelete: Trust line has locked count: "
+                       << sleRippleState->key();
+        return tecHAS_OBLIGATIONS;
+    }
+
     JLOG(j.trace()) << "trustDelete: Deleting ripple line: low";
 
     if (!view.dirRemove(


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

- add `sfLockedCount` to IOU trustline. (increase and decrease)
- user/issuer cannot delete IOU trustline if user has `sfLockedCount`
- remove `requireAuth` check in `EscrowCancel`

### Context of Change

Issues:

1. CancelAfter was not required

If an account creates an escrow, does not specify CancelAfter and then deletes their trustline the escrow object could become "orphaned".

2. Require Auth is checked on EscrowCancel

If an IOU requires trustline authorization and the account sends their tokens back to the issuer, deletes the trustline and the adds the trustline back (in unauthorized state), the EscrowCancel transactor will fail with `tecNO_AUTH` which leaves the escrow object "orphaned"

Same for MPT, if the issuer unauthorizes the MPT, the EscrowCancel transactor will fail with `tecNO_AUTH` which leaves the escrow object "orphaned"

Solutions:

1. By adding the sfLockedCount onto the IOU trustline and incrementing when an escrow object is created we update the `deleteTrustline` function to check for a positive sfLockedCount and if there is a positive value, we reject the deletion of the trustline.

2. 1 above solves the issue of an account deleting the IOU. So they will always have an authorized trustline. For MPT we remove the requireAuth check in the EscrowCancel transactor (IOU & MPT).

removing `requireAuth` check in `EscrowCancel` effects;

Note: `requireAuth` is checked for both account and destination in `EscrowCreate`

IOU: Technically this would never be possible because you cannot delete a trustline that has an escrow and you cannot unauthorize a trustline. So there is no way to get to EscrowCancel with an unauthorized trustline that was previously authorized.
MPT: On EscrowCancel the funds would return to the account, however the funds remain unauthorized.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
