### PR TITLE
Downgrade required CMake version for Antithesis SDK

### DIFF
--- a/external/antithesis-sdk/CMakeLists.txt
+++ b/external/antithesis-sdk/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.18)
 
 # Note, version set explicitly by rippled project
 project(antithesis-sdk-cpp VERSION 0.4.4 LANGUAGES CXX)


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

This was copied from [antithesis-sdk-cpp](https://github.com/antithesishq/antithesis-sdk-cpp) but there is no logical reason to require this specific version of CMake. Downgrade to make this project build with older CMake versions

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
