### PR TITLE
Fix: Don't flag consensus as stalled prematurely (2.5.1 hotfix)

### DIFF
--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.5.0"
+char const* const versionString = "2.5.1"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/xrpld/app/consensus/RCLValidations.cpp
+++ b/src/xrpld/app/consensus/RCLValidations.cpp
@@ -136,7 +136,7 @@ RCLValidationsAdaptor::acquire(LedgerHash const& hash)
 
     if (!ledger)
     {
-        JLOG(j_.debug())
+        JLOG(j_.warn())
             << "Need validated ledger for preferred ledger analysis " << hash;
 
         Application* pApp = &app_;

--- a/src/xrpld/consensus/Consensus.cpp
+++ b/src/xrpld/consensus/Consensus.cpp
@@ -139,11 +139,11 @@ checkConsensusReached(
         return false;
     }
 
-    // We only get stalled when every disputed transaction unequivocally has 80%
-    // (minConsensusPct) agreement, either for or against. That is: either under
-    // 20% or over 80% consensus (repectively "nay" or "yay"). This prevents
-    // manipulation by a minority of byzantine peers of which transactions make
-    // the cut to get into the ledger.
+    // We only get stalled when there are disputed transactions and all of them
+    // unequivocally have 80% (minConsensusPct) agreement, either for or
+    // against. That is: either under 20% or over 80% consensus (repectively
+    // "nay" or "yay"). This prevents manipulation by a minority of byzantine
+    // peers of which transactions make the cut to get into the ledger.
     if (stalled)
     {
         CLOG(clog) << "consensus stalled. ";

--- a/src/xrpld/consensus/Consensus.h
+++ b/src/xrpld/consensus/Consensus.h
@@ -84,8 +84,8 @@ shouldCloseLedger(
                             agree
     @param stalled the network appears to be stalled, where
            neither we nor our peers have changed their vote on any disputes in a
-           while. This is undesirable, and will cause us to end consensus
-           without 80% agreement.
+           while. This is undesirable, and should be rare, and will cause us to
+           end consensus without 80% agreement.
     @param parms            Consensus constant parameters
     @param proposing        whether we should count ourselves
     @param j                journal for logging
@@ -1712,15 +1712,29 @@ Consensus<Adaptor>::haveConsensus(
                      << ", disagree=" << disagree;
 
     ConsensusParms const& parms = adaptor_.parms();
-    // Stalling is BAD
+    // Stalling is BAD. It means that we have a consensus on the close time, so
+    // peers are talking, but we have disputed transactions that peers are
+    // unable or unwilling to come to agreement on one way or the other.
     bool const stalled = haveCloseTimeConsensus_ &&
+        !result_->disputes.empty() &&
         std::ranges::all_of(result_->disputes,
-                            [this, &parms](auto const& dispute) {
+                            [this, &parms, &clog](auto const& dispute) {
                                 return dispute.second.stalled(
                                     parms,
                                     mode_.get() == ConsensusMode::proposing,
-                                    peerUnchangedCounter_);
+                                    peerUnchangedCounter_,
+                                    j_,
+                                    clog);
                             });
+    if (stalled)
+    {
+        std::stringstream ss;
+        ss << "Consensus detects as stalled with " << (agree + disagree) << "/"
+           << prevProposers_ << " proposers, and " << result_->disputes.size()
+           << " stalled disputed transactions.";
+        JLOG(j_.error()) << ss.str();
+        CLOG(clog) << ss.str();
+    }
 
     // Determine if we actually have consensus or not
     result_->state = checkConsensus(


### PR DESCRIPTION
## High Level Overview of Change

This is a duplicate of the changes from #5627, isolated against the `master` branch for testing purposes (and in case we need to release it as a hotfix).

> Fix stalled consensus detection to prevent false positives in situations where there are no disputed transactions.

### Context of Change

> Stalled consensus detection was added to 2.5.0 in response to a network consensus halt that caused a round to run for over an hour. See https://github.com/XRPLF/rippled/pull/5277 and https://github.com/XRPLF/rippled/pull/5318.
>
> It has a flaw that makes it very easy to have false positives. Those false positives are usually mitigated by other checks that prevent them from having an effect, but there have been several instances of validators "running ahead" because there are circumstances where the other checks are "successful", allowing the stall state to be checked.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
