### PR TITLE
chore: Run test jobs if files changed or "Ready to merge"

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -84,19 +84,35 @@ jobs:
     needs: any-changed
     runs-on: ubuntu-latest
     steps:
-      - name: Check Ready to merge
-        id: ready
+      - name: Check whether to run
+        id: go
         env:
+          FILES: ${{ needs.any-changed.outputs.changed == 'true' }}
+          DRAFT: ${{ github.event.pull_request.draft }}
           READY: ${{ contains(github.event.pull_request.labels.*.name, 'Ready to merge') }}
+          MERGE: ${{ github.event_name == 'merge_group' }}
         run: |
+          # These messages are included for auditability
+          if [[ "${FILES}" == "true" ]]
+          then
+            echo "INFO: Relevant files were changed"
+          fi
+          if [[ "${DRAFT}" == "true" ]]
+          then
+            echo "INFO: PR is marked as a draft"
+          fi
           if [[ "${READY}" == "true" ]]
           then
-            echo "PR is labeled as 'Ready to merge'."
+            echo "INFO: PR is labeled as 'Ready to merge'."
           fi
-          echo "ready=${{ !github.event.pull_request.draft && env.READY == 'true' }}" >> "${GITHUB_OUTPUT}"
+          if [[ "${MERGE}" == "true" ]]
+          then
+            echo "INFO: In merge queue"
+          fi
+          echo "go=${{ (env.DRAFT != 'true' && env.READY == 'true') || env.FILES == 'true' || env.MERGE == 'true' }}" >> "${GITHUB_OUTPUT}"
           cat "${GITHUB_OUTPUT}"
     outputs:
-      go: ${{ needs.any-changed.outputs.changed == 'true' || steps.ready.outputs.ready == 'true' || github.event_name == 'merge_group' }}
+      go: ${{ steps.go.outputs.go == 'true' }}
 
   check-format:
     needs: should-run

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -28,21 +28,26 @@ env:
   CONAN_REMOTE_URL: https://conan.ripplex.io
 
 jobs:
-  # This job checks whether any files have changed that should cause the next
-  # jobs to run. We do it this way rather than using `paths` in the `on:`
-  # section, because all required checks must pass, even for changes that do not
-  # modify anything that affects those checks. We would therefore like to make
-  # the checks required only if the job runs, but GitHub does not support that
-  # directly. By always executing the workflow on new commits and by using the
-  # changed-files action below, we ensure that Github considers any skipped jobs
-  # to have passed, and in turn the required checks as well.
-  any-changed:
+  # This job determines whether the rest of the workflow should run. It runs
+  # when the PR is not a draft (which should also cover merge-group) or
+  # has the 'DraftRunCI' label.
+  should-run:
     if: ${{ !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'DraftRunCI') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Determine changed files
+        # This step checks whether any files have changed that should
+        # cause the next jobs to run. We do it this way rather than
+        # using `paths` in the `on:` section, because all required
+        # checks must pass, even for changes that do not modify anything
+        # that affects those checks. We would therefore like to make the
+        # checks required only if the job runs, but GitHub does not
+        # support that directly. By always executing the workflow on new
+        # commits and by using the changed-files action below, we ensure
+        # that Github considers any skipped jobs to have passed, and in
+        # turn the required checks as well.
         id: changes
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
@@ -70,24 +75,16 @@ jobs:
             tests/**
             CMakeLists.txt
             conanfile.py
-    outputs:
-      changed: ${{ steps.changes.outputs.any_changed }}
-
-  # This job determines whether the rest of the workflow should run. It runs
-  # when the PR is not a draft or has the 'DraftRunCI' label.
-  # The rest of the workflow will run if this job runs AND at least one
-  # of:
-  # * Any of the files checked in the `any-changed` job were modified
-  # * The PR is NOT a draft and is labeled "Ready to merge"
-  # * The workflow is running from the merge queue
-  should-run:
-    needs: any-changed
-    runs-on: ubuntu-latest
-    steps:
       - name: Check whether to run
+        # This step determines whether the rest of the workflow should
+        # run. The rest of the workflow will run if this job runs AND at
+        # least one of:
+        # * Any of the files checked in the `changes` step were modified
+        # * The PR is NOT a draft and is labeled "Ready to merge"
+        # * The workflow is running from the merge queue
         id: go
         env:
-          FILES: ${{ needs.any-changed.outputs.changed == 'true' }}
+          FILES: ${{ steps.changes.outputs.any_changed }}
           DRAFT: ${{ github.event.pull_request.draft }}
           READY: ${{ contains(github.event.pull_request.labels.*.name, 'Ready to merge') }}
           MERGE: ${{ github.event_name == 'merge_group' }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -34,8 +34,14 @@ jobs:
     if: ${{ !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'DraftRunCI') }}
     runs-on: ubuntu-latest
     steps:
-      - name: No-op
-        run: true
+      - name: Check Ready to merge
+        id: ready
+        run: |
+          echo "ready=${{ contains(github.event.pull_request.labels.*.name, 'Ready to merge') }}" >> "${GITHUB_OUTPUT}"
+          echo "force=${{ !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'Ready to merge') }}" >> "${GITHUB_OUTPUT}"
+          cat "${GITHUB_OUTPUT}"
+    outputs:
+      force: ${{ steps.ready.outputs.force }}
 
   # This job checks whether any files have changed that should cause the next
   # jobs to run. We do it this way rather than using `paths` in the `on:`
@@ -82,21 +88,33 @@ jobs:
     outputs:
       changed: ${{ steps.changes.outputs.any_changed }}
 
+  do-run:
+    needs:
+      - should-run
+      - any-changed
+    if: ${{ needs.should-run.outputs.force == 'true' || needs.any-changed.outputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op
+        run: true
+    outputs:
+      go: true
+
   check-format:
-    needs: any-changed
-    if: needs.any-changed.outputs.changed == 'true'
+    needs: do-run
+    if: needs.do-run.outputs.go == 'true'
     uses: ./.github/workflows/check-format.yml
 
   check-levelization:
-    needs: any-changed
-    if: needs.any-changed.outputs.changed == 'true'
+    needs: do-run
+    if: needs.do-run.outputs.go == 'true'
     uses: ./.github/workflows/check-levelization.yml
 
   # This job works around the limitation that GitHub Actions does not support
   # using environment variables as inputs for reusable workflows.
   generate-outputs:
-    needs: any-changed
-    if: needs.any-changed.outputs.changed == 'true'
+    needs: do-run
+    if: needs.do-run.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: No-op
@@ -130,3 +148,13 @@ jobs:
       clio_notify_token: ${{ secrets.CLIO_NOTIFY_TOKEN }}
       conan_remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}
       conan_remote_password: ${{ secrets.CONAN_REMOTE_PASSWORD }}
+
+  passed:
+    needs:
+      - build-test
+      - check-format
+      - check-levelization
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op
+        run: true

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -28,21 +28,6 @@ env:
   CONAN_REMOTE_URL: https://conan.ripplex.io
 
 jobs:
-  # This job determines whether the workflow should run. It runs when the PR is
-  # not a draft or has the 'DraftRunCI' label.
-  should-run:
-    if: ${{ !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'DraftRunCI') }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check Ready to merge
-        id: ready
-        run: |
-          echo "ready=${{ contains(github.event.pull_request.labels.*.name, 'Ready to merge') }}" >> "${GITHUB_OUTPUT}"
-          echo "force=${{ !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'Ready to merge') }}" >> "${GITHUB_OUTPUT}"
-          cat "${GITHUB_OUTPUT}"
-    outputs:
-      force: ${{ steps.ready.outputs.force }}
-
   # This job checks whether any files have changed that should cause the next
   # jobs to run. We do it this way rather than using `paths` in the `on:`
   # section, because all required checks must pass, even for changes that do not
@@ -52,7 +37,6 @@ jobs:
   # changed-files action below, we ensure that Github considers any skipped jobs
   # to have passed, and in turn the required checks as well.
   any-changed:
-    needs: should-run
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -88,33 +72,47 @@ jobs:
     outputs:
       changed: ${{ steps.changes.outputs.any_changed }}
 
-  do-run:
-    needs:
-      - should-run
-      - any-changed
-    if: ${{ needs.should-run.outputs.force == 'true' || needs.any-changed.outputs.changed == 'true' }}
+  # This job determines whether the rest of the workflow should run. It runs
+  # when the PR is not a draft or has the 'DraftRunCI' label.
+  # The rest of the workflow will run if this job runs AND at least one
+  # of:
+  # * Any of the files checked in the `any-changed` job were modified
+  # * The PR is NOT a draft and is labeled "Ready to merge"
+  # * The workflow is running from the merge queue
+  should-run:
+    if: ${{ !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'DraftRunCI') }}
+    needs: any-changed
     runs-on: ubuntu-latest
     steps:
-      - name: No-op
-        run: true
+      - name: Check Ready to merge
+        id: ready
+        env:
+          READY: ${{ contains(github.event.pull_request.labels.*.name, 'Ready to merge') }}
+        run: |
+          if [[ "${READY}" == "true" ]]
+          then
+            echo "PR is labeled as 'Ready to merge'."
+          fi
+          echo "ready=${{ !github.event.pull_request.draft && env.READY == 'true' }}" >> "${GITHUB_OUTPUT}"
+          cat "${GITHUB_OUTPUT}"
     outputs:
-      go: true
+      go: ${{ needs.any-changed.outputs.changed == 'true' || steps.ready.outputs.ready == 'true' || github.event_name == 'merge_group' }}
 
   check-format:
-    needs: do-run
-    if: needs.do-run.outputs.go == 'true'
+    needs: should-run
+    if: needs.should-run.outputs.go == 'true'
     uses: ./.github/workflows/check-format.yml
 
   check-levelization:
-    needs: do-run
-    if: needs.do-run.outputs.go == 'true'
+    needs: should-run
+    if: needs.should-run.outputs.go == 'true'
     uses: ./.github/workflows/check-levelization.yml
 
   # This job works around the limitation that GitHub Actions does not support
   # using environment variables as inputs for reusable workflows.
   generate-outputs:
-    needs: do-run
-    if: needs.do-run.outputs.go == 'true'
+    needs: should-run
+    if: needs.should-run.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: No-op

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -37,6 +37,7 @@ jobs:
   # changed-files action below, we ensure that Github considers any skipped jobs
   # to have passed, and in turn the required checks as well.
   any-changed:
+    if: ${{ !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'DraftRunCI') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -80,7 +81,6 @@ jobs:
   # * The PR is NOT a draft and is labeled "Ready to merge"
   # * The workflow is running from the merge queue
   should-run:
-    if: ${{ !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'DraftRunCI') }}
     needs: any-changed
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -92,23 +92,6 @@ jobs:
           READY: ${{ contains(github.event.pull_request.labels.*.name, 'Ready to merge') }}
           MERGE: ${{ github.event_name == 'merge_group' }}
         run: |
-          # These messages are included for auditability
-          if [[ "${FILES}" == "true" ]]
-          then
-            echo "INFO: Relevant files were changed"
-          fi
-          if [[ "${DRAFT}" == "true" ]]
-          then
-            echo "INFO: PR is marked as a draft"
-          fi
-          if [[ "${READY}" == "true" ]]
-          then
-            echo "INFO: PR is labeled as 'Ready to merge'."
-          fi
-          if [[ "${MERGE}" == "true" ]]
-          then
-            echo "INFO: In merge queue"
-          fi
           echo "go=${{ (env.DRAFT != 'true' && env.READY == 'true') || env.FILES == 'true' || env.MERGE == 'true' }}" >> "${GITHUB_OUTPUT}"
           cat "${GITHUB_OUTPUT}"
     outputs:


### PR DESCRIPTION
## High Level Overview of Change

Optimizes when CI jobs are run.

### Context of Change

Came out of a discussion related to #5728, #5734, and #5736

### Type of Change

- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)

## Before / After

Before:

Test jobs would only run if
* Either the PR is non-draft or has the "DraftRunCI" label set *AND*
* Certain files were changed.

Required jobs in branch protection rule required jobs need to be specified by OS/compiler/etc. combination. Since those jobs aren't run for some PRs, those PRs could not be merged without some kind of override.

After:

Test jobs will run if
* Either the PR is non-draft or has the "DraftRunCI" label set *AND*
* One of the following:
	* Certain files were changed *OR*
	* The PR is non-draft and has the "Ready to merge" flag *OR*
	* The workflow is being run from the merge queue.

Additionally, a meta "passed" job is dependent on all the other test jobs, so branch protection rule required jobs only need to specify "passed" to ensure that *either* all the test jobs pass *or* all the test jobs are skipped because they don't need to be run.

This allows PRs to be merged without overriding.