### PR TITLE
Use OS-specific Conan remotes

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -39,7 +39,7 @@ runs:
       shell: bash
       run: |
         conan remote login recipes "${{ env.CONAN_REMOTE_USERNAME }}" --password "${{ env.CONAN_REMOTE_PASSWORD }}"
-        conan remote login ${{ inputs.conan_remote_name }} "${{ env.CONAN_REMOTE_USERNAME }}" --password "${{ env.CONAN_REMOTE_PASSWORD }}"
+        conan remote login ${{ inputs.remote_name }} "${{ env.CONAN_REMOTE_USERNAME }}" --password "${{ env.CONAN_REMOTE_PASSWORD }}"
         conan remote list-users
     - name: list missing binaries
       id: binaries

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -14,7 +14,7 @@ runs:
         conan export --version 1.1.10 external/snappy
         conan export --version 4.0.3 external/soci
     - name: add Conan remotes
-      if: vars.CONAN_REMOTE_URL != ''
+      if: env.CONAN_REMOTE_URL != ''
       shell: bash
       run: |
         echo "Adding Conan remotes for recipes."
@@ -34,12 +34,12 @@ runs:
           echo "Added new conan remote '${{ inputs.remote_name }}' at ${CONAN_URL}/${{ inputs.remote_name }}."
         fi
     - name: Log into Conan remotes
-      if: vars.CONAN_REMOTE_URL != '' && secrets.CONAN_REMOTE_USERNAME != '' && secrets.CONAN_REMOTE_PASSWORD != ''
+      if: env.CONAN_REMOTE_URL != '' && env.CONAN_REMOTE_USERNAME != '' && env.CONAN_REMOTE_PASSWORD != ''
       id: remote
       shell: bash
       run: |
-        conan remote login recipes "${{ secrets.CONAN_REMOTE_USERNAME }}" --password "${{ secrets.CONAN_REMOTE_PASSWORD }}"
-        conan remote login ${{ inputs.conan_remote_name }} "${{ secrets.CONAN_REMOTE_USERNAME }}" --password "${{ secrets.CONAN_REMOTE_PASSWORD }}"
+        conan remote login recipes "${{ env.CONAN_REMOTE_USERNAME }}" --password "${{ env.CONAN_REMOTE_PASSWORD }}"
+        conan remote login ${{ inputs.conan_remote_name }} "${{ env.CONAN_REMOTE_USERNAME }}" --password "${{ env.CONAN_REMOTE_PASSWORD }}"
         conan remote list-users
     - name: list missing binaries
       id: binaries

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -33,14 +33,6 @@ runs:
           conan remote add --index 1 ${{ inputs.remote_name }} ${{ env.CONAN_REMOTE_URL }}/${{ inputs.remote_name }}
           echo "Added new conan remote '${{ inputs.remote_name }}' at ${{ env.CONAN_REMOTE_URL }}/${{ inputs.remote_name }}."
         fi
-    - name: Log into Conan remotes
-      if: env.CONAN_REMOTE_URL != '' && env.CONAN_REMOTE_USERNAME != '' && env.CONAN_REMOTE_PASSWORD != ''
-      id: remote
-      shell: bash
-      run: |
-        conan remote login recipes "${{ env.CONAN_REMOTE_USERNAME }}" --password "${{ env.CONAN_REMOTE_PASSWORD }}"
-        conan remote login ${{ inputs.remote_name }} "${{ env.CONAN_REMOTE_USERNAME }}" --password "${{ env.CONAN_REMOTE_PASSWORD }}"
-        conan remote list-users
     - name: list missing binaries
       id: binaries
       shell: bash

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -3,7 +3,7 @@ inputs:
   configuration:
     required: true
   remote_name:
-    required: false
+    required: true
 # An implicit input is the environment variable `build_dir`.
 runs:
   using: composite

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -14,7 +14,7 @@ runs:
         conan export --version 1.1.10 external/snappy
         conan export --version 4.0.3 external/soci
     - name: add Conan remotes
-      if: env.CONAN_URL != ''
+      if: vars.CONAN_REMOTE_URL != ''
       shell: bash
       run: |
         echo "Adding Conan remotes for recipes."
@@ -34,12 +34,12 @@ runs:
           echo "Added new conan remote '${{ inputs.remote_name }}' at ${CONAN_URL}/${{ inputs.remote_name }}."
         fi
     - name: Log into Conan remotes
-      if: env.CONAN_URL != '' && env.CONAN_LOGIN_USERNAME_RIPPLE != '' && env.CONAN_PASSWORD_RIPPLE != ''
+      if: vars.CONAN_REMOTE_URL != '' && secrets.CONAN_REMOTE_USERNAME != '' && secrets.CONAN_REMOTE_PASSWORD != ''
       id: remote
       shell: bash
       run: |
-        conan remote login recipes "${{ env.CONAN_LOGIN_USERNAME_RIPPLE }}" --password "${{ env.CONAN_PASSWORD_RIPPLE }}"
-        conan remote login ${{ inputs.conan_remote_name }} "${{ env.CONAN_LOGIN_USERNAME_RIPPLE }}" --password "${{ env.CONAN_PASSWORD_RIPPLE }}"
+        conan remote login recipes "${{ secrets.CONAN_REMOTE_USERNAME }}" --password "${{ secrets.CONAN_REMOTE_PASSWORD }}"
+        conan remote login ${{ inputs.conan_remote_name }} "${{ secrets.CONAN_REMOTE_USERNAME }}" --password "${{ secrets.CONAN_REMOTE_PASSWORD }}"
         conan remote list-users
     - name: list missing binaries
       id: binaries

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -2,7 +2,7 @@ name: dependencies
 inputs:
   configuration:
     required: true
-  os:
+  remote_name:
     required: false
 # An implicit input is the environment variable `build_dir`.
 runs:
@@ -13,23 +13,33 @@ runs:
       run: |
         conan export --version 1.1.10 external/snappy
         conan export --version 4.0.3 external/soci
-    - name: add Ripple Conan remote
+    - name: add Conan remotes
       if: env.CONAN_URL != ''
       shell: bash
       run: |
-        if conan remote list | grep -q "ripple"; then
-            conan remote remove ripple
-            echo "Removed conan remote ripple"
+        echo "Adding Conan remotes for recipes."
+        if conan remote list | grep -q "recipes"; then
+          conan remote update recipes --index 0 --url ${CONAN_URL}/recipes
+          echo "Updated Conan remote 'recipes' to ${CONAN_URL}/recipes."
+        elif
+          conan remote add --index 0 recipes ${CONAN_URL}/recipes
+          echo "Added new conan remote 'recipes' at ${CONAN_URL}/recipes."
         fi
-        conan remote add --index 0 ripple "${CONAN_URL}"
-        echo "Added conan remote ripple at ${CONAN_URL}"
-    - name: try to authenticate to Ripple Conan remote
-      if: env.CONAN_LOGIN_USERNAME_RIPPLE != '' && env.CONAN_PASSWORD_RIPPLE != ''
+        echo "Adding Conan remotes for packages."
+        if conan remote list | grep -q "${{ inputs.remote_name }}"; then
+          conan remote update ${{ inputs.remote_name }} --index 1 --url ${CONAN_URL}/${{ inputs.remote_name }}
+          echo "Updated Conan remote '${{ inputs.remote_name }}' to ${CONAN_URL}/${{ inputs.remote_name }}."
+        elif
+          conan remote add --index 1 ${{ inputs.remote_name }} ${CONAN_URL}/${{ inputs.remote_name }}
+          echo "Added new conan remote '${{ inputs.remote_name }}' at ${CONAN_URL}/${{ inputs.remote_name }}."
+        fi
+    - name: Log into Conan remotes
+      if: env.CONAN_URL != '' && env.CONAN_LOGIN_USERNAME_RIPPLE != '' && env.CONAN_PASSWORD_RIPPLE != ''
       id: remote
       shell: bash
       run: |
-        echo "Authenticating to ripple remote..."
-        conan remote auth ripple --force
+        conan remote login recipes "${{ env.CONAN_LOGIN_USERNAME_RIPPLE }}" --password "${{ env.CONAN_PASSWORD_RIPPLE }}"
+        conan remote login ${{ inputs.conan_remote_name }} "${{ env.CONAN_LOGIN_USERNAME_RIPPLE }}" --password "${{ env.CONAN_PASSWORD_RIPPLE }}"
         conan remote list-users
     - name: list missing binaries
       id: binaries
@@ -37,7 +47,7 @@ runs:
       # Print the list of dependencies that would need to be built locally.
       # A non-empty list means we have "failed" to cache binaries remotely.
       run: |
-        echo missing=$(conan info . --build missing --settings build_type=${{ inputs.configuration }} ${{ inputs.os && '--settings os=' || '' }}${{ inputs.os }} --json 2>/dev/null  | grep '^\[') | tee ${GITHUB_OUTPUT}
+        echo missing=$(conan info . --build missing --settings build_type=${{ inputs.configuration }} --json 2>/dev/null  | grep '^\[') | tee ${GITHUB_OUTPUT}
     - name: install dependencies
       shell: bash
       run: |
@@ -49,5 +59,4 @@ runs:
           --options:host "&:tests=True" \
           --options:host "&:xrpld=True" \
           --settings:all build_type=${{ inputs.configuration }} \
-          ${{ inputs.os && '--settings:all os=' || '' }}${{ inputs.os }} \
           ..

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -21,7 +21,7 @@ runs:
         if conan remote list | grep -q "recipes"; then
           conan remote update recipes --index 0 --url ${CONAN_URL}/recipes
           echo "Updated Conan remote 'recipes' to ${CONAN_URL}/recipes."
-        elif
+        else
           conan remote add --index 0 recipes ${CONAN_URL}/recipes
           echo "Added new conan remote 'recipes' at ${CONAN_URL}/recipes."
         fi
@@ -29,7 +29,7 @@ runs:
         if conan remote list | grep -q "${{ inputs.remote_name }}"; then
           conan remote update ${{ inputs.remote_name }} --index 1 --url ${CONAN_URL}/${{ inputs.remote_name }}
           echo "Updated Conan remote '${{ inputs.remote_name }}' to ${CONAN_URL}/${{ inputs.remote_name }}."
-        elif
+        else
           conan remote add --index 1 ${{ inputs.remote_name }} ${CONAN_URL}/${{ inputs.remote_name }}
           echo "Added new conan remote '${{ inputs.remote_name }}' at ${CONAN_URL}/${{ inputs.remote_name }}."
         fi

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -19,19 +19,19 @@ runs:
       run: |
         echo "Adding Conan remotes for recipes."
         if conan remote list | grep -q "recipes"; then
-          conan remote update recipes --index 0 --url ${CONAN_URL}/recipes
-          echo "Updated Conan remote 'recipes' to ${CONAN_URL}/recipes."
+          conan remote update recipes --index 0 --url ${{ env.CONAN_REMOTE_URL }}/recipes
+          echo "Updated Conan remote 'recipes' to ${{ env.CONAN_REMOTE_URL }}/recipes."
         else
-          conan remote add --index 0 recipes ${CONAN_URL}/recipes
-          echo "Added new conan remote 'recipes' at ${CONAN_URL}/recipes."
+          conan remote add --index 0 recipes ${{ env.CONAN_REMOTE_URL }}/recipes
+          echo "Added new conan remote 'recipes' at ${{ env.CONAN_REMOTE_URL }}/recipes."
         fi
         echo "Adding Conan remotes for packages."
         if conan remote list | grep -q "${{ inputs.remote_name }}"; then
-          conan remote update ${{ inputs.remote_name }} --index 1 --url ${CONAN_URL}/${{ inputs.remote_name }}
-          echo "Updated Conan remote '${{ inputs.remote_name }}' to ${CONAN_URL}/${{ inputs.remote_name }}."
+          conan remote update ${{ inputs.remote_name }} --index 1 --url ${{ env.CONAN_REMOTE_URL }}/${{ inputs.remote_name }}
+          echo "Updated Conan remote '${{ inputs.remote_name }}' to ${{ env.CONAN_REMOTE_URL }}/${{ inputs.remote_name }}."
         else
-          conan remote add --index 1 ${{ inputs.remote_name }} ${CONAN_URL}/${{ inputs.remote_name }}
-          echo "Added new conan remote '${{ inputs.remote_name }}' at ${CONAN_URL}/${{ inputs.remote_name }}."
+          conan remote add --index 1 ${{ inputs.remote_name }} ${{ env.CONAN_REMOTE_URL }}/${{ inputs.remote_name }}
+          echo "Added new conan remote '${{ inputs.remote_name }}' at ${{ env.CONAN_REMOTE_URL }}/${{ inputs.remote_name }}."
         fi
     - name: Log into Conan remotes
       if: env.CONAN_REMOTE_URL != '' && env.CONAN_REMOTE_USERNAME != '' && env.CONAN_REMOTE_PASSWORD != ''

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -2,6 +2,8 @@ name: dependencies
 inputs:
   configuration:
     required: true
+  os:
+    required: false
 # An implicit input is the environment variable `build_dir`.
 runs:
   using: composite
@@ -35,7 +37,7 @@ runs:
       # Print the list of dependencies that would need to be built locally.
       # A non-empty list means we have "failed" to cache binaries remotely.
       run: |
-        echo missing=$(conan info . --build missing --settings build_type=${{ inputs.configuration }} --json 2>/dev/null  | grep '^\[') | tee ${GITHUB_OUTPUT}
+        echo missing=$(conan info . --build missing --settings build_type=${{ inputs.configuration }} ${{ inputs.os && '--settings os=' || '' }}${{ inputs.os }} --json 2>/dev/null  | grep '^\[') | tee ${GITHUB_OUTPUT}
     - name: install dependencies
       shell: bash
       run: |
@@ -47,4 +49,5 @@ runs:
           --options:host "&:tests=True" \
           --options:host "&:xrpld=True" \
           --settings:all build_type=${{ inputs.configuration }} \
+          ${{ inputs.os && '--settings:all os=' || '' }}${{ inputs.os }} \
           ..

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -43,7 +43,7 @@ runs:
         cd ${build_dir}
         conan install \
           --output-folder . \
-          --build '*' \
+          --build missing \
           --options:host "&:tests=True" \
           --options:host "&:xrpld=True" \
           --settings:all build_type=${{ inputs.configuration }} \

--- a/.github/workflows/libxrpl.yml
+++ b/.github/workflows/libxrpl.yml
@@ -1,8 +1,8 @@
 name: Check libXRPL compatibility with Clio
 env:
-  CONAN_URL: http://18.143.149.228:8081/artifactory/api/conan/dev
-  CONAN_LOGIN_USERNAME_RIPPLE: ${{ secrets.CONAN_USERNAME }}
-  CONAN_PASSWORD_RIPPLE: ${{ secrets.CONAN_TOKEN }}
+  CONAN_REMOTE_URL: ${{ vars.CONAN_REMOTE_URL }}
+  CONAN_REMOTE_USERNAME: ${{ secrets.CONAN_REMOTE_USERNAME }}
+  CONAN_REMOTE_PASSWORD: ${{ secrets.CONAN_REMOTE_PASSWORD }}
 on:
   pull_request:
     paths:
@@ -34,6 +34,12 @@ jobs:
           wait-interval: 10
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Parse new version
+        id: version
+        shell: bash
+        run: |
+          echo version="$(cat src/libxrpl/protocol/BuildInfo.cpp | grep "versionString =" \
+            | awk -F '"' '{print $2}')" | tee ${GITHUB_OUTPUT}
       - name: Generate channel
         id: channel
         shell: bash
@@ -43,36 +49,26 @@ jobs:
         shell: bash
         run: |
           conan export . ${{ steps.channel.outputs.channel }}
-      - name: Add Ripple Conan remote
+      - name: Add Conan remote
         shell: bash
         run: |
           conan remote list
-          conan remote remove ripple || true
+          conan remote remove ubuntu-jammy || true
           # Do not quote the URL. An empty string will be accepted (with a non-fatal warning), but a missing argument will not.
-          conan remote add ripple ${{ vars.CONAN_REMOTE_URL }} --insert 0
-      - name: Parse new version
-        id: version
-        shell: bash
-        run: |
-          echo version="$(cat src/libxrpl/protocol/BuildInfo.cpp | grep "versionString =" \
-            | awk -F '"' '{print $2}')" | tee ${GITHUB_OUTPUT}
-      - name: Try to authenticate to Ripple Conan remote
+          conan remote add ubuntu-jammy ${{ env.CONAN_REMOTE_URL }}/ubuntu-jammy --insert 0
+      - name: Log into Conan remote
+        if: env.CONAN_REMOTE_URL != '' && env.CONAN_REMOTE_USERNAME != '' && env.CONAN_REMOTE_PASSWORD != ''
         id: remote
         shell: bash
         run: |
-          # `conan user` implicitly uses the environment variables CONAN_LOGIN_USERNAME_<REMOTE> and CONAN_PASSWORD_<REMOTE>.
-          # https://docs.conan.io/1/reference/commands/misc/user.html#using-environment-variables
-          # https://docs.conan.io/1/reference/env_vars.html#conan-login-username-conan-login-username-remote-name
-          # https://docs.conan.io/1/reference/env_vars.html#conan-password-conan-password-remote-name
-          echo outcome=$(conan user --remote ripple --password >&2 \
-            && echo success || echo failure) | tee ${GITHUB_OUTPUT}
+          echo outcome=$(conan remote login ubuntu-jammy "${{ env.CONAN_REMOTE_USERNAME }}" --password "${{ env.CONAN_REMOTE_PASSWORD }}" >&2 && echo success || echo failure) | tee ${GITHUB_OUTPUT}
       - name: Upload new package
         id: upload
         if: (steps.remote.outputs.outcome == 'success')
         shell: bash
         run: |
           echo "conan upload version ${{ steps.version.outputs.version }} on channel ${{ steps.channel.outputs.channel }}"
-          echo outcome=$(conan upload xrpl/${{ steps.version.outputs.version }}@${{ steps.channel.outputs.channel }} --remote ripple --confirm >&2 \
+          echo outcome=$(conan upload xrpl/${{ steps.version.outputs.version }}@${{ steps.channel.outputs.channel }} --remote ubuntu-jammy --confirm >&2 \
             && echo success || echo failure) | tee ${GITHUB_OUTPUT}
   notify_clio:
     name: Notify Clio

--- a/.github/workflows/libxrpl.yml
+++ b/.github/workflows/libxrpl.yml
@@ -1,8 +1,9 @@
 name: Check libXRPL compatibility with Clio
 env:
   CONAN_REMOTE_URL: ${{ vars.CONAN_REMOTE_URL }}
-  CONAN_REMOTE_USERNAME: ${{ secrets.CONAN_REMOTE_USERNAME }}
-  CONAN_REMOTE_PASSWORD: ${{ secrets.CONAN_REMOTE_PASSWORD }}
+  CONAN_REMOTE_NAME: ubuntu-jammy
+  CONAN_LOGIN_USERNAME: ${{ secrets.CONAN_REMOTE_USERNAME }}
+  CONAN_PASSWORD: ${{ secrets.CONAN_REMOTE_PASSWORD }}
 on:
   pull_request:
     paths:
@@ -53,23 +54,30 @@ jobs:
         shell: bash
         run: |
           conan remote list
-          conan remote remove ubuntu-jammy || true
+          conan remote remove ${{ env.CONAN_REMOTE_NAME }} || true
           # Do not quote the URL. An empty string will be accepted (with a non-fatal warning), but a missing argument will not.
-          conan remote add ubuntu-jammy ${{ env.CONAN_REMOTE_URL }}/ubuntu-jammy --insert 0
+          conan remote add ${{ env.CONAN_REMOTE_NAME }} ${{ env.CONAN_REMOTE_URL }}/${{ env.CONAN_REMOTE_NAME }} --insert 0
       - name: Log into Conan remote
-        if: env.CONAN_REMOTE_URL != '' && env.CONAN_REMOTE_USERNAME != '' && env.CONAN_REMOTE_PASSWORD != ''
+        if: env.CONAN_REMOTE_URL != '' && env.CONAN_LOGIN_USERNAME != '' && env.CONAN_PASSWORD != ''
         id: remote
         shell: bash
         run: |
-          echo outcome=$(conan remote login ubuntu-jammy "${{ env.CONAN_REMOTE_USERNAME }}" --password "${{ env.CONAN_REMOTE_PASSWORD }}" >&2 && echo success || echo failure) | tee ${GITHUB_OUTPUT}
+          # `conan user` implicitly uses the environment variables CONAN_LOGIN_USERNAME_<REMOTE> and CONAN_PASSWORD_<REMOTE>,
+          # with <REMOTE> being the name of the remote. If not set it will fallback to the global variables
+          # CONAN_LOGIN_USERNAME and CONAN_PASSWORD.
+          # https://docs.conan.io/1/reference/commands/misc/user.html#using-environment-variables
+          # https://docs.conan.io/1/reference/env_vars.html#conan-login-username-conan-login-username-remote-name
+          # https://docs.conan.io/1/reference/env_vars.html#conan-password-conan-password-remote-name
+          echo outcome=$(conan user --remote ${{ env.CONAN_REMOTE_NAME }} --password >&2 && echo success || echo failure) | tee ${GITHUB_OUTPUT}
       - name: Upload new package
         id: upload
         if: (steps.remote.outputs.outcome == 'success')
         shell: bash
         run: |
           echo "conan upload version ${{ steps.version.outputs.version }} on channel ${{ steps.channel.outputs.channel }}"
-          echo outcome=$(conan upload xrpl/${{ steps.version.outputs.version }}@${{ steps.channel.outputs.channel }} --remote ubuntu-jammy --confirm >&2 \
+          echo outcome=$(conan upload xrpl/${{ steps.version.outputs.version }}@${{ steps.channel.outputs.channel }} --remote ${{ env.CONAN_REMOTE_NAME }} --confirm >&2 \
             && echo success || echo failure) | tee ${GITHUB_OUTPUT}
+
   notify_clio:
     name: Notify Clio
     runs-on: ubuntu-latest

--- a/.github/workflows/libxrpl.yml
+++ b/.github/workflows/libxrpl.yml
@@ -49,7 +49,7 @@ jobs:
           conan remote list
           conan remote remove ripple || true
           # Do not quote the URL. An empty string will be accepted (with a non-fatal warning), but a missing argument will not.
-          conan remote add ripple ${{ env.CONAN_URL }} --insert 0
+          conan remote add ripple ${{ vars.CONAN_REMOTE_URL }} --insert 0
       - name: Parse new version
         id: version
         shell: bash

--- a/.github/workflows/libxrpl.yml
+++ b/.github/workflows/libxrpl.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           running-workflow-name: wait-for-check-regexp
-          check-regexp: '(dependencies|test).*linux.*' # Ignore windows and mac tests but make sure linux passes
+          check-regexp: '(dependencies|test).*(gcc|clang).*' # Ignore windows and mac tests but make sure linux passes
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
       - name: Checkout

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -92,7 +92,7 @@ jobs:
           echo "Conan profile:"
           conan profile show
           echo "Conan configuration:"
-          conan config list
+          conan config show '*'
       - name: export custom recipes
         shell: bash
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -112,6 +112,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
+          remote_name: macos
       - name: build
         uses: ./.github/actions/build
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,8 +19,6 @@ concurrency:
 # to pollute conan/profiles directory with settings which might not work for others
 env:
   CONAN_REMOTE_URL: ${{ vars.CONAN_REMOTE_URL }}
-  CONAN_REMOTE_USERNAME: ${{ secrets.CONAN_REMOTE_USERNAME }}
-  CONAN_REMOTE_PASSWORD: ${{ secrets.CONAN_REMOTE_PASSWORD }}
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}
@@ -29,7 +27,6 @@ env:
     tools.compilation:verbosity=verbose
 
 jobs:
-
   test:
     if: ${{ github.event_name == 'push' || github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'DraftRunCI') }}
     strategy:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -98,16 +98,6 @@ jobs:
         run: |
           conan export --version 1.1.10 external/snappy
           conan export --version 4.0.3 external/soci
-      - name: add Ripple Conan remote
-        if: env.CONAN_URL != ''
-        shell: bash
-        run: |
-          if conan remote list | grep -q "ripple"; then
-              conan remote remove ripple
-              echo "Removed conan remote ripple"
-          fi
-          conan remote add --index 0 ripple "${CONAN_URL}"
-          echo "Added conan remote ripple at ${CONAN_URL}"
       - name: build dependencies
         uses: ./.github/actions/dependencies
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,9 +18,6 @@ concurrency:
 # This part of Conan configuration is specific to this workflow only; we do not want
 # to pollute conan/profiles directory with settings which might not work for others
 env:
-  CONAN_URL: http://18.143.149.228:8081/artifactory/api/conan/dev
-  CONAN_LOGIN_USERNAME_RIPPLE: ${{ secrets.CONAN_USERNAME }}
-  CONAN_PASSWORD_RIPPLE: ${{ secrets.CONAN_TOKEN }}
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -92,7 +92,7 @@ jobs:
           echo "Conan profile:"
           conan profile show
           echo "Conan configuration:"
-          conan config show
+          conan config list
       - name: export custom recipes
         shell: bash
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,9 +37,7 @@ jobs:
           - Release
     runs-on: [self-hosted, macOS, mac-runner-m1]
     env:
-      # The `build` action requires these variables.
       build_dir: .build
-      NUM_PROCESSORS: 12
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -82,7 +80,7 @@ jobs:
           clang --version
       - name: configure Conan
         run : |
-          echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
+          echo "${{ env.CONAN_GLOBAL_CONF }}" >> $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
           echo "Conan profile:"
           conan profile show
@@ -109,6 +107,6 @@ jobs:
           n=$(nproc)
           echo "Using $n test jobs"
 
-          cd ${build_dir}
+          cd ${{ env.build_dir }}
           ./rippled --unittest --unittest-jobs $n
           ctest -j $n --output-on-failure

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -89,8 +89,10 @@ jobs:
         run : |
           echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
+          echo "Conan profile:"
           conan profile show
-          conan config show 'core*'
+          echo "Conan configuration:"
+          conan config show
       - name: export custom recipes
         shell: bash
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,8 +34,6 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'DraftRunCI') }}
     strategy:
       matrix:
-        platform:
-          - macos
         generator:
           - Ninja
         configuration:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -90,6 +90,7 @@ jobs:
           echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
           conan profile show
+          conan config show 'core*'
       - name: export custom recipes
         shell: bash
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,6 +18,9 @@ concurrency:
 # This part of Conan configuration is specific to this workflow only; we do not want
 # to pollute conan/profiles directory with settings which might not work for others
 env:
+  CONAN_REMOTE_URL: ${{ vars.CONAN_REMOTE_URL }}
+  CONAN_REMOTE_USERNAME: ${{ secrets.CONAN_REMOTE_USERNAME }}
+  CONAN_REMOTE_PASSWORD: ${{ secrets.CONAN_REMOTE_PASSWORD }}
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -91,7 +91,7 @@ jobs:
           env | sort
       - name: configure Conan
         run: |
-          echo "${CONAN_GLOBAL_CONF}" > $(conan config home)/global.conf
+          echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
           echo "Conan profile:"
           conan profile show
@@ -104,7 +104,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
-          os: ${{ matrix.distro }}-${{ matrix.codename }}
+          remote_name: ${{ matrix.distro }}-${{ matrix.codename }}
       - name: upload archive
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -162,7 +162,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
-          os: ${{ matrix.distro }}-${{ matrix.codename }}
+          remote_name: ${{ matrix.distro }}-${{ matrix.codename }}
       - name: build
         uses: ./.github/actions/build
         with:
@@ -224,7 +224,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
-          os: ubuntu-jammy
+          remote_name: ubuntu-jammy
       - name: build
         uses: ./.github/actions/build
         with:
@@ -275,7 +275,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
-          os: ubuntu-jammy
+          remote_name: ubuntu-jammy
       - name: build
         uses: ./.github/actions/build
         with:
@@ -346,7 +346,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ env.configuration }}
-          os: ubuntu-jammy
+          remote_name: ubuntu-jammy
       - name: export
         run: |
           conan export . --version head
@@ -397,7 +397,7 @@ jobs:
           uses: ./.github/actions/dependencies
           with:
             configuration: Debug
-            os: debian-bookworm
+            remote_name: debian-bookworm
 
         - name: prepare environment
           run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,8 +20,6 @@ concurrency:
 # to pollute conan/profiles directory with settings which might not work for others
 env:
   CONAN_REMOTE_URL: ${{ vars.CONAN_REMOTE_URL }}
-  CONAN_REMOTE_USERNAME: ${{ secrets.CONAN_REMOTE_USERNAME }}
-  CONAN_REMOTE_PASSWORD: ${{ secrets.CONAN_REMOTE_PASSWORD }}
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{ os.cpu_count() }}
     core.upload:parallel={{ os.cpu_count() }}
@@ -126,7 +124,7 @@ jobs:
           - "-Dunity=ON"
     needs: dependencies
     runs-on: [self-hosted, heavy]
-    container: ghcr.io/xrplf/ci/${{ matrix.distro }}-${{ matrix.codename }}:${{ matrix.compiler }}
+    container: ghcr.io/xrplf/ci/${{ matrix.distro }}:${{ matrix.compiler }}
     env:
       build_dir: .build
     steps:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -96,7 +96,7 @@ jobs:
           echo "Conan profile:"
           conan profile show
           echo "Conan configuration:"
-          conan config show
+          conan config list
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar.gz -C ${CONAN_HOME} .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -356,7 +356,6 @@ jobs:
           mkdir ${build_dir} && cd ${build_dir}
           conan install .. \
             --settings:all build_type=${configuration} \
-            --settings:all os=ubuntu-jammy \
             --output-folder . \
             --build missing
           cmake .. \

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -89,9 +89,6 @@ jobs:
           conan --version
           cmake --version
           env | sort
-          
-          ls $(conan config home)
-          cat $(conan config home)/settings.yml
       - name: configure Conan
         run: |
           echo "Installing Conan configuration and profile."
@@ -102,7 +99,9 @@ jobs:
           os:
             ${{ matrix.distro }}-${{ matrix.codename }}:
           EOT
-          sed -i "s/os=Linux/os=${{ matrix.distro }}-${{ matrix.codename }}/1" $(conan config home)/profiles/default
+          cat $(conan config home)/profiles/default
+          sed -i "s/os=Linux/os=${{ matrix.distro }}-${{ matrix.codename }}/g" $(conan config home)/profiles/default
+          cat $(conan config home)/profiles/default
           echo "Conan profile:"
           conan profile show
           echo "Conan configuration:"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -93,8 +93,10 @@ jobs:
         run: |
           echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
+          echo "Conan profile:"
           conan profile show
-          conan config show 'core*'
+          echo "Conan configuration:"
+          conan config show
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar.gz -C ${CONAN_HOME} .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -91,8 +91,15 @@ jobs:
           env | sort
       - name: configure Conan
         run: |
+          echo "Installing Conan configuration and profile."
           echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
+          echo "Overriding default OS in profile by '${{ matrix.include.distro }}-${{ matrix.include.codename }}'"
+          cat >> $(conan config home)/settings_user.yml <<EOT
+          os:
+            ${{ matrix.include.distro }}-${{ matrix.include.codename }}:
+          EOT
+          sed -i "s/os=Linux/os=${{ matrix.include.distro }}-${{ matrix.include.codename }}/1" $(conan config home)/profiles/default
           echo "Conan profile:"
           conan profile show
           echo "Conan configuration:"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,6 +19,9 @@ concurrency:
 # This part of Conan configuration is specific to this workflow only; we do not want
 # to pollute conan/profiles directory with settings which might not work for others
 env:
+  CONAN_REMOTE_URL: ${{ vars.CONAN_REMOTE_URL }}
+  CONAN_REMOTE_USERNAME: ${{ secrets.CONAN_REMOTE_USERNAME }}
+  CONAN_REMOTE_PASSWORD: ${{ secrets.CONAN_REMOTE_PASSWORD }}
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{ os.cpu_count() }}
     core.upload:parallel={{ os.cpu_count() }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -157,7 +157,7 @@ jobs:
           cmake-args: "-Dassert=TRUE -Dwerr=TRUE ${{ matrix.cmake-args }}"
       - name: check linking
         run: |
-          cd ${build_dir}
+          cd ${{ env.build_dir }}
           ldd ./rippled
           if [ "$(ldd ./rippled | grep -E '(libstdc\+\+|libgcc)' | wc -l)" -eq 0 ]; then
             echo 'The binary is statically linked.'
@@ -167,7 +167,7 @@ jobs:
           fi
       - name: test
         run: |
-          cd ${build_dir}
+          cd ${{ env.build_dir }}
           ./rippled --unittest --unittest-jobs $(nproc)
           ctest -j $(nproc) --output-on-failure
 
@@ -219,7 +219,7 @@ jobs:
           cmake-args: "-Dassert=TRUE -Dwerr=TRUE ${{ matrix.cmake-args }}"
       - name: test
         run: |
-          cd ${build_dir}
+          cd ${{ env.build_dir }}
           ./rippled --unittest --unittest-jobs $(nproc)
           ctest -j $(nproc) --output-on-failure
 
@@ -279,7 +279,7 @@ jobs:
       - name: move coverage report
         shell: bash
         run: |
-          mv "${build_dir}/coverage.xml" ./
+          mv "${{ env.build_dir }}/coverage.xml" ./
       - name: archive coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -343,14 +343,14 @@ jobs:
       - name: build
         run: |
           cd tests/conan
-          mkdir ${build_dir} && cd ${build_dir}
+          mkdir ${{ env.build_dir }} && cd ${{ env.build_dir }}
           conan install .. \
-            --settings:all build_type=${configuration} \
+            --settings:all build_type=${{ matrix.configuration }} \
             --output-folder . \
             --build missing
           cmake .. \
-            -DCMAKE_TOOLCHAIN_FILE:FILEPATH=./build/${configuration}/generators/conan_toolchain.cmake \
-            -DCMAKE_BUILD_TYPE=${configuration}
+            -DCMAKE_TOOLCHAIN_FILE:FILEPATH=./build/${{ matrix.configuration }}/generators/conan_toolchain.cmake \
+            -DCMAKE_BUILD_TYPE=${{ matrix.configuration }}
           cmake --build .
           ./example | grep '^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+'
 
@@ -361,7 +361,7 @@ jobs:
         distro:
           - debian-bookworm
         compiler:
-          - clang-162
+          - clang-16
         configuration:
           - Debug
     needs: dependencies
@@ -394,9 +394,9 @@ jobs:
             remote_name: ${{ matrix.distro }}
         - name: prepare environment
           run: |
-            mkdir -p ${build_dir}
+            mkdir -p ${{ env.build_dir }}
             echo "SOURCE_DIR=$(pwd)" >> $GITHUB_ENV
-            echo "BUILD_DIR=$(pwd)/${build_dir}" >> $GITHUB_ENV
+            echo "BUILD_DIR=$(pwd)/${{ env.build_dir }}" >> $GITHUB_ENV
         - name: build with instrumentation
           run: |
             cd ${BUILD_DIR}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -96,7 +96,7 @@ jobs:
           echo "Conan profile:"
           conan profile show
           echo "Conan configuration:"
-          conan config list
+          conan config show '*'
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar.gz -C ${CONAN_HOME} .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -89,17 +89,20 @@ jobs:
           conan --version
           cmake --version
           env | sort
+          
+          ls $(conan config home)
+          cat $(conan config home)/settings.yml
       - name: configure Conan
         run: |
           echo "Installing Conan configuration and profile."
-          echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
+          echo "${CONAN_GLOBAL_CONF}" > $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
-          echo "Overriding default OS in profile by '${{ matrix.include.distro }}-${{ matrix.include.codename }}'"
+          echo "Overriding OS in profile by '${{ matrix.distro }}-${{ matrix.codename }}'"
           cat >> $(conan config home)/settings_user.yml <<EOT
           os:
-            ${{ matrix.include.distro }}-${{ matrix.include.codename }}:
+            ${{ matrix.distro }}-${{ matrix.codename }}:
           EOT
-          sed -i "s/os=Linux/os=${{ matrix.include.distro }}-${{ matrix.include.codename }}/1" $(conan config home)/profiles/default
+          sed -i "s/os=Linux/os=${{ matrix.distro }}-${{ matrix.codename }}/1" $(conan config home)/profiles/default
           echo "Conan profile:"
           conan profile show
           echo "Conan configuration:"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -94,6 +94,7 @@ jobs:
           echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
           conan profile show
+          conan config show 'core*'
       - name: archive profile
         # Create this archive before dependencies are added to the local cache.
         run: tar -czf conan.tar.gz -C ${CONAN_HOME} .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,9 +19,6 @@ concurrency:
 # This part of Conan configuration is specific to this workflow only; we do not want
 # to pollute conan/profiles directory with settings which might not work for others
 env:
-  CONAN_URL: http://18.143.149.228:8081/artifactory/api/conan/dev
-  CONAN_LOGIN_USERNAME_RIPPLE: ${{ secrets.CONAN_USERNAME }}
-  CONAN_PASSWORD_RIPPLE: ${{ secrets.CONAN_TOKEN }}
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{ os.cpu_count() }}
     core.upload:parallel={{ os.cpu_count() }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -91,17 +91,8 @@ jobs:
           env | sort
       - name: configure Conan
         run: |
-          echo "Installing Conan configuration and profile."
           echo "${CONAN_GLOBAL_CONF}" > $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
-          echo "Overriding OS in profile by '${{ matrix.distro }}-${{ matrix.codename }}'"
-          cat >> $(conan config home)/settings_user.yml <<EOT
-          os:
-            ${{ matrix.distro }}-${{ matrix.codename }}:
-          EOT
-          cat $(conan config home)/profiles/default
-          sed -i "s/os=Linux/os=${{ matrix.distro }}-${{ matrix.codename }}/g" $(conan config home)/profiles/default
-          cat $(conan config home)/profiles/default
           echo "Conan profile:"
           conan profile show
           echo "Conan configuration:"
@@ -113,6 +104,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
+          os: ${{ matrix.distro }}-${{ matrix.codename }}
       - name: upload archive
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -170,6 +162,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
+          os: ${{ matrix.distro }}-${{ matrix.codename }}
       - name: build
         uses: ./.github/actions/build
         with:
@@ -231,6 +224,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
+          os: ubuntu-jammy
       - name: build
         uses: ./.github/actions/build
         with:
@@ -281,6 +275,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
+          os: ubuntu-jammy
       - name: build
         uses: ./.github/actions/build
         with:
@@ -351,6 +346,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ env.configuration }}
+          os: ubuntu-jammy
       - name: export
         run: |
           conan export . --version head
@@ -360,6 +356,7 @@ jobs:
           mkdir ${build_dir} && cd ${build_dir}
           conan install .. \
             --settings:all build_type=${configuration} \
+            --settings:all os=ubuntu-jammy \
             --output-folder . \
             --build missing
           cmake .. \
@@ -400,6 +397,7 @@ jobs:
           uses: ./.github/actions/dependencies
           with:
             configuration: Debug
+            os: debian-bookworm
 
         - name: prepare environment
           run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -57,25 +57,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux
         compiler:
-          - gcc
-          - clang
+          - gcc-12
+          - clang-16
         configuration:
           - Debug
           - Release
         include:
-          - compiler: gcc
-            compiler_version: 12
-            distro: ubuntu
-            codename: jammy
-          - compiler: clang
-            compiler_version: 16
-            distro: debian
-            codename: bookworm
+          - compiler: gcc-12
+            distro: ubuntu-jammy
+          - compiler: clang-16
+            distro: debian-bookworm
     runs-on: [self-hosted, heavy]
-    container: ghcr.io/xrplf/ci/${{ matrix.distro }}-${{ matrix.codename }}:${{ matrix.compiler }}-${{ matrix.compiler_version }}
+    container: ghcr.io/xrplf/ci/${{ matrix.distro }}:${{ matrix.compiler }}
     env:
       build_dir: .build
     steps:
@@ -85,7 +79,7 @@ jobs:
         run: |
           echo ${PATH} | tr ':' '\n'
           lsb_release -a || true
-          ${{ matrix.compiler }}-${{ matrix.compiler_version }} --version
+          ${{ matrix.compiler }} --version
           conan --version
           cmake --version
           env | sort
@@ -104,11 +98,11 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
-          remote_name: ${{ matrix.distro }}-${{ matrix.codename }}
+          remote_name: ${{ matrix.distro }}
       - name: upload archive
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: ${{ matrix.platform }}-${{ matrix.compiler }}-${{ matrix.configuration }}
+          name: ${{ matrix.distro }}-${{ matrix.compiler }}-${{ matrix.configuration }}
           path: conan.tar.gz
           if-no-files-found: error
 
@@ -116,36 +110,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux
         compiler:
-          - gcc
-          - clang
+          - gcc-12
+          - clang-16
         configuration:
           - Debug
           - Release
         include:
-          - compiler: gcc
-            compiler_version: 12
-            distro: ubuntu
-            codename: jammy
-          - compiler: clang
-            compiler_version: 16
-            distro: debian
-            codename: bookworm
+          - compiler: gcc-12
+            distro: ubuntu-jammy
+          - compiler: clang-16
+            distro: debian-bookworm
         cmake-args:
           -
           - "-Dunity=ON"
     needs: dependencies
     runs-on: [self-hosted, heavy]
-    container: ghcr.io/xrplf/ci/${{ matrix.distro }}-${{ matrix.codename }}:${{ matrix.compiler }}-${{ matrix.compiler_version }}
+    container: ghcr.io/xrplf/ci/${{ matrix.distro }}-${{ matrix.codename }}:${{ matrix.compiler }}
     env:
       build_dir: .build
     steps:
       - name: download cache
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          name: ${{ matrix.platform }}-${{ matrix.compiler }}-${{ matrix.configuration }}
+          name: ${{ matrix.distro }}-${{ matrix.compiler }}-${{ matrix.configuration }}
       - name: extract cache
         run: |
           mkdir -p ${CONAN_HOME}
@@ -162,7 +150,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
-          remote_name: ${{ matrix.distro }}-${{ matrix.codename }}
+          remote_name: ${{ matrix.distro }}
       - name: build
         uses: ./.github/actions/build
         with:
@@ -189,10 +177,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux
+        distro:
+          - ubuntu-jammy
         compiler:
-          - gcc
+          - gcc-12
         configuration:
           - Debug
         cmake-args:
@@ -200,14 +188,14 @@ jobs:
           - "-DUNIT_TEST_REFERENCE_FEE=1000"
     needs: dependencies
     runs-on: [self-hosted, heavy]
-    container: ghcr.io/xrplf/ci/ubuntu-jammy:gcc-12
+    container: ghcr.io/xrplf/ci/${{ matrix.distro }}:${{ matrix.compiler }}
     env:
       build_dir: .build
     steps:
       - name: download cache
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          name: ${{ matrix.platform }}-${{ matrix.compiler }}-${{ matrix.configuration }}
+          name: ${{ matrix.distro }}-${{ matrix.compiler }}-${{ matrix.configuration }}
       - name: extract cache
         run: |
           mkdir -p ${CONAN_HOME}
@@ -224,7 +212,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
-          remote_name: ubuntu-jammy
+          remote_name: ${{ matrix.distro }}
       - name: build
         uses: ./.github/actions/build
         with:
@@ -241,22 +229,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux
+        distro:
+          - ubuntu-jammy
         compiler:
-          - gcc
+          - gcc-12
         configuration:
           - Debug
     needs: dependencies
     runs-on: [self-hosted, heavy]
-    container: ghcr.io/xrplf/ci/ubuntu-jammy:gcc-12
+    container: ghcr.io/xrplf/ci/${{ matrix.distro }}:${{ matrix.compiler }}
     env:
       build_dir: .build
     steps:
       - name: download cache
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          name: ${{ matrix.platform }}-${{ matrix.compiler }}-${{ matrix.configuration }}
+          name: ${{ matrix.distro }}-${{ matrix.compiler }}-${{ matrix.configuration }}
       - name: extract cache
         run: |
           mkdir -p ${CONAN_HOME}
@@ -275,7 +263,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration }}
-          remote_name: ubuntu-jammy
+          remote_name: ${{ matrix.distro }}
       - name: build
         uses: ./.github/actions/build
         with:
@@ -315,21 +303,25 @@ jobs:
           attempt_delay: 210000 # in milliseconds
 
   conan:
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - ubuntu-jammy
+        compiler:
+          - gcc-12
+        configuration:
+          - Release
     needs: dependencies
     runs-on: [self-hosted, heavy]
-    container:
-      image: ghcr.io/xrplf/ci/ubuntu-jammy:gcc-12
+    container: ghcr.io/xrplf/ci/${{ matrix.distro }}:${{ matrix.compiler }}
     env:
       build_dir: .build
-      platform: linux
-      compiler: gcc
-      compiler_version: 12
-      configuration: Release
     steps:
       - name: download cache
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          name: ${{ env.platform }}-${{ env.compiler }}-${{ env.configuration }}
+          name: ${{ matrix.distro }}-${{ matrix.compiler }}-${{ matrix.configuration }}
       - name: extract cache
         run: |
           mkdir -p ${CONAN_HOME}
@@ -345,8 +337,8 @@ jobs:
       - name: dependencies
         uses: ./.github/actions/dependencies
         with:
-          configuration: ${{ env.configuration }}
-          remote_name: ubuntu-jammy
+          configuration: ${{ matrix.configuration }}
+          remote_name: ${{ matrix.distro }}
       - name: export
         run: |
           conan export . --version head
@@ -365,22 +357,29 @@ jobs:
           ./example | grep '^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+'
 
   instrumentation-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - debian-bookworm
+        compiler:
+          - clang-162
+        configuration:
+          - Debug
     needs: dependencies
     runs-on: [self-hosted, heavy]
-    container: ghcr.io/xrplf/ci/debian-bookworm:clang-16
+    container: ghcr.io/xrplf/ci/${{ matrix.distro }}:${{ matrix.compiler }}
     env:
       build_dir: .build
     steps:
         - name: download cache
           uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
           with:
-            name: linux-clang-Debug
-
+            name: ${{ matrix.distro }}-${{ matrix.compiler }}-${{ matrix.configuration }}
         - name: extract cache
           run: |
             mkdir -p ${CONAN_HOME}
             tar -xzf conan.tar.gz -C ${CONAN_HOME}
-
         - name: check environment
           run: |
             echo ${PATH} | tr ':' '\n'
@@ -388,22 +387,18 @@ jobs:
             cmake --version
             env | sort
             ls ${CONAN_HOME}
-
         - name: checkout
           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-
         - name: dependencies
           uses: ./.github/actions/dependencies
           with:
-            configuration: Debug
-            remote_name: debian-bookworm
-
+            configuration: ${{ matrix.configuration }}
+            remote_name: ${{ matrix.distro }}
         - name: prepare environment
           run: |
             mkdir -p ${build_dir}
             echo "SOURCE_DIR=$(pwd)" >> $GITHUB_ENV
             echo "BUILD_DIR=$(pwd)/${build_dir}" >> $GITHUB_ENV
-
         - name: build with instrumentation
           run: |
             cd ${BUILD_DIR}
@@ -417,12 +412,10 @@ jobs:
               -DSECP256K1_BUILD_EXHAUSTIVE_TESTS=OFF \
               -DCMAKE_TOOLCHAIN_FILE=${BUILD_DIR}/build/generators/conan_toolchain.cmake
             cmake --build .  --parallel $(nproc)
-
         - name: verify instrumentation enabled
           run: |
             cd ${BUILD_DIR}
             ./rippled --version | grep libvoidstar
-
         - name: run unit tests
           run: |
             cd ${BUILD_DIR}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,8 +84,10 @@ jobs:
         run: |
           echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
+          echo "Conan profile:"
           conan profile show
-          conan config show 'core*'
+          echo "Conan configuration:"
+          conan config show
       - name: export custom recipes
         shell: bash
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,6 +85,7 @@ jobs:
           echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
           conan profile show
+          conan config show 'core*'
       - name: export custom recipes
         shell: bash
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,6 +21,9 @@ concurrency:
 # This part of Conan configuration is specific to this workflow only; we do not want
 # to pollute conan/profiles directory with settings which might not work for others
 env:
+  CONAN_REMOTE_URL: ${{ vars.CONAN_REMOTE_URL }}
+  CONAN_REMOTE_USERNAME: ${{ secrets.CONAN_REMOTE_USERNAME }}
+  CONAN_REMOTE_PASSWORD: ${{ secrets.CONAN_REMOTE_PASSWORD }}
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -97,7 +97,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration.type }}
-          remote_name: ${{ matrix.platform }}
+          remote_name: windows
       - name: build
         uses: ./.github/actions/build
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -107,6 +107,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration.type }}
+          remote_name: windows
       - name: build
         uses: ./.github/actions/build
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -93,16 +93,6 @@ jobs:
         run: |
           conan export --version 1.1.10 external/snappy
           conan export --version 4.0.3 external/soci
-      - name: add Ripple Conan remote
-        if: env.CONAN_URL != ''
-        shell: bash
-        run: |
-          if conan remote list | grep -q "ripple"; then
-              conan remote remove ripple
-              echo "Removed conan remote ripple"
-          fi
-          conan remote add --index 0 ripple "${CONAN_URL}"
-          echo "Added conan remote ripple at ${CONAN_URL}"
       - name: build dependencies
         uses: ./.github/actions/dependencies
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,7 +87,7 @@ jobs:
           echo "Conan profile:"
           conan profile show
           echo "Conan configuration:"
-          conan config list
+          conan config show '*'
       - name: export custom recipes
         shell: bash
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -97,7 +97,7 @@ jobs:
         uses: ./.github/actions/dependencies
         with:
           configuration: ${{ matrix.configuration.type }}
-          remote_name: windows
+          remote_name: ${{ matrix.platform }}
       - name: build
         uses: ./.github/actions/build
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,7 +79,7 @@ jobs:
       - name: configure Conan
         shell: bash
         run: |
-          echo "${CONAN_GLOBAL_CONF}" >> $(conan config home)/global.conf
+          echo "${{ env.CONAN_GLOBAL_CONF }}" >> $(conan config home)/global.conf
           conan config install conan/profiles/ -tf $(conan config home)/profiles/
           echo "Conan profile:"
           conan profile show
@@ -107,6 +107,6 @@ jobs:
         shell: bash
         if: ${{ matrix.configuration.tests }}
         run: |
-          cd ${build_dir}/${{ matrix.configuration.type }}
+          cd ${{ env.build_dir }}/${{ matrix.configuration.type }}
           ./rippled --unittest --unittest-jobs $(nproc)
           ctest -j $(nproc) --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,9 +21,6 @@ concurrency:
 # This part of Conan configuration is specific to this workflow only; we do not want
 # to pollute conan/profiles directory with settings which might not work for others
 env:
-  CONAN_URL: http://18.143.149.228:8081/artifactory/api/conan/dev
-  CONAN_LOGIN_USERNAME_RIPPLE: ${{ secrets.CONAN_USERNAME }}
-  CONAN_PASSWORD_RIPPLE: ${{ secrets.CONAN_TOKEN }}
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,8 +22,6 @@ concurrency:
 # to pollute conan/profiles directory with settings which might not work for others
 env:
   CONAN_REMOTE_URL: ${{ vars.CONAN_REMOTE_URL }}
-  CONAN_REMOTE_USERNAME: ${{ secrets.CONAN_REMOTE_USERNAME }}
-  CONAN_REMOTE_PASSWORD: ${{ secrets.CONAN_REMOTE_PASSWORD }}
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}
@@ -32,7 +30,6 @@ env:
     tools.compilation:verbosity=verbose
 
 jobs:
-
   test:
     if: ${{ github.event_name == 'push' || github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'DraftRunCI') }}
     strategy:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,7 +87,7 @@ jobs:
           echo "Conan profile:"
           conan profile show
           echo "Conan configuration:"
-          conan config show
+          conan config list
       - name: export custom recipes
         shell: bash
         run: |


### PR DESCRIPTION
## High Level Overview of Change

Conan recipes are now stored in a recipe-specific remote, and dependencies are uploaded to OS-specific remotes, with a separate remote per Linux distro. This PR adjusts the CI pipelines to leverage these changes.

### Context of Change

Conan does not distinguish between Linux distros when building and consuming dependencies, which has resulted in compilation failures due to incompatibilities after existing packages in the Conan remote were overwritten - with the last distro to write a package "winning". Many attempts were made to propagate the distro to the dependent packages, to enforce Conan assigning different package IDs to each built dependency, but those attempts were unsuccessful. Now multiple remotes have been created, so e.g. Debian Bookworm GCC 12 packages are kept separate from Ubuntu Jammy GCC 12 ones. 

This PR also reverts commit 9b45b6888b9bfc4ca81d0fb71e0b6f2f3a120bae, which was a temporary workaround to unblock the pipelines by rebuilding every dependency from scratch for every commit.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
