### PR TITLE
fix: Correctly check for build_only when deciding whether to run tests

### DIFF
--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -75,7 +75,7 @@ runs:
         echo 'Verifying presence of instrumentation.'
         ./rippled --version | grep libvoidstar
     - name: Test the binary
-      if: ${{ inputs.build_only == 'true' }}
+      if: ${{ inputs.build_only == 'false' }}
       shell: bash
       working-directory: ${{ inputs.build_dir }}/${{ inputs.os == 'windows' && inputs.build_type || '' }}
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -88,6 +88,19 @@ jobs:
     runs-on: ${{ matrix.architecture.runner }}
     container: ${{ inputs.os == 'linux' && format('ghcr.io/xrplf/ci/{0}-{1}:{2}-{3}', matrix.os.distro_name, matrix.os.distro_version, matrix.os.compiler_name, matrix.os.compiler_version) || null }}
     steps:
+      - name: Check strategy matrix
+        run: |
+          echo 'Operating system distro name: ${{ matrix.os.distro_name }}'
+          echo 'Operating system distro version: ${{ matrix.os.distro_version }}'
+          echo 'Operating system compiler name: ${{ matrix.os.compiler_name }}'
+          echo 'Operating system compiler version: ${{ matrix.os.compiler_version }}'
+          echo 'Architecture platform: ${{ matrix.architecture.platform }}'
+          echo 'Architecture runner: ${{ matrix.architecture.runner }}'
+          echo 'Build type: ${{ matrix.build_type }}'
+          echo 'Build only: ${{ matrix.build_only }}'
+          echo 'CMake arguments: ${{ matrix.cmake_args }}'
+          echo 'CMake target: ${{ matrix.cmake_target }}'
+          echo 'Config name: ${{ matrix.config_name }}'
       - name: Clean workspace (MacOS)
         if: ${{ inputs.os == 'macos' }}
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -95,7 +95,7 @@ jobs:
           echo 'Operating system compiler name: ${{ matrix.os.compiler_name }}'
           echo 'Operating system compiler version: ${{ matrix.os.compiler_version }}'
           echo 'Architecture platform: ${{ matrix.architecture.platform }}'
-          echo 'Architecture runner: ${{ matrix.architecture.runner }}'
+          echo 'Architecture runner: ${{ toJson(matrix.architecture.runner) }}'
           echo 'Build type: ${{ matrix.build_type }}'
           echo 'Build only: ${{ matrix.build_only }}'
           echo 'CMake arguments: ${{ matrix.cmake_args }}'


### PR DESCRIPTION
## High Level Overview of Change

This PR modifies the `build_only` check used to determine whether to run tests. For easier debugging in the future it also prints out the contents of the strategy matrix.

### Context of Change

The if-statement that determined whether to run tests in the CI pipeline performed the inverse check.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release