### PR TITLE
[RELEASE] Downgrade version 2.6 to boost 1.83

### DIFF
--- a/conan/profiles/default
+++ b/conan/profiles/default
@@ -26,6 +26,9 @@ tools.build:cxxflags=['-Wno-missing-template-arg-list-after-template-kw']
 {% if compiler == "apple-clang" and compiler_version >= 17 %}
 tools.build:cxxflags=['-Wno-missing-template-arg-list-after-template-kw']
 {% endif %}
+{% if compiler == "clang" and compiler_version == 16 %}
+tools.build:cxxflags=['-DBOOST_ASIO_DISABLE_CONCEPTS']
+{% endif %}
 {% if compiler == "gcc" and compiler_version < 13 %}
 tools.build:cxxflags=['-Wno-restrict']
 {% endif %}

--- a/conanfile.py
+++ b/conanfile.py
@@ -104,7 +104,7 @@ class Xrpl(ConanFile):
     def requirements(self):
         # Conan 2 requires transitive headers to be specified
         transitive_headers_opt = {'transitive_headers': True} if conan_version.split('.')[0] == '2' else {}
-        self.requires('boost/1.86.0', force=True, **transitive_headers_opt)
+        self.requires('boost/1.83.0', force=True, **transitive_headers_opt)
         self.requires('date/3.0.4', **transitive_headers_opt)
         self.requires('lz4/1.10.0', force=True)
         self.requires('protobuf/3.21.12', force=True)

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.6.0"
+char const* const versionString = "2.6.1-rc1"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -681,7 +681,7 @@ class ServerStatus_test : public beast::unit_test::suite,
             resp["Upgrade"] == "websocket");
         BEAST_EXPECT(
             resp.find("Connection") != resp.end() &&
-            resp["Connection"] == "Upgrade");
+            resp["Connection"] == "upgrade");
     }
 
     void


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

# NOTE this is for `release` branch only

## High Level Overview of Change

This fixes a problem where `rippled` could crash due a regression bug in boost 1.86 

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

This is the result of an internal investigation into `rippled` crashes in testnet. We found the crashes to correspond to a documented regression in boost 1.86 and confirmed that this bug is not present in the older version of boost 1.83 , which was used before #5264 . We do not fully revert this PR since there is no need.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

