### PR TITLE
Only notify clio for PRs targeting the release and master branches

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -92,12 +92,12 @@ jobs:
 
   check-levelization:
     needs: should-run
-    if: needs.should-run.outputs.go == 'true'
+    if: ${{ needs.should-run.outputs.go == 'true' }}
     uses: ./.github/workflows/check-levelization.yml
 
   build-test:
     needs: should-run
-    if: needs.should-run.outputs.go == 'true'
+    if: ${{ needs.should-run.outputs.go == 'true' }}
     uses: ./.github/workflows/build-test.yml
     strategy:
       matrix:
@@ -111,7 +111,7 @@ jobs:
     needs:
       - should-run
       - build-test
-    if: needs.should-run.outputs.go == 'true'
+    if: ${{ needs.should-run.outputs.go == 'true' && contains(fromJSON('["release", "master"]'), github.ref_name) }}
     uses: ./.github/workflows/notify-clio.yml
     secrets:
       clio_notify_token: ${{ secrets.CLIO_NOTIFY_TOKEN }}

--- a/.github/workflows/upload-conan-deps.yml
+++ b/.github/workflows/upload-conan-deps.yml
@@ -83,9 +83,9 @@ jobs:
           force_build: ${{ github.event_name == 'schedule' || github.event.inputs.force_source_build == 'true' }}
 
       - name: Log into Conan remote
-        if: github.repository_owner == 'XRPLF' && github.event_name != 'pull_request'
+        if: ${{ github.repository_owner == 'XRPLF' && github.event_name != 'pull_request' }}
         run: conan remote login ${{ env.CONAN_REMOTE_NAME }} "${{ secrets.CONAN_REMOTE_USERNAME }}" --password "${{ secrets.CONAN_REMOTE_PASSWORD }}"
 
       - name: Upload Conan packages
-        if: github.repository_owner == 'XRPLF' && github.event_name != 'pull_request' && github.event_name != 'schedule'
+        if: ${{ github.repository_owner == 'XRPLF' && github.event_name != 'pull_request' && github.event_name != 'schedule' }}
         run: conan upload "*" -r=${{ env.CONAN_REMOTE_NAME }} --confirm ${{ github.event.inputs.force_upload == 'true' && '--force' || '' }}


### PR DESCRIPTION
## High Level Overview of Change

This change only notifies Clio when a PR targets the release or master branch.

It also wraps some GitHub conditionals in `${{ .. }}` for consistency and to reduce unexpected failures, because I previously noticed that not conditionals work without those curly braces.

### Context of Change

Clio should only be notified when releases are about to be made, instead of for all PRs.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
