### PR TITLE
docs: Add remote to `conan lock create` command

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -586,6 +586,11 @@ After any updates or changes to dependencies, you may need to do the following:
 4. [Regenerate lockfile](#conan-lockfile).
 5. Re-run [conan install](#build-and-test).
 
+#### ERROR: Package not resolved
+
+If you're seeing an error like `ERROR: Package 'snappy/1.1.10' not resolved: Unable to find 'snappy/1.1.10#968fef506ff261592ec30c574d4a7809%1756234314.246' in remotes.`,
+please add `xrplf` remote or re-run for [patched recipes](#patched-recipes).
+
 ### `protobuf/port_def.inc` file not found
 
 If `cmake --build .` results in an error due to a missing a protobuf file, then

--- a/BUILD.md
+++ b/BUILD.md
@@ -132,7 +132,7 @@ higher index than the default Conan Center remote, so it is consulted first. You
 can do this by running:
 
 ```bash
-conan remote add --index 0 xrplf "https://conan.ripplex.io"
+conan remote add --index 0 xrplf https://conan.ripplex.io
 ```
 
 Alternatively, you can pull the patched recipes into the repository and use them
@@ -479,20 +479,22 @@ It is implicitly used when running `conan` commands, you don't need to specify i
 
 You have to update this file every time you add a new dependency or change a revision or version of an existing dependency.
 
-> ![NOTE]
+> [!NOTE]
 > Conan uses local cache by default when creating a lockfile.
-
-To ensure, that lockfile creation works the same way on all developer machines, we recommend to clear the local cache before creating a new lockfile.
+>
+> To ensure, that lockfile creation works the same way on all developer machines, you should clear the local cache before creating a new lockfile.
 
 To create a new lockfile, run the following commands in the repository root:
 
 ```bash
 conan remove '*' --confirm
 rm conan.lock
+# This ensure that xrplf remote is the first to be consulted
+conan remote add --force --index 0 xrplf https://conan.ripplex.io
 conan lock create . -o '&:jemalloc=True' -o '&:rocksdb=True'
 ```
 
-> ![NOTE]
+> [!NOTE]
 > If some dependencies are exclusive for some OS, you may need to run the last command for them adding `--profile:all <PROFILE>`.
 
 ## Coverage report

--- a/BUILD.md
+++ b/BUILD.md
@@ -479,11 +479,21 @@ It is implicitly used when running `conan` commands, you don't need to specify i
 
 You have to update this file every time you add a new dependency or change a revision or version of an existing dependency.
 
-To do that, run the following command in the repository root:
+> ![NOTE]
+> Conan uses local cache by default when creating a lockfile.
+
+To ensure, that lockfile creation works the same way on all developer machines, we recommend to clear the local cache before creating a new lockfile.
+
+To create a new lockfile, run the following commands in the repository root:
 
 ```bash
-conan lock create . -o '&:jemalloc=True' -o '&:rocksdb=True' -r=xrplf
+conan remove '*' --confirm
+rm conan.lock
+conan lock create . -o '&:jemalloc=True' -o '&:rocksdb=True'
 ```
+
+> ![NOTE]
+> If some dependencies are exclusive for some OS, you may need to run the last command for them adding `--profile:all <PROFILE>`.
 
 ## Coverage report
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -589,7 +589,7 @@ After any updates or changes to dependencies, you may need to do the following:
 #### ERROR: Package not resolved
 
 If you're seeing an error like `ERROR: Package 'snappy/1.1.10' not resolved: Unable to find 'snappy/1.1.10#968fef506ff261592ec30c574d4a7809%1756234314.246' in remotes.`,
-please add `xrplf` remote or re-run for [patched recipes](#patched-recipes).
+please add `xrplf` remote or re-run `conan export` for [patched recipes](#patched-recipes).
 
 ### `protobuf/port_def.inc` file not found
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -482,7 +482,7 @@ You have to update this file every time you add a new dependency or change a rev
 To do that, run the following command in the repository root:
 
 ```bash
-conan lock create . -o '&:jemalloc=True' -o '&:rocksdb=True'
+conan lock create . -o '&:jemalloc=True' -o '&:rocksdb=True' -r=xrplf
 ```
 
 ## Coverage report


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

This should make the result not depend on the local cache and only use the remote

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
