### PR TITLE
Setting up developer environment with specific XCode version

### DIFF
--- a/docs/build/environment.md
+++ b/docs/build/environment.md
@@ -55,7 +55,8 @@ clang --version
 
 ### Install Xcode Specific Version (Optional)
 
-If you develop other applications using XCode you might be consistantly updating to the newest version of Apple Clang. This will likely cause issues building rippled. You may want to install a specific version of Xcode:
+If you develop other applications using XCode you might be consistently updating to the newest version of Apple Clang. 
+This will likely cause issues building rippled. You may want to install a specific version of Xcode:
 
 1. **Download Xcode**
 

--- a/docs/build/environment.md
+++ b/docs/build/environment.md
@@ -53,6 +53,33 @@ minimum required (see [BUILD.md][]).
 clang --version
 ```
 
+### Install Xcode Specific Version (Optional)
+
+If you develop other applications using XCode you might be consistantly updating to the newest version of Apple Clang. This will likely cause issues building rippled. You may want to install a specific version of Xcode:
+
+1. **Download Xcode**
+
+   - Visit [Apple Developer Downloads](https://developer.apple.com/download/more/)
+   - Sign in with your Apple Developer account
+   - Search for an Xcode version that includes **Apple Clang (Expected Version)**
+   - Download the `.xip` file
+
+2. **Install and Configure Xcode**
+
+   ```bash
+   # Extract the .xip file and rename for version management
+   # Example: Xcode_16.2.app
+
+   # Move to Applications directory
+   sudo mv Xcode_16.2.app /Applications/
+
+   # Set as default toolchain (persistent)
+   sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+
+   # Set as environment variable (temporary)
+   export DEVELOPER_DIR=/Applications/Xcode_16.2.app/Contents/Developer
+   ```
+
 The command line developer tools should include Git too:
 
 ```


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

Added MacOS building instructions for specific versions of AppleClang

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

I develop mobile/desktop applications outside of ripple(d) and therefore I'm usually on the most recent version of XCode - AppleClang. This causes all kinds of issues when building, mostly when updating my OS or Xcode. 

I've always had these instructions for me and shared them privately. However they helped a few bootcamp developers and others install a specific version of AppleClang. 

Maybe they will help others too.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
