### PR TITLE
chore: Add `conan.lock` to workflow file checks

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -75,6 +75,7 @@ jobs:
             tests/**
             CMakeLists.txt
             conanfile.py
+            conan.lock
       - name: Check whether to run
         # This step determines whether the rest of the workflow should
         # run. The rest of the workflow will run if this job runs AND at


### PR DESCRIPTION
## High Level Overview of Change

This PR adds `conan.lock` to the list of files that, when changed, will trigger the CI pipeline.

### Context of Change

#5768 

### Type of Change

- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)


## Test Plan

Worked in #5768
