### PR TITLE
chore: Sets free-form CI inputs as env vars

### DIFF
--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -20,14 +20,18 @@ runs:
   steps:
     - name: Install Conan dependencies
       shell: bash
+      env:
+        BUILD_DIR: ${{ inputs.build_dir }}
+        BUILD_OPTION: ${{ inputs.force_build == 'true' && '*' || 'missing' }}
+        BUILD_TYPE: ${{ inputs.build_type }}
       run: |
         echo 'Installing dependencies.'
-        mkdir -p ${{ inputs.build_dir }}
-        cd ${{ inputs.build_dir }}
+        mkdir -p '${{ env.BUILD_DIR }}'
+        cd '${{ env.BUILD_DIR }}'
         conan install \
           --output-folder . \
-          --build ${{ inputs.force_build == 'true' && '"*"' || 'missing' }} \
-          --options:host '&:tests=True' \
-          --options:host '&:xrpld=True' \
-          --settings:all build_type=${{ inputs.build_type }} \
+          --build=${{ env.BUILD_OPTION }} \
+          --options:host='&:tests=True' \
+          --options:host='&:xrpld=True' \
+          --settings:all build_type='${{ env.BUILD_TYPE }}' \
           ..

--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -35,9 +35,12 @@ runs:
 
     - name: Set up Conan remote
       shell: bash
+      env:
+        CONAN_REMOTE_NAME: ${{ inputs.conan_remote_name }}
+        CONAN_REMOTE_URL: ${{ inputs.conan_remote_url }}
       run: |
-        echo "Adding Conan remote '${{ inputs.conan_remote_name }}' at ${{ inputs.conan_remote_url }}."
-        conan remote add --index 0 --force ${{ inputs.conan_remote_name }} ${{ inputs.conan_remote_url }}
+        echo "Adding Conan remote '${{ env.CONAN_REMOTE_NAME }}' at '${{ env.CONAN_REMOTE_URL }}'."
+        conan remote add --index 0 --force '${{ env.CONAN_REMOTE_NAME }}' '${{ env.CONAN_REMOTE_URL }}'
 
         echo 'Listing Conan remotes.'
         conan remote list

--- a/.github/workflows/reusable-strategy-matrix.yml
+++ b/.github/workflows/reusable-strategy-matrix.yml
@@ -35,4 +35,7 @@ jobs:
       - name: Generate strategy matrix
         working-directory: .github/scripts/strategy-matrix
         id: generate
-        run: ./generate.py ${{ inputs.strategy_matrix == 'all' && '--all' || '' }} ${{ inputs.os != '' && format('--config={0}.json', inputs.os) || '' }} >> "${GITHUB_OUTPUT}"
+        env:
+          GENERATE_CONFIG: ${{ inputs.os != '' && format('--config={0}.json', inputs.os) || '' }}
+          GENERATE_OPTION: ${{ inputs.strategy_matrix == 'all' && '--all' || '' }}
+        run: ./generate.py ${{ env.GENERATE_OPTION }} ${{ env.GENERATE_CONFIG }} >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/upload-conan-deps.yml
+++ b/.github/workflows/upload-conan-deps.yml
@@ -24,13 +24,10 @@ on:
     branches: [develop]
     paths:
       - .github/workflows/upload-conan-deps.yml
-
       - .github/workflows/reusable-strategy-matrix.yml
-
       - .github/actions/build-deps/action.yml
       - .github/actions/setup-conan/action.yml
       - ".github/scripts/strategy-matrix/**"
-
       - conanfile.py
       - conan.lock
 
@@ -88,4 +85,6 @@ jobs:
 
       - name: Upload Conan packages
         if: ${{ github.repository_owner == 'XRPLF' && github.event_name != 'pull_request' && github.event_name != 'schedule' }}
-        run: conan upload "*" -r=${{ env.CONAN_REMOTE_NAME }} --confirm ${{ github.event.inputs.force_upload == 'true' && '--force' || '' }}
+        env:
+          FORCE_OPTION: ${{ github.event.inputs.force_upload == 'true' && '--force' || '' }}
+        run: conan upload "*" --remote='${{ env.CONAN_REMOTE_NAME }}' --confirm ${{ env.FORCE_OPTION }}


### PR DESCRIPTION
## High Level Overview of Change

This change moves CI values that could be user-provided into environment variables.

### Context of Change

Semgrep scanning indicated:

> Using variable interpolation `${{...}}` with `github` context data in a `run: step` could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: `"$ENVVAR"`.

I performed the changes in the locations indicated by Semgrep, although made slight changes:
* Some inputs were used as a ternary operator, and that functionality is maintained by moving the whole operation into the env var. As the outputs were used to either apply a flag or not, these cannot be surrounded by quotes.
* I used GitHubs `{{ env.ENVVAR }}` instead of `$ENVVAR` (or `${ENVVAR}`) for consistency with the existing use of environment variables. In this case only single quotes are needed instead of double.

As for the Conan commands whereby the arguments now have changed slightly, I checked locally whether the `conan install` and `conan remote` calls would accept arguments surrounded by quotes, and they did function as before.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release