### PR TITLE
refactor: Replace 'on: pull_request: paths' by 'changed-files' action

### DIFF
--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -38,7 +38,7 @@ def generate_strategy_matrix(all: bool, architecture: list[dict], os: list[dict]
             # - Bookworm using GCC 13: Release and Unity on linux/arm64, set
             #   the reference fee to 500.
             # - Bookworm using GCC 15: Debug and no Unity on linux/amd64, enable
-            #   code coverage.
+            #   code coverage (which will be done below).
             # - Bookworm using Clang 16: Debug and no Unity on linux/arm64,
             #   enable voidstar.
             # - Bookworm using Clang 17: Release and no Unity on linux/amd64,
@@ -51,9 +51,6 @@ def generate_strategy_matrix(all: bool, architecture: list[dict], os: list[dict]
                         cmake_args = f'-DUNIT_TEST_REFERENCE_FEE=500 {cmake_args}'
                         skip = False
                     if f'{os['compiler_name']}-{os['compiler_version']}' == 'gcc-15' and build_type == 'Debug' and '-Dunity=OFF' in cmake_args and architecture['platform'] == 'linux/amd64':
-                        cmake_args = f'-Dcoverage=ON -Dcoverage_format=xml -DCODE_COVERAGE_VERBOSE=ON -DCMAKE_C_FLAGS=-O0 -DCMAKE_CXX_FLAGS=-O0 {cmake_args}'
-                        cmake_target = 'coverage'
-                        build_only = True
                         skip = False
                     if f'{os['compiler_name']}-{os['compiler_version']}' == 'clang-16' and build_type == 'Debug' and '-Dunity=OFF' in cmake_args and architecture['platform'] == 'linux/arm64':
                         cmake_args = f'-Dvoidstar=ON {cmake_args}'
@@ -126,6 +123,13 @@ def generate_strategy_matrix(all: bool, architecture: list[dict], os: list[dict]
         # We skip all clang-20 on arm64 due to boost 1.86 build error
         if f'{os['compiler_name']}-{os['compiler_version']}' == 'clang-20' and architecture['platform'] == 'linux/arm64':
             continue
+
+        # Enable code coverage for Debian Bookworm using GCC 15 in Debug and no
+        # Unity on linux/amd64
+        if f'{os['compiler_name']}-{os['compiler_version']}' == 'gcc-15' and build_type == 'Debug' and '-Dunity=OFF' in cmake_args and architecture['platform'] == 'linux/amd64':
+            cmake_args = f'-Dcoverage=ON -Dcoverage_format=xml -DCODE_COVERAGE_VERBOSE=ON -DCMAKE_C_FLAGS=-O0 -DCMAKE_CXX_FLAGS=-O0 {cmake_args}'
+            cmake_target = 'coverage'
+            build_only = True
 
         # Generate a unique name for the configuration, e.g. macos-arm64-debug
         # or debian-bookworm-gcc-12-amd64-release-unity.

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -6,29 +6,6 @@ name: PR
 
 on:
   pull_request:
-    paths:
-      - ".github/actions/build-deps/**"
-      - ".github/actions/build-test/**"
-      - ".github/scripts/levelization/**"
-      - ".github/scripts/strategy-matrix/**"
-      - ".github/workflows/build-test.yml"
-      - ".github/workflows/check-format.yml"
-      - ".github/workflows/check-levelization.yml"
-      - ".github/workflows/notify-clio.yml"
-      - ".github/workflows/on-pr.yml"
-      # Keep the list of paths below in sync with those in the `on-trigger.yml`
-      # file.
-      - "cmake/**"
-      - "conan/**"
-      - "external/**"
-      - "include/**"
-      - "src/**"
-      - "tests/**"
-      - ".clang-format"
-      - ".codecov.yml"
-      - ".pre-commit-config.yaml"
-      - "CMakeLists.txt"
-      - "conanfile.py"
     types:
       - opened
       - synchronize
@@ -71,18 +48,65 @@ jobs:
       - name: No-op
         run: true
 
-  check-format:
+  # This job checks whether any files have changed that should cause the next
+  # jobs to run. We do it this way rather than using `paths` in the `on:`
+  # section, because all required checks must pass, even for changes that do not
+  # modify anything that affects those checks. We would therefore like to make
+  # the checks required only if the job runs, but GitHub does not support that
+  # directly. By always executing the workflow on new commits and by using the
+  # changed-files action below, we ensure that Github considers any skipped jobs
+  # to have passed, and in turn the required checks as well.
+  any-changed:
     needs: should-run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - name: Determine changed files
+        id: changes
+        with:
+          uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+          files: |
+            ".github/actions/build-deps/**"
+            ".github/actions/build-test/**"
+            ".github/scripts/levelization/**"
+            ".github/scripts/strategy-matrix/**"
+            ".github/workflows/build-test.yml"
+            ".github/workflows/check-format.yml"
+            ".github/workflows/check-levelization.yml"
+            ".github/workflows/notify-clio.yml"
+            ".github/workflows/on-pr.yml"
+            # Keep the list of paths below in sync with those in the
+            # `on-trigger.yml` file.
+            "cmake/**"
+            "conan/**"
+            "external/**"
+            "include/**"
+            "src/**"
+            "tests/**"
+            ".clang-format"
+            ".codecov.yml"
+            ".pre-commit-config.yaml"
+            "CMakeLists.txt"
+            "conanfile.py"
+    outputs:
+      changed: ${{ steps.changes.outputs.any_changed }}
+
+  check-format:
+    needs: any-changed
+    if: needs.any-changed.outputs.changed == 'true'
     uses: ./.github/workflows/check-format.yml
 
   check-levelization:
-    needs: should-run
+    needs: any-changed
+    if: needs.any-changed.outputs.changed == 'true'
     uses: ./.github/workflows/check-levelization.yml
 
   # This job works around the limitation that GitHub Actions does not support
   # using environment variables as inputs for reusable workflows.
   generate-outputs:
-    needs: should-run
+    needs: any-changed
+    if: needs.any-changed.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: No-op

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -60,7 +60,6 @@ jobs:
             .github/workflows/notify-clio.yml
             .github/workflows/on-pr.yml
             .clang-format
-            .codecov.yml
             .pre-commit-config.yaml
 
             # Keep the paths below in sync with those in `on-trigger.yml`.
@@ -68,6 +67,7 @@ jobs:
             .github/actions/build-test/**
             .github/scripts/strategy-matrix/**
             .github/workflows/build-test.yml
+            .codecov.yml
             cmake/**
             conan/**
             external/**

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -73,6 +73,9 @@ jobs:
             .github/workflows/check-levelization.yml
             .github/workflows/notify-clio.yml
             .github/workflows/on-pr.yml
+            .clang-format
+            .codecov.yml
+            .pre-commit-config.yaml
             # Keep the paths below in sync with those in `on-trigger.yml`.
             .github/actions/build-deps/**
             .github/actions/build-test/**
@@ -84,9 +87,6 @@ jobs:
             include/**
             src/**
             tests/**
-            .clang-format
-            .codecov.yml
-            .pre-commit-config.yaml
             CMakeLists.txt
             conanfile.py
     outputs:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -66,19 +66,18 @@ jobs:
         id: changes
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
-          # Keep the list of paths below in sync with those in the
-          # `on-trigger.yml` file, except for applicable differences in the
-          # .github directory.
           files: |
-            .github/actions/build-deps/**
-            .github/actions/build-test/**
+            # These paths are unique to `on-pr.yml`.
             .github/scripts/levelization/**
-            .github/scripts/strategy-matrix/**
-            .github/workflows/build-test.yml
             .github/workflows/check-format.yml
             .github/workflows/check-levelization.yml
             .github/workflows/notify-clio.yml
             .github/workflows/on-pr.yml
+            # Keep the paths below in sync with those in `on-trigger.yml`.
+            .github/actions/build-deps/**
+            .github/actions/build-test/**
+            .github/scripts/strategy-matrix/**
+            .github/workflows/build-test.yml
             cmake/**
             conan/**
             external/**

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -64,31 +64,31 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Determine changed files
         id: changes
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
-          uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+          # Keep the list of paths below in sync with those in the
+          # `on-trigger.yml` file.
           files: |
-            ".github/actions/build-deps/**"
-            ".github/actions/build-test/**"
-            ".github/scripts/levelization/**"
-            ".github/scripts/strategy-matrix/**"
-            ".github/workflows/build-test.yml"
-            ".github/workflows/check-format.yml"
-            ".github/workflows/check-levelization.yml"
-            ".github/workflows/notify-clio.yml"
-            ".github/workflows/on-pr.yml"
-            # Keep the list of paths below in sync with those in the
-            # `on-trigger.yml` file.
-            "cmake/**"
-            "conan/**"
-            "external/**"
-            "include/**"
-            "src/**"
-            "tests/**"
-            ".clang-format"
-            ".codecov.yml"
-            ".pre-commit-config.yaml"
-            "CMakeLists.txt"
-            "conanfile.py"
+            .github/actions/build-deps/**
+            .github/actions/build-test/**
+            .github/scripts/levelization/**
+            .github/scripts/strategy-matrix/**
+            .github/workflows/build-test.yml
+            .github/workflows/check-format.yml
+            .github/workflows/check-levelization.yml
+            .github/workflows/notify-clio.yml
+            .github/workflows/on-pr.yml
+            cmake/**
+            conan/**
+            external/**
+            include/**
+            src/**
+            tests/**
+            .clang-format
+            .codecov.yml
+            .pre-commit-config.yaml
+            CMakeLists.txt
+            conanfile.py
     outputs:
       changed: ${{ steps.changes.outputs.any_changed }}
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -67,7 +67,8 @@ jobs:
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
           # Keep the list of paths below in sync with those in the
-          # `on-trigger.yml` file.
+          # `on-trigger.yml` file, except for applicable differences in the
+          # .github directory.
           files: |
             .github/actions/build-deps/**
             .github/actions/build-test/**

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -62,6 +62,7 @@ jobs:
             .clang-format
             .codecov.yml
             .pre-commit-config.yaml
+
             # Keep the paths below in sync with those in `on-trigger.yml`.
             .github/actions/build-deps/**
             .github/actions/build-test/**

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -17,6 +17,7 @@ on:
       - ".github/workflows/check-missing-commits.yml"
       - ".github/workflows/on-trigger.yml"
       - ".github/workflows/publish-docs.yml"
+
       # Keep the paths below in sync with those in `on-pr.yml`.
       - ".github/actions/build-deps/**"
       - ".github/actions/build-test/**"
@@ -30,12 +31,14 @@ on:
       - "tests/**"
       - "CMakeLists.txt"
       - "conanfile.py"
+
   # Run at 06:32 UTC on every day of the week from Monday through Friday. This
   # will force all dependencies to be rebuilt, which is useful to verify that
   # all dependencies can be built successfully. Only the dependencies that
   # are actually missing from the remote will be uploaded.
   schedule:
     - cron: "32 6 * * 1-5"
+
   # Run when manually triggered via the GitHub UI or API. If `force_upload` is
   # true, then the dependencies that were missing (`force_rebuild` is false) or
   # rebuilt (`force_rebuild` is true) will be uploaded, overwriting existing

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -28,9 +28,6 @@ on:
       - "include/**"
       - "src/**"
       - "tests/**"
-      - ".clang-format"
-      - ".codecov.yml"
-      - ".pre-commit-config.yaml"
       - "CMakeLists.txt"
       - "conanfile.py"
   # Run at 06:32 UTC on every day of the week from Monday through Friday. This

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -13,14 +13,15 @@ on:
       - release
       - master
     paths:
+      # These paths are unique to `on-trigger.yml`.
+      - ".github/workflows/check-missing-commits.yml"
+      - ".github/workflows/on-trigger.yml"
+      - ".github/workflows/publish-docs.yml"
+      # Keep the paths below in sync with those in `on-pr.yml`.
       - ".github/actions/build-deps/**"
       - ".github/actions/build-test/**"
       - ".github/scripts/strategy-matrix/**"
       - ".github/workflows/build-test.yml"
-      - ".github/workflows/check-missing-commits.yml"
-      - ".github/workflows/on-trigger.yml"
-      - ".github/workflows/publish-docs.yml"
-      # Keep the list of paths below in sync with those in `on-pr.yml`.
       - "cmake/**"
       - "conan/**"
       - "external/**"

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -23,6 +23,7 @@ on:
       - ".github/actions/build-test/**"
       - ".github/scripts/strategy-matrix/**"
       - ".github/workflows/build-test.yml"
+      - ".codecov.yml"
       - "cmake/**"
       - "conan/**"
       - "external/**"


### PR DESCRIPTION
## High Level Overview of Change

This PR moves the list of files from the `paths:` section in the `on: pull_request` into a separate job.

### Context of Change

We use required status checks to ensure our code compiles before merging it. However, not all PRs modify code, and then forcing the code to build is wasteful. Unfortunately, GitHub does not support having optional status checks, i.e. they don't need to run but if they do run then they must be successful. When a PR doesn't change any code and the status checks therefore don't run, only an administrator can bypass the required checks, as opposed to a maintainer; this is not ideal.

To work around this, we leverage the fact that GitHub will consider skipped jobs to have passed _provided the pipeline started_, see [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks). So, by moving the paths into a separate job, we will ensure that any change will trigger the pipeline, but that we can still skip building the binary if none of the changed files affect the code. We use the [changed-files](https://github.com/tj-actions/changed-files) action to achieve this.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
