### PR TITLE
Release 2.6.0

### DIFF
--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.6.0-rc3"
+char const* const versionString = "2.6.0"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)


### PR DESCRIPTION
The base branch is `master`. This PR branch will be pushed directly to `release` and `master` (not squashed or rebased, and not using the GitHub UI).
# Release Notes

![XRP](docs/images/xrp-text-mark-black-small@2x.png)
This document contains the notes for the release `2.6.0` of `rippled` , the reference server implementation of the XRP Ledger protocol. To learn more about how to build, run or update a `rippled` server, visit https://xrpl.org/install-rippled.html

This release adds new features and bug fixes.

## [2.6.0] - 2025-08-27

### 🐛 Bug Fixes
- Change log to debug level for AMM offer retrieval and IOU payment check (#5686) by @intelliot
- Add -Wno-deprecated-declarations for Clang only (#5680) by @bthomee
- Improve logging of the reason to refuse a peer connection (#5664) by @Tapanito
- Make test suite names match the directory name (#5597) by @Afformativ
- Don't flag consensus as stalled prematurely (#5627) by @ximinez
- VaultWithdraw destination account bugfix (#5572) by @Bronek
- Add allowTrustLineLocking flag for account_info (#5525) by @dangell7
- Link with boost libraries explicitly (#5546) by @mathbunnyru
- Crash when trace-logging in tests (#5529) by @mvadari
- Crash in Slot::deletePeer (#5635) by @Bronek
- Clang-format CI job (#5598) by @Bronek
- macOS runner (#5585) by @a1q123456

### 🚀 Features

- Include `network_id` in validations and subscription stream responses (#5579) by @ckeshava
- Add support for `DomainID` in `MPTokenIssuance` transactions (#5509) by @Bronek
- Add MPT related txns into issuer's account history  (#5530) by @shawnxie999
- Add nftoken_id, nftoken_ids, offer_id to meta for transaction stream (#5230) by @tequdev

### 💼 Other

- Set version to 2.6.0 by @legleux
- Set version to 2.6.0-rc3 by @ximinez
- Set version to 2.6.0-rc2 by @legleux
- Update .git-blame-ignore-revs for #5657 (#5675) by @intelliot
- Fix BUILD.md instruction (#5676) by @Bronek
- Set version to 2.6.0-rc1 by @legleux
- Switch Conan 1 commands to Conan 2 and fix credentials (#5655) by @bthomee
- Upload Conan dependencies upon merge into develop (#5654) by @bthomee
- Build options cleanup (#5581) by @Bronek
- Updates Conan dependencies: Boost 1.86 (#5264) by @bthomee
- Update rocksdb (#5568) by @bthomee
- Switch instrumentation workflow to use dependencies (#5607) by @Bronek
- Remove the type filter from "ledger" RPC command (#4934) by @ckeshava
- Retire Flow Cross amendment (#5562) by @vvysokikh1
- Downgrade required CMake version for Antithesis SDK (#5548) by @Bronek
- Remove OwnerPaysFee as it's never fully supported (#5435) by @a1q123456
- Removes release notes from codebase (#5508) by @bthomee

### 🚜 Refactor

- Decouple CredentialHelpers from xrpld/app/tx (#5487) by @a1q123456
- Add XRPL_ABANDON and use it to abandon OwnerPaysFee (#5510) by @a1q123456
- Remove obsolete owner pays fee feature and XRPL_ABANDON stanza (#5550) by @a1q123456
- Restructure beast::rngfill (#5563) by @lmaisons
- Remove external libraries as they are hosted in our Conan Center Index fork (#5643) by @bthomee
- Decouple ledger from xrpld/app (#5492) by @a1q123456
- Makes HashRouter flags more type-safe (#5371) by @vlntb
- Change boost::shared_mutex to std::shared_mutex (#5576) by @Tapanito
- Update date, libarchive, nudb, openssl, sqlite3, xxhash packages (#5567) by @bthomee

### 📚 Documentation

- Updates list of maintainers and reviewers (#5687) by @bthomee
- Update BUILD.md for Conan 2 (#5478) by @Bronek
- Set up developer environment with specific XCode version (#5645) by @dangell7

### ⚡ Performance
- Revert ["perf: Move mutex to the partition level](https://github.com/XRPLF/rippled/pull/5486)" @ximinez 
- Optimize hash performance by avoiding allocating hash state object (#5469) by @a1q123456
- Move mutex to the partition level (#5486) by @vlntb

### 🧪 Testing

- Run unit tests regardless of 'Supported' amendment status (#5537) by @vvysokikh1
- Remove circular jtx.h dependencies (#5544) by @Bronek
- switch some unit tests to doctest (#5383) by @vvysokikh1

### ⚙️ Miscellaneous Tasks

- Run prettier on all files (#5657) by @mvadari
- Set CONAN_REMOTE_URL also for forks (#5662) by @Bronek
- Cleanup bin/ directory (#5660) by @bthomee
- Remove `include(default)` from libxrpl profile (#5587) by @Bronek
- Rename conan profile to `default` (#5599) by @Bronek
- Remove unused code after flow cross retirement (#5575) by @vvysokikh1
- Update CI to use Conan 2 (#5556) by @legleux
- Add gcc-12 workaround (#5554) by @Bronek
- Remove unused headers (#5526) by @vvysokikh1
- Fix compilation error with clang-20 and cleanup (#5543) by @Bronek
