### PR TITLE
Pre-lending protocol refactoring 3: Transactors

### DIFF
--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -3328,7 +3328,7 @@ private:
                     env.current()->rules(),
                     tapNONE,
                     env.journal);
-                auto pf = AMMBid::preflight(pfctx);
+                auto pf = Transactor::preflight<AMMBid>(pfctx);
                 BEAST_EXPECT(pf == temDISABLED);
                 env.app().config().features.insert(featureAMM);
             }
@@ -3343,7 +3343,7 @@ private:
                     env.current()->rules(),
                     tapNONE,
                     env.journal);
-                auto pf = AMMBid::preflight(pfctx);
+                auto pf = Transactor::preflight<AMMBid>(pfctx);
                 BEAST_EXPECT(pf != tesSUCCESS);
             }
 
@@ -3358,7 +3358,7 @@ private:
                     env.current()->rules(),
                     tapNONE,
                     env.journal);
-                auto pf = AMMBid::preflight(pfctx);
+                auto pf = Transactor::preflight<AMMBid>(pfctx);
                 BEAST_EXPECT(pf == temBAD_AMM_TOKENS);
             }
         }

--- a/src/xrpld/app/tx/detail/AMMBid.cpp
+++ b/src/xrpld/app/tx/detail/AMMBid.cpp
@@ -30,21 +30,15 @@
 
 namespace ripple {
 
-NotTEC
-AMMBid::preflight(PreflightContext const& ctx)
+bool
+AMMBid::isEnabled(PreflightContext const& ctx)
 {
-    if (!ammEnabled(ctx.rules))
-        return temDISABLED;
+    return ammEnabled(ctx.rules);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-    {
-        JLOG(ctx.j.debug()) << "AMM Bid: invalid flags.";
-        return temINVALID_FLAG;
-    }
-
+NotTEC
+AMMBid::doPreflight(PreflightContext const& ctx)
+{
     if (auto const res = invalidAMMAssetPair(
             ctx.tx[sfAsset].get<Issue>(), ctx.tx[sfAsset2].get<Issue>()))
     {
@@ -80,7 +74,7 @@ AMMBid::preflight(PreflightContext const& ctx)
         }
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/AMMBid.h
+++ b/src/xrpld/app/tx/detail/AMMBid.h
@@ -71,8 +71,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/AMMClawback.cpp
+++ b/src/xrpld/app/tx/detail/AMMClawback.cpp
@@ -33,19 +33,21 @@
 
 namespace ripple {
 
-NotTEC
-AMMClawback::preflight(PreflightContext const& ctx)
+bool
+AMMClawback::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureAMMClawback))
-        return temDISABLED;
+    return ctx.rules.enabled(featureAMMClawback);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;  // LCOV_EXCL_LINE
+std::uint32_t
+AMMClawback::getFlagsMask(PreflightContext const& ctx)
+{
+    return tfAMMClawbackMask;
+}
 
-    auto const flags = ctx.tx.getFlags();
-    if (flags & tfAMMClawbackMask)
-        return temINVALID_FLAG;
-
+NotTEC
+AMMClawback::doPreflight(PreflightContext const& ctx)
+{
     AccountID const issuer = ctx.tx[sfAccount];
     AccountID const holder = ctx.tx[sfHolder];
 
@@ -62,6 +64,8 @@ AMMClawback::preflight(PreflightContext const& ctx)
 
     if (isXRP(asset))
         return temMALFORMED;
+
+    auto const flags = ctx.tx.getFlags();
 
     if (flags & tfClawTwoAssets && asset.account != asset2.account)
     {
@@ -88,7 +92,7 @@ AMMClawback::preflight(PreflightContext const& ctx)
     if (clawAmount && *clawAmount <= beast::zero)
         return temBAD_AMOUNT;
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/AMMClawback.h
+++ b/src/xrpld/app/tx/detail/AMMClawback.h
@@ -33,8 +33,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/AMMCreate.cpp
+++ b/src/xrpld/app/tx/detail/AMMCreate.cpp
@@ -31,21 +31,15 @@
 
 namespace ripple {
 
-NotTEC
-AMMCreate::preflight(PreflightContext const& ctx)
+bool
+AMMCreate::isEnabled(PreflightContext const& ctx)
 {
-    if (!ammEnabled(ctx.rules))
-        return temDISABLED;
+    return ammEnabled(ctx.rules);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-    {
-        JLOG(ctx.j.debug()) << "AMM Instance: invalid flags.";
-        return temINVALID_FLAG;
-    }
-
+NotTEC
+AMMCreate::doPreflight(PreflightContext const& ctx)
+{
     auto const amount = ctx.tx[sfAmount];
     auto const amount2 = ctx.tx[sfAmount2];
 
@@ -74,14 +68,14 @@ AMMCreate::preflight(PreflightContext const& ctx)
         return temBAD_FEE;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 XRPAmount
 AMMCreate::calculateBaseFee(ReadView const& view, STTx const& tx)
 {
     // The fee required for AMMCreate is one owner reserve.
-    return view.fees().increment;
+    return calculateOwnerReserveFee(view, tx);
 }
 
 TER

--- a/src/xrpld/app/tx/detail/AMMCreate.h
+++ b/src/xrpld/app/tx/detail/AMMCreate.h
@@ -63,8 +63,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static XRPAmount
     calculateBaseFee(ReadView const& view, STTx const& tx);

--- a/src/xrpld/app/tx/detail/AMMDelete.cpp
+++ b/src/xrpld/app/tx/detail/AMMDelete.cpp
@@ -27,22 +27,16 @@
 
 namespace ripple {
 
-NotTEC
-AMMDelete::preflight(PreflightContext const& ctx)
+bool
+AMMDelete::isEnabled(PreflightContext const& ctx)
 {
-    if (!ammEnabled(ctx.rules))
-        return temDISABLED;
+    return ammEnabled(ctx.rules);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-    {
-        JLOG(ctx.j.debug()) << "AMM Delete: invalid flags.";
-        return temINVALID_FLAG;
-    }
-
-    return preflight2(ctx);
+NotTEC
+AMMDelete::doPreflight(PreflightContext const& ctx)
+{
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/AMMDelete.h
+++ b/src/xrpld/app/tx/detail/AMMDelete.h
@@ -39,8 +39,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/AMMDeposit.cpp
+++ b/src/xrpld/app/tx/detail/AMMDeposit.cpp
@@ -29,21 +29,23 @@
 
 namespace ripple {
 
-NotTEC
-AMMDeposit::preflight(PreflightContext const& ctx)
+bool
+AMMDeposit::isEnabled(PreflightContext const& ctx)
 {
-    if (!ammEnabled(ctx.rules))
-        return temDISABLED;
+    return ammEnabled(ctx.rules);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+std::uint32_t
+AMMDeposit::getFlagsMask(PreflightContext const& ctx)
 
+{
+    return tfDepositMask;
+}
+
+NotTEC
+AMMDeposit::doPreflight(PreflightContext const& ctx)
+{
     auto const flags = ctx.tx.getFlags();
-    if (flags & tfDepositMask)
-    {
-        JLOG(ctx.j.debug()) << "AMM Deposit: invalid flags.";
-        return temINVALID_FLAG;
-    }
 
     auto const amount = ctx.tx[~sfAmount];
     auto const amount2 = ctx.tx[~sfAmount2];
@@ -159,7 +161,7 @@ AMMDeposit::preflight(PreflightContext const& ctx)
         return temBAD_FEE;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/AMMDeposit.h
+++ b/src/xrpld/app/tx/detail/AMMDeposit.h
@@ -68,8 +68,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/AMMVote.cpp
+++ b/src/xrpld/app/tx/detail/AMMVote.cpp
@@ -27,26 +27,20 @@
 
 namespace ripple {
 
-NotTEC
-AMMVote::preflight(PreflightContext const& ctx)
+bool
+AMMVote::isEnabled(PreflightContext const& ctx)
 {
-    if (!ammEnabled(ctx.rules))
-        return temDISABLED;
+    return ammEnabled(ctx.rules);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
+NotTEC
+AMMVote::doPreflight(PreflightContext const& ctx)
+{
     if (auto const res = invalidAMMAssetPair(
             ctx.tx[sfAsset].get<Issue>(), ctx.tx[sfAsset2].get<Issue>()))
     {
         JLOG(ctx.j.debug()) << "AMM Vote: invalid asset pair.";
         return res;
-    }
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-    {
-        JLOG(ctx.j.debug()) << "AMM Vote: invalid flags.";
-        return temINVALID_FLAG;
     }
 
     if (ctx.tx[sfTradingFee] > TRADING_FEE_THRESHOLD)
@@ -55,7 +49,7 @@ AMMVote::preflight(PreflightContext const& ctx)
         return temBAD_FEE;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/AMMVote.h
+++ b/src/xrpld/app/tx/detail/AMMVote.h
@@ -56,8 +56,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/AMMWithdraw.cpp
+++ b/src/xrpld/app/tx/detail/AMMWithdraw.cpp
@@ -28,21 +28,22 @@
 
 namespace ripple {
 
-NotTEC
-AMMWithdraw::preflight(PreflightContext const& ctx)
+bool
+AMMWithdraw::isEnabled(PreflightContext const& ctx)
 {
-    if (!ammEnabled(ctx.rules))
-        return temDISABLED;
+    return ammEnabled(ctx.rules);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+std::uint32_t
+AMMWithdraw::getFlagsMask(PreflightContext const& ctx)
+{
+    return tfWithdrawMask;
+}
 
+NotTEC
+AMMWithdraw::doPreflight(PreflightContext const& ctx)
+{
     auto const flags = ctx.tx.getFlags();
-    if (flags & tfWithdrawMask)
-    {
-        JLOG(ctx.j.debug()) << "AMM Withdraw: invalid flags.";
-        return temINVALID_FLAG;
-    }
 
     auto const amount = ctx.tx[~sfAmount];
     auto const amount2 = ctx.tx[~sfAmount2];
@@ -150,7 +151,7 @@ AMMWithdraw::preflight(PreflightContext const& ctx)
         }
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 static std::optional<STAmount>

--- a/src/xrpld/app/tx/detail/AMMWithdraw.h
+++ b/src/xrpld/app/tx/detail/AMMWithdraw.h
@@ -75,8 +75,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/CancelCheck.cpp
+++ b/src/xrpld/app/tx/detail/CancelCheck.cpp
@@ -29,24 +29,16 @@
 
 namespace ripple {
 
-NotTEC
-CancelCheck::preflight(PreflightContext const& ctx)
+bool
+CancelCheck::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureChecks))
-        return temDISABLED;
+    return ctx.rules.enabled(featureChecks);
+}
 
-    NotTEC const ret{preflight1(ctx)};
-    if (!isTesSuccess(ret))
-        return ret;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-    {
-        // There are no flags (other than universal) for CreateCheck yet.
-        JLOG(ctx.j.warn()) << "Malformed transaction: Invalid flags set.";
-        return temINVALID_FLAG;
-    }
-
-    return preflight2(ctx);
+NotTEC
+CancelCheck::doPreflight(PreflightContext const& ctx)
+{
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/CancelCheck.h
+++ b/src/xrpld/app/tx/detail/CancelCheck.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/CancelOffer.cpp
+++ b/src/xrpld/app/tx/detail/CancelOffer.cpp
@@ -26,27 +26,15 @@
 namespace ripple {
 
 NotTEC
-CancelOffer::preflight(PreflightContext const& ctx)
+CancelOffer::doPreflight(PreflightContext const& ctx)
 {
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
-    auto const uTxFlags = ctx.tx.getFlags();
-
-    if (uTxFlags & tfUniversalMask)
-    {
-        JLOG(ctx.j.trace()) << "Malformed transaction: "
-                            << "Invalid flags set.";
-        return temINVALID_FLAG;
-    }
-
     if (!ctx.tx[sfOfferSequence])
     {
         JLOG(ctx.j.trace()) << "CancelOffer::preflight: missing sequence";
         return temBAD_SEQUENCE;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 //------------------------------------------------------------------------------

--- a/src/xrpld/app/tx/detail/CancelOffer.h
+++ b/src/xrpld/app/tx/detail/CancelOffer.h
@@ -36,7 +36,7 @@ public:
     }
 
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/CashCheck.cpp
+++ b/src/xrpld/app/tx/detail/CashCheck.cpp
@@ -32,23 +32,15 @@
 
 namespace ripple {
 
-NotTEC
-CashCheck::preflight(PreflightContext const& ctx)
+bool
+CashCheck::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureChecks))
-        return temDISABLED;
+    return ctx.rules.enabled(featureChecks);
+}
 
-    NotTEC const ret{preflight1(ctx)};
-    if (!isTesSuccess(ret))
-        return ret;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-    {
-        // There are no flags (other than universal) for CashCheck yet.
-        JLOG(ctx.j.warn()) << "Malformed transaction: Invalid flags set.";
-        return temINVALID_FLAG;
-    }
-
+NotTEC
+CashCheck::doPreflight(PreflightContext const& ctx)
+{
     // Exactly one of Amount or DeliverMin must be present.
     auto const optAmount = ctx.tx[~sfAmount];
     auto const optDeliverMin = ctx.tx[~sfDeliverMin];
@@ -76,7 +68,7 @@ CashCheck::preflight(PreflightContext const& ctx)
         return temBAD_CURRENCY;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/CashCheck.h
+++ b/src/xrpld/app/tx/detail/CashCheck.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/Change.cpp
+++ b/src/xrpld/app/tx/detail/Change.cpp
@@ -33,11 +33,12 @@
 
 namespace ripple {
 
+template <>
 NotTEC
-Change::preflight(PreflightContext const& ctx)
+Transactor::preflight<Change>(PreflightContext const& ctx)
 {
-    auto const ret = preflight0(ctx);
-    if (!isTesSuccess(ret))
+    // 0 means "Allow any flags"
+    if (auto const ret = preflight0(ctx, 0))
         return ret;
 
     auto account = ctx.tx.getAccountID(sfAccount);

--- a/src/xrpld/app/tx/detail/Change.h
+++ b/src/xrpld/app/tx/detail/Change.h
@@ -33,9 +33,6 @@ public:
     {
     }
 
-    static NotTEC
-    preflight(PreflightContext const& ctx);
-
     TER
     doApply() override;
     void

--- a/src/xrpld/app/tx/detail/Clawback.cpp
+++ b/src/xrpld/app/tx/detail/Clawback.cpp
@@ -75,25 +75,28 @@ preflightHelper<MPTIssue>(PreflightContext const& ctx)
     return tesSUCCESS;
 }
 
-NotTEC
-Clawback::preflight(PreflightContext const& ctx)
+bool
+Clawback::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureClawback))
-        return temDISABLED;
+    return ctx.rules.enabled(featureClawback);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+std::uint32_t
+Clawback::getFlagsMask(PreflightContext const& ctx)
+{
+    return tfClawbackMask;
+}
 
-    if (ctx.tx.getFlags() & tfClawbackMask)
-        return temINVALID_FLAG;
-
+NotTEC
+Clawback::doPreflight(PreflightContext const& ctx)
+{
     if (auto const ret = std::visit(
             [&]<typename T>(T const&) { return preflightHelper<T>(ctx); },
             ctx.tx[sfAmount].asset().value());
         !isTesSuccess(ret))
         return ret;
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 template <ValidIssueType T>

--- a/src/xrpld/app/tx/detail/Clawback.h
+++ b/src/xrpld/app/tx/detail/Clawback.h
@@ -33,8 +33,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/CreateCheck.cpp
+++ b/src/xrpld/app/tx/detail/CreateCheck.cpp
@@ -28,22 +28,15 @@
 
 namespace ripple {
 
-NotTEC
-CreateCheck::preflight(PreflightContext const& ctx)
+bool
+CreateCheck::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureChecks))
-        return temDISABLED;
+    return ctx.rules.enabled(featureChecks);
+}
 
-    NotTEC const ret{preflight1(ctx)};
-    if (!isTesSuccess(ret))
-        return ret;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-    {
-        // There are no flags (other than universal) for CreateCheck yet.
-        JLOG(ctx.j.warn()) << "Malformed transaction: Invalid flags set.";
-        return temINVALID_FLAG;
-    }
+NotTEC
+CreateCheck::doPreflight(PreflightContext const& ctx)
+{
     if (ctx.tx[sfAccount] == ctx.tx[sfDestination])
     {
         // They wrote a check to themselves.
@@ -76,7 +69,7 @@ CreateCheck::preflight(PreflightContext const& ctx)
         }
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/CreateCheck.h
+++ b/src/xrpld/app/tx/detail/CreateCheck.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/CreateOffer.cpp
+++ b/src/xrpld/app/tx/detail/CreateOffer.cpp
@@ -39,22 +39,19 @@ CreateOffer::makeTxConsequences(PreflightContext const& ctx)
     return TxConsequences{ctx.tx, calculateMaxXRPSpend(ctx.tx)};
 }
 
-NotTEC
-CreateOffer::preflight(PreflightContext const& ctx)
+std::uint32_t
+CreateOffer::getFlagsMask(PreflightContext const& ctx)
 {
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+    return tfOfferCreateMask;
+}
 
+NotTEC
+CreateOffer::doPreflight(PreflightContext const& ctx)
+{
     auto& tx = ctx.tx;
     auto& j = ctx.j;
 
     std::uint32_t const uTxFlags = tx.getFlags();
-
-    if (uTxFlags & tfOfferCreateMask)
-    {
-        JLOG(j.debug()) << "Malformed transaction: Invalid flags set.";
-        return temINVALID_FLAG;
-    }
 
     bool const bImmediateOrCancel(uTxFlags & tfImmediateOrCancel);
     bool const bFillOrKill(uTxFlags & tfFillOrKill);
@@ -122,7 +119,7 @@ CreateOffer::preflight(PreflightContext const& ctx)
         return temBAD_ISSUER;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/CreateOffer.h
+++ b/src/xrpld/app/tx/detail/CreateOffer.h
@@ -44,9 +44,12 @@ public:
     static TxConsequences
     makeTxConsequences(PreflightContext const& ctx);
 
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     /** Enforce constraints beyond those of the Transactor base class. */
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     /** Enforce constraints beyond those of the Transactor base class. */
     static TER

--- a/src/xrpld/app/tx/detail/CreateTicket.cpp
+++ b/src/xrpld/app/tx/detail/CreateTicket.cpp
@@ -33,23 +33,20 @@ CreateTicket::makeTxConsequences(PreflightContext const& ctx)
     return TxConsequences{ctx.tx, ctx.tx[sfTicketCount]};
 }
 
-NotTEC
-CreateTicket::preflight(PreflightContext const& ctx)
+bool
+CreateTicket::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureTicketBatch))
-        return temDISABLED;
+    return ctx.rules.enabled(featureTicketBatch);
+}
 
-    if (ctx.tx.getFlags() & tfUniversalMask)
-        return temINVALID_FLAG;
-
+NotTEC
+CreateTicket::doPreflight(PreflightContext const& ctx)
+{
     if (std::uint32_t const count = ctx.tx[sfTicketCount];
         count < minValidCount || count > maxValidCount)
         return temINVALID_COUNT;
 
-    if (NotTEC const ret{preflight1(ctx)}; !isTesSuccess(ret))
-        return ret;
-
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/CreateTicket.h
+++ b/src/xrpld/app/tx/detail/CreateTicket.h
@@ -69,9 +69,12 @@ public:
     static TxConsequences
     makeTxConsequences(PreflightContext const& ctx);
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     /** Enforce constraints beyond those of the Transactor base class. */
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     /** Enforce constraints beyond those of the Transactor base class. */
     static TER

--- a/src/xrpld/app/tx/detail/Credentials.cpp
+++ b/src/xrpld/app/tx/detail/Credentials.cpp
@@ -48,27 +48,24 @@ using namespace credentials;
 
 // ------- CREATE --------------------------
 
-NotTEC
-CredentialCreate::preflight(PreflightContext const& ctx)
+bool
+CredentialCreate::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureCredentials))
-    {
-        JLOG(ctx.j.trace()) << "featureCredentials is disabled.";
-        return temDISABLED;
-    }
+    return ctx.rules.enabled(featureCredentials);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+std::uint32_t
+CredentialCreate::getFlagsMask(PreflightContext const& ctx)
+{
+    // 0 means "Allow any flags"
+    return ctx.rules.enabled(fixInvalidTxFlags) ? tfUniversalMask : 0;
+}
 
+NotTEC
+CredentialCreate::doPreflight(PreflightContext const& ctx)
+{
     auto const& tx = ctx.tx;
     auto& j = ctx.j;
-
-    if (ctx.rules.enabled(fixInvalidTxFlags) &&
-        (tx.getFlags() & tfUniversalMask))
-    {
-        JLOG(ctx.j.debug()) << "CredentialCreate: invalid flags.";
-        return temINVALID_FLAG;
-    }
 
     if (!tx[sfSubject])
     {
@@ -91,7 +88,7 @@ CredentialCreate::preflight(PreflightContext const& ctx)
         return temMALFORMED;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER
@@ -202,25 +199,22 @@ CredentialCreate::doApply()
 }
 
 // ------- DELETE --------------------------
-NotTEC
-CredentialDelete::preflight(PreflightContext const& ctx)
+bool
+CredentialDelete::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureCredentials))
-    {
-        JLOG(ctx.j.trace()) << "featureCredentials is disabled.";
-        return temDISABLED;
-    }
+    return ctx.rules.enabled(featureCredentials);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+std::uint32_t
+CredentialDelete::getFlagsMask(PreflightContext const& ctx)
+{
+    // 0 means "Allow any flags"
+    return ctx.rules.enabled(fixInvalidTxFlags) ? tfUniversalMask : 0;
+}
 
-    if (ctx.rules.enabled(fixInvalidTxFlags) &&
-        (ctx.tx.getFlags() & tfUniversalMask))
-    {
-        JLOG(ctx.j.debug()) << "CredentialDelete: invalid flags.";
-        return temINVALID_FLAG;
-    }
-
+NotTEC
+CredentialDelete::doPreflight(PreflightContext const& ctx)
+{
     auto const subject = ctx.tx[~sfSubject];
     auto const issuer = ctx.tx[~sfIssuer];
 
@@ -248,7 +242,7 @@ CredentialDelete::preflight(PreflightContext const& ctx)
         return temMALFORMED;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER
@@ -289,25 +283,22 @@ CredentialDelete::doApply()
 
 // ------- APPLY --------------------------
 
-NotTEC
-CredentialAccept::preflight(PreflightContext const& ctx)
+bool
+CredentialAccept::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureCredentials))
-    {
-        JLOG(ctx.j.trace()) << "featureCredentials is disabled.";
-        return temDISABLED;
-    }
+    return ctx.rules.enabled(featureCredentials);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+std::uint32_t
+CredentialAccept::getFlagsMask(PreflightContext const& ctx)
+{
+    // 0 means "Allow any flags"
+    return ctx.rules.enabled(fixInvalidTxFlags) ? tfUniversalMask : 0;
+}
 
-    if (ctx.rules.enabled(fixInvalidTxFlags) &&
-        (ctx.tx.getFlags() & tfUniversalMask))
-    {
-        JLOG(ctx.j.debug()) << "CredentialAccept: invalid flags.";
-        return temINVALID_FLAG;
-    }
-
+NotTEC
+CredentialAccept::doPreflight(PreflightContext const& ctx)
+{
     if (!ctx.tx[sfIssuer])
     {
         JLOG(ctx.j.trace()) << "Malformed transaction: Issuer field zeroed.";
@@ -322,7 +313,7 @@ CredentialAccept::preflight(PreflightContext const& ctx)
         return temMALFORMED;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/Credentials.h
+++ b/src/xrpld/app/tx/detail/Credentials.h
@@ -33,8 +33,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);
@@ -54,8 +60,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);
@@ -75,8 +87,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/DID.cpp
+++ b/src/xrpld/app/tx/detail/DID.cpp
@@ -42,18 +42,15 @@ namespace ripple {
 
 //------------------------------------------------------------------------------
 
-NotTEC
-DIDSet::preflight(PreflightContext const& ctx)
+bool
+DIDSet::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureDID))
-        return temDISABLED;
+    return ctx.rules.enabled(featureDID);
+}
 
-    if (ctx.tx.getFlags() & tfUniversalMask)
-        return temINVALID_FLAG;
-
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
+NotTEC
+DIDSet::doPreflight(PreflightContext const& ctx)
+{
     if (!ctx.tx.isFieldPresent(sfURI) &&
         !ctx.tx.isFieldPresent(sfDIDDocument) && !ctx.tx.isFieldPresent(sfData))
         return temEMPTY_DID;
@@ -74,7 +71,7 @@ DIDSet::preflight(PreflightContext const& ctx)
         isTooLong(sfData, maxDIDAttestationLength))
         return temMALFORMED;
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER
@@ -171,19 +168,16 @@ DIDSet::doApply()
     return addSLE(ctx_, sleDID, account_);
 }
 
-NotTEC
-DIDDelete::preflight(PreflightContext const& ctx)
+bool
+DIDDelete::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureDID))
-        return temDISABLED;
+    return ctx.rules.enabled(featureDID);
+}
 
-    if (ctx.tx.getFlags() & tfUniversalMask)
-        return temINVALID_FLAG;
-
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
-    return preflight2(ctx);
+NotTEC
+DIDDelete::doPreflight(PreflightContext const& ctx)
+{
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/DID.h
+++ b/src/xrpld/app/tx/detail/DID.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     TER
     doApply() override;
@@ -51,8 +54,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     deleteSLE(ApplyContext& ctx, Keylet sleKeylet, AccountID const owner);

--- a/src/xrpld/app/tx/detail/DelegateSet.cpp
+++ b/src/xrpld/app/tx/detail/DelegateSet.cpp
@@ -28,15 +28,15 @@
 
 namespace ripple {
 
-NotTEC
-DelegateSet::preflight(PreflightContext const& ctx)
+bool
+DelegateSet::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featurePermissionDelegation))
-        return temDISABLED;
+    return ctx.rules.enabled(featurePermissionDelegation);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
+NotTEC
+DelegateSet::doPreflight(PreflightContext const& ctx)
+{
     auto const& permissions = ctx.tx.getFieldArray(sfPermissions);
     if (permissions.size() > permissionMaxSize)
         return temARRAY_TOO_LARGE;
@@ -53,7 +53,7 @@ DelegateSet::preflight(PreflightContext const& ctx)
             return temMALFORMED;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/DelegateSet.h
+++ b/src/xrpld/app/tx/detail/DelegateSet.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/DeleteAccount.cpp
+++ b/src/xrpld/app/tx/detail/DeleteAccount.cpp
@@ -38,22 +38,19 @@
 
 namespace ripple {
 
-NotTEC
-DeleteAccount::preflight(PreflightContext const& ctx)
+bool
+DeleteAccount::isEnabled(PreflightContext const& ctx)
 {
     if (!ctx.rules.enabled(featureDeletableAccounts))
-        return temDISABLED;
+        return false;
 
-    if (ctx.tx.isFieldPresent(sfCredentialIDs) &&
-        !ctx.rules.enabled(featureCredentials))
-        return temDISABLED;
+    return !ctx.tx.isFieldPresent(sfCredentialIDs) ||
+        ctx.rules.enabled(featureCredentials);
+}
 
-    if (ctx.tx.getFlags() & tfUniversalMask)
-        return temINVALID_FLAG;
-
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
+NotTEC
+DeleteAccount::doPreflight(PreflightContext const& ctx)
+{
     if (ctx.tx[sfAccount] == ctx.tx[sfDestination])
         // An account cannot be deleted and give itself the resulting XRP.
         return temDST_IS_SRC;
@@ -61,14 +58,14 @@ DeleteAccount::preflight(PreflightContext const& ctx)
     if (auto const err = credentials::checkFields(ctx); !isTesSuccess(err))
         return err;
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 XRPAmount
 DeleteAccount::calculateBaseFee(ReadView const& view, STTx const& tx)
 {
     // The fee required for AccountDelete is one owner reserve.
-    return view.fees().increment;
+    return calculateOwnerReserveFee(view, tx);
 }
 
 namespace {

--- a/src/xrpld/app/tx/detail/DeleteAccount.h
+++ b/src/xrpld/app/tx/detail/DeleteAccount.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static XRPAmount
     calculateBaseFee(ReadView const& view, STTx const& tx);

--- a/src/xrpld/app/tx/detail/DeleteOracle.cpp
+++ b/src/xrpld/app/tx/detail/DeleteOracle.cpp
@@ -26,22 +26,16 @@
 
 namespace ripple {
 
-NotTEC
-DeleteOracle::preflight(PreflightContext const& ctx)
+bool
+DeleteOracle::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featurePriceOracle))
-        return temDISABLED;
+    return ctx.rules.enabled(featurePriceOracle);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-    {
-        JLOG(ctx.j.debug()) << "Oracle Delete: invalid flags.";
-        return temINVALID_FLAG;
-    }
-
-    return preflight2(ctx);
+NotTEC
+DeleteOracle::doPreflight(PreflightContext const& ctx)
+{
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/DeleteOracle.h
+++ b/src/xrpld/app/tx/detail/DeleteOracle.h
@@ -42,8 +42,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/DepositPreauth.h
+++ b/src/xrpld/app/tx/detail/DepositPreauth.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/Escrow.h
+++ b/src/xrpld/app/tx/detail/Escrow.h
@@ -36,8 +36,11 @@ public:
     static TxConsequences
     makeTxConsequences(PreflightContext const& ctx);
 
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);
@@ -57,8 +60,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static XRPAmount
     calculateBaseFee(ReadView const& view, STTx const& tx);
@@ -81,8 +90,11 @@ public:
     {
     }
 
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     TER
     doApply() override;

--- a/src/xrpld/app/tx/detail/LedgerStateFix.cpp
+++ b/src/xrpld/app/tx/detail/LedgerStateFix.cpp
@@ -27,18 +27,15 @@
 
 namespace ripple {
 
-NotTEC
-LedgerStateFix::preflight(PreflightContext const& ctx)
+bool
+LedgerStateFix::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(fixNFTokenPageLinks))
-        return temDISABLED;
+    return ctx.rules.enabled(fixNFTokenPageLinks);
+}
 
-    if (ctx.tx.getFlags() & tfUniversalMask)
-        return temINVALID_FLAG;
-
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
+NotTEC
+LedgerStateFix::doPreflight(PreflightContext const& ctx)
+{
     switch (ctx.tx[sfLedgerFixType])
     {
         case FixType::nfTokenPageLink:
@@ -50,7 +47,7 @@ LedgerStateFix::preflight(PreflightContext const& ctx)
             return tefINVALID_LEDGER_FIX_TYPE;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 XRPAmount
@@ -58,7 +55,7 @@ LedgerStateFix::calculateBaseFee(ReadView const& view, STTx const& tx)
 {
     // The fee required for LedgerStateFix is one owner reserve, just like
     // the fee for AccountDelete.
-    return view.fees().increment;
+    return calculateOwnerReserveFee(view, tx);
 }
 
 TER

--- a/src/xrpld/app/tx/detail/LedgerStateFix.h
+++ b/src/xrpld/app/tx/detail/LedgerStateFix.h
@@ -37,8 +37,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static XRPAmount
     calculateBaseFee(ReadView const& view, STTx const& tx);

--- a/src/xrpld/app/tx/detail/MPTokenAuthorize.cpp
+++ b/src/xrpld/app/tx/detail/MPTokenAuthorize.cpp
@@ -26,22 +26,25 @@
 
 namespace ripple {
 
-NotTEC
-MPTokenAuthorize::preflight(PreflightContext const& ctx)
+bool
+MPTokenAuthorize::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureMPTokensV1))
-        return temDISABLED;
+    return ctx.rules.enabled(featureMPTokensV1);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+std::uint32_t
+MPTokenAuthorize::getFlagsMask(PreflightContext const& ctx)
+{
+    return tfMPTokenAuthorizeMask;
+}
 
-    if (ctx.tx.getFlags() & tfMPTokenAuthorizeMask)
-        return temINVALID_FLAG;
-
+NotTEC
+MPTokenAuthorize::doPreflight(PreflightContext const& ctx)
+{
     if (ctx.tx[sfAccount] == ctx.tx[~sfHolder])
         return temMALFORMED;
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/MPTokenAuthorize.h
+++ b/src/xrpld/app/tx/detail/MPTokenAuthorize.h
@@ -42,8 +42,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/MPTokenIssuanceCreate.cpp
+++ b/src/xrpld/app/tx/detail/MPTokenIssuanceCreate.cpp
@@ -25,18 +25,21 @@
 
 namespace ripple {
 
-NotTEC
-MPTokenIssuanceCreate::preflight(PreflightContext const& ctx)
+bool
+MPTokenIssuanceCreate::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureMPTokensV1))
-        return temDISABLED;
+    return ctx.rules.enabled(featureMPTokensV1);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+std::uint32_t
+MPTokenIssuanceCreate::getFlagsMask(PreflightContext const& ctx)
+{
+    return tfMPTokenIssuanceCreateMask;
+}
 
-    if (ctx.tx.getFlags() & tfMPTokenIssuanceCreateMask)
-        return temINVALID_FLAG;
-
+NotTEC
+MPTokenIssuanceCreate::doPreflight(PreflightContext const& ctx)
+{
     if (auto const fee = ctx.tx[~sfTransferFee])
     {
         if (fee > maxTransferFee)
@@ -64,7 +67,7 @@ MPTokenIssuanceCreate::preflight(PreflightContext const& ctx)
         if (maxAmt > maxMPTokenAmount)
             return temMALFORMED;
     }
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 Expected<MPTID, TER>

--- a/src/xrpld/app/tx/detail/MPTokenIssuanceCreate.h
+++ b/src/xrpld/app/tx/detail/MPTokenIssuanceCreate.h
@@ -49,8 +49,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     TER
     doApply() override;

--- a/src/xrpld/app/tx/detail/MPTokenIssuanceDestroy.cpp
+++ b/src/xrpld/app/tx/detail/MPTokenIssuanceDestroy.cpp
@@ -25,20 +25,22 @@
 
 namespace ripple {
 
-NotTEC
-MPTokenIssuanceDestroy::preflight(PreflightContext const& ctx)
+bool
+MPTokenIssuanceDestroy::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureMPTokensV1))
-        return temDISABLED;
+    return ctx.rules.enabled(featureMPTokensV1);
+}
 
-    // check flags
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+std::uint32_t
+MPTokenIssuanceDestroy::getFlagsMask(PreflightContext const& ctx)
+{
+    return tfMPTokenIssuanceDestroyMask;
+}
 
-    if (ctx.tx.getFlags() & tfMPTokenIssuanceDestroyMask)
-        return temINVALID_FLAG;
-
-    return preflight2(ctx);
+NotTEC
+MPTokenIssuanceDestroy::doPreflight(PreflightContext const& ctx)
+{
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/MPTokenIssuanceDestroy.h
+++ b/src/xrpld/app/tx/detail/MPTokenIssuanceDestroy.h
@@ -33,8 +33,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/MPTokenIssuanceSet.cpp
+++ b/src/xrpld/app/tx/detail/MPTokenIssuanceSet.cpp
@@ -25,22 +25,25 @@
 
 namespace ripple {
 
-NotTEC
-MPTokenIssuanceSet::preflight(PreflightContext const& ctx)
+bool
+MPTokenIssuanceSet::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureMPTokensV1))
-        return temDISABLED;
+    return ctx.rules.enabled(featureMPTokensV1);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+std::uint32_t
+MPTokenIssuanceSet::getFlagsMask(PreflightContext const& ctx)
+{
+    return tfMPTokenIssuanceSetMask;
+}
 
+NotTEC
+MPTokenIssuanceSet::doPreflight(PreflightContext const& ctx)
+{
     auto const txFlags = ctx.tx.getFlags();
 
-    // check flags
-    if (txFlags & tfMPTokenIssuanceSetMask)
-        return temINVALID_FLAG;
     // fails if both flags are set
-    else if ((txFlags & tfMPTLock) && (txFlags & tfMPTUnlock))
+    if ((txFlags & tfMPTLock) && (txFlags & tfMPTUnlock))
         return temINVALID_FLAG;
 
     auto const accountID = ctx.tx[sfAccount];
@@ -48,7 +51,7 @@ MPTokenIssuanceSet::preflight(PreflightContext const& ctx)
     if (holderID && accountID == holderID)
         return temMALFORMED;
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/MPTokenIssuanceSet.h
+++ b/src/xrpld/app/tx/detail/MPTokenIssuanceSet.h
@@ -33,8 +33,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     checkPermission(ReadView const& view, STTx const& tx);

--- a/src/xrpld/app/tx/detail/NFTokenAcceptOffer.cpp
+++ b/src/xrpld/app/tx/detail/NFTokenAcceptOffer.cpp
@@ -27,18 +27,21 @@
 
 namespace ripple {
 
-NotTEC
-NFTokenAcceptOffer::preflight(PreflightContext const& ctx)
+bool
+NFTokenAcceptOffer::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureNonFungibleTokensV1))
-        return temDISABLED;
+    return ctx.rules.enabled(featureNonFungibleTokensV1);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+std::uint32_t
+NFTokenAcceptOffer::getFlagsMask(PreflightContext const& ctx)
+{
+    return tfNFTokenAcceptOfferMask;
+}
 
-    if (ctx.tx.getFlags() & tfNFTokenAcceptOfferMask)
-        return temINVALID_FLAG;
-
+NotTEC
+NFTokenAcceptOffer::doPreflight(PreflightContext const& ctx)
+{
     auto const bo = ctx.tx[~sfNFTokenBuyOffer];
     auto const so = ctx.tx[~sfNFTokenSellOffer];
 
@@ -57,7 +60,7 @@ NFTokenAcceptOffer::preflight(PreflightContext const& ctx)
             return temMALFORMED;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/NFTokenAcceptOffer.h
+++ b/src/xrpld/app/tx/detail/NFTokenAcceptOffer.h
@@ -59,8 +59,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/NFTokenBurn.cpp
+++ b/src/xrpld/app/tx/detail/NFTokenBurn.cpp
@@ -26,19 +26,16 @@
 
 namespace ripple {
 
-NotTEC
-NFTokenBurn::preflight(PreflightContext const& ctx)
+bool
+NFTokenBurn::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureNonFungibleTokensV1))
-        return temDISABLED;
+    return ctx.rules.enabled(featureNonFungibleTokensV1);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-        return temINVALID_FLAG;
-
-    return preflight2(ctx);
+NotTEC
+NFTokenBurn::doPreflight(PreflightContext const& ctx)
+{
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/NFTokenBurn.h
+++ b/src/xrpld/app/tx/detail/NFTokenBurn.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/NFTokenCancelOffer.cpp
+++ b/src/xrpld/app/tx/detail/NFTokenCancelOffer.cpp
@@ -28,18 +28,21 @@
 
 namespace ripple {
 
-NotTEC
-NFTokenCancelOffer::preflight(PreflightContext const& ctx)
+bool
+NFTokenCancelOffer::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureNonFungibleTokensV1))
-        return temDISABLED;
+    return ctx.rules.enabled(featureNonFungibleTokensV1);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+std::uint32_t
+NFTokenCancelOffer::getFlagsMask(PreflightContext const& ctx)
+{
+    return tfNFTokenCancelOfferMask;
+}
 
-    if (ctx.tx.getFlags() & tfNFTokenCancelOfferMask)
-        return temINVALID_FLAG;
-
+NotTEC
+NFTokenCancelOffer::doPreflight(PreflightContext const& ctx)
+{
     if (auto const& ids = ctx.tx[sfNFTokenOffers];
         ids.empty() || (ids.size() > maxTokenOfferCancelCount))
         return temMALFORMED;
@@ -51,7 +54,7 @@ NFTokenCancelOffer::preflight(PreflightContext const& ctx)
     if (std::adjacent_find(ids.begin(), ids.end()) != ids.end())
         return temMALFORMED;
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/NFTokenCancelOffer.h
+++ b/src/xrpld/app/tx/detail/NFTokenCancelOffer.h
@@ -33,8 +33,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/NFTokenCreateOffer.cpp
+++ b/src/xrpld/app/tx/detail/NFTokenCreateOffer.cpp
@@ -26,19 +26,22 @@
 
 namespace ripple {
 
-NotTEC
-NFTokenCreateOffer::preflight(PreflightContext const& ctx)
+bool
+NFTokenCreateOffer::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureNonFungibleTokensV1))
-        return temDISABLED;
+    return ctx.rules.enabled(featureNonFungibleTokensV1);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+std::uint32_t
+NFTokenCreateOffer::getFlagsMask(PreflightContext const& ctx)
+{
+    return tfNFTokenCreateOfferMask;
+}
 
+NotTEC
+NFTokenCreateOffer::doPreflight(PreflightContext const& ctx)
+{
     auto const txFlags = ctx.tx.getFlags();
-
-    if (txFlags & tfNFTokenCreateOfferMask)
-        return temINVALID_FLAG;
 
     auto const nftFlags = nft::getFlags(ctx.tx[sfNFTokenID]);
 
@@ -55,7 +58,7 @@ NFTokenCreateOffer::preflight(PreflightContext const& ctx)
         !isTesSuccess(notTec))
         return notTec;
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/NFTokenCreateOffer.h
+++ b/src/xrpld/app/tx/detail/NFTokenCreateOffer.h
@@ -33,8 +33,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/NFTokenMint.h
+++ b/src/xrpld/app/tx/detail/NFTokenMint.h
@@ -36,8 +36,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/NFTokenModify.cpp
+++ b/src/xrpld/app/tx/detail/NFTokenModify.cpp
@@ -25,19 +25,16 @@
 
 namespace ripple {
 
-NotTEC
-NFTokenModify::preflight(PreflightContext const& ctx)
+bool
+NFTokenModify::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureNonFungibleTokensV1_1) ||
-        !ctx.rules.enabled(featureDynamicNFT))
-        return temDISABLED;
+    return ctx.rules.enabled(featureNonFungibleTokensV1_1) &&
+        ctx.rules.enabled(featureDynamicNFT);
+}
 
-    if (NotTEC const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-        return temINVALID_FLAG;
-
+NotTEC
+NFTokenModify::doPreflight(PreflightContext const& ctx)
+{
     if (auto owner = ctx.tx[~sfOwner]; owner == ctx.tx[sfAccount])
         return temMALFORMED;
 
@@ -47,7 +44,7 @@ NFTokenModify::preflight(PreflightContext const& ctx)
             return temMALFORMED;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/NFTokenModify.h
+++ b/src/xrpld/app/tx/detail/NFTokenModify.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/PayChan.h
+++ b/src/xrpld/app/tx/detail/PayChan.h
@@ -36,8 +36,11 @@ public:
     static TxConsequences
     makeTxConsequences(PreflightContext const& ctx);
 
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);
@@ -62,8 +65,11 @@ public:
     static TxConsequences
     makeTxConsequences(PreflightContext const& ctx);
 
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     TER
     doApply() override;
@@ -82,8 +88,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/Payment.h
+++ b/src/xrpld/app/tx/detail/Payment.h
@@ -42,8 +42,14 @@ public:
     static TxConsequences
     makeTxConsequences(PreflightContext const& ctx);
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     checkPermission(ReadView const& view, STTx const& tx);

--- a/src/xrpld/app/tx/detail/PermissionedDomainDelete.cpp
+++ b/src/xrpld/app/tx/detail/PermissionedDomainDelete.cpp
@@ -24,26 +24,20 @@
 
 namespace ripple {
 
-NotTEC
-PermissionedDomainDelete::preflight(PreflightContext const& ctx)
+bool
+PermissionedDomainDelete::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featurePermissionedDomains))
-        return temDISABLED;
+    return ctx.rules.enabled(featurePermissionedDomains);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-    {
-        JLOG(ctx.j.debug()) << "PermissionedDomainDelete: invalid flags.";
-        return temINVALID_FLAG;
-    }
-
+NotTEC
+PermissionedDomainDelete::doPreflight(PreflightContext const& ctx)
+{
     auto const domain = ctx.tx.getFieldH256(sfDomainID);
     if (domain == beast::zero)
         return temMALFORMED;
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/PermissionedDomainDelete.h
+++ b/src/xrpld/app/tx/detail/PermissionedDomainDelete.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/PermissionedDomainSet.cpp
+++ b/src/xrpld/app/tx/detail/PermissionedDomainSet.cpp
@@ -28,22 +28,16 @@
 
 namespace ripple {
 
-NotTEC
-PermissionedDomainSet::preflight(PreflightContext const& ctx)
+bool
+PermissionedDomainSet::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featurePermissionedDomains) ||
-        !ctx.rules.enabled(featureCredentials))
-        return temDISABLED;
+    return ctx.rules.enabled(featurePermissionedDomains) &&
+        ctx.rules.enabled(featureCredentials);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-    {
-        JLOG(ctx.j.debug()) << "PermissionedDomainSet: invalid flags.";
-        return temINVALID_FLAG;
-    }
-
+NotTEC
+PermissionedDomainSet::doPreflight(PreflightContext const& ctx)
+{
     if (auto err = credentials::checkArray(
             ctx.tx.getFieldArray(sfAcceptedCredentials),
             maxPermissionedDomainCredentialsArraySize,
@@ -55,7 +49,7 @@ PermissionedDomainSet::preflight(PreflightContext const& ctx)
     if (domain && *domain == beast::zero)
         return temMALFORMED;
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/PermissionedDomainSet.h
+++ b/src/xrpld/app/tx/detail/PermissionedDomainSet.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/SetAccount.cpp
+++ b/src/xrpld/app/tx/detail/SetAccount.cpp
@@ -57,22 +57,19 @@ SetAccount::makeTxConsequences(PreflightContext const& ctx)
     return TxConsequences{ctx.tx, getTxConsequencesCategory(ctx.tx)};
 }
 
-NotTEC
-SetAccount::preflight(PreflightContext const& ctx)
+std::uint32_t
+SetAccount::getFlagsMask(PreflightContext const& ctx)
 {
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+    return tfAccountSetMask;
+}
 
+NotTEC
+SetAccount::doPreflight(PreflightContext const& ctx)
+{
     auto& tx = ctx.tx;
     auto& j = ctx.j;
 
     std::uint32_t const uTxFlags = tx.getFlags();
-
-    if (uTxFlags & tfAccountSetMask)
-    {
-        JLOG(j.trace()) << "Malformed transaction: Invalid flags set.";
-        return temINVALID_FLAG;
-    }
 
     std::uint32_t const uSetFlag = tx.getFieldU32(sfSetFlag);
     std::uint32_t const uClearFlag = tx.getFieldU32(sfClearFlag);
@@ -186,7 +183,7 @@ SetAccount::preflight(PreflightContext const& ctx)
             return temMALFORMED;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/SetAccount.h
+++ b/src/xrpld/app/tx/detail/SetAccount.h
@@ -38,8 +38,11 @@ public:
     static TxConsequences
     makeTxConsequences(PreflightContext const& ctx);
 
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     checkPermission(ReadView const& view, STTx const& tx);

--- a/src/xrpld/app/tx/detail/SetOracle.cpp
+++ b/src/xrpld/app/tx/detail/SetOracle.cpp
@@ -36,18 +36,15 @@ tokenPairKey(STObject const& pair)
         pair.getFieldCurrency(sfQuoteAsset).currency());
 }
 
-NotTEC
-SetOracle::preflight(PreflightContext const& ctx)
+bool
+SetOracle::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featurePriceOracle))
-        return temDISABLED;
+    return ctx.rules.enabled(featurePriceOracle);
+}
 
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-        return temINVALID_FLAG;
-
+NotTEC
+SetOracle::doPreflight(PreflightContext const& ctx)
+{
     auto const& dataSeries = ctx.tx.getFieldArray(sfPriceDataSeries);
     if (dataSeries.empty())
         return temARRAY_EMPTY;
@@ -64,7 +61,7 @@ SetOracle::preflight(PreflightContext const& ctx)
         isInvalidLength(sfAssetClass, maxOracleSymbolClass))
         return temMALFORMED;
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/SetOracle.h
+++ b/src/xrpld/app/tx/detail/SetOracle.h
@@ -42,8 +42,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/SetRegularKey.cpp
+++ b/src/xrpld/app/tx/detail/SetRegularKey.cpp
@@ -49,20 +49,8 @@ SetRegularKey::calculateBaseFee(ReadView const& view, STTx const& tx)
 }
 
 NotTEC
-SetRegularKey::preflight(PreflightContext const& ctx)
+SetRegularKey::doPreflight(PreflightContext const& ctx)
 {
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
-
-    std::uint32_t const uTxFlags = ctx.tx.getFlags();
-
-    if (uTxFlags & tfUniversalMask)
-    {
-        JLOG(ctx.j.trace()) << "Malformed transaction: Invalid flags set.";
-
-        return temINVALID_FLAG;
-    }
-
     if (ctx.rules.enabled(fixMasterKeyAsRegularKey) &&
         ctx.tx.isFieldPresent(sfRegularKey) &&
         (ctx.tx.getAccountID(sfRegularKey) == ctx.tx.getAccountID(sfAccount)))
@@ -70,7 +58,7 @@ SetRegularKey::preflight(PreflightContext const& ctx)
         return temBAD_REGKEY;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/SetRegularKey.h
+++ b/src/xrpld/app/tx/detail/SetRegularKey.h
@@ -34,7 +34,7 @@ public:
     }
 
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static XRPAmount
     calculateBaseFee(ReadView const& view, STTx const& tx);

--- a/src/xrpld/app/tx/detail/SetSignerList.cpp
+++ b/src/xrpld/app/tx/detail/SetSignerList.cpp
@@ -77,19 +77,16 @@ SetSignerList::determineOperation(
     return std::make_tuple(tesSUCCESS, quorum, sign, op);
 }
 
-NotTEC
-SetSignerList::preflight(PreflightContext const& ctx)
+std::uint32_t
+SetSignerList::getFlagsMask(PreflightContext const& ctx)
 {
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+    // 0 means "Allow any flags"
+    return ctx.rules.enabled(fixInvalidTxFlags) ? tfUniversalMask : 0;
+}
 
-    if (ctx.rules.enabled(fixInvalidTxFlags) &&
-        (ctx.tx.getFlags() & tfUniversalMask))
-    {
-        JLOG(ctx.j.debug()) << "SetSignerList: invalid flags.";
-        return temINVALID_FLAG;
-    }
-
+NotTEC
+SetSignerList::doPreflight(PreflightContext const& ctx)
+{
     auto const result = determineOperation(ctx.tx, ctx.flags, ctx.j);
 
     if (std::get<0>(result) != tesSUCCESS)
@@ -119,7 +116,7 @@ SetSignerList::preflight(PreflightContext const& ctx)
         }
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/SetSignerList.h
+++ b/src/xrpld/app/tx/detail/SetSignerList.h
@@ -51,8 +51,11 @@ public:
     {
     }
 
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     TER
     doApply() override;

--- a/src/xrpld/app/tx/detail/SetTrust.cpp
+++ b/src/xrpld/app/tx/detail/SetTrust.cpp
@@ -67,22 +67,19 @@ computeFreezeFlags(
 
 namespace ripple {
 
-NotTEC
-SetTrust::preflight(PreflightContext const& ctx)
+std::uint32_t
+SetTrust::getFlagsMask(PreflightContext const& ctx)
 {
-    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
-        return ret;
+    return tfTrustSetMask;
+}
 
+NotTEC
+SetTrust::doPreflight(PreflightContext const& ctx)
+{
     auto& tx = ctx.tx;
     auto& j = ctx.j;
 
     std::uint32_t const uTxFlags = tx.getFlags();
-
-    if (uTxFlags & tfTrustSetMask)
-    {
-        JLOG(j.trace()) << "Malformed transaction: Invalid flags set.";
-        return temINVALID_FLAG;
-    }
 
     if (!ctx.rules.enabled(featureDeepFreeze))
     {
@@ -127,7 +124,7 @@ SetTrust::preflight(PreflightContext const& ctx)
         return temDST_NEEDED;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/SetTrust.h
+++ b/src/xrpld/app/tx/detail/SetTrust.h
@@ -35,8 +35,11 @@ public:
     {
     }
 
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     checkPermission(ReadView const& view, STTx const& tx);

--- a/src/xrpld/app/tx/detail/VaultClawback.cpp
+++ b/src/xrpld/app/tx/detail/VaultClawback.cpp
@@ -30,18 +30,15 @@
 
 namespace ripple {
 
-NotTEC
-VaultClawback::preflight(PreflightContext const& ctx)
+bool
+VaultClawback::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureSingleAssetVault))
-        return temDISABLED;
+    return ctx.rules.enabled(featureSingleAssetVault);
+}
 
-    if (auto const ter = preflight1(ctx))
-        return ter;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-        return temINVALID_FLAG;
-
+NotTEC
+VaultClawback::doPreflight(PreflightContext const& ctx)
+{
     if (ctx.tx[sfVaultID] == beast::zero)
     {
         JLOG(ctx.j.debug()) << "VaultClawback: zero/empty vault ID.";
@@ -76,7 +73,7 @@ VaultClawback::preflight(PreflightContext const& ctx)
         }
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/VaultClawback.h
+++ b/src/xrpld/app/tx/detail/VaultClawback.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/VaultCreate.cpp
+++ b/src/xrpld/app/tx/detail/VaultCreate.cpp
@@ -33,28 +33,28 @@
 
 namespace ripple {
 
-NotTEC
-VaultCreate::preflight(PreflightContext const& ctx)
+bool
+VaultCreate::isEnabled(PreflightContext const& ctx)
 {
     if (!ctx.rules.enabled(featureSingleAssetVault) ||
         !ctx.rules.enabled(featureMPTokensV1))
-        return temDISABLED;
+        return false;
 
-    if (ctx.tx.isFieldPresent(sfDomainID) &&
-        !ctx.rules.enabled(featurePermissionedDomains))
-        return temDISABLED;
+    return !ctx.tx.isFieldPresent(sfDomainID) ||
+        ctx.rules.enabled(featurePermissionedDomains);
+}
 
-    if (auto const ter = preflight1(ctx))
-        return ter;
+std::uint32_t
+VaultCreate::getFlagsMask(PreflightContext const& ctx)
+{
+    return tfVaultCreateMask;
+}
 
-    if (ctx.tx.getFlags() & tfVaultCreateMask)
-        return temINVALID_FLAG;
-
-    if (auto const data = ctx.tx[~sfData])
-    {
-        if (data->empty() || data->length() > maxDataPayloadLength)
-            return temMALFORMED;
-    }
+NotTEC
+VaultCreate::doPreflight(PreflightContext const& ctx)
+{
+    if (!validDataLength(ctx.tx[~sfData], maxDataPayloadLength))
+        return temMALFORMED;
 
     if (auto const withdrawalPolicy = ctx.tx[~sfWithdrawalPolicy])
     {
@@ -84,14 +84,14 @@ VaultCreate::preflight(PreflightContext const& ctx)
             return temMALFORMED;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 XRPAmount
 VaultCreate::calculateBaseFee(ReadView const& view, STTx const& tx)
 {
     // One reserve increment is typically much greater than one base fee.
-    return view.fees().increment;
+    return calculateOwnerReserveFee(view, tx);
 }
 
 TER
@@ -100,32 +100,8 @@ VaultCreate::preclaim(PreclaimContext const& ctx)
     auto vaultAsset = ctx.tx[sfAsset];
     auto account = ctx.tx[sfAccount];
 
-    if (vaultAsset.native())
-        ;  // No special checks for XRP
-    else if (vaultAsset.holds<MPTIssue>())
-    {
-        auto mptID = vaultAsset.get<MPTIssue>().getMptID();
-        auto issuance = ctx.view.read(keylet::mptIssuance(mptID));
-        if (!issuance)
-            return tecOBJECT_NOT_FOUND;
-        if (!issuance->isFlag(lsfMPTCanTransfer))
-        {
-            // NOTE: flag lsfMPTCanTransfer is immutable, so this is debug in
-            // VaultCreate only; in other vault function it's an error.
-            JLOG(ctx.j.debug())
-                << "VaultCreate: vault assets are non-transferable.";
-            return tecNO_AUTH;
-        }
-    }
-    else if (vaultAsset.holds<Issue>())
-    {
-        auto const issuer =
-            ctx.view.read(keylet::account(vaultAsset.getIssuer()));
-        if (!issuer)
-            return terNO_ACCOUNT;
-        else if (!issuer->isFlag(lsfDefaultRipple))
-            return terNO_RIPPLE;
-    }
+    if (auto const ter = canAddHolding(ctx.view, vaultAsset))
+        return ter;
 
     // Check for pseudo-account issuers - we do not want a vault to hold such
     // assets (e.g. MPT shares to other vaults or AMM LPTokens) as they would be

--- a/src/xrpld/app/tx/detail/VaultCreate.h
+++ b/src/xrpld/app/tx/detail/VaultCreate.h
@@ -33,8 +33,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static XRPAmount
     calculateBaseFee(ReadView const& view, STTx const& tx);

--- a/src/xrpld/app/tx/detail/VaultDelete.cpp
+++ b/src/xrpld/app/tx/detail/VaultDelete.cpp
@@ -27,25 +27,22 @@
 
 namespace ripple {
 
-NotTEC
-VaultDelete::preflight(PreflightContext const& ctx)
+bool
+VaultDelete::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureSingleAssetVault))
-        return temDISABLED;
+    return ctx.rules.enabled(featureSingleAssetVault);
+}
 
-    if (auto const ter = preflight1(ctx))
-        return ter;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-        return temINVALID_FLAG;
-
+NotTEC
+VaultDelete::doPreflight(PreflightContext const& ctx)
+{
     if (ctx.tx[sfVaultID] == beast::zero)
     {
         JLOG(ctx.j.debug()) << "VaultDelete: zero/empty vault ID.";
         return temMALFORMED;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/VaultDelete.h
+++ b/src/xrpld/app/tx/detail/VaultDelete.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/VaultDeposit.cpp
+++ b/src/xrpld/app/tx/detail/VaultDeposit.cpp
@@ -32,18 +32,15 @@
 
 namespace ripple {
 
-NotTEC
-VaultDeposit::preflight(PreflightContext const& ctx)
+bool
+VaultDeposit::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureSingleAssetVault))
-        return temDISABLED;
+    return ctx.rules.enabled(featureSingleAssetVault);
+}
 
-    if (auto const ter = preflight1(ctx))
-        return ter;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-        return temINVALID_FLAG;
-
+NotTEC
+VaultDeposit::doPreflight(PreflightContext const& ctx)
+{
     if (ctx.tx[sfVaultID] == beast::zero)
     {
         JLOG(ctx.j.debug()) << "VaultDeposit: zero/empty vault ID.";
@@ -53,7 +50,7 @@ VaultDeposit::preflight(PreflightContext const& ctx)
     if (ctx.tx[sfAmount] <= beast::zero)
         return temBAD_AMOUNT;
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/VaultDeposit.h
+++ b/src/xrpld/app/tx/detail/VaultDeposit.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/VaultSet.cpp
+++ b/src/xrpld/app/tx/detail/VaultSet.cpp
@@ -30,27 +30,24 @@
 
 namespace ripple {
 
-NotTEC
-VaultSet::preflight(PreflightContext const& ctx)
+bool
+VaultSet::isEnabled(PreflightContext const& ctx)
 {
     if (!ctx.rules.enabled(featureSingleAssetVault))
-        return temDISABLED;
+        return false;
 
-    if (ctx.tx.isFieldPresent(sfDomainID) &&
-        !ctx.rules.enabled(featurePermissionedDomains))
-        return temDISABLED;
+    return !ctx.tx.isFieldPresent(sfDomainID) ||
+        ctx.rules.enabled(featurePermissionedDomains);
+}
 
-    if (auto const ter = preflight1(ctx))
-        return ter;
-
+NotTEC
+VaultSet::doPreflight(PreflightContext const& ctx)
+{
     if (ctx.tx[sfVaultID] == beast::zero)
     {
         JLOG(ctx.j.debug()) << "VaultSet: zero/empty vault ID.";
         return temMALFORMED;
     }
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-        return temINVALID_FLAG;
 
     if (auto const data = ctx.tx[~sfData])
     {
@@ -78,7 +75,7 @@ VaultSet::preflight(PreflightContext const& ctx)
         return temMALFORMED;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/VaultSet.h
+++ b/src/xrpld/app/tx/detail/VaultSet.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/VaultWithdraw.cpp
+++ b/src/xrpld/app/tx/detail/VaultWithdraw.cpp
@@ -30,18 +30,15 @@
 
 namespace ripple {
 
-NotTEC
-VaultWithdraw::preflight(PreflightContext const& ctx)
+bool
+VaultWithdraw::isEnabled(PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled(featureSingleAssetVault))
-        return temDISABLED;
+    return ctx.rules.enabled(featureSingleAssetVault);
+}
 
-    if (auto const ter = preflight1(ctx))
-        return ter;
-
-    if (ctx.tx.getFlags() & tfUniversalMask)
-        return temINVALID_FLAG;
-
+NotTEC
+VaultWithdraw::doPreflight(PreflightContext const& ctx)
+{
     if (ctx.tx[sfVaultID] == beast::zero)
     {
         JLOG(ctx.j.debug()) << "VaultWithdraw: zero/empty vault ID.";
@@ -58,7 +55,7 @@ VaultWithdraw::preflight(PreflightContext const& ctx)
         return temMALFORMED;
     }
 
-    return preflight2(ctx);
+    return tesSUCCESS;
 }
 
 TER

--- a/src/xrpld/app/tx/detail/VaultWithdraw.h
+++ b/src/xrpld/app/tx/detail/VaultWithdraw.h
@@ -33,8 +33,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/XChainBridge.h
+++ b/src/xrpld/app/tx/detail/XChainBridge.h
@@ -39,8 +39,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);
@@ -58,8 +61,14 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
+    static std::uint32_t
+    getFlagsMask(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);
@@ -91,8 +100,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);
@@ -118,8 +130,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);
@@ -147,8 +162,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);
@@ -176,8 +194,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);
@@ -197,8 +218,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);
@@ -241,8 +265,11 @@ public:
     {
     }
 
+    static bool
+    isEnabled(PreflightContext const& ctx);
+
     static NotTEC
-    preflight(PreflightContext const& ctx);
+    doPreflight(PreflightContext const& ctx);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/src/xrpld/app/tx/detail/applySteps.cpp
+++ b/src/xrpld/app/tx/detail/applySteps.cpp
@@ -120,7 +120,7 @@ invoke_preflight(PreflightContext const& ctx)
     try
     {
         return with_txn_type(ctx.tx.getTxnType(), [&]<typename T>() {
-            auto const tec = T::preflight(ctx);
+            auto const tec = Transactor::preflight<T>(ctx);
             return std::make_pair(
                 tec,
                 isTesSuccess(tec) ? consequences_helper<T>(ctx)


### PR DESCRIPTION
## High Level Overview of Change

This PR is number three of four which contain several small changes that are used as the baseline of #5270. Since they are significant and useful, I created this separate PR to get them merged sooner.

(No new functionality is introduced by this PR.)

### Context of Change

#5270 is large and complicated, and I had to lay some groundwork before I could implement the feature.

### Type of Change

- [X] Refactor (non-breaking change that only restructures code)

## Before / After

Highlights:
* Restructures `Transactor::preflight` to create several functions that will remove the need error-prone boilerplate code in derived classes' implementations of `preflight`. 
