### PR TITLE
fix(test): handle null metadata for transaction ID in Env::meta

### DIFF
--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -499,7 +499,14 @@ Env::meta()
         close();
     }
     auto const item = closed()->txRead(txid_);
-    return item.second;
+    auto const result = item.second;
+    if (result == nullptr)
+    {
+        test.log << "Env::meta: no metadata for txid: " << txid_ << std::endl;
+        test.log << "This is probably because the transaction failed with a non-tec error." << std::endl;
+        Throw<std::runtime_error>("Env::meta: no metadata for txid");
+    }
+    return result;
 }
 
 std::shared_ptr<STTx const>


### PR DESCRIPTION
## High Level Overview of Change

This PR handles errors better when calling `env.meta`. It prints some debug help and throws an error if `env.meta` is going to return a `nullptr`.

### Context of Change

I ran into this issue while working on #5714 - I was getting a segfault in my tests, and it was very difficult to debug the issue.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (you added tests for code that already exists, or your new feature included in this PR)

### API Impact

N/A

## Test Plan

CI passes