### PR TITLE
Switch Conan 1 commands to Conan 2 and fix credentials

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -34,6 +34,7 @@ runs:
     - name: upload dependencies
       #if: ${{ env.CONAN_REMOTE_URL != '' && env.CONAN_REMOTE_USERNAME != '' && env.CONAN_REMOTE_PASSWORD != '' && github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
       shell: bash
+      working-directory: ${{ env.build_dir }}
       run: |
         echo "Logging into Conan remote 'xrplf' at ${{ env.CONAN_REMOTE_URL }}."
         conan remote login xrplf "${{ env.CONAN_REMOTE_USERNAME }}" --password "${{ env.CONAN_REMOTE_PASSWORD }}"

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -32,7 +32,7 @@ runs:
           --settings:all build_type=${{ inputs.configuration }} \
           --format=json .. > build.json
     - name: upload dependencies
-      #if: ${{ env.CONAN_REMOTE_URL != '' && env.CONAN_REMOTE_USERNAME != '' && env.CONAN_REMOTE_PASSWORD != '' && github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
+      if: ${{ env.CONAN_REMOTE_URL != '' && env.CONAN_REMOTE_USERNAME != '' && env.CONAN_REMOTE_PASSWORD != '' && github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
       shell: bash
       working-directory: ${{ env.build_dir }}
       run: |

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -3,7 +3,7 @@ inputs:
   configuration:
     required: true
 # Implicit inputs are the environment variables `build_dir`, CONAN_REMOTE_URL,
-# CONAN_REMOTE_USERNAME, and CONAN_REMOTE_PASSWORD. The latter three are only
+# CONAN_REMOTE_USERNAME, and CONAN_REMOTE_PASSWORD. The latter two are only
 # used to upload newly built dependencies to the Conan remote.
 runs:
   using: composite
@@ -27,14 +27,12 @@ runs:
           --options:host "&:tests=True" \
           --options:host "&:xrpld=True" \
           --settings:all build_type=${{ inputs.configuration }} \
-          --format=json .. > build.json
+          ..
     - name: upload dependencies
       if: ${{ env.CONAN_REMOTE_URL != '' && env.CONAN_REMOTE_USERNAME != '' && env.CONAN_REMOTE_PASSWORD != '' && github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
       shell: bash
-      working-directory: ${{ env.build_dir }}
       run: |
         echo "Logging into Conan remote 'xrplf' at ${{ env.CONAN_REMOTE_URL }}."
         conan remote login xrplf "${{ env.CONAN_REMOTE_USERNAME }}" --password "${{ env.CONAN_REMOTE_PASSWORD }}"
-        echo "Uploading missing dependencies."
-        conan list --graph=build.json --graph-binaries=build --format=json > pkgs.json
-        conan upload --list=pkgs.json --confirm --check --remote xrplf
+        echo "Uploading dependencies."
+        conan upload '*' --confirm --check --remote xrplf

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -2,45 +2,41 @@ name: dependencies
 inputs:
   configuration:
     required: true
-# An implicit input is the environment variable `build_dir`.
+# Implicit inputs are the environment variables `build_dir`, CONAN_REMOTE_URL,
+# CONAN_REMOTE_USERNAME, and CONAN_REMOTE_PASSWORD. The latter three are only
+# used to upload newly built dependencies to the Conan remote.
 runs:
   using: composite
   steps:
     - name: add Conan remote
-      if: env.CONAN_URL != ''
+      if: env.CONAN_REMOTE_URL != ''
       shell: bash
       run: |
         if conan remote list | grep -q 'xrplf'; then
-          conan remote update --index 0 --url ${CONAN_URL} xrplf
-          echo "Updated Conan remote 'xrplf' to ${CONAN_URL}."
+          conan remote update --index 0 --url ${{ env.CONAN_REMOTE_URL }} xrplf
+          echo "Updated Conan remote 'xrplf' to ${{ env.CONAN_REMOTE_URL }}."
         else
-          conan remote add --index 0 xrplf ${CONAN_URL}
-          echo "Added new Conan remote 'xrplf' at ${CONAN_URL}."
+          conan remote add --index 0 xrplf ${{ env.CONAN_REMOTE_URL }}
+          echo "Added new Conan remote 'xrplf' at ${{ env.CONAN_REMOTE_URL }}."
         fi
-    - name: list missing binaries
-      id: binaries
-      shell: bash
-      # Print the list of dependencies that would need to be built locally.
-      # A non-empty list means we have "failed" to cache binaries remotely.
-      run: |
-        echo missing=$(conan info . --build missing --settings build_type=${{ inputs.configuration }} --json 2>/dev/null  | grep '^\[') | tee ${GITHUB_OUTPUT}
     - name: install dependencies
       shell: bash
       run: |
-        mkdir ${build_dir}
-        cd ${build_dir}
+        mkdir ${{ env.build_dir }}
+        cd ${{ env.build_dir }}
         conan install \
           --output-folder . \
           --build missing \
           --options:host "&:tests=True" \
           --options:host "&:xrpld=True" \
           --settings:all build_type=${{ inputs.configuration }} \
-          ..
+          --format=json .. > build.json
     - name: upload dependencies
-      if: ${{ env.CONAN_URL != '' && env.CONAN_LOGIN_USERNAME_XRPLF != '' && env.CONAN_PASSWORD_XRPLF != '' && github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
+      #if: ${{ env.CONAN_REMOTE_URL != '' && env.CONAN_REMOTE_USERNAME != '' && env.CONAN_REMOTE_PASSWORD != '' && github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
       shell: bash
       run: |
-        echo "Logging into Conan remote 'xrplf' at ${CONAN_URL}."
-        conan remote login xrplf "${{ env.CONAN_LOGIN_USERNAME_XRPLF }}" --password "${{ env.CONAN_PASSWORD_XRPLF }}"
-        echo "Uploading dependencies for configuration '${{ inputs.configuration }}'."
-        conan upload --all --confirm --remote xrplf . --settings build_type=${{ inputs.configuration }}
+        echo "Logging into Conan remote 'xrplf' at ${{ env.CONAN_REMOTE_URL }}."
+        conan remote login xrplf "${{ env.CONAN_REMOTE_USERNAME }}" --password "${{ env.CONAN_REMOTE_PASSWORD }}"
+        echo "Uploading missing dependencies."
+        conan list --graph=build.json --graph-binaries=build --format=json > pkgs.json
+        conan upload --list=pkgs.json --confirm --check --remote xrplf

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -12,9 +12,9 @@ runs:
       if: ${{ env.CONAN_REMOTE_URL != '' }}
       shell: bash
       run: |
-        conan remote list
+        echo "Adding Conan remote 'xrplf' at ${{ env.CONAN_REMOTE_URL }}."
         conan remote add --index 0 --force xrplf ${{ env.CONAN_REMOTE_URL }}
-        echo "Added Conan remote 'xrplf' at ${{ env.CONAN_REMOTE_URL }}."
+        echo "Listing Conan remotes."
         conan remote list
     - name: install dependencies
       shell: bash

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -9,16 +9,13 @@ runs:
   using: composite
   steps:
     - name: add Conan remote
-      if: env.CONAN_REMOTE_URL != ''
+      if: ${{ env.CONAN_REMOTE_URL != '' }}
       shell: bash
       run: |
-        if conan remote list | grep -q 'xrplf'; then
-          conan remote update --index 0 --url ${{ env.CONAN_REMOTE_URL }} xrplf
-          echo "Updated Conan remote 'xrplf' to ${{ env.CONAN_REMOTE_URL }}."
-        else
-          conan remote add --index 0 xrplf ${{ env.CONAN_REMOTE_URL }}
-          echo "Added new Conan remote 'xrplf' at ${{ env.CONAN_REMOTE_URL }}."
-        fi
+        conan remote list
+        conan remote add --index 0 --force xrplf ${{ env.CONAN_REMOTE_URL }}
+        echo "Added Conan remote 'xrplf' at ${{ env.CONAN_REMOTE_URL }}."
+        conan remote list
     - name: install dependencies
       shell: bash
       run: |

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: install dependencies
       shell: bash
       run: |
-        mkdir ${{ env.build_dir }}
+        mkdir -p ${{ env.build_dir }}
         cd ${{ env.build_dir }}
         conan install \
           --output-folder . \

--- a/.github/workflows/libxrpl.yml
+++ b/.github/workflows/libxrpl.yml
@@ -46,10 +46,10 @@ jobs:
       - name: Add Conan remote
         shell: bash
         run: |
+          echo "Adding Conan remote 'xrplf' at ${{ env.CONAN_REMOTE_URL }}."
+          conan remote add xrplf ${{ env.CONAN_REMOTE_URL }} --insert 0 --force 
+          echo "Listing Conan remotes."
           conan remote list
-          conan remote remove xrplf || true
-          # Do not quote the URL. An empty string will be accepted (with a non-fatal warning), but a missing argument will not.
-          conan remote add xrplf ${{ env.CONAN_REMOTE_URL }} --insert 0
       - name: Parse new version
         id: version
         shell: bash

--- a/.github/workflows/libxrpl.yml
+++ b/.github/workflows/libxrpl.yml
@@ -1,8 +1,8 @@
 name: Check libXRPL compatibility with Clio
 env:
-  CONAN_URL: https://conan.ripplex.io
-  CONAN_LOGIN_USERNAME_XRPLF: ${{ secrets.CONAN_USERNAME }}
-  CONAN_PASSWORD_XRPLF: ${{ secrets.CONAN_TOKEN }}
+  CONAN_REMOTE_URL: ${{ vars.CONAN_REMOTE_URL }}
+  CONAN_LOGIN_USERNAME_XRPLF: ${{ secrets.CONAN_REMOTE_USERNAME }}
+  CONAN_PASSWORD_XRPLF: ${{ secrets.CONAN_REMOTE_PASSWORD }}
 on:
   pull_request:
     paths:
@@ -49,7 +49,7 @@ jobs:
           conan remote list
           conan remote remove xrplf || true
           # Do not quote the URL. An empty string will be accepted (with a non-fatal warning), but a missing argument will not.
-          conan remote add xrplf ${{ env.CONAN_URL }} --insert 0
+          conan remote add xrplf ${{ env.CONAN_REMOTE_URL }} --insert 0
       - name: Parse new version
         id: version
         shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,9 +18,12 @@ concurrency:
 # This part of Conan configuration is specific to this workflow only; we do not want
 # to pollute conan/profiles directory with settings which might not work for others
 env:
-  CONAN_URL: https://conan.ripplex.io
-  CONAN_LOGIN_USERNAME_XRPLF: ${{ secrets.CONAN_USERNAME }}
-  CONAN_PASSWORD_XRPLF: ${{ secrets.CONAN_TOKEN }}
+  CONAN_REMOTE_URL: ${{ vars.CONAN_REMOTE_URL }}
+  CONAN_REMOTE_USERNAME: ${{ secrets.CONAN_REMOTE_USERNAME }}
+  CONAN_REMOTE_PASSWORD: ${{ secrets.CONAN_REMOTE_PASSWORD }}
+  # This part of the Conan configuration is specific to this workflow only; we
+  # do not want to pollute the 'conan/profiles' directory with settings that
+  # might not work for other workflows.
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,12 +16,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# This part of Conan configuration is specific to this workflow only; we do not want
-# to pollute conan/profiles directory with settings which might not work for others
 env:
-  CONAN_URL: https://conan.ripplex.io
-  CONAN_LOGIN_USERNAME_XRPLF: ${{ secrets.CONAN_USERNAME }}
-  CONAN_PASSWORD_XRPLF: ${{ secrets.CONAN_TOKEN }}
+  CONAN_REMOTE_URL: ${{ vars.CONAN_REMOTE_URL }}
+  CONAN_REMOTE_USERNAME: ${{ secrets.CONAN_REMOTE_USERNAME }}
+  CONAN_REMOTE_PASSWORD: ${{ secrets.CONAN_REMOTE_PASSWORD }}
+  # This part of the Conan configuration is specific to this workflow only; we
+  # do not want to pollute the 'conan/profiles' directory with settings that
+  # might not work for other workflows.
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{ os.cpu_count() }}
     core.upload:parallel={{ os.cpu_count() }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,12 +18,13 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-# This part of Conan configuration is specific to this workflow only; we do not want
-# to pollute conan/profiles directory with settings which might not work for others
 env:
-  CONAN_URL: https://conan.ripplex.io
-  CONAN_LOGIN_USERNAME_XRPLF: ${{ secrets.CONAN_USERNAME }}
-  CONAN_PASSWORD_XRPLF: ${{ secrets.CONAN_TOKEN }}
+  CONAN_REMOTE_URL: ${{ vars.CONAN_REMOTE_URL }}
+  CONAN_REMOTE_USERNAME: ${{ secrets.CONAN_REMOTE_USERNAME }}
+  CONAN_REMOTE_PASSWORD: ${{ secrets.CONAN_REMOTE_PASSWORD }}
+  # This part of the Conan configuration is specific to this workflow only; we
+  # do not want to pollute the 'conan/profiles' directory with settings that
+  # might not work for other workflows.
   CONAN_GLOBAL_CONF: |
     core.download:parallel={{os.cpu_count()}}
     core.upload:parallel={{os.cpu_count()}}


### PR DESCRIPTION
## High Level Overview of Change

This change updates some incorrect Conan commands for Conan 2. This change further uses the org-level variables and secrets rather than the repo-level ones.

### Context of Change

Some of the Conan commands were still for 1.x. This change updates them to Conan 2.x. As some flags do not exist in Conan 2, such as `--settings build_type=[configuration]`, the commands have been adjusted accordingly.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
