### PR TITLE
Fix: Don't flag consensus as stalled prematurely

### DIFF
--- a/src/test/consensus/Consensus_test.cpp
+++ b/src/test/consensus/Consensus_test.cpp
@@ -91,44 +91,44 @@ public:
         // Not enough time has elapsed
         BEAST_EXPECT(
             ConsensusState::No ==
-            checkConsensus(10, 2, 2, 0, 3s, 2s, false, p, true, journal_));
+            checkConsensus(false, 2, 2, 0, 3s, 2s, false, p, true, journal_));
 
         // If not enough peers have propsed, ensure
         // more time for proposals
         BEAST_EXPECT(
             ConsensusState::No ==
-            checkConsensus(10, 2, 2, 0, 3s, 4s, false, p, true, journal_));
+            checkConsensus(false, 2, 2, 0, 3s, 4s, false, p, true, journal_));
 
         // Enough time has elapsed and we all agree
         BEAST_EXPECT(
             ConsensusState::Yes ==
-            checkConsensus(10, 2, 2, 0, 3s, 10s, false, p, true, journal_));
+            checkConsensus(false, 2, 2, 0, 3s, 10s, false, p, true, journal_));
 
         // Enough time has elapsed and we don't yet agree
         BEAST_EXPECT(
             ConsensusState::No ==
-            checkConsensus(10, 2, 1, 0, 3s, 10s, false, p, true, journal_));
+            checkConsensus(false, 2, 1, 0, 3s, 10s, false, p, true, journal_));
 
         // Our peers have moved on
         // Enough time has elapsed and we all agree
         BEAST_EXPECT(
             ConsensusState::MovedOn ==
-            checkConsensus(10, 2, 1, 8, 3s, 10s, false, p, true, journal_));
+            checkConsensus(false, 2, 1, 8, 3s, 10s, false, p, true, journal_));
 
         // If no peers, don't agree until time has passed.
         BEAST_EXPECT(
             ConsensusState::No ==
-            checkConsensus(0, 0, 0, 0, 3s, 10s, false, p, true, journal_));
+            checkConsensus(true, 0, 0, 0, 3s, 10s, false, p, true, journal_));
 
         // Agree if no peers and enough time has passed.
         BEAST_EXPECT(
             ConsensusState::Yes ==
-            checkConsensus(0, 0, 0, 0, 3s, 16s, false, p, true, journal_));
+            checkConsensus(true, 0, 0, 0, 3s, 16s, false, p, true, journal_));
 
         // Expire if too much time has passed without agreement
         BEAST_EXPECT(
             ConsensusState::Expired ==
-            checkConsensus(10, 8, 1, 0, 1s, 19s, false, p, true, journal_));
+            checkConsensus(true, 8, 1, 0, 1s, 19s, false, p, true, journal_));
 
         ///////////////
         // Stalled
@@ -136,46 +136,46 @@ public:
         // Not enough time has elapsed
         BEAST_EXPECT(
             ConsensusState::No ==
-            checkConsensus(10, 2, 2, 0, 3s, 2s, true, p, true, journal_));
+            checkConsensus(false, 2, 2, 0, 3s, 2s, true, p, true, journal_));
 
         // If not enough peers have propsed, ensure
         // more time for proposals
         BEAST_EXPECT(
             ConsensusState::No ==
-            checkConsensus(10, 2, 2, 0, 3s, 4s, true, p, true, journal_));
+            checkConsensus(false, 2, 2, 0, 3s, 4s, true, p, true, journal_));
 
         // Enough time has elapsed and we all agree
         BEAST_EXPECT(
             ConsensusState::Yes ==
-            checkConsensus(10, 2, 2, 0, 3s, 10s, true, p, true, journal_));
+            checkConsensus(false, 2, 2, 0, 3s, 10s, true, p, true, journal_));
 
         // Enough time has elapsed and we don't yet agree, but there's nothing
         // left to dispute
         BEAST_EXPECT(
             ConsensusState::Yes ==
-            checkConsensus(10, 2, 1, 0, 3s, 10s, true, p, true, journal_));
+            checkConsensus(false, 2, 1, 0, 3s, 10s, true, p, true, journal_));
 
         // Our peers have moved on
         // Enough time has elapsed and we all agree, nothing left to dispute
         BEAST_EXPECT(
             ConsensusState::Yes ==
-            checkConsensus(10, 2, 1, 8, 3s, 10s, true, p, true, journal_));
+            checkConsensus(false, 2, 1, 8, 3s, 10s, true, p, true, journal_));
 
         // If no peers, don't agree until time has passed.
         BEAST_EXPECT(
             ConsensusState::No ==
-            checkConsensus(0, 0, 0, 0, 3s, 10s, true, p, true, journal_));
+            checkConsensus(true, 0, 0, 0, 3s, 10s, true, p, true, journal_));
 
         // Agree if no peers and enough time has passed.
         BEAST_EXPECT(
             ConsensusState::Yes ==
-            checkConsensus(0, 0, 0, 0, 3s, 16s, true, p, true, journal_));
+            checkConsensus(true, 0, 0, 0, 3s, 16s, true, p, true, journal_));
 
         // We are done if there's nothing left to dispute, no matter how much
         // time has passed
         BEAST_EXPECT(
             ConsensusState::Yes ==
-            checkConsensus(10, 8, 1, 0, 1s, 19s, true, p, true, journal_));
+            checkConsensus(true, 8, 1, 0, 1s, 19s, true, p, true, journal_));
     }
 
     void

--- a/src/xrpld/consensus/Consensus.cpp
+++ b/src/xrpld/consensus/Consensus.cpp
@@ -175,7 +175,7 @@ checkConsensusReached(
 
 ConsensusState
 checkConsensus(
-    std::size_t prevProposers,
+    bool sufficientProposers,
     std::size_t currentProposers,
     std::size_t currentAgree,
     std::size_t currentFinished,
@@ -188,8 +188,8 @@ checkConsensus(
     std::unique_ptr<std::stringstream> const& clog)
 {
     CLOG(clog) << "checkConsensus: prop=" << currentProposers << "/"
-               << prevProposers << " agree=" << currentAgree
-               << " validated=" << currentFinished
+               << (sufficientProposers ? "sufficient" : "insufficient")
+               << " agree=" << currentAgree << " validated=" << currentFinished
                << " time=" << currentAgreeTime.count() << "/"
                << previousAgreeTime.count() << " proposing? " << proposing
                << " minimum duration to reach consensus: "
@@ -205,7 +205,7 @@ checkConsensus(
         return ConsensusState::No;
     }
 
-    if (currentProposers < (prevProposers * 3 / 4))
+    if (!sufficientProposers)
     {
         // Less than 3/4 of the last ledger's proposers are present; don't
         // rush: we may need more time.


### PR DESCRIPTION
## High Level Overview of Change

Fix stalled consensus detection to prevent false positives in situations where insufficient proposals[^1] have been received and there are no disputed transactions.

[^1]: Insufficient meaning the node has received proposals from fewer than 3/4 of the number of participants in the previous round.

### Context of Change

Stalled consensus detection was added to 2.5.0 in response to a network consensus halt that caused a round to run for over an hour. See #5277 and #5318.

It has a flaw that makes it very easy to have false positives. Those false positives are usually mitigated by other checks that prevent them from having an effect, but there have been several instances of validators "running ahead" because there are circumstances where the other checks are "successful", allowing the stall state to be checked.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

