### PR TITLE
fix: crash when trace-logging in tests

### DIFF
--- a/src/test/unit_test/SuiteJournal.h
+++ b/src/test/unit_test/SuiteJournal.h
@@ -94,6 +94,8 @@ SuiteJournalSink::writeAlways(
         return "FTL:";
     }();
 
+    static std::mutex log_mutex_;
+    std::lock_guard lock(log_mutex_);
     suite_.log << s << partition_ << text << std::endl;
 }
 

--- a/src/test/unit_test/SuiteJournal.h
+++ b/src/test/unit_test/SuiteJournal.h
@@ -95,7 +95,7 @@ SuiteJournalSink::writeAlways(
     }();
 
     static std::mutex log_mutex;
-    std::lock_guard lock(log_mutex_);
+    std::lock_guard lock(log_mutex);
     suite_.log << s << partition_ << text << std::endl;
 }
 

--- a/src/test/unit_test/SuiteJournal.h
+++ b/src/test/unit_test/SuiteJournal.h
@@ -94,7 +94,7 @@ SuiteJournalSink::writeAlways(
         return "FTL:";
     }();
 
-    static std::mutex log_mutex_;
+    static std::mutex log_mutex;
     std::lock_guard lock(log_mutex_);
     suite_.log << s << partition_ << text << std::endl;
 }


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes a crash in tests when the test `Env is run at trace/debug log level.

This issue only affects tests, and only if logging at trace/debug level, so really only relevant during rippled development, and does not affect production servers.

Note: I think the logs run a bit slower with this fix, due to the lock, but IMO that's not a big deal since this is only relevant for development

h/t @sublimator for the fix in the issue

### Context of Change

Fixes #5388 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### API Impact

N/A

## Test Plan

Worked locally.

Repro instructions are in the issue. 
