### PR TITLE
fix: Adjust the CI workflows

### DIFF
--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -55,17 +55,17 @@ runs:
         cd ${{ inputs.build_dir }}
         conan install \
           --output-folder . \
-          --build ${{ inputs.force_build && '"*"' || 'missing' }} \
+          --build ${{ inputs.force_build == 'true' && '"*"' || 'missing' }} \
           --options:host '&:tests=True' \
           --options:host '&:xrpld=True' \
           --settings:all build_type=${{ inputs.build_type }} \
           --format=json ..
     - name: Upload Conan dependencies
-      if: ${{ inputs.conan_remote_username && inputs.conan_remote_password }}
+      if: ${{ inputs.conan_remote_username != '' && inputs.conan_remote_password != '' }}
       shell: bash
       working-directory: ${{ inputs.build_dir }}
       run: |
         echo "Logging into Conan remote '${{ inputs.conan_remote_name }}' at ${{ inputs.conan_remote_url }}."
         conan remote login ${{ inputs.conan_remote_name }} "${{ inputs.conan_remote_username }}" --password "${{ inputs.conan_remote_password }}"
         echo 'Uploading dependencies.'
-        conan upload '*' --confirm --check ${{ inputs.force_upload && '--force' || '' }} --remote=${{ inputs.conan_remote_name }}
+        conan upload '*' --confirm --check ${{ inputs.force_upload == 'true' && '--force' || '' }} --remote=${{ inputs.conan_remote_name }}

--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -9,12 +9,9 @@ inputs:
     required: true
     type: string
   build_type:
-    description: 'The build type to use.'
+    description: 'The build type to use ("Debug", "Release").'
     required: true
-    type: choice
-    options:
-      - 'Debug'
-      - 'Release'
+    type: string
   conan_remote_name:
     description: 'The name of the Conan remote to use.'
     required: true
@@ -34,20 +31,14 @@ inputs:
     type: string
     default: ''
   force_build:
-    description: 'Force building of all dependencies.'
+    description: 'Force building of all dependencies. ("yes", "no").'
     required: false
-    type: choice
-    options:
-      - 'yes'
-      - 'no'
+    type: string
     default: 'no'
   force_upload:
-    description: 'Force uploading of all dependencies.'
+    description: 'Force uploading of all dependencies. ("yes", "no").'
     required: false
-    type: choice
-    options:
-      - 'yes'
-      - 'no'
+    type: string
     default: 'no'
 
 runs:

--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -7,38 +7,30 @@ inputs:
   build_dir:
     description: 'The directory where to build.'
     required: true
-    type: string
   build_type:
     description: 'The build type to use ("Debug", "Release").'
     required: true
-    type: string
   conan_remote_name:
     description: 'The name of the Conan remote to use.'
     required: true
-    type: string
   conan_remote_url:
     description: 'The URL of the Conan endpoint to use.'
     required: true
-    type: string
   conan_remote_username:
     description: 'The username for logging into the Conan remote. If not provided, the dependencies will not be uploaded.'
     required: false
-    type: string
     default: ''
   conan_remote_password:
     description: 'The password for logging into the Conan remote. If not provided, the dependencies will not be uploaded.'
     required: false
-    type: string
     default: ''
   force_build:
-    description: 'Force building of all dependencies. ("yes", "no").'
+    description: 'Force building of all dependencies ("true", "false").'
     required: false
-    type: string
     default: 'no'
   force_upload:
-    description: 'Force uploading of all dependencies. ("yes", "no").'
+    description: 'Force uploading of all dependencies ("true", "false").'
     required: false
-    type: string
     default: 'no'
 
 runs:
@@ -52,7 +44,7 @@ runs:
         cd ${{ inputs.build_dir }}
         conan install \
           --output-folder . \
-          --build ${{ inputs.force_build == 'yes' && '"*"' || 'missing' }} \
+          --build ${{ inputs.force_build == 'true' && '"*"' || 'missing' }} \
           --options:host '&:tests=True' \
           --options:host '&:xrpld=True' \
           --settings:all build_type=${{ inputs.build_type }} \
@@ -65,4 +57,4 @@ runs:
         echo "Logging into Conan remote '${{ inputs.conan_remote_name }}' at ${{ inputs.conan_remote_url }}."
         conan remote login ${{ inputs.conan_remote_name }} "${{ inputs.conan_remote_username }}" --password "${{ inputs.conan_remote_password }}"
         echo 'Uploading dependencies.'
-        conan upload '*' --confirm --check ${{ inputs.force_upload == 'yes' && '--force' || '' }} --remote=${{ inputs.conan_remote_name }}
+        conan upload '*' --confirm --check ${{ inputs.force_upload == 'true' && '--force' || '' }} --remote=${{ inputs.conan_remote_name }}

--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -3,6 +3,8 @@
 # provided.
 name: Build Conan dependencies
 
+# Note that actions do not support 'type' and all inputs are strings, see
+# https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#inputs.
 inputs:
   build_dir:
     description: 'The directory where to build.'

--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -55,17 +55,17 @@ runs:
         cd ${{ inputs.build_dir }}
         conan install \
           --output-folder . \
-          --build ${{ inputs.force_build == 'true' && '"*"' || 'missing' }} \
+          --build ${{ inputs.force_build && '"*"' || 'missing' }} \
           --options:host '&:tests=True' \
           --options:host '&:xrpld=True' \
           --settings:all build_type=${{ inputs.build_type }} \
           --format=json ..
     - name: Upload Conan dependencies
-      if: ${{ inputs.conan_remote_username != '' && inputs.conan_remote_password != '' }}
+      if: ${{ inputs.conan_remote_username && inputs.conan_remote_password }}
       shell: bash
       working-directory: ${{ inputs.build_dir }}
       run: |
         echo "Logging into Conan remote '${{ inputs.conan_remote_name }}' at ${{ inputs.conan_remote_url }}."
         conan remote login ${{ inputs.conan_remote_name }} "${{ inputs.conan_remote_username }}" --password "${{ inputs.conan_remote_password }}"
         echo 'Uploading dependencies.'
-        conan upload '*' --confirm --check ${{ inputs.force_upload == 'true' && '--force' || '' }} --remote=${{ inputs.conan_remote_name }}
+        conan upload '*' --confirm --check ${{ inputs.force_upload && '--force' || '' }} --remote=${{ inputs.conan_remote_name }}

--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -36,13 +36,19 @@ inputs:
   force_build:
     description: 'Force building of all dependencies.'
     required: false
-    type: boolean
-    default: false
+    type: choice
+    options:
+      - 'yes'
+      - 'no'
+    default: 'no'
   force_upload:
     description: 'Force uploading of all dependencies.'
     required: false
-    type: boolean
-    default: false
+    type: choice
+    options:
+      - 'yes'
+      - 'no'
+    default: 'no'
 
 runs:
   using: composite
@@ -55,17 +61,17 @@ runs:
         cd ${{ inputs.build_dir }}
         conan install \
           --output-folder . \
-          --build ${{ inputs.force_build && '"*"' || 'missing' }} \
+          --build ${{ inputs.force_build == 'yes' && '"*"' || 'missing' }} \
           --options:host '&:tests=True' \
           --options:host '&:xrpld=True' \
           --settings:all build_type=${{ inputs.build_type }} \
           --format=json ..
     - name: Upload Conan dependencies
-      if: ${{ inputs.conan_remote_username && inputs.conan_remote_password }}
+      if: ${{ inputs.conan_remote_username != '' && inputs.conan_remote_password != '' }}
       shell: bash
       working-directory: ${{ inputs.build_dir }}
       run: |
         echo "Logging into Conan remote '${{ inputs.conan_remote_name }}' at ${{ inputs.conan_remote_url }}."
         conan remote login ${{ inputs.conan_remote_name }} "${{ inputs.conan_remote_username }}" --password "${{ inputs.conan_remote_password }}"
         echo 'Uploading dependencies.'
-        conan upload '*' --confirm --check ${{ inputs.force_upload && '--force' || '' }} --remote=${{ inputs.conan_remote_name }}
+        conan upload '*' --confirm --check ${{ inputs.force_upload == 'yes' && '--force' || '' }} --remote=${{ inputs.conan_remote_name }}

--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -27,11 +27,11 @@ inputs:
   force_build:
     description: 'Force building of all dependencies ("true", "false").'
     required: false
-    default: 'no'
+    default: 'false'
   force_upload:
     description: 'Force uploading of all dependencies ("true", "false").'
     required: false
-    default: 'no'
+    default: 'false'
 
 runs:
   using: composite

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -2,6 +2,8 @@
 # already been installed (see the build-deps action).
 name: Build and Test
 
+# Note that actions do not support 'type' and all inputs are strings, see
+# https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#inputs.
 inputs:
   build_dir:
     description: 'The directory where to build.'

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -9,7 +9,7 @@ inputs:
   build_only:
     description: 'Whether to only build or to build and test the code ("true", "false").'
     required: false
-    default: 'no'
+    default: 'false'
   build_type:
     description: 'The build type to use ("Debug", "Release").'
     required: true

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -7,13 +7,15 @@ inputs:
     description: 'The directory where to build.'
     required: true
     type: string
+  build_only:
+    description: 'Whether to only build or build and test the code ("yes", "no").'
+    required: false
+    type: string
+    default: 'no'
   build_type:
-    description: 'The build type to use.'
+    description: 'The build type to use ("Debug", "Release").'
     required: true
-    type: choice
-    options:
-      - 'Debug'
-      - 'Release'
+    type: string
   cmake_args:
     description: 'Additional arguments to pass to CMake.'
     required: false
@@ -82,7 +84,7 @@ runs:
         echo 'Verifying presence of instrumentation.'
         ./rippled --version | grep libvoidstar
     - name: Test the binary
-      if: ${{ inputs.cmake_target != 'coverage' }}
+      if: ${{ inputs.build_only == 'no' }}
       shell: bash
       working-directory: ${{ inputs.build_dir }}/${{ inputs.os == 'windows' && inputs.build_type || '' }}
       run: |

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -6,38 +6,27 @@ inputs:
   build_dir:
     description: 'The directory where to build.'
     required: true
-    type: string
   build_only:
-    description: 'Whether to only build or build and test the code ("yes", "no").'
+    description: 'Whether to only build or to build and test the code ("true", "false").'
     required: false
-    type: string
     default: 'no'
   build_type:
     description: 'The build type to use ("Debug", "Release").'
     required: true
-    type: string
   cmake_args:
     description: 'Additional arguments to pass to CMake.'
     required: false
-    type: string
     default: ''
   cmake_target:
     description: 'The CMake target to build.'
     required: true
-    type: string
   codecov_token:
     description: 'The Codecov token to use for uploading coverage reports.'
     required: false
-    type: string
     default: ''
   os:
     description: 'The operating system to use for the build ("linux", "macos", "windows").'
     required: true
-    type: choice
-    options:
-      - 'linux'
-      - 'macos'
-      - 'windows'
 
 runs:
   using: composite
@@ -84,7 +73,7 @@ runs:
         echo 'Verifying presence of instrumentation.'
         ./rippled --version | grep libvoidstar
     - name: Test the binary
-      if: ${{ inputs.build_only == 'no' }}
+      if: ${{ inputs.build_only == 'true' }}
       shell: bash
       working-directory: ${{ inputs.build_dir }}/${{ inputs.os == 'windows' && inputs.build_type || '' }}
       run: |

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -29,7 +29,7 @@ inputs:
     type: string
     default: ''
   os:
-    description: 'The operating system to use for the build (linux, macos, or windows).'
+    description: 'The operating system to use for the build ("linux", "macos", "windows").'
     required: true
     type: choice
     options:

--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -141,7 +141,7 @@ def generate_strategy_matrix(all: bool, architecture: list[dict], os: list[dict]
             'architecture': architecture,
             'os': os,
             'build_type': build_type,
-            'build_only': 'yes' if build_only else 'no',
+            'build_only': 'true' if build_only else 'false',
             'cmake_args': cmake_args,
             'cmake_target': cmake_target,
             'config_name': config_name,

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -101,9 +101,11 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.13
-      - name: Install Conan (Windows)
+      - name: Install build tools (Windows)
         if: ${{ inputs.os == 'windows' }}
-        run: pip install wheel conan
+        run: |
+          echo 'Installing build tools.'
+          pip install wheel conan
       - name: Check configuration (Windows)
         if: ${{ inputs.os == 'windows' }}
         run: |
@@ -115,6 +117,21 @@ jobs:
 
           echo 'Checking Conan version.'
           conan --version
+      - name: Install build tools (MacOS)
+        if: ${{ inputs.os == 'macos' }}
+        run: |
+          echo 'Installing build tools.'
+          for TOOL in cmake conan ninja nproc; do
+            if which ${TOOL} > /dev/null 2>&1; then
+              echo "The ${TOOL} executable already exists, skipping installation."
+            else
+              echo "The ${TOOL} executable does not exist, installing."
+              if [ "${TOOL}" = 'nproc' ]; then
+                TOOL='coreutils'
+              fi
+              brew install ${TOOL}
+            fi
+          done
       - name: Check configuration (Linux and MacOS)
         if: ${{ inputs.os == 'linux' || inputs.os == 'macos' }}
         run: |
@@ -135,6 +152,9 @@ jobs:
 
           echo 'Checking Ninja version.'
           ninja --version
+
+          echo 'Checking nproc version.'
+          nproc --version
       - name: Set up Conan home directory (MacOS)
         if: ${{ inputs.os == 'macos' }}
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,10 +2,9 @@
 name: Build and test
 
 # This workflow can only be triggered by other workflows. Note that the
-# workflow_call event does not support the 'choice' input type (see
-# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_callinputsinput_idtype),
-# so we use 'string' instead; in contrast, actions do support 'choice'. Also
-# note that the 'boolean' input type is troublesome, so we use 'string' instead.
+# workflow_call event does not support the 'choice' input type, see
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_callinputsinput_idtype,
+# so we use 'string' instead.
 on:
   workflow_call:
     inputs:
@@ -126,7 +125,7 @@ jobs:
         if: ${{ inputs.os == 'macos' }}
         run: |
           echo 'Installing build tools.'
-          brew install cmake conan ninja nproc
+          brew install cmake conan ninja coreutils
       - name: Check configuration (Linux and MacOS)
         if: ${{ inputs.os == 'linux' || inputs.os == 'macos' }}
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,12 +25,12 @@ on:
         description: 'Force building of all dependencies ("yes", "no").'
         required: false
         type: string
-        default: false
+        default: 'no'
       dependencies_force_upload:
         description: 'Force uploading of all dependencies ("yes", "no").'
         required: false
         type: string
-        default: false
+        default: 'no'
       os:
         description: 'The operating system to use for the build ("linux", "macos", "windows").'
         required: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Generate strategy matrix
         working-directory: .github/scripts/strategy-matrix
         id: generate
-        run: python generate.py ${{ inputs.strategy_matrix_all == 'true' && '--all' || '' }} --config=${{ inputs.os }}.json >> "${GITHUB_OUTPUT}"
+        run: python generate.py ${{ inputs.strategy_matrix_all && '--all' || '' }} --config=${{ inputs.os }}.json >> "${GITHUB_OUTPUT}"
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,15 +23,15 @@ on:
         required: true
         type: string
       dependencies_force_build:
-        description: 'Force building of all dependencies ("yes", "no").'
+        description: 'Force building of all dependencies.'
         required: false
-        type: string
-        default: 'no'
+        type: boolean
+        default: false
       dependencies_force_upload:
-        description: 'Force uploading of all dependencies ("yes", "no").'
+        description: 'Force uploading of all dependencies.'
         required: false
-        type: string
-        default: 'no'
+        type: boolean
+        default: false
       os:
         description: 'The operating system to use for the build ("linux", "macos", "windows").'
         required: true
@@ -126,17 +126,7 @@ jobs:
         if: ${{ inputs.os == 'macos' }}
         run: |
           echo 'Installing build tools.'
-          for TOOL in cmake conan ninja nproc; do
-            if which ${TOOL} > /dev/null 2>&1; then
-              echo "The ${TOOL} executable already exists, skipping installation."
-            else
-              echo "The ${TOOL} executable does not exist, installing."
-              if [ "${TOOL}" = 'nproc' ]; then
-                TOOL='coreutils'
-              fi
-              brew install ${TOOL}
-            fi
-          done
+          brew install cmake conan ninja nproc
       - name: Check configuration (Linux and MacOS)
         if: ${{ inputs.os == 'linux' || inputs.os == 'macos' }}
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,8 +2,9 @@
 name: Build and test
 
 # This workflow can only be triggered by other workflows. Note that the
-# workflow_call event does not support the 'choice' input type, so we use
-# 'string' instead. The workflow calls actions, which do support 'choice'. Also
+# workflow_call event does not support the 'choice' input type (see
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_callinputsinput_idtype),
+# so we use 'string' instead; in contrast, actions do support 'choice'. Also
 # note that the 'boolean' input type is troublesome, so we use 'string' instead.
 on:
   workflow_call:
@@ -208,6 +209,7 @@ jobs:
         uses: ./.github/actions/build-test
         with:
           build_dir: ${{ inputs.build_dir }}
+          build_only: ${{ matrix.build_only }}
           build_type: ${{ matrix.build_type }}
           cmake_args: ${{ matrix.cmake_args }}
           cmake_target: ${{ matrix.cmake_target }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Generate strategy matrix
         working-directory: .github/scripts/strategy-matrix
         id: generate
-        run: python generate.py ${{ inputs.strategy_matrix_all && '--all' || '' }} --config=${{ inputs.os }}.json >> "${GITHUB_OUTPUT}"
+        run: python generate.py ${{ inputs.strategy_matrix_all == 'true' && '--all' || '' }} --config=${{ inputs.os }}.json >> "${GITHUB_OUTPUT}"
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,7 +1,10 @@
 # This workflow builds and tests the binary for various configurations.
 name: Build and test
 
-# This workflow can only be triggered by other workflows.
+# This workflow can only be triggered by other workflows. Note that the
+# workflow_call event does not support the 'choice' input type, so we use
+# 'string' instead. The workflow calls actions, which do support 'choice'. Also
+# note that the 'boolean' input type is troublesome, so we use 'string' instead.
 on:
   workflow_call:
     inputs:
@@ -19,24 +22,25 @@ on:
         required: true
         type: string
       dependencies_force_build:
-        description: 'Force building of all dependencies.'
+        description: 'Force building of all dependencies ("yes", "no").'
         required: false
-        type: boolean
+        type: string
         default: false
       dependencies_force_upload:
-        description: 'Force uploading of all dependencies.'
+        description: 'Force uploading of all dependencies ("yes", "no").'
         required: false
-        type: boolean
+        type: string
         default: false
       os:
-        description: 'The operating system to use for the build (linux, macos, or windows).'
+        description: 'The operating system to use for the build ("linux", "macos", "windows").'
         required: true
         type: string
-      strategy_matrix_all:
-        description: 'Generate a strategy matrix containing all configurations.'
+      strategy_matrix:
+        # TODO: Support additional strategies, e.g. "ubuntu" for generating all Ubuntu configurations.
+        description: 'The strategy matrix to use for generating the configurations ("minimal", "all").'
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: 'minimal'
     secrets:
       codecov_token:
         description: 'The Codecov token to use for uploading coverage reports.'
@@ -70,7 +74,7 @@ jobs:
       - name: Generate strategy matrix
         working-directory: .github/scripts/strategy-matrix
         id: generate
-        run: python generate.py ${{ inputs.strategy_matrix_all && '--all' || '' }} --config=${{ inputs.os }}.json >> "${GITHUB_OUTPUT}"
+        run: python generate.py ${{ inputs.strategy_matrix == 'all' && '--all' || '' }} --config=${{ inputs.os }}.json >> "${GITHUB_OUTPUT}"
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
 

--- a/.github/workflows/notify-clio.yml
+++ b/.github/workflows/notify-clio.yml
@@ -59,9 +59,7 @@ jobs:
         run: conan remote login ${{ inputs.conan_remote_name }} "${{ secrets.conan_remote_username }}" --password "${{ secrets.conan_remote_password }}"
       - name: Upload package
         run: |
-          echo "Exporting package with user to channel '${{ steps.generate.outputs.channel }}'."
           conan export --user=${{ steps.generate.outputs.user }} --channel=${{ steps.generate.outputs.channel }} .
-          echo 'Uploading package version ${{ steps.generate.outputs.version }}.'
           conan upload --confirm --check --remote=${{ inputs.conan_remote_name }} xrpl/${{ steps.generate.outputs.version }}@${{ steps.generate.outputs.user }}/${{ steps.generate.outputs.channel }}
     outputs:
       channel: ${{ steps.generate.outputs.channel }}

--- a/.github/workflows/notify-clio.yml
+++ b/.github/workflows/notify-clio.yml
@@ -45,10 +45,10 @@ jobs:
         id: generate
         run: |
           echo 'Generating user and channel.'
-          echo user="clio" >> "${GITHUB_OUTPUT}"
-          echo channel="pr_${{ github.event.pull_request.number }}" >> "${GITHUB_OUTPUT}"
+          echo "user=clio" >> "${GITHUB_OUTPUT}"
+          echo "channel=pr_${{ github.event.pull_request.number }}" >> "${GITHUB_OUTPUT}"
           echo 'Extracting version.'
-          echo version="$(cat src/libxrpl/protocol/BuildInfo.cpp | grep "versionString =" | awk -F '"' '{print $2}')" >> "${GITHUB_OUTPUT}"
+          echo "version=$(cat src/libxrpl/protocol/BuildInfo.cpp | grep "versionString =" | awk -F '"' '{print $2}')" >> "${GITHUB_OUTPUT}"
       - name: Add Conan remote
         run: |
           echo "Adding Conan remote '${{ inputs.conan_remote_name }}' at ${{ inputs.conan_remote_url }}."

--- a/.github/workflows/notify-clio.yml
+++ b/.github/workflows/notify-clio.yml
@@ -44,8 +44,9 @@ jobs:
       - name: Generate outputs
         id: generate
         run: |
-          echo 'Generating channel.'
-          echo channel="clio/pr_${{ github.event.pull_request.number }}" >> "${GITHUB_OUTPUT}"
+          echo 'Generating user and channel.'
+          echo user="clio" >> "${GITHUB_OUTPUT}"
+          echo channel="pr_${{ github.event.pull_request.number }}" >> "${GITHUB_OUTPUT}"
           echo 'Extracting version.'
           echo version="$(cat src/libxrpl/protocol/BuildInfo.cpp | grep "versionString =" | awk -F '"' '{print $2}')" >> "${GITHUB_OUTPUT}"
       - name: Add Conan remote
@@ -58,10 +59,10 @@ jobs:
         run: conan remote login ${{ inputs.conan_remote_name }} "${{ secrets.conan_remote_username }}" --password "${{ secrets.conan_remote_password }}"
       - name: Upload package
         run: |
-          echo 'Exporting package to channel ${{ steps.generate.outputs.channel }}.'
-          conan export --user=clio --channel=${{ steps.generate.outputs.channel }} .
-          echo 'Uploading package version ${{ steps.generate.outputs.version }} on channel ${{ steps.generate.outputs.channel }}.'
-          conan upload --confirm --check --remote=${{ inputs.conan_remote_name }} xrpl/${{ steps.generate.outputs.version }}@${{ steps.generate.outputs.channel }}
+          echo "Exporting package with user to channel '${{ steps.generate.outputs.channel }}'."
+          conan export --user=${{ steps.generate.outputs.user }} --channel=${{ steps.generate.outputs.channel }} .
+          echo 'Uploading package version ${{ steps.generate.outputs.version }}.'
+          conan upload --confirm --check --remote=${{ inputs.conan_remote_name }} xrpl/${{ steps.generate.outputs.version }}@${{ steps.generate.outputs.user }}/${{ steps.generate.outputs.channel }}
     outputs:
       channel: ${{ steps.generate.outputs.channel }}
       version: ${{ steps.generate.outputs.version }}
@@ -76,5 +77,5 @@ jobs:
         run: |
           gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
           /repos/xrplf/clio/dispatches -f "event_type=check_libxrpl" \
-          -F "client_payload[version]=${{ needs.upload.outputs.version }}@${{ needs.upload.outputs.channel }}" \
+          -F "client_payload[version]=${{ needs.upload.outputs.version }}@${{ needs.upload.outputs.user }}/${{ needs.upload.outputs.channel }}" \
           -F "client_payload[pr]=${{ github.event.pull_request.number }}"

--- a/.github/workflows/notify-clio.yml
+++ b/.github/workflows/notify-clio.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Upload package
         run: |
           echo 'Exporting package to channel ${{ steps.generate.outputs.channel }}.'
-          conan export --channel=${{ steps.generate.outputs.channel }} .
+          conan export --user=clio --channel=${{ steps.generate.outputs.channel }} .
           echo 'Uploading package version ${{ steps.generate.outputs.version }} on channel ${{ steps.generate.outputs.channel }}.'
           conan upload --confirm --check --remote=${{ inputs.conan_remote_name }} xrpl/${{ steps.generate.outputs.version }}@${{ steps.generate.outputs.channel }}
     outputs:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -71,7 +71,7 @@ jobs:
       - name: No-op
         run: echo ''
 
-  check-clang-format:
+  check-format:
     needs: should-run
     uses: ./.github/workflows/check-format.yml
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -91,38 +91,23 @@ jobs:
       conan_remote_name: ${{ env.CONAN_REMOTE_NAME }}
       conan_remote_url: ${{ env.CONAN_REMOTE_URL }}
 
-  build-linux:
+  build-test:
     needs: generate-outputs
     uses: ./.github/workflows/build-test.yml
+    strategy:
+      matrix:
+        os: [linux, macos, windows]
     with:
       conan_remote_name: ${{ needs.generate-outputs.outputs.conan_remote_name }}
       conan_remote_url: ${{ needs.generate-outputs.outputs.conan_remote_url }}
-      os: 'linux'
+      os: ${{ matrix.os }}
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
-
-  build-macos:
-    needs: generate-outputs
-    uses: ./.github/workflows/build-test.yml
-    with:
-      conan_remote_name: ${{ needs.generate-outputs.outputs.conan_remote_name }}
-      conan_remote_url: ${{ needs.generate-outputs.outputs.conan_remote_url }}
-      os: 'macos'
-
-  build-windows:
-    needs: generate-outputs
-    uses: ./.github/workflows/build-test.yml
-    with:
-      conan_remote_name: ${{ needs.generate-outputs.outputs.conan_remote_name }}
-      conan_remote_url: ${{ needs.generate-outputs.outputs.conan_remote_url }}
-      os: 'windows'
 
   notify-clio:
     needs:
       - generate-outputs
-      - build-linux
-      - build-macos
-      - build-windows
+      - build-test
     uses: ./.github/workflows/notify-clio.yml
     with:
       conan_remote_name: ${{ needs.generate-outputs.outputs.conan_remote_name }}

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -103,10 +103,10 @@ jobs:
     with:
       conan_remote_name: ${{ needs.generate-outputs.outputs.conan_remote_name }}
       conan_remote_url: ${{ needs.generate-outputs.outputs.conan_remote_url }}
-      dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build }}
-      dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload }}
+      dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build == 'true' }}
+      dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload == 'true' }}
       os: 'linux'
-      strategy_matrix_all: 'true'
+      strategy_matrix_all: true
     secrets:
       conan_remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}
       conan_remote_password: ${{ secrets.CONAN_REMOTE_PASSWORD }}
@@ -117,10 +117,10 @@ jobs:
     with:
       conan_remote_name: ${{ needs.generate-outputs.outputs.conan_remote_name }}
       conan_remote_url: ${{ needs.generate-outputs.outputs.conan_remote_url }}
-      dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build }}
-      dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload }}
+      dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build == 'true' }}
+      dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload == 'true' }}
       os: 'macos'
-      strategy_matrix_all: 'true'
+      strategy_matrix_all: true
     secrets:
       conan_remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}
       conan_remote_password: ${{ secrets.CONAN_REMOTE_PASSWORD }}
@@ -131,10 +131,10 @@ jobs:
     with:
       conan_remote_name: ${{ needs.generate-outputs.outputs.conan_remote_name }}
       conan_remote_url: ${{ needs.generate-outputs.outputs.conan_remote_url }}
-      dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build }}
-      dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload }}
+      dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build == 'true' }}
+      dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload == 'true' }}
       os: 'windows'
-      strategy_matrix_all: 'true'
+      strategy_matrix_all: true
     secrets:
       conan_remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}
       conan_remote_password: ${{ secrets.CONAN_REMOTE_PASSWORD }}

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -81,10 +81,10 @@ jobs:
       - name: Check inputs and set outputs
         id: generate
         run: |
-          if [[ "${{ github.event_name }}" == 'push' ]]; then
+          if [[ '${{ github.event_name }}' == 'push' ]]; then
             echo 'dependencies_force_build=false' >> "${GITHUB_OUTPUT}"
             echo 'dependencies_force_upload=false' >> "${GITHUB_OUTPUT}"
-          elif [[ "${{ github.event_name }}" == 'schedule' ]]; then
+          elif [[ '${{ github.event_name }}' == 'schedule' ]]; then
             echo 'dependencies_force_build=true' >> "${GITHUB_OUTPUT}"
             echo 'dependencies_force_upload=false' >> "${GITHUB_OUTPUT}"
           else
@@ -106,7 +106,7 @@ jobs:
       dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build }}
       dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload }}
       os: 'linux'
-      strategy_matrix_all: true
+      strategy_matrix_all: 'true'
     secrets:
       conan_remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}
       conan_remote_password: ${{ secrets.CONAN_REMOTE_PASSWORD }}
@@ -120,7 +120,7 @@ jobs:
       dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build }}
       dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload }}
       os: 'macos'
-      strategy_matrix_all: true
+      strategy_matrix_all: 'true'
     secrets:
       conan_remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}
       conan_remote_password: ${{ secrets.CONAN_REMOTE_PASSWORD }}
@@ -134,7 +134,7 @@ jobs:
       dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build }}
       dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload }}
       os: 'windows'
-      strategy_matrix_all: true
+      strategy_matrix_all: 'true'
     secrets:
       conan_remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}
       conan_remote_password: ${{ secrets.CONAN_REMOTE_PASSWORD }}

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -97,43 +97,18 @@ jobs:
       dependencies_force_build: ${{ steps.generate.outputs.dependencies_force_build }}
       dependencies_force_upload: ${{ steps.generate.outputs.dependencies_force_upload }}
 
-  build-linux:
+  build-test:
     needs: generate-outputs
     uses: ./.github/workflows/build-test.yml
+    strategy:
+      matrix:
+        os: [linux, macos, windows]
     with:
       conan_remote_name: ${{ needs.generate-outputs.outputs.conan_remote_name }}
       conan_remote_url: ${{ needs.generate-outputs.outputs.conan_remote_url }}
       dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build == 'true' }}
       dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload == 'true' }}
-      os: 'linux'
-      strategy_matrix_all: true
-    secrets:
-      conan_remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}
-      conan_remote_password: ${{ secrets.CONAN_REMOTE_PASSWORD }}
-
-  build-macos:
-    needs: generate-outputs
-    uses: ./.github/workflows/build-test.yml
-    with:
-      conan_remote_name: ${{ needs.generate-outputs.outputs.conan_remote_name }}
-      conan_remote_url: ${{ needs.generate-outputs.outputs.conan_remote_url }}
-      dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build == 'true' }}
-      dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload == 'true' }}
-      os: 'macos'
-      strategy_matrix_all: true
-    secrets:
-      conan_remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}
-      conan_remote_password: ${{ secrets.CONAN_REMOTE_PASSWORD }}
-
-  build-windows:
-    needs: generate-outputs
-    uses: ./.github/workflows/build-test.yml
-    with:
-      conan_remote_name: ${{ needs.generate-outputs.outputs.conan_remote_name }}
-      conan_remote_url: ${{ needs.generate-outputs.outputs.conan_remote_url }}
-      dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build == 'true' }}
-      dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload == 'true' }}
-      os: 'windows'
+      os: ${{ matrix.os }}
       strategy_matrix_all: true
     secrets:
       conan_remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -82,14 +82,14 @@ jobs:
         id: generate
         run: |
           if [[ '${{ github.event_name }}' == 'push' ]]; then
-            echo 'dependencies_force_build=no' >> "${GITHUB_OUTPUT}"
-            echo 'dependencies_force_upload=no' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_build=false' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_upload=false' >> "${GITHUB_OUTPUT}"
           elif [[ '${{ github.event_name }}' == 'schedule' ]]; then
-            echo 'dependencies_force_build=yes' >> "${GITHUB_OUTPUT}"
-            echo 'dependencies_force_upload=no' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_build=true' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_upload=false' >> "${GITHUB_OUTPUT}"
           else
-            echo 'dependencies_force_build=${{ inputs.dependencies_force_build == true && 'yes' || 'no' }}' >> "${GITHUB_OUTPUT}"
-            echo 'dependencies_force_upload=${{ inputs.dependencies_force_upload == true && 'yes' || 'no' }}' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_build=${{ inputs.dependencies_force_build }}' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_upload=${{ inputs.dependencies_force_upload }}' >> "${GITHUB_OUTPUT}"
           fi
     outputs:
       conan_remote_name: ${{ env.CONAN_REMOTE_NAME }}
@@ -106,8 +106,8 @@ jobs:
     with:
       conan_remote_name: ${{ needs.generate-outputs.outputs.conan_remote_name }}
       conan_remote_url: ${{ needs.generate-outputs.outputs.conan_remote_url }}
-      dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build }}
-      dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload }}
+      dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build == 'true' }}
+      dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload == 'true' }}
       os: ${{ matrix.os }}
       strategy_matrix: 'all'
     secrets:

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -82,14 +82,14 @@ jobs:
         id: generate
         run: |
           if [[ '${{ github.event_name }}' == 'push' ]]; then
-            echo 'dependencies_force_build=false' >> "${GITHUB_OUTPUT}"
-            echo 'dependencies_force_upload=false' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_build=no' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_upload=no' >> "${GITHUB_OUTPUT}"
           elif [[ '${{ github.event_name }}' == 'schedule' ]]; then
-            echo 'dependencies_force_build=true' >> "${GITHUB_OUTPUT}"
-            echo 'dependencies_force_upload=false' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_build=yes' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_upload=no' >> "${GITHUB_OUTPUT}"
           else
-            echo 'dependencies_force_build=${{ inputs.dependencies_force_build }}' >> "${GITHUB_OUTPUT}"
-            echo 'dependencies_force_upload=${{ inputs.dependencies_force_upload }}' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_build=${{ inputs.dependencies_force_build == true && 'yes' || 'no' }}' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_upload=${{ inputs.dependencies_force_upload == true && 'yes' || 'no' }}' >> "${GITHUB_OUTPUT}"
           fi
     outputs:
       conan_remote_name: ${{ env.CONAN_REMOTE_NAME }}
@@ -106,10 +106,10 @@ jobs:
     with:
       conan_remote_name: ${{ needs.generate-outputs.outputs.conan_remote_name }}
       conan_remote_url: ${{ needs.generate-outputs.outputs.conan_remote_url }}
-      dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build == 'true' }}
-      dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload == 'true' }}
+      dependencies_force_build: ${{ needs.generate-outputs.outputs.dependencies_force_build }}
+      dependencies_force_upload: ${{ needs.generate-outputs.outputs.dependencies_force_upload }}
       os: ${{ matrix.os }}
-      strategy_matrix_all: true
+      strategy_matrix: 'all'
     secrets:
       conan_remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}
       conan_remote_password: ${{ secrets.CONAN_REMOTE_PASSWORD }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -28,6 +28,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     container: ghcr.io/xrplf/ci/tools-rippled-documentation
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes a couple of small issues with the CI workflows and makes a small improvement.
* Removes 'boolean' inputs as GitHub sometimes treats them as strings and sometimes as booleans depending on how the values are provided (e.g. via workflow dispatch, via a reusable workflow), which causes unexpected and inconsistent behavior.
  * Instead these have been made a 'choice' between 'yes' and 'no' (in the actions) and made a 'string' (in the reusable workflows, which don't support the 'choice' type).
* Adds the necessary permissions to the publish-docs workflow so it can push to the `gh-pages` branch.
* Updates the notify-clio job as it still used some Conan 1-style commands.
* Reduces the separate jobs for Linux, MacOS, and Windows into one by using a strategy matrix.
* Installs missing build tools on MacOS if they aren't present.
  * Newly added runners do not have all tools, so installing is a one-time operation.

### Context of Change

The revamped CI workflows have a couple of issues.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
