### PR TITLE
fix: Add codecov token to trigger workflow

### DIFF
--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -113,5 +113,6 @@ jobs:
       os: ${{ matrix.os }}
       strategy_matrix: "all"
     secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
       conan_remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}
       conan_remote_password: ${{ secrets.CONAN_REMOTE_PASSWORD }}


### PR DESCRIPTION
## High Level Overview of Change

This change adds the Codecov token to the `on-trigger` workflow.

### Context of Change

In https://github.com/XRPLF/rippled/pull/5734 the Codecov job was also enabled for the `on-trigger` workflow, but to upload the report the token is needed.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release