### PR TITLE
Fix compilation error with clang-20, cleanup

### DIFF
--- a/cmake/RippledSettings.cmake
+++ b/cmake/RippledSettings.cmake
@@ -18,7 +18,7 @@ if(tests)
   endif()
 endif()
 
-option(unity "Creates a build using UNITY support in cmake. This is the default" ON)
+option(unity "Creates a build using UNITY support in cmake." OFF)
 if(unity)
   if(NOT is_ci)
     set(CMAKE_UNITY_BUILD_BATCH_SIZE 15 CACHE STRING "")

--- a/include/xrpl/basics/Expected.h
+++ b/include/xrpl/basics/Expected.h
@@ -22,7 +22,17 @@
 
 #include <xrpl/basics/contract.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <boost/outcome.hpp>
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #include <stdexcept>
 

--- a/include/xrpl/beast/hash/hash_append.h
+++ b/include/xrpl/beast/hash/hash_append.h
@@ -24,13 +24,38 @@
 #include <boost/container/flat_set.hpp>
 #include <boost/endian/conversion.hpp>
 
+/*
+
+Workaround for overzealous clang warning, which trips on libstdc++ headers
+
+  In file included from
+  /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_algo.h:61:
+  /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_tempbuf.h:263:8:
+  error: 'get_temporary_buffer<std::pair<ripple::Quality, const
+  std::vector<std::unique_ptr<ripple::Step>> *>>' is deprecated
+  [-Werror,-Wdeprecated-declarations] 263 |
+  std::get_temporary_buffer<value_type>(_M_original_len));
+       ^
+*/
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+#include <functional>
+#include <memory>
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
 #include <array>
 #include <chrono>
 #include <cstdint>
 #include <cstring>
-#include <functional>
 #include <map>
-#include <memory>
 #include <set>
 #include <string>
 #include <system_error>

--- a/src/test/basics/Buffer_test.cpp
+++ b/src/test/basics/Buffer_test.cpp
@@ -98,8 +98,7 @@ struct Buffer_test : beast::unit_test::suite
             x = b0;
             BEAST_EXPECT(x == b0);
             BEAST_EXPECT(sane(x));
-#if defined(__clang__) && (!defined(__APPLE__) && (__clang_major__ >= 7)) || \
-    (defined(__APPLE__) && (__apple_build_version__ >= 10010043))
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-assign-overloaded"
 #endif
@@ -111,8 +110,7 @@ struct Buffer_test : beast::unit_test::suite
             BEAST_EXPECT(y == b3);
             BEAST_EXPECT(sane(y));
 
-#if defined(__clang__) && (!defined(__APPLE__) && (__clang_major__ >= 7)) || \
-    (defined(__APPLE__) && (__apple_build_version__ >= 10010043))
+#if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
         }


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Workaround for compilation error with `clang-20`, also remove clutter.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->


<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->


- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)


