### PR TITLE
Upload Conan dependencies upon merge into develop

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -37,7 +37,7 @@ runs:
           --settings:all build_type=${{ inputs.configuration }} \
           ..
     - name: upload dependencies
-      if: ${{ env.CONAN_URL != '' && env.CONAN_LOGIN_USERNAME_XRPLF != '' && env.CONAN_PASSWORD_XRPLF != '' && github.ref_type == 'branch' && contains(fromJson('["develop", "release", "master"]'), github.ref_name) }}
+      if: ${{ env.CONAN_URL != '' && env.CONAN_LOGIN_USERNAME_XRPLF != '' && env.CONAN_PASSWORD_XRPLF != '' && github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
       shell: bash
       run: |
         echo "Logging into Conan remote 'xrplf' at ${CONAN_URL}."

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -15,7 +15,7 @@ runs:
           echo "Updated Conan remote 'xrplf' to ${CONAN_URL}."
         else
           conan remote add --index 0 xrplf ${CONAN_URL}
-          echo "Added new conan remote 'xrplf' at ${CONAN_URL}."
+          echo "Added new Conan remote 'xrplf' at ${CONAN_URL}."
         fi
     - name: list missing binaries
       id: binaries
@@ -36,3 +36,11 @@ runs:
           --options:host "&:xrpld=True" \
           --settings:all build_type=${{ inputs.configuration }} \
           ..
+    - name: upload dependencies
+      if: ${{ env.CONAN_URL != '' && env.CONAN_LOGIN_USERNAME_XRPLF != '' && env.CONAN_PASSWORD_XRPLF != '' && github.ref_type == 'branch' && contains(fromJson('["develop", "release", "master"]'), github.ref_name) }}
+      shell: bash
+      run: |
+        echo "Logging into Conan remote 'xrplf' at ${CONAN_URL}."
+        conan remote login xrplf "${{ env.CONAN_LOGIN_USERNAME_XRPLF }}" --password "${{ env.CONAN_PASSWORD_XRPLF }}"
+        echo "Uploading dependencies for configuration '${{ inputs.configuration }}'."
+        conan upload --all --confirm --remote xrplf . --settings build_type=${{ inputs.configuration }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,6 +19,8 @@ concurrency:
 # to pollute conan/profiles directory with settings which might not work for others
 env:
   CONAN_URL: https://conan.ripplex.io
+  CONAN_LOGIN_USERNAME_XRPLF: ${{ secrets.CONAN_USERNAME }}
+  CONAN_PASSWORD_XRPLF: ${{ secrets.CONAN_TOKEN }}
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,6 +20,8 @@ concurrency:
 # to pollute conan/profiles directory with settings which might not work for others
 env:
   CONAN_URL: https://conan.ripplex.io
+  CONAN_LOGIN_USERNAME_XRPLF: ${{ secrets.CONAN_USERNAME }}
+  CONAN_PASSWORD_XRPLF: ${{ secrets.CONAN_TOKEN }}
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{ os.cpu_count() }}
     core.upload:parallel={{ os.cpu_count() }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,6 +22,8 @@ concurrency:
 # to pollute conan/profiles directory with settings which might not work for others
 env:
   CONAN_URL: https://conan.ripplex.io
+  CONAN_LOGIN_USERNAME_XRPLF: ${{ secrets.CONAN_USERNAME }}
+  CONAN_PASSWORD_XRPLF: ${{ secrets.CONAN_TOKEN }}
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}


### PR DESCRIPTION
## High Level Overview of Change

This change uploads built Conan dependencies to the Conan remote upon merge into the `develop`branch.

### Context of Change

At the moment, whenever Conan dependencies change, we need to remember to manually push them to our Conan remote, so they are cached for future reuse. If we forget to do so, these changed dependencies need to be rebuilt over and over again, which can take a long time.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
