### PR TITLE
chore: Remove codecov token check to support tokenless uploads on forks

### DIFF
--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -83,7 +83,7 @@ runs:
         ./rippled --unittest --unittest-jobs $(nproc)
         ctest -j $(nproc) --output-on-failure
     - name: Upload coverage report
-      if: ${{ inputs.cmake_target == 'coverage' && inputs.codecov_token }}
+      if: ${{ inputs.cmake_target == 'coverage' }}
       uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
       with:
         disable_search: true


### PR DESCRIPTION
## High Level Overview of Change

This PR removes the check for whether a codecov token is provided before attempting to upload the codecov report.

### Context of Change

Per https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token, Codecov does not require a token for an upload when the repository is public and the upload is for a commit that is on an "unprotected" branch (like forkname:main). However, as we check for a valid token and forks do not get access to our secrets, coverage reports are not currently being uploaded for PRs in forks, even though no token is needed for them.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
