### PR TITLE
fix: Skip notify-clio when running in a fork, reorder config fields

### DIFF
--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -137,14 +137,17 @@ def generate_strategy_matrix(all: bool, architecture: list[dict], os: list[dict]
         if '-Dunity=ON' in cmake_args:
             config_name += '-unity'
 
+        # Add the configuration to the list, with the most unique fields first,
+        # so that they are easier to identify in the GitHub Actions UI, as long
+        # names get truncated.
         configurations.append({
-            'architecture': architecture,
-            'os': os,
-            'build_type': build_type,
-            'build_only': 'true' if build_only else 'false',
+            'config_name': config_name,
             'cmake_args': cmake_args,
             'cmake_target': cmake_target,
-            'config_name': config_name,
+            'build_only': 'true' if build_only else 'false',
+            'build_type': build_type,
+            'os': os,
+            'architecture': architecture,
         })
 
     return {'include': configurations}

--- a/.github/workflows/notify-clio.yml
+++ b/.github/workflows/notify-clio.yml
@@ -36,6 +36,7 @@ defaults:
 
 jobs:
   upload:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     container: ghcr.io/xrplf/ci/ubuntu-noble:gcc-13
     steps:


### PR DESCRIPTION
## High Level Overview of Change

Skips running the `notify-clio` job when a PR is created from a fork, and reorders the strategy matrix configuration fields so GitHub will more clearly show which configuration is running.

### Context of Change

Secrets are not available in forks, and GitHub does not support skipping jobs based on whether a secret exists or what its value is. Although ideally we directly check whether Clio is compatible with libxrpl, so no secrets will be necessary at all, for the time being it is better to skip running the job than having it fail.

Separately, GitHub truncates long job names, and a job name is created based on the values in a strategy matrix configuration. In our case, the least useful fields (i.e. runner tags) were listed first, such that it wasn't easy to determine which exact configuration was being executed.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release