### PR TITLE
Pin all CI Docker tags

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,6 +46,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  DOCKER_CI_SHA: sha-5dd7158
+
 jobs:
   # Generate the strategy matrix to be used by the following job.
   generate-matrix:
@@ -63,7 +66,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       max-parallel: 10
     runs-on: ${{ matrix.architecture.runner }}
-    container: ${{ inputs.os == 'linux' && format('ghcr.io/xrplf/ci/{0}-{1}:{2}-{3}', matrix.os.distro_name, matrix.os.distro_version, matrix.os.compiler_name, matrix.os.compiler_version) || null }}
+    container: ${{ inputs.os == 'linux' && format('ghcr.io/xrplf/ci/{0}-{1}:{2}-{3}-{4}', matrix.os.distro_name, matrix.os.distro_version, matrix.os.compiler_name, matrix.os.compiler_version, env.DOCKER_CI_SHA) || null }}
     steps:
       - name: Check strategy matrix
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,9 +46,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  DOCKER_CI_SHA: sha-5dd7158
-
 jobs:
   # Generate the strategy matrix to be used by the following job.
   generate-matrix:
@@ -66,7 +63,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       max-parallel: 10
     runs-on: ${{ matrix.architecture.runner }}
-    container: ${{ inputs.os == 'linux' && format('ghcr.io/xrplf/ci/{0}-{1}:{2}-{3}-{4}', matrix.os.distro_name, matrix.os.distro_version, matrix.os.compiler_name, matrix.os.compiler_version, env.DOCKER_CI_SHA) || null }}
+    container: ${{ inputs.os == 'linux' && format('ghcr.io/xrplf/ci/{0}-{1}:{2}-{3}-sha-5dd7158', matrix.os.distro_name, matrix.os.distro_version, matrix.os.compiler_name, matrix.os.compiler_version) || null }}
     steps:
       - name: Check strategy matrix
         run: |

--- a/.github/workflows/notify-clio.yml
+++ b/.github/workflows/notify-clio.yml
@@ -36,14 +36,11 @@ defaults:
   run:
     shell: bash
 
-env:
-  DOCKER_CI_SHA: sha-5dd7158
-
 jobs:
   upload:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
-    container: ghcr.io/xrplf/ci/ubuntu-noble:gcc-13-${{ env.DOCKER_CI_SHA }}
+    container: ghcr.io/xrplf/ci/ubuntu-noble:gcc-13-sha-5dd7158
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/notify-clio.yml
+++ b/.github/workflows/notify-clio.yml
@@ -36,11 +36,14 @@ defaults:
   run:
     shell: bash
 
+env:
+  DOCKER_CI_SHA: sha-5dd7158
+
 jobs:
   upload:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
-    container: ghcr.io/xrplf/ci/ubuntu-noble:gcc-13
+    container: ghcr.io/xrplf/ci/ubuntu-noble:gcc-13-${{ env.DOCKER_CI_SHA }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,4 +12,4 @@ jobs:
     uses: XRPLF/actions/.github/workflows/pre-commit.yml@af1b0f0d764cda2e5435f5ac97b240d4bd4d95d3
     with:
       runs_on: ubuntu-latest
-      container: '{ "image": "ghcr.io/xrplf/ci/tools-rippled-pre-commit:sha-5dd7158" }'
+      container: '{ "image": "ghcr.io/xrplf/ci/tools-rippled-pre-commit:sha-d1496b8" }'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,13 +6,10 @@ on:
     branches: [develop, release, master]
   workflow_dispatch:
 
-env:
-  DOCKER_CI_SHA: sha-5dd7158
-
 jobs:
   # Call the workflow in the XRPLF/actions repo that runs the pre-commit hooks.
   run-hooks:
     uses: XRPLF/actions/.github/workflows/pre-commit.yml@af1b0f0d764cda2e5435f5ac97b240d4bd4d95d3
     with:
       runs_on: ubuntu-latest
-      container: '{ "image": "ghcr.io/xrplf/ci/tools-rippled-pre-commit-${{ env.DOCKER_CI_SHA }}" }'
+      container: '{ "image": "ghcr.io/xrplf/ci/tools-rippled-pre-commit-sha-5dd7158" }'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,9 +6,13 @@ on:
     branches: [develop, release, master]
   workflow_dispatch:
 
+env:
+  DOCKER_CI_SHA: sha-5dd7158
+
 jobs:
+  # Call the workflow in the XRPLF/actions repo that runs the pre-commit hooks.
   run-hooks:
     uses: XRPLF/actions/.github/workflows/pre-commit.yml@af1b0f0d764cda2e5435f5ac97b240d4bd4d95d3
     with:
       runs_on: ubuntu-latest
-      container: '{ "image": "ghcr.io/xrplf/ci/tools-rippled-pre-commit" }'
+      container: '{ "image": "ghcr.io/xrplf/ci/tools-rippled-pre-commit-${{ env.DOCKER_CI_SHA }}" }'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,4 +12,4 @@ jobs:
     uses: XRPLF/actions/.github/workflows/pre-commit.yml@af1b0f0d764cda2e5435f5ac97b240d4bd4d95d3
     with:
       runs_on: ubuntu-latest
-      container: '{ "image": "ghcr.io/xrplf/ci/tools-rippled-pre-commit-sha-5dd7158" }'
+      container: '{ "image": "ghcr.io/xrplf/ci/tools-rippled-pre-commit:sha-5dd7158" }'

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    container: ghcr.io/xrplf/ci/tools-rippled-documentation:sha-5dd7158
+    container: ghcr.io/xrplf/ci/tools-rippled-documentation:sha-d1496b8
     permissions:
       contents: write
     steps:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -23,12 +23,11 @@ defaults:
 
 env:
   BUILD_DIR: .build
-  DOCKER_CI_SHA: sha-5dd7158
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    container: ghcr.io/xrplf/ci/tools-rippled-documentation-${{ env.DOCKER_CI_SHA }}
+    container: ghcr.io/xrplf/ci/tools-rippled-documentation-sha-5dd7158
     permissions:
       contents: write
     steps:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    container: ghcr.io/xrplf/ci/tools-rippled-documentation-sha-5dd7158
+    container: ghcr.io/xrplf/ci/tools-rippled-documentation:sha-5dd7158
     permissions:
       contents: write
     steps:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -23,11 +23,12 @@ defaults:
 
 env:
   BUILD_DIR: .build
+  DOCKER_CI_SHA: sha-5dd7158
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    container: ghcr.io/xrplf/ci/tools-rippled-documentation
+    container: ghcr.io/xrplf/ci/tools-rippled-documentation-${{ env.DOCKER_CI_SHA }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/upload-conan-deps.yml
+++ b/.github/workflows/upload-conan-deps.yml
@@ -37,6 +37,7 @@ on:
 env:
   CONAN_REMOTE_NAME: xrplf
   CONAN_REMOTE_URL: https://conan.ripplex.io
+  DOCKER_CI_SHA: sha-5dd7158
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -56,7 +57,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       max-parallel: 10
     runs-on: ${{ matrix.architecture.runner }}
-    container: ${{ contains(matrix.architecture.platform, 'linux') && format('ghcr.io/xrplf/ci/{0}-{1}:{2}-{3}', matrix.os.distro_name, matrix.os.distro_version, matrix.os.compiler_name, matrix.os.compiler_version) || null }}
+    container: ${{ contains(matrix.architecture.platform, 'linux') && format('ghcr.io/xrplf/ci/{0}-{1}:{2}-{3}-{4}', matrix.os.distro_name, matrix.os.distro_version, matrix.os.compiler_name, matrix.os.compiler_version, env.DOCKER_CI_SHA) || null }}
 
     steps:
       - name: Cleanup workspace

--- a/.github/workflows/upload-conan-deps.yml
+++ b/.github/workflows/upload-conan-deps.yml
@@ -37,7 +37,6 @@ on:
 env:
   CONAN_REMOTE_NAME: xrplf
   CONAN_REMOTE_URL: https://conan.ripplex.io
-  DOCKER_CI_SHA: sha-5dd7158
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -57,7 +56,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       max-parallel: 10
     runs-on: ${{ matrix.architecture.runner }}
-    container: ${{ contains(matrix.architecture.platform, 'linux') && format('ghcr.io/xrplf/ci/{0}-{1}:{2}-{3}-{4}', matrix.os.distro_name, matrix.os.distro_version, matrix.os.compiler_name, matrix.os.compiler_version, env.DOCKER_CI_SHA) || null }}
+    container: ${{ contains(matrix.architecture.platform, 'linux') && format('ghcr.io/xrplf/ci/{0}-{1}:{2}-{3}-sha-5dd7158', matrix.os.distro_name, matrix.os.distro_version, matrix.os.compiler_name, matrix.os.compiler_version) || null }}
 
     steps:
       - name: Cleanup workspace


### PR DESCRIPTION
## High Level Overview of Change

This change pins all CI Docker image tags to the latest version in the XRPLF/CI repo.

### Context of Change

To avoid surprises and ensure reproducibility, all things that can be pinned should be pinned.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release