### PR TITLE
chore: Build and test all configs for daily scheduled run

### DIFF
--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -80,6 +80,6 @@ jobs:
         os: [linux, macos, windows]
     with:
       os: ${{ matrix.os }}
-      strategy_matrix: "minimal"
+      strategy_matrix: ${{ github.event_name == 'schedule' && 'all' || 'minimal' }}
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## High Level Overview of Change

Re-enables building and testing all configurations, but only for the daily scheduled run.

### Context of Change

Previously all configurations were run for each merge into the develop branch, but that overwhelmed both the GitHub runners and the Conan remote, and thus they were limited to just a subset of configurations. However, with the success shown by setting `max-parallel: 10` when uploading Conan dependencies, we will apply the same for building and testing as is done in https://github.com/XRPLF/rippled/pull/5799. Once the latter PR has been merged, we should be able to safely enable building all configurations again. However, building them all once a day instead of for each PR merge should be sufficient.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
