### PR TITLE
chore: Add support for merge_group event in GitHub CI

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -5,6 +5,9 @@
 name: PR
 
 on:
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     types:
       - opened


### PR DESCRIPTION
## High Level Overview of Change

This change adds support for the `merge_group` CI event, which will allow us to enable merge queues.

### Context of Change

Before a PR can be merged we require that status checks have passed and that the branch is up to date. This costs time and effort when there are several PRs ready to be merged. Merge groups allow us to relax the requirement that the branch is up to date. When added to the queue, the merge queue logic will ensure each PR in the queue is updated with the latest changes from the develop branch, run all the tests, and then merge it as per usual - saving us a lot of manual effort.

If a PR that has been added to the merge queue has conflicts or fails the required tests, it will be removed from the queue, so the author can inspect what the issue is.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release