### PR TITLE
Add -Wno-deprecated-declarations for Clang only

### DIFF
--- a/cmake/RippledCompiler.cmake
+++ b/cmake/RippledCompiler.cmake
@@ -94,6 +94,7 @@ else ()
     INTERFACE
       -Wall
       -Wdeprecated
+      $<$<BOOL:${is_clang}>:-Wno-deprecated-declarations>
       $<$<BOOL:${wextra}>:-Wextra -Wno-unused-parameter>
       $<$<BOOL:${werr}>:-Werror>
       -fstack-protector

--- a/include/xrpl/basics/Expected.h
+++ b/include/xrpl/basics/Expected.h
@@ -22,17 +22,7 @@
 
 #include <xrpl/basics/contract.h>
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
 #include <boost/outcome.hpp>
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
 
 #include <stdexcept>
 

--- a/include/xrpl/beast/hash/hash_append.h
+++ b/include/xrpl/beast/hash/hash_append.h
@@ -24,35 +24,10 @@
 #include <boost/container/flat_set.hpp>
 #include <boost/endian/conversion.hpp>
 
-/*
-
-Workaround for overzealous clang warning, which trips on libstdc++ headers
-
-  In file included from
-  /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_algo.h:61:
-  /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_tempbuf.h:263:8:
-  error: 'get_temporary_buffer<std::pair<ripple::Quality, const
-  std::vector<std::unique_ptr<ripple::Step>> *>>' is deprecated
-  [-Werror,-Wdeprecated-declarations] 263 |
-  std::get_temporary_buffer<value_type>(_M_original_len));
-       ^
-*/
-
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
-#include <functional>
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
-
 #include <array>
 #include <chrono>
 #include <cstring>
+#include <functional>
 #include <memory>
 #include <string>
 #include <system_error>


### PR DESCRIPTION
## High Level Overview of Change

This change adds `-Wno-deprecated-declarations` for Clang only (not for gcc) builds in `cmake/RippledCompiler.cmake`.

### Context of Change

There is tension/incompatibility between clang and libstdc++ (which is part of gcc). Perhaps the problem is limited to the version of libstdc++ which comes with gcc-12, but installing a newer version using another distro such as Debian Bookworm would be tricky and probably not a good workaround. The way the workaround in `hash_append.h` and `contract.h` works is basically by disabling a warning around a standard C++ (libstdc++) include, and that workaround has a problem that it does not scale - it may need to be applied in different locations, especially if you have a Unity build.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
