### PR TITLE
Remove include(default) from libxrpl profile

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,7 +87,7 @@ jobs:
           clang --version
       - name: configure Conan
         run : |
-          echo "${CONAN_GLOBAL_CONF}" > global.conf
+          echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
           conan profile show
       - name: export custom recipes

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,6 +24,8 @@ env:
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}
+    core:default_build_profile=libxrpl
+    core:default_profile=libxrpl
     tools.build:jobs={{ (os.cpu_count() * 4/5) | int }}
     tools.build:verbosity=verbose
     tools.compilation:verbosity=verbose

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -25,6 +25,8 @@ env:
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{ os.cpu_count() }}
     core.upload:parallel={{ os.cpu_count() }}
+    core:default_build_profile=libxrpl
+    core:default_profile=libxrpl
     tools.build:jobs={{ (os.cpu_count() * 4/5) | int }}
     tools.build:verbosity=verbose
     tools.compilation:verbosity=verbose

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -91,7 +91,8 @@ jobs:
           env | sort
       - name: configure Conan
         run: |
-          echo "${CONAN_GLOBAL_CONF}" >> ${CONAN_HOME}/global.conf
+          echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
+          conan config install conan/profiles/ -tf $(conan config home)/profiles/
           conan profile show
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
@@ -379,7 +380,8 @@ jobs:
 
         - name: configure Conan
           run: |
-            echo "${CONAN_GLOBAL_CONF}" >> ${CONAN_HOME}/global.conf
+            echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
+            conan config install conan/profiles/ -tf $(conan config home)/profiles/
             conan profile show
         - name: build dependencies
           run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,8 +82,7 @@ jobs:
       - name: configure Conan
         shell: bash
         run: |
-          echo "${CONAN_GLOBAL_CONF}" > global.conf
-          mv conan/profiles/libxrpl conan/profiles/default
+          echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
           conan profile show
       - name: export custom recipes

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,6 +27,8 @@ env:
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}
+    core:default_build_profile=libxrpl
+    core:default_profile=libxrpl
     tools.build:jobs=24
     tools.build:verbosity=verbose
     tools.compilation:verbosity=verbose

--- a/conan/profiles/libxrpl
+++ b/conan/profiles/libxrpl
@@ -6,10 +6,6 @@
 {% set compiler_version = detect_api.default_compiler_version(compiler, version) %}
 {% endif %}
 
-{% if os == "Linux" %}
-include(default)
-{% endif %}
-
 [settings]
 os={{ os }}
 arch={{ arch }}


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Remove `include(default)` from `conan/profiles/libxrpl` ; this means that we will now rely on compiler workarounds stored elsewhere e.g. in `global.conf`

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

Simplification of conan 2 workflows.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
