### PR TITLE
chore: "passed" job fails if any previous jobs failed

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -123,11 +123,12 @@ jobs:
       conan_remote_password: ${{ secrets.CONAN_REMOTE_PASSWORD }}
 
   passed:
+    if: failure()
     needs:
       - build-test
       - check-format
       - check-levelization
     runs-on: ubuntu-latest
     steps:
-      - name: No-op
-        run: true
+      - name: Fail
+        run: false

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -125,7 +125,7 @@ jobs:
       conan_remote_password: ${{ secrets.CONAN_REMOTE_PASSWORD }}
 
   passed:
-    if: failure()
+    if: failure() || cancelled()
     needs:
       - build-test
       - check-format


### PR DESCRIPTION
## High Level Overview of Change

Ensure the new-ish `passed` job only flags as passed if all its dependencies passed or were skipped.

### Context of Change

For the purposes of being able to merge a PR, Github Actions jobs count as passed if they ran and passed, or were skipped. The current iteration of `passed` depends on several other jobs, but if any of those jobs fail, `passed` is skipped. This results in a false positive when checking for whether a PR can be merged.

With this change, if any of the dependent jobs fail, then `passed` will fail. If they all succeed or are skipped, then `passed` is skipped.

This saves spinning up a runner in the usual case where things work, and will simplify our branch protection rules, so that only `passed` will need to be checked.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)

