### PR TITLE
cache data instead of setting it in updateData

### DIFF
--- a/src/xrpld/app/misc/WasmHostFuncImpl.cpp
+++ b/src/xrpld/app/misc/WasmHostFuncImpl.cpp
@@ -417,11 +417,7 @@ WasmHostFunctionsImpl::updateData(Slice const& data)
     {
         return Unexpected(HostFunctionError::DATA_FIELD_TOO_LARGE);
     }
-    auto sle = ctx.view().peek(leKey);
-    if (!sle)
-        return Unexpected(HostFunctionError::LEDGER_OBJ_NOT_FOUND);
-    sle->setFieldVL(sfData, data);
-    ctx.view().update(sle);
+    data_ = data;
     return 0;
 }
 

--- a/src/xrpld/app/misc/WasmHostFuncImpl.h
+++ b/src/xrpld/app/misc/WasmHostFuncImpl.h
@@ -32,6 +32,7 @@ class WasmHostFunctionsImpl : public HostFunctions
 
     static int constexpr MAX_CACHE = 256;
     std::array<std::shared_ptr<SLE const>, MAX_CACHE> cache;
+    std::optional<Slice> data_;
 
     void const* rt_ = nullptr;
 
@@ -73,6 +74,12 @@ public:
     getJournal() override
     {
         return ctx.journal;
+    }
+
+    std::optional<Slice>
+    getData(Slice const& data)
+    {
+        return data_;
     }
 
     Expected<std::uint32_t, HostFunctionError>

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -1282,6 +1282,10 @@ EscrowFinish::doApply()
         if (re.has_value())
         {
             auto reValue = re.value().result;
+            if (auto const data = ledgerDataProvider.data; data.has_value())
+            {
+                slep->setFieldVL(sfData, data);
+            }
             // TODO: better error handling for this conversion
             ctx_.setGasUsed(static_cast<uint32_t>(re.value().cost));
             JLOG(j_.debug()) << "WASM Success: " + std::to_string(reValue)


### PR DESCRIPTION
## High Level Overview of Change

This PR switches the `updateData` function from actually updating the SLE in place to caching it and updating it after the escrow has finished executing. This will be much more efficient.

### Context of Change

More efficient host functions

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)


## Test Plan

CI passes.
