### PR TITLE
chore: remove unneeded float stuff

### DIFF
--- a/src/xrpld/app/wasm/detail/WamrVM.cpp
+++ b/src/xrpld/app/wasm/detail/WamrVM.cpp
@@ -424,11 +424,7 @@ ModuleWrapper::makeImpParams(wasm_valtype_vec_t& v, WasmImportFunc const& imp)
                 v.data[i] = wasm_valtype_new_i64();
                 break;
             case WT_F32:
-                v.data[i] = wasm_valtype_new_f32();
-                break;
             case WT_F64:
-                v.data[i] = wasm_valtype_new_f64();
-                break;
             default:
                 throw std::runtime_error("invalid import type");
         }
@@ -451,11 +447,7 @@ ModuleWrapper::makeImpReturn(wasm_valtype_vec_t& v, WasmImportFunc const& imp)
                 v.data[0] = wasm_valtype_new_i64();
                 break;
             case WT_F32:
-                v.data[0] = wasm_valtype_new_f32();
-                break;
             case WT_F64:
-                v.data[0] = wasm_valtype_new_f64();
-                break;
             default:
                 throw std::runtime_error("invalid return type");
         }
@@ -672,12 +664,6 @@ WamrEngine::convertParams(std::vector<WasmParam> const& params)
             case WT_I64:
                 v.push_back(WASM_I64_VAL(p.of.i64));
                 break;
-            case WT_F32:
-                v.push_back(WASM_F32_VAL(p.of.f32));
-                break;
-            case WT_F64:
-                v.push_back(WASM_F64_VAL(p.of.f64));
-                break;
             case WT_U8V: {
                 auto const sz = p.of.u8v.sz;
                 auto const ptr = allocate(sz);
@@ -688,6 +674,8 @@ WamrEngine::convertParams(std::vector<WasmParam> const& params)
                 v.push_back(WASM_I32_VAL(sz));
             }
             break;
+            case WT_F32:
+            case WT_F64:
             default:
                 throw std::runtime_error(
                     "unknown parameter type: " + std::to_string(p.type));


### PR DESCRIPTION
## High Level Overview of Change

There were some switch statements that were processing floats in `WamrVM.cpp`. This PR removes the float parts.

### Context of Change

code cleanup

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)

## Test Plan

CI passes.