### PR TITLE
fix: ensure `GasUsed` shows up in the metadata even on `tecWASM_REJECTED`

### DIFF
--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -1913,7 +1913,7 @@ struct Escrow_test : public beast::unit_test::suite
         }
 
         {
-            uint32_t const allowance = 10'000;
+            uint32_t const allowance = 5'664;
             Env env(*this);
             env.fund(XRP(5000), alice, carol);
             auto const seq = env.seq(alice);
@@ -1937,6 +1937,10 @@ struct Escrow_test : public beast::unit_test::suite
                 escrow::comp_allowance(allowance),
                 fee(txnFees),
                 ter(tecWASM_REJECTED));
+
+            auto const txMeta = env.meta();
+            if (BEAST_EXPECT(txMeta->isFieldPresent(sfGasUsed)))
+                BEAST_EXPECT(txMeta->getFieldU32(sfGasUsed) == allowance);
         }
 
         Env env(*this);
@@ -2067,6 +2071,14 @@ struct Escrow_test : public beast::unit_test::suite
                     fee(txnFees),
                     ter(tecWASM_REJECTED));
                 env.close();
+
+                {
+                    auto const txMeta = env.meta();
+                    if (BEAST_EXPECT(txMeta->isFieldPresent(sfGasUsed)))
+                        BEAST_EXPECT(
+                            txMeta->getFieldU32(sfGasUsed) == allowance);
+                }
+
                 env(escrow::finish(alice, alice, seq),
                     fee(txnFees),
                     escrow::comp_allowance(allowance),
@@ -2116,6 +2128,9 @@ struct Escrow_test : public beast::unit_test::suite
                     escrow::comp_allowance(allowance),
                     fee(txnFees),
                     ter(tecWASM_REJECTED));
+                if (BEAST_EXPECT(env.meta()->isFieldPresent(sfGasUsed)))
+                    BEAST_EXPECT(
+                        env.meta()->getFieldU32(sfGasUsed) == allowance);
                 env.close();
                 // no fulfillment provided, function succeeds
                 env(escrow::finish(alice, alice, seq),
@@ -2227,6 +2242,9 @@ struct Escrow_test : public beast::unit_test::suite
                     escrow::comp_allowance(allowance),
                     fee(txnFees),
                     ter(tecWASM_REJECTED));
+                if (BEAST_EXPECT(env.meta()->isFieldPresent(sfGasUsed)))
+                    BEAST_EXPECT(
+                        env.meta()->getFieldU32(sfGasUsed) == allowance);
                 env.close();
                 // finish time has passed, function succeeds, tx succeeds
                 env(escrow::finish(carol, alice, seq),
@@ -2371,12 +2389,17 @@ struct Escrow_test : public beast::unit_test::suite
                 env.close();
                 env.close();
 
-                auto const allowance = 1'000'000;
+                auto const allowance = 99'596;
 
                 env(escrow::finish(carol, alice, seq),
                     escrow::comp_allowance(allowance),
                     fee(txnFees));
                 env.close();
+
+                auto const txMeta = env.meta();
+                if (BEAST_EXPECT(txMeta && txMeta->isFieldPresent(sfGasUsed)))
+                    BEAST_EXPECT(txMeta->getFieldU32(sfGasUsed) == allowance);
+                BEAST_EXPECT((*env.le(alice))[sfOwnerCount] == 12);
             }
         }
     }

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -296,7 +296,7 @@ struct Escrow_test : public beast::unit_test::suite
         {
             testcase("Implied Finish Time (without fix1571)");
 
-            Env env(*this, testable_amendments() - fix1571);
+            Env env(*this, features - fix1571);
             auto const baseFee = env.current()->fees().base;
             env.fund(XRP(5000), "alice", "bob", "carol");
             env.close();
@@ -1696,7 +1696,7 @@ struct Escrow_test : public beast::unit_test::suite
     }
 
     void
-    testCreateFinishFunctionPreflight()
+    testCreateFinishFunctionPreflight(FeatureBitset features)
     {
         testcase("Test preflight checks involving FinishFunction");
 
@@ -1712,7 +1712,7 @@ struct Escrow_test : public beast::unit_test::suite
 
         {
             // featureSmartEscrow disabled
-            Env env(*this, testable_amendments() - featureSmartEscrow);
+            Env env(*this, features - featureSmartEscrow);
             env.fund(XRP(5000), alice, carol);
             XRPAmount const txnFees = env.current()->fees().base + 1000;
             auto escrowCreate = escrow::create(alice, carol, XRP(1000));
@@ -1726,10 +1726,13 @@ struct Escrow_test : public beast::unit_test::suite
 
         {
             // FinishFunction > max length
-            Env env(*this, envconfig([](std::unique_ptr<Config> cfg) {
-                cfg->FEES.extension_size_limit = 10;  // 10 bytes
-                return cfg;
-            }));
+            Env env(
+                *this,
+                envconfig([](std::unique_ptr<Config> cfg) {
+                    cfg->FEES.extension_size_limit = 10;  // 10 bytes
+                    return cfg;
+                }),
+                features);
             XRPAmount const txnFees = env.current()->fees().base + 1000;
             // create escrow
             env.fund(XRP(5000), alice, carol);
@@ -1746,10 +1749,13 @@ struct Escrow_test : public beast::unit_test::suite
             env.close();
         }
 
-        Env env(*this, envconfig([](std::unique_ptr<Config> cfg) {
-            cfg->START_UP = Config::FRESH;
-            return cfg;
-        }));
+        Env env(
+            *this,
+            envconfig([](std::unique_ptr<Config> cfg) {
+                cfg->START_UP = Config::FRESH;
+                return cfg;
+            }),
+            features);
         XRPAmount const txnFees = env.current()->fees().base * 10 + 1000;
         // create escrow
         env.fund(XRP(5000), alice, carol);
@@ -1866,7 +1872,7 @@ struct Escrow_test : public beast::unit_test::suite
     }
 
     void
-    testFinishWasmFailures()
+    testFinishWasmFailures(FeatureBitset features)
     {
         testcase("EscrowFinish Smart Escrow failures");
 
@@ -1882,7 +1888,7 @@ struct Escrow_test : public beast::unit_test::suite
 
         {
             // featureSmartEscrow disabled
-            Env env(*this, testable_amendments() - featureSmartEscrow);
+            Env env(*this, features - featureSmartEscrow);
             env.fund(XRP(5000), alice, carol);
             XRPAmount const txnFees = env.current()->fees().base + 1000;
             env(escrow::finish(carol, alice, 1),
@@ -1894,10 +1900,13 @@ struct Escrow_test : public beast::unit_test::suite
 
         {
             // ComputationAllowance > max compute limit
-            Env env(*this, envconfig([](std::unique_ptr<Config> cfg) {
-                cfg->FEES.extension_compute_limit = 1'000;  // in gas
-                return cfg;
-            }));
+            Env env(
+                *this,
+                envconfig([](std::unique_ptr<Config> cfg) {
+                    cfg->FEES.extension_compute_limit = 1'000;  // in gas
+                    return cfg;
+                }),
+                features);
             env.fund(XRP(5000), alice, carol);
             // Run past the flag ledger so that a Fee change vote occurs and
             // updates FeeSettings. (It also activates all supported
@@ -1914,7 +1923,7 @@ struct Escrow_test : public beast::unit_test::suite
 
         {
             uint32_t const allowance = 5'664;
-            Env env(*this);
+            Env env(*this, features);
             env.fund(XRP(5000), alice, carol);
             auto const seq = env.seq(alice);
             XRPAmount const createFee = env.current()->fees().base + 1000;
@@ -1943,7 +1952,7 @@ struct Escrow_test : public beast::unit_test::suite
                 BEAST_EXPECT(txMeta->getFieldU32(sfGasUsed) == allowance);
         }
 
-        Env env(*this);
+        Env env(*this, features);
 
         // Run past the flag ledger so that a Fee change vote occurs and
         // updates FeeSettings. (It also activates all supported
@@ -2015,7 +2024,7 @@ struct Escrow_test : public beast::unit_test::suite
     }
 
     void
-    testFinishFunction()
+    testFinishFunction(FeatureBitset features)
     {
         testcase("Example escrow function");
 
@@ -2032,7 +2041,7 @@ struct Escrow_test : public beast::unit_test::suite
 
         {
             // basic FinishFunction situation
-            Env env(*this);
+            Env env(*this, features);
             // create escrow
             env.fund(XRP(5000), alice, carol);
             auto const seq = env.seq(alice);
@@ -2094,7 +2103,7 @@ struct Escrow_test : public beast::unit_test::suite
 
         {
             // FinishFunction + Condition
-            Env env(*this);
+            Env env(*this, features);
             env.fund(XRP(5000), alice, carol);
             BEAST_EXPECT((*env.le(alice))[sfOwnerCount] == 0);
             auto const seq = env.seq(alice);
@@ -2163,7 +2172,7 @@ struct Escrow_test : public beast::unit_test::suite
 
         {
             // FinishFunction + FinishAfter
-            Env env(*this);
+            Env env(*this, features);
             // create escrow
             env.fund(XRP(5000), alice, carol);
             auto const seq = env.seq(alice);
@@ -2211,7 +2220,7 @@ struct Escrow_test : public beast::unit_test::suite
 
         {
             // FinishFunction + FinishAfter #2
-            Env env(*this);
+            Env env(*this, features);
             // create escrow
             env.fund(XRP(5000), alice, carol);
             auto const seq = env.seq(alice);
@@ -2263,7 +2272,7 @@ struct Escrow_test : public beast::unit_test::suite
     }
 
     void
-    testAllHostFunctions()
+    testAllHostFunctions(FeatureBitset features)
     {
         testcase("Test all host functions");
 
@@ -2277,7 +2286,7 @@ struct Escrow_test : public beast::unit_test::suite
         Account const carol{"carol"};
 
         {
-            Env env(*this);
+            Env env(*this, features);
             // create escrow
             env.fund(XRP(5000), alice, carol);
             auto const seq = env.seq(alice);
@@ -2329,7 +2338,7 @@ struct Escrow_test : public beast::unit_test::suite
     }
 
     void
-    testKeyletHostFunctions()
+    testKeyletHostFunctions(FeatureBitset features)
     {
         testcase("Test all keylet host functions");
 
@@ -2419,13 +2428,13 @@ struct Escrow_test : public beast::unit_test::suite
         testConsequences(features);
         testEscrowWithTickets(features);
         testCredentials(features);
-        testCreateFinishFunctionPreflight();
-        testFinishWasmFailures();
-        testFinishFunction();
+        testCreateFinishFunctionPreflight(features);
+        testFinishWasmFailures(features);
+        testFinishFunction(features);
 
         // TODO: Update module with new host functions
-        testAllHostFunctions();
-        testKeyletHostFunctions();
+        testAllHostFunctions(features);
+        testKeyletHostFunctions(features);
     }
 
 public:

--- a/src/xrpld/app/tx/detail/ApplyContext.cpp
+++ b/src/xrpld/app/tx/detail/ApplyContext.cpp
@@ -59,6 +59,7 @@ ApplyContext::discard()
 std::optional<TxMeta>
 ApplyContext::apply(TER ter)
 {
+    view_->setGasUsed(gasUsed_);
     return view_->apply(
         base_, tx, ter, parentBatchId_, flags_ & tapDRY_RUN, journal);
 }

--- a/src/xrpld/app/tx/detail/ApplyContext.h
+++ b/src/xrpld/app/tx/detail/ApplyContext.h
@@ -108,9 +108,9 @@ public:
 
     /** Sets the gas used in the metadata */
     void
-    setGasUsed(std::uint32_t const& gasUsed)
+    setGasUsed(std::uint32_t const gasUsed)
     {
-        view_->setGasUsed(gasUsed);
+        gasUsed_ = gasUsed;
     }
 
     /** Discard changes and start fresh. */
@@ -164,6 +164,7 @@ private:
 
     // The ID of the batch transaction we are executing under, if seated.
     std::optional<uint256 const> parentBatchId_;
+    std::optional<std::uint32_t> gasUsed_;
 };
 
 }  // namespace ripple

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -1279,11 +1279,11 @@ EscrowFinish::doApply()
         auto re =
             runEscrowWasm(wasm, funcName, {}, &ledgerDataProvider, allowance);
         JLOG(j_.trace()) << "Escrow WASM ran";
-        ctx_.setGasUsed(static_cast<uint32_t>(re.value().cost));
         if (re.has_value())
         {
             auto reValue = re.value().result;
             // TODO: better error handling for this conversion
+            ctx_.setGasUsed(static_cast<uint32_t>(re.value().cost));
             JLOG(j_.debug()) << "WASM Success: " + std::to_string(reValue)
                              << ", cost: " << re.value().cost;
             if (!reValue)

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -1279,11 +1279,11 @@ EscrowFinish::doApply()
         auto re =
             runEscrowWasm(wasm, funcName, {}, &ledgerDataProvider, allowance);
         JLOG(j_.trace()) << "Escrow WASM ran";
+        ctx_.setGasUsed(static_cast<uint32_t>(re.value().cost));
         if (re.has_value())
         {
             auto reValue = re.value().result;
             // TODO: better error handling for this conversion
-            ctx_.setGasUsed(static_cast<uint32_t>(re.value().cost));
             JLOG(j_.debug()) << "WASM Success: " + std::to_string(reValue)
                              << ", cost: " << re.value().cost;
             if (!reValue)

--- a/src/xrpld/ledger/ApplyViewImpl.h
+++ b/src/xrpld/ledger/ApplyViewImpl.h
@@ -76,7 +76,7 @@ public:
     }
 
     void
-    setGasUsed(std::uint32_t const& gasUsed)
+    setGasUsed(std::optional<std::uint32_t> const gasUsed)
     {
         gasUsed_ = gasUsed;
     }


### PR DESCRIPTION
## High Level Overview of Change

This PR ensures that the `sfGasUsed` field is always included in the metadata, regardless of failure. It adds tests and cleans up some of the diff in `Escrow_test`.

### Context of Change

Found a minor annoyance in that a `tecWASM_REJECTED` error would result in the `GasUsed` metadata parameter not showing up.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan
Added tests in `Escrow_test`
