### PR TITLE
Rename conan profile to `default`

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,8 +24,6 @@ env:
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}
-    core:default_build_profile=libxrpl
-    core:default_profile=libxrpl
     tools.build:jobs={{ (os.cpu_count() * 4/5) | int }}
     tools.build:verbosity=verbose
     tools.compilation:verbosity=verbose

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -25,8 +25,6 @@ env:
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{ os.cpu_count() }}
     core.upload:parallel={{ os.cpu_count() }}
-    core:default_build_profile=libxrpl
-    core:default_profile=libxrpl
     tools.build:jobs={{ (os.cpu_count() * 4/5) | int }}
     tools.build:verbosity=verbose
     tools.compilation:verbosity=verbose

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,8 +27,6 @@ env:
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}
-    core:default_build_profile=libxrpl
-    core:default_profile=libxrpl
     tools.build:jobs=24
     tools.build:verbosity=verbose
     tools.compilation:verbosity=verbose

--- a/conan/profiles/default
+++ b/conan/profiles/default
@@ -9,6 +9,7 @@
 [settings]
 os={{ os }}
 arch={{ arch }}
+build_type=Debug
 compiler={{compiler}}
 compiler.version={{ compiler_version }}
 compiler.cppstd=20
@@ -17,3 +18,17 @@ compiler.runtime=static
 {% else %}
 compiler.libcxx={{detect_api.detect_libcxx(compiler, version, compiler_exe)}}
 {% endif %}
+
+[conf]
+{% if compiler == "clang" and compiler_version >= 19 %}
+tools.build:cxxflags=['-Wno-missing-template-arg-list-after-template-kw']
+{% endif %}
+{% if compiler == "apple-clang" and compiler_version >= 17 %}
+tools.build:cxxflags=['-Wno-missing-template-arg-list-after-template-kw']
+{% endif %}
+{% if compiler == "gcc" and compiler_version < 13 %}
+tools.build:cxxflags=['-Wno-restrict']
+{% endif %}
+
+[tool_requires]
+!cmake/*: cmake/[>=3 <4]


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Rename `libxrpl` profile to `default` making it more usable.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

This will simplify the build (at the cost of "hijacking" the `default` Conan profile). Also put all
the normally used workarounds in the `default` profile.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
