### PR TITLE
refactor: Remove ripplerpc RPC parameter

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -214,7 +214,6 @@ words:
   - ripdtop
   - rippleci
   - rippled
-  - ripplerpc
   - rippletest
   - RLUSD
   - rngfill

--- a/include/xrpl/protocol/jss.h
+++ b/include/xrpl/protocol/jss.h
@@ -531,7 +531,6 @@ JSS(response);                // websocket
 JSS(result);                  // RPC
 JSS(ripple_lines);            // out: NetworkOPs
 JSS(ripple_state);            // in: LedgerEntr
-JSS(ripplerpc);               // ripple RPC version
 JSS(role);                    // out: Ping.cpp
 JSS(rpc);
 JSS(rt_accounts);             // in: Subscribe, Unsubscribe

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -2105,7 +2105,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jrr.isMember(jss::jsonrpc) && jrr[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jrr.isMember(jss::ripplerpc) && jrr[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jrr.isMember(jss::id) && jrr[jss::id] == 5);
         }
 

--- a/src/test/jtx/impl/JSONRPCClient.cpp
+++ b/src/test/jtx/impl/JSONRPCClient.cpp
@@ -107,7 +107,6 @@ public:
             if (rpc_version_ == 2)
             {
                 jr[jss::jsonrpc] = "2.0";
-                jr[jss::ripplerpc] = "2.0";
                 jr[jss::id] = 5;
             }
             if (params)

--- a/src/test/jtx/impl/WSClient.cpp
+++ b/src/test/jtx/impl/WSClient.cpp
@@ -174,7 +174,6 @@ public:
             {
                 jp[jss::method] = cmd;
                 jp[jss::jsonrpc] = "2.0";
-                jp[jss::ripplerpc] = "2.0";
                 jp[jss::id] = 5;
             }
             else

--- a/src/test/jtx/impl/utility.cpp
+++ b/src/test/jtx/impl/utility.cpp
@@ -82,8 +82,6 @@ cmdToJSONRPC(std::vector<std::string> const& args, beast::Journal j, unsigned in
     }
     if (paramsObj.isMember(jss::jsonrpc))
         jv[jss::jsonrpc] = paramsObj[jss::jsonrpc];
-    if (paramsObj.isMember(jss::ripplerpc))
-        jv[jss::ripplerpc] = paramsObj[jss::ripplerpc];
     if (paramsObj.isMember(jss::id))
         jv[jss::id] = paramsObj[jss::id];
     return jv;

--- a/src/test/rpc/AccountInfo_test.cpp
+++ b/src/test/rpc/AccountInfo_test.cpp
@@ -335,7 +335,6 @@ public:
 
         auto const withoutSigners = std::string("{ ") +
             "\"jsonrpc\": \"2.0\", "
-            "\"ripplerpc\": \"2.0\", "
             "\"id\": 5, "
             "\"method\": \"account_info\", "
             "\"params\": { "
@@ -344,7 +343,6 @@ public:
 
         auto const withSigners = std::string("{ ") +
             "\"jsonrpc\": \"2.0\", "
-            "\"ripplerpc\": \"2.0\", "
             "\"id\": 6, "
             "\"method\": \"account_info\", "
             "\"params\": { "
@@ -358,7 +356,6 @@ public:
                 info.isMember(jss::result) && info[jss::result].isMember(jss::account_data));
             BEAST_EXPECT(!info[jss::result][jss::account_data].isMember(jss::signer_lists));
             BEAST_EXPECT(info.isMember(jss::jsonrpc) && info[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(info.isMember(jss::ripplerpc) && info[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(info.isMember(jss::id) && info[jss::id] == 5);
         }
         {
@@ -372,7 +369,6 @@ public:
             BEAST_EXPECT(signerLists.isArray());
             BEAST_EXPECT(signerLists.size() == 0);
             BEAST_EXPECT(info.isMember(jss::jsonrpc) && info[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(info.isMember(jss::ripplerpc) && info[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(info.isMember(jss::id) && info[jss::id] == 6);
         }
         {
@@ -383,7 +379,6 @@ public:
                 info[0u][jss::result].isMember(jss::account_data));
             BEAST_EXPECT(!info[0u][jss::result][jss::account_data].isMember(jss::signer_lists));
             BEAST_EXPECT(info[0u].isMember(jss::jsonrpc) && info[0u][jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(info[0u].isMember(jss::ripplerpc) && info[0u][jss::ripplerpc] == "2.0");
             BEAST_EXPECT(info[0u].isMember(jss::id) && info[0u][jss::id] == 5);
 
             BEAST_EXPECT(
@@ -395,7 +390,6 @@ public:
             BEAST_EXPECT(signerLists.isArray());
             BEAST_EXPECT(signerLists.size() == 0);
             BEAST_EXPECT(info[1u].isMember(jss::jsonrpc) && info[1u][jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(info[1u].isMember(jss::ripplerpc) && info[1u][jss::ripplerpc] == "2.0");
             BEAST_EXPECT(info[1u].isMember(jss::id) && info[1u][jss::id] == 6);
         }
 
@@ -411,7 +405,6 @@ public:
                 info.isMember(jss::result) && info[jss::result].isMember(jss::account_data));
             BEAST_EXPECT(!info[jss::result][jss::account_data].isMember(jss::signer_lists));
             BEAST_EXPECT(info.isMember(jss::jsonrpc) && info[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(info.isMember(jss::ripplerpc) && info[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(info.isMember(jss::id) && info[jss::id] == 5);
         }
         {
@@ -432,7 +425,6 @@ public:
             auto const& entry0 = signerEntries[0u][sfSignerEntry.jsonName];
             BEAST_EXPECT(entry0[sfSignerWeight.jsonName] == 3);
             BEAST_EXPECT(info.isMember(jss::jsonrpc) && info[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(info.isMember(jss::ripplerpc) && info[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(info.isMember(jss::id) && info[jss::id] == 6);
         }
 
@@ -482,7 +474,6 @@ public:
                 BEAST_EXPECT(entry[sfSignerWeight.jsonName] == 1);
             }
             BEAST_EXPECT(info.isMember(jss::jsonrpc) && info[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(info.isMember(jss::ripplerpc) && info[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(info.isMember(jss::id) && info[jss::id] == 6);
         }
     }

--- a/src/test/rpc/AccountLines_test.cpp
+++ b/src/test/rpc/AccountLines_test.cpp
@@ -685,24 +685,20 @@ public:
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             auto const lines = env.rpc("json2", to_string(request));
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
         }
         {
             // account_lines with no account.
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             request[jss::id] = 5;
             auto const lines = env.rpc("json2", to_string(request));
             BEAST_EXPECT(
                 lines[jss::error][jss::message] ==
                 RPC::missing_field_error(jss::account)[jss::error_message]);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         {
@@ -712,7 +708,6 @@ public:
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             request[jss::id] = 5;
             request[jss::params] = params;
             auto const lines = env.rpc("json2", to_string(request));
@@ -720,7 +715,6 @@ public:
                 lines[jss::error][jss::message] ==
                 RPC::make_error(rpcACT_MALFORMED)[jss::error_message]);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         Account const alice{"alice"};
@@ -731,7 +725,6 @@ public:
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             request[jss::id] = 5;
             request[jss::params] = params;
             auto const lines = env.rpc("json2", to_string(request));
@@ -739,7 +732,6 @@ public:
                 lines[jss::error][jss::message] ==
                 RPC::make_error(rpcACT_NOT_FOUND)[jss::error_message]);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         env.fund(XRP(10000), alice);
@@ -754,14 +746,12 @@ public:
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             request[jss::id] = 5;
             request[jss::params] = params;
             auto const lines = env.rpc("json2", to_string(request));
             BEAST_EXPECT(lines[jss::result][jss::lines].isArray());
             BEAST_EXPECT(lines[jss::result][jss::lines].size() == 0);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         {
@@ -772,7 +762,6 @@ public:
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             request[jss::id] = 5;
             request[jss::params] = params;
             auto const lines = env.rpc("json2", to_string(request));
@@ -780,7 +769,6 @@ public:
                 lines[jss::error][jss::message] ==
                 "Invalid field 'ledger_index', not string or number.");
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         {
@@ -791,13 +779,11 @@ public:
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             request[jss::id] = 5;
             request[jss::params] = params;
             auto const lines = env.rpc("json2", to_string(request));
             BEAST_EXPECT(lines[jss::error][jss::message] == "ledgerNotFound");
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         // Create trust lines to share with alice.
@@ -850,44 +836,38 @@ public:
         BEAST_EXPECT(ledger58Info.seq == 58);
 
         // A re-usable test for historic ledgers.
-        auto testAccountLinesHistory = [this, &env](
-                                           Account const& account,
-                                           LedgerHeader const& info,
-                                           int count) {
-            // Get account_lines by ledger index.
-            Json::Value paramsSeq;
-            paramsSeq[jss::account] = account.human();
-            paramsSeq[jss::ledger_index] = info.seq;
-            Json::Value requestSeq;
-            requestSeq[jss::method] = "account_lines";
-            requestSeq[jss::jsonrpc] = "2.0";
-            requestSeq[jss::ripplerpc] = "2.0";
-            requestSeq[jss::id] = 5;
-            requestSeq[jss::params] = paramsSeq;
-            auto const linesSeq = env.rpc("json2", to_string(requestSeq));
-            BEAST_EXPECT(linesSeq[jss::result][jss::lines].isArray());
-            BEAST_EXPECT(linesSeq[jss::result][jss::lines].size() == count);
-            BEAST_EXPECT(linesSeq.isMember(jss::jsonrpc) && linesSeq[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(linesSeq.isMember(jss::ripplerpc) && linesSeq[jss::ripplerpc] == "2.0");
-            BEAST_EXPECT(linesSeq.isMember(jss::id) && linesSeq[jss::id] == 5);
+        auto testAccountLinesHistory =
+            [this, &env](Account const& account, LedgerHeader const& info, int count) {
+                // Get account_lines by ledger index.
+                Json::Value paramsSeq;
+                paramsSeq[jss::account] = account.human();
+                paramsSeq[jss::ledger_index] = info.seq;
+                Json::Value requestSeq;
+                requestSeq[jss::method] = "account_lines";
+                requestSeq[jss::jsonrpc] = "2.0";
+                requestSeq[jss::id] = 5;
+                requestSeq[jss::params] = paramsSeq;
+                auto const linesSeq = env.rpc("json2", to_string(requestSeq));
+                BEAST_EXPECT(linesSeq[jss::result][jss::lines].isArray());
+                BEAST_EXPECT(linesSeq[jss::result][jss::lines].size() == count);
+                BEAST_EXPECT(linesSeq.isMember(jss::jsonrpc) && linesSeq[jss::jsonrpc] == "2.0");
+                BEAST_EXPECT(linesSeq.isMember(jss::id) && linesSeq[jss::id] == 5);
 
-            // Get account_lines by ledger hash.
-            Json::Value paramsHash;
-            paramsHash[jss::account] = account.human();
-            paramsHash[jss::ledger_hash] = to_string(info.hash);
-            Json::Value requestHash;
-            requestHash[jss::method] = "account_lines";
-            requestHash[jss::jsonrpc] = "2.0";
-            requestHash[jss::ripplerpc] = "2.0";
-            requestHash[jss::id] = 5;
-            requestHash[jss::params] = paramsHash;
-            auto const linesHash = env.rpc("json2", to_string(requestHash));
-            BEAST_EXPECT(linesHash[jss::result][jss::lines].isArray());
-            BEAST_EXPECT(linesHash[jss::result][jss::lines].size() == count);
-            BEAST_EXPECT(linesHash.isMember(jss::jsonrpc) && linesHash[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(linesHash.isMember(jss::ripplerpc) && linesHash[jss::ripplerpc] == "2.0");
-            BEAST_EXPECT(linesHash.isMember(jss::id) && linesHash[jss::id] == 5);
-        };
+                // Get account_lines by ledger hash.
+                Json::Value paramsHash;
+                paramsHash[jss::account] = account.human();
+                paramsHash[jss::ledger_hash] = to_string(info.hash);
+                Json::Value requestHash;
+                requestHash[jss::method] = "account_lines";
+                requestHash[jss::jsonrpc] = "2.0";
+                requestHash[jss::id] = 5;
+                requestHash[jss::params] = paramsHash;
+                auto const linesHash = env.rpc("json2", to_string(requestHash));
+                BEAST_EXPECT(linesHash[jss::result][jss::lines].isArray());
+                BEAST_EXPECT(linesHash[jss::result][jss::lines].size() == count);
+                BEAST_EXPECT(linesHash.isMember(jss::jsonrpc) && linesHash[jss::jsonrpc] == "2.0");
+                BEAST_EXPECT(linesHash.isMember(jss::id) && linesHash[jss::id] == 5);
+            };
 
         // Alice should have no trust lines in ledger 3.
         testAccountLinesHistory(alice, ledger3Info, 0);
@@ -908,7 +888,6 @@ public:
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             request[jss::id] = 5;
             request[jss::params] = params;
             auto const lines = env.rpc("json2", to_string(request));
@@ -918,7 +897,6 @@ public:
                 "Exactly one of 'ledger_hash' or 'ledger_index' can be "
                 "specified.");
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         {
@@ -928,14 +906,12 @@ public:
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             request[jss::id] = 5;
             request[jss::params] = params;
             auto const lines = env.rpc("json2", to_string(request));
             BEAST_EXPECT(lines[jss::result][jss::lines].isArray());
             BEAST_EXPECT(lines[jss::result][jss::lines].size() == 52);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         {
@@ -946,14 +922,12 @@ public:
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             request[jss::id] = 5;
             request[jss::params] = params;
             auto const lines = env.rpc("json2", to_string(request));
             BEAST_EXPECT(lines[jss::result][jss::lines].isArray());
             BEAST_EXPECT(lines[jss::result][jss::lines].size() == 26);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         {
@@ -964,7 +938,6 @@ public:
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             request[jss::id] = 5;
             request[jss::params] = params;
             auto const lines = env.rpc("json2", to_string(request));
@@ -972,7 +945,6 @@ public:
                 lines[jss::error][jss::message] ==
                 RPC::make_error(rpcACT_MALFORMED)[jss::error_message]);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         {
@@ -983,7 +955,6 @@ public:
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             request[jss::id] = 5;
             request[jss::params] = params;
             auto const lines = env.rpc("json2", to_string(request));
@@ -991,7 +962,6 @@ public:
                 lines[jss::error][jss::message] ==
                 RPC::expected_field_message(jss::limit, "unsigned integer"));
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         {
@@ -1002,14 +972,12 @@ public:
             Json::Value requestA;
             requestA[jss::method] = "account_lines";
             requestA[jss::jsonrpc] = "2.0";
-            requestA[jss::ripplerpc] = "2.0";
             requestA[jss::id] = 5;
             requestA[jss::params] = paramsA;
             auto const linesA = env.rpc("json2", to_string(requestA));
             BEAST_EXPECT(linesA[jss::result][jss::lines].isArray());
             BEAST_EXPECT(linesA[jss::result][jss::lines].size() == 1);
             BEAST_EXPECT(linesA.isMember(jss::jsonrpc) && linesA[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(linesA.isMember(jss::ripplerpc) && linesA[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(linesA.isMember(jss::id) && linesA[jss::id] == 5);
 
             // Pick up from where the marker left off.  We should get 51.
@@ -1020,14 +988,12 @@ public:
             Json::Value requestB;
             requestB[jss::method] = "account_lines";
             requestB[jss::jsonrpc] = "2.0";
-            requestB[jss::ripplerpc] = "2.0";
             requestB[jss::id] = 5;
             requestB[jss::params] = paramsB;
             auto const linesB = env.rpc("json2", to_string(requestB));
             BEAST_EXPECT(linesB[jss::result][jss::lines].isArray());
             BEAST_EXPECT(linesB[jss::result][jss::lines].size() == 51);
             BEAST_EXPECT(linesB.isMember(jss::jsonrpc) && linesB[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(linesB.isMember(jss::ripplerpc) && linesB[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(linesB.isMember(jss::id) && linesB[jss::id] == 5);
 
             // Go again from where the marker left off, but set a limit of 3.
@@ -1038,14 +1004,12 @@ public:
             Json::Value requestC;
             requestC[jss::method] = "account_lines";
             requestC[jss::jsonrpc] = "2.0";
-            requestC[jss::ripplerpc] = "2.0";
             requestC[jss::id] = 5;
             requestC[jss::params] = paramsC;
             auto const linesC = env.rpc("json2", to_string(requestC));
             BEAST_EXPECT(linesC[jss::result][jss::lines].isArray());
             BEAST_EXPECT(linesC[jss::result][jss::lines].size() == 3);
             BEAST_EXPECT(linesC.isMember(jss::jsonrpc) && linesC[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(linesC.isMember(jss::ripplerpc) && linesC[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(linesC.isMember(jss::id) && linesC[jss::id] == 5);
 
             // Mess with the marker so it becomes bad and check for the error.
@@ -1056,7 +1020,6 @@ public:
             Json::Value requestD;
             requestD[jss::method] = "account_lines";
             requestD[jss::jsonrpc] = "2.0";
-            requestD[jss::ripplerpc] = "2.0";
             requestD[jss::id] = 5;
             requestD[jss::params] = paramsD;
             auto const linesD = env.rpc("json2", to_string(requestD));
@@ -1064,7 +1027,6 @@ public:
                 linesD[jss::error][jss::message] ==
                 RPC::make_error(rpcINVALID_PARAMS)[jss::error_message]);
             BEAST_EXPECT(linesD.isMember(jss::jsonrpc) && linesD[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(linesD.isMember(jss::ripplerpc) && linesD[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(linesD.isMember(jss::id) && linesD[jss::id] == 5);
         }
         {
@@ -1075,7 +1037,6 @@ public:
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             request[jss::id] = 5;
             request[jss::params] = params;
             auto const lines = env.rpc("json2", to_string(request));
@@ -1083,7 +1044,6 @@ public:
                 lines[jss::error][jss::message] ==
                 RPC::expected_field_message(jss::marker, "string"));
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         {
@@ -1095,7 +1055,6 @@ public:
             Json::Value request;
             request[jss::method] = "account_lines";
             request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
             request[jss::id] = 5;
             request[jss::params] = params;
             auto const lines = env.rpc("json2", to_string(request));
@@ -1105,7 +1064,6 @@ public:
             BEAST_EXPECT(line[jss::no_ripple].asBool() == true);
             BEAST_EXPECT(line[jss::peer_authorized].asBool() == true);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         {
@@ -1117,7 +1075,6 @@ public:
             Json::Value requestA;
             requestA[jss::method] = "account_lines";
             requestA[jss::jsonrpc] = "2.0";
-            requestA[jss::ripplerpc] = "2.0";
             requestA[jss::id] = 5;
             requestA[jss::params] = paramsA;
             auto const linesA = env.rpc("json2", to_string(requestA));
@@ -1127,7 +1084,6 @@ public:
             BEAST_EXPECT(lineA[jss::no_ripple_peer].asBool() == true);
             BEAST_EXPECT(lineA[jss::authorized].asBool() == true);
             BEAST_EXPECT(linesA.isMember(jss::jsonrpc) && linesA[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(linesA.isMember(jss::ripplerpc) && linesA[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(linesA.isMember(jss::id) && linesA[jss::id] == 5);
 
             // Continue from the returned marker to make sure that works.
@@ -1141,7 +1097,6 @@ public:
             Json::Value requestB;
             requestB[jss::method] = "account_lines";
             requestB[jss::jsonrpc] = "2.0";
-            requestB[jss::ripplerpc] = "2.0";
             requestB[jss::id] = 5;
             requestB[jss::params] = paramsB;
             auto const linesB = env.rpc("json2", to_string(requestB));
@@ -1149,7 +1104,6 @@ public:
             BEAST_EXPECT(linesB[jss::result][jss::lines].size() == 25);
             BEAST_EXPECT(!linesB[jss::result].isMember(jss::marker));
             BEAST_EXPECT(linesB.isMember(jss::jsonrpc) && linesB[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(linesB.isMember(jss::ripplerpc) && linesB[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(linesB.isMember(jss::id) && linesB[jss::id] == 5);
         }
     }
@@ -1210,14 +1164,12 @@ public:
         Json::Value linesBegRequest;
         linesBegRequest[jss::method] = "account_lines";
         linesBegRequest[jss::jsonrpc] = "2.0";
-        linesBegRequest[jss::ripplerpc] = "2.0";
         linesBegRequest[jss::id] = 5;
         linesBegRequest[jss::params] = linesBegParams;
         auto const linesBeg = env.rpc("json2", to_string(linesBegRequest));
         BEAST_EXPECT(linesBeg[jss::result][jss::lines][0u][jss::currency] == "USD");
         BEAST_EXPECT(linesBeg[jss::result].isMember(jss::marker));
         BEAST_EXPECT(linesBeg.isMember(jss::jsonrpc) && linesBeg[jss::jsonrpc] == "2.0");
-        BEAST_EXPECT(linesBeg.isMember(jss::ripplerpc) && linesBeg[jss::ripplerpc] == "2.0");
         BEAST_EXPECT(linesBeg.isMember(jss::id) && linesBeg[jss::id] == 5);
 
         // alice pays 100 USD to cheri.
@@ -1232,7 +1184,6 @@ public:
         Json::Value linesEndRequest;
         linesEndRequest[jss::method] = "account_lines";
         linesEndRequest[jss::jsonrpc] = "2.0";
-        linesEndRequest[jss::ripplerpc] = "2.0";
         linesEndRequest[jss::id] = 5;
         linesEndRequest[jss::params] = linesEndParams;
         auto const linesEnd = env.rpc("json2", to_string(linesEndRequest));
@@ -1240,7 +1191,6 @@ public:
             linesEnd[jss::error][jss::message] ==
             RPC::make_error(rpcINVALID_PARAMS)[jss::error_message]);
         BEAST_EXPECT(linesEnd.isMember(jss::jsonrpc) && linesEnd[jss::jsonrpc] == "2.0");
-        BEAST_EXPECT(linesEnd.isMember(jss::ripplerpc) && linesEnd[jss::ripplerpc] == "2.0");
         BEAST_EXPECT(linesEnd.isMember(jss::id) && linesEnd[jss::id] == 5);
     }
 

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -66,7 +66,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             if (!BEAST_EXPECT(jv[jss::status] == "success"))
@@ -104,7 +103,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
     }
@@ -143,7 +141,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             if (!BEAST_EXPECT(jv[jss::status] == "success"))
@@ -187,7 +184,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
     }
@@ -220,7 +216,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             if (!BEAST_EXPECT(jv[jss::status] == "success"))
@@ -266,7 +261,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
     }
@@ -306,7 +300,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             if (!BEAST_EXPECT(jv[jss::status] == "success"))
@@ -364,7 +357,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
     }
@@ -406,7 +398,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             if (!BEAST_EXPECT(jv[jss::status] == "success"))
@@ -465,7 +456,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
     }
@@ -520,7 +510,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             if (!BEAST_EXPECT(jv[jss::status] == "success"))
@@ -591,7 +580,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
     }
@@ -635,7 +623,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             if (!BEAST_EXPECT(jv[jss::status] == "success"))
@@ -709,7 +696,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
     }
@@ -767,7 +753,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             if (!BEAST_EXPECT(jv[jss::status] == "success"))
@@ -865,7 +850,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
     }
@@ -899,7 +883,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             if (!BEAST_EXPECT(jv[jss::status] == "success"))
@@ -930,7 +913,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
         auto jrr = jv[jss::result];
@@ -974,7 +956,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
         jrr = jv[jss::result];
@@ -998,7 +979,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
         BEAST_EXPECT(jv[jss::status] == "success");

--- a/src/test/rpc/DeliveredAmount_test.cpp
+++ b/src/test/rpc/DeliveredAmount_test.cpp
@@ -218,7 +218,6 @@ class DeliveredAmount_test : public beast::unit_test::suite
                 if (wsc->version() == 2)
                 {
                     BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                    BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                     BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
                 }
                 BEAST_EXPECT(jv[jss::result][jss::ledger_index] == 3);

--- a/src/test/rpc/GatewayBalances_test.cpp
+++ b/src/test/rpc/GatewayBalances_test.cpp
@@ -77,7 +77,6 @@ public:
             if (wsc->version() == 2)
             {
                 expect(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                expect(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 expect(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
 

--- a/src/test/rpc/RPCCall_test.cpp
+++ b/src/test/rpc/RPCCall_test.cpp
@@ -3006,7 +3006,7 @@ static RPCCallTestData const rpcCallTestArray[] = {
      __LINE__,
      {
          "json2",
-         R"({"jsonrpc":"2.0","ripplerpc":"2.0","id":"A1","method":"call_1"})",
+         R"({"jsonrpc":"2.0","id":"A1","method":"call_1"})",
      },
      RPCCallTestData::no_exception,
      R"({
@@ -3019,10 +3019,8 @@ static RPCCallTestData const rpcCallTestArray[] = {
          "id" : "A1",
          "jsonrpc" : "2.0",
          "method" : "call_1",
-         "ripplerpc" : "2.0"
       }
     ],
-    "ripplerpc" : "2.0"
     })"},
     {"json2: object with nested params.",
      __LINE__,
@@ -3030,7 +3028,6 @@ static RPCCallTestData const rpcCallTestArray[] = {
          "json2",
          R"({
         "jsonrpc" : "2.0",
-        "ripplerpc" : "2.0",
         "id" : "A1",
         "method" : "call_1",
         "params" : [{"inner_arg" : "yup"}]
@@ -3050,16 +3047,14 @@ static RPCCallTestData const rpcCallTestArray[] = {
          "id" : "A1",
          "jsonrpc" : "2.0",
          "method" : "call_1",
-         "ripplerpc" : "2.0"
       }
     ],
-    "ripplerpc" : "2.0"
     })"},
     {"json2: minimal array.",
      __LINE__,
      {
          "json2",
-         R"([{"jsonrpc":"2.0","ripplerpc":"2.0","id":"A1","method":"call_1"}])",
+         R"([{"jsonrpc":"2.0","id":"A1","method":"call_1"}])",
      },
      RPCCallTestData::no_exception,
      R"({
@@ -3071,8 +3066,7 @@ static RPCCallTestData const rpcCallTestArray[] = {
             "id" : "A1",
             "jsonrpc" : "2.0",
             "method" : "call_1",
-            "ripplerpc" : "2.0"
-         }
+            }
       ]
     ]
     })"},
@@ -3082,7 +3076,6 @@ static RPCCallTestData const rpcCallTestArray[] = {
          "json2",
          R"([
         {"jsonrpc":"2.0",
-        "ripplerpc":"2.0",
         "id":"A1",
         "method":"call_1",
         "params" : [{"inner_arg" : "yup"}]}
@@ -3101,8 +3094,7 @@ static RPCCallTestData const rpcCallTestArray[] = {
             "id" : "A1",
             "jsonrpc" : "2.0",
             "method" : "call_1",
-            "ripplerpc" : "2.0"
-         }
+            }
       ]
     ]})"},
     {"json2: too few arguments.",
@@ -3123,7 +3115,7 @@ static RPCCallTestData const rpcCallTestArray[] = {
     })"},
     {"json2: too many arguments.",
      __LINE__,
-     {"json2", R"({"jsonrpc":"2.0","ripplerpc":"2.0","id":"A1","method":"call_this"})", "extra"},
+     {"json2", R"({"jsonrpc":"2.0","id":"A1","method":"call_this"})", "extra"},
      RPCCallTestData::no_exception,
      R"({
     "method" : "json2",
@@ -3139,7 +3131,7 @@ static RPCCallTestData const rpcCallTestArray[] = {
      __LINE__,
      {
          "json2",
-         R"({"jsonrpc":"2.0","ripplerpc":"2.0","id":"A1","method":"call_1",})",
+         R"({"jsonrpc":"2.0","id":"A1","method":"call_1",})",
      },
      RPCCallTestData::no_exception,
      R"({
@@ -3153,16 +3145,14 @@ static RPCCallTestData const rpcCallTestArray[] = {
          "error_message" : "Invalid parameters.",
          "id" : "A1",
          "jsonrpc" : "2.0",
-         "ripplerpc" : "2.0"
       }
     ],
-    "ripplerpc" : "2.0"
     })"},
     {"json2: omit jsonrpc.",
      __LINE__,
      {
          "json2",
-         R"({"ripplerpc":"2.0","id":"A1","method":"call_1"})",
+         R"({"id":"A1","method":"call_1"})",
      },
      RPCCallTestData::no_exception,
      R"({
@@ -3174,16 +3164,14 @@ static RPCCallTestData const rpcCallTestArray[] = {
          "error_code" : 31,
          "error_message" : "Invalid parameters.",
          "id" : "A1",
-         "ripplerpc" : "2.0"
       }
     ],
-    "ripplerpc" : "2.0"
     })"},
     {"json2: wrong jsonrpc version.",
      __LINE__,
      {
          "json2",
-         R"({"jsonrpc":"2.1","ripplerpc":"2.0","id":"A1","method":"call_1"})",
+         R"({"jsonrpc":"2.1","id":"A1","method":"call_1"})",
      },
      RPCCallTestData::no_exception,
      R"({
@@ -3197,60 +3185,14 @@ static RPCCallTestData const rpcCallTestArray[] = {
          "error_message" : "Invalid parameters.",
          "id" : "A1",
          "jsonrpc" : "2.1",
-         "ripplerpc" : "2.0"
       }
     ],
-    "ripplerpc" : "2.0"
-    })"},
-    {"json2: omit ripplerpc.",
-     __LINE__,
-     {
-         "json2",
-         R"({"jsonrpc":"2.0","id":"A1","method":"call_1"})",
-     },
-     RPCCallTestData::no_exception,
-     R"({
-    "id" : "A1",
-    "jsonrpc" : "2.0",
-    "method" : "json2",
-    "params" : [
-      {
-         "error" : "invalidParams",
-         "error_code" : 31,
-         "error_message" : "Invalid parameters.",
-         "id" : "A1",
-         "jsonrpc" : "2.0"
-      }
-    ]
-    })"},
-    {"json2: wrong ripplerpc version.",
-     __LINE__,
-     {
-         "json2",
-         R"({"jsonrpc":"2.0","ripplerpc":"2.00","id":"A1","method":"call_1"})",
-     },
-     RPCCallTestData::no_exception,
-     R"({
-    "id" : "A1",
-    "jsonrpc" : "2.0",
-    "method" : "json2",
-    "params" : [
-      {
-         "error" : "invalidParams",
-         "error_code" : 31,
-         "error_message" : "Invalid parameters.",
-         "id" : "A1",
-         "jsonrpc" : "2.0",
-         "ripplerpc" : "2.00"
-      }
-    ],
-    "ripplerpc" : "2.00"
     })"},
     {"json2: omit id.",
      __LINE__,
      {
          "json2",
-         R"({"jsonrpc":"2.0","ripplerpc":"2.0","method":"call_1"})",
+         R"({"jsonrpc":"2.0","method":"call_1"})",
      },
      RPCCallTestData::no_exception,
      R"({
@@ -3262,16 +3204,14 @@ static RPCCallTestData const rpcCallTestArray[] = {
          "error_code" : 31,
          "error_message" : "Invalid parameters.",
          "jsonrpc" : "2.0",
-         "ripplerpc" : "2.0"
       }
     ],
-   "ripplerpc" : "2.0"
     })"},
     {"json2: omit method.",
      __LINE__,
      {
          "json2",
-         R"({"jsonrpc":"2.0","ripplerpc":"2.0","id":"A1"})",
+         R"({"jsonrpc":"2.0","id":"A1"})",
      },
      RPCCallTestData::no_exception,
      R"({
@@ -3285,10 +3225,8 @@ static RPCCallTestData const rpcCallTestArray[] = {
          "error_message" : "Invalid parameters.",
          "id" : "A1",
          "jsonrpc" : "2.0",
-         "ripplerpc" : "2.0"
       }
     ],
-   "ripplerpc" : "2.0"
     })"},
     {"json2: empty outer array.",
      __LINE__,
@@ -3311,7 +3249,7 @@ static RPCCallTestData const rpcCallTestArray[] = {
      __LINE__,
      {
          "json2",
-         R"([{"jsonrpc":"2.0","ripplerpc":"2.0","id":"A1","method":"call_1",[]}])",
+         R"([{"jsonrpc":"2.0","id":"A1","method":"call_1",[]}])",
      },
      RPCCallTestData::no_exception,
      R"({
@@ -3330,7 +3268,6 @@ static RPCCallTestData const rpcCallTestArray[] = {
          "json2",
          R"([
             {"jsonrpc" : "2.1",
-            "ripplerpc" : "2.0",
             "id" : "A1",
             "method" : "call_1"
             }
@@ -3353,7 +3290,6 @@ static RPCCallTestData const rpcCallTestArray[] = {
          "json2",
          R"({
         "jsonrpc" : "2.0",
-        "ripplerpc" : "2.0",
         "id" : "A1",
         "method" : "call_1",
         "params" : true
@@ -3371,10 +3307,8 @@ static RPCCallTestData const rpcCallTestArray[] = {
          "error_message" : "Invalid parameters.",
          "id" : "A1",
          "jsonrpc" : "2.0",
-         "ripplerpc" : "2.0"
       }
    ],
-   "ripplerpc" : "2.0"
     })"},
 
     // ledger

--- a/src/test/rpc/RobustTransaction_test.cpp
+++ b/src/test/rpc/RobustTransaction_test.cpp
@@ -31,7 +31,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
         }
@@ -46,7 +45,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::result][jss::engine_result] == "tefMAX_LEDGER");
@@ -58,7 +56,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::result][jss::engine_result] == "tefPAST_SEQ");
@@ -69,7 +66,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::result][jss::engine_result] == "terPRE_SEQ");
@@ -80,7 +76,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::result][jss::engine_result] == "tesSUCCESS");
@@ -93,7 +88,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::result].isMember(jss::ledger_current_index));
@@ -121,7 +115,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::status] == "success");
@@ -157,7 +150,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::result][jss::engine_result] == "tesSUCCESS");
@@ -180,7 +172,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
 
@@ -211,7 +202,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::result][jss::engine_result] == "tesSUCCESS");
@@ -221,7 +211,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::result].isMember(jss::ledger_current_index));
@@ -240,7 +229,6 @@ public:
                 if (wsc->version() == 2)
                 {
                     BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                    BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                     BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
                 }
                 BEAST_EXPECT(jv[jss::status] == "success");
@@ -253,7 +241,6 @@ public:
                 if (wsc->version() == 2)
                 {
                     BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                    BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                     BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
                 }
                 BEAST_EXPECT(jv[jss::result].isMember(jss::ledger_current_index));
@@ -274,7 +261,6 @@ public:
                 if (wsc->version() == 2)
                 {
                     BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                    BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                     BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
                 }
                 BEAST_EXPECT(jv[jss::status] == "success");
@@ -293,7 +279,6 @@ public:
                 if (wsc->version() == 2)
                 {
                     BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                    BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                     BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
                 }
                 BEAST_EXPECT(jv[jss::status] == "success");
@@ -306,7 +291,6 @@ public:
                 if (wsc->version() == 2)
                 {
                     BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                    BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                     BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
                 }
                 BEAST_EXPECT(jv[jss::result].isMember(jss::ledger_current_index));
@@ -327,7 +311,6 @@ public:
                 if (wsc->version() == 2)
                 {
                     BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                    BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                     BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
                 }
                 BEAST_EXPECT(jv[jss::status] == "success");
@@ -345,7 +328,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
 
@@ -376,7 +358,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::status] == "success");
@@ -392,7 +373,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::result][jss::engine_result] == "tesSUCCESS");
@@ -414,7 +394,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::status] == "success");

--- a/src/test/rpc/Subscribe_test.cpp
+++ b/src/test/rpc/Subscribe_test.cpp
@@ -38,7 +38,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::status] == "success");
@@ -68,7 +67,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::status] == "success");
@@ -104,7 +102,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::result][jss::ledger_index] == 2);
@@ -139,7 +136,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
         BEAST_EXPECT(jv[jss::status] == "success");
@@ -163,7 +159,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::status] == "success");
@@ -225,7 +220,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::status] == "success");
@@ -240,7 +234,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::status] == "success");
@@ -273,7 +266,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
         BEAST_EXPECT(jv[jss::status] == "success");
@@ -303,7 +295,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::status] == "success");
@@ -350,7 +341,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::status] == "success");
@@ -373,7 +363,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::status] == "success");
@@ -384,7 +373,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
         BEAST_EXPECT(jv[jss::status] == "success");
@@ -419,7 +407,6 @@ public:
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-                BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
                 BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
             }
             BEAST_EXPECT(jv[jss::status] == "success");
@@ -495,7 +482,6 @@ public:
         if (wsc->version() == 2)
         {
             BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             BEAST_EXPECT(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
         BEAST_EXPECT(jv[jss::status] == "success");

--- a/src/test/rpc/Version_test.cpp
+++ b/src/test/rpc/Version_test.cpp
@@ -120,13 +120,11 @@ class Version_test : public beast::unit_test::suite
 
         auto const without_api_verion = std::string("{ ") +
             "\"jsonrpc\": \"2.0\", "
-            "\"ripplerpc\": \"2.0\", "
             "\"id\": 5, "
             "\"method\": \"version\", "
             "\"params\": {}}";
         auto const with_api_verion = std::string("{ ") +
             "\"jsonrpc\": \"2.0\", "
-            "\"ripplerpc\": \"2.0\", "
             "\"id\": 6, "
             "\"method\": \"version\", "
             "\"params\": { "
@@ -153,14 +151,12 @@ class Version_test : public beast::unit_test::suite
         BEAST_EXPECT(env.app().config().BETA_RPC_API);
         auto const without_api_verion = std::string("{ ") +
             "\"jsonrpc\": \"2.0\", "
-            "\"ripplerpc\": \"2.0\", "
             "\"id\": 5, "
             "\"method\": \"version\", "
             "\"params\": {}}";
         auto const with_wrong_api_verion =
             std::string("{ ") +
             "\"jsonrpc\": \"2.0\", "
-            "\"ripplerpc\": \"2.0\", "
             "\"id\": 6, "
             "\"method\": \"version\", "
             "\"params\": { "

--- a/src/xrpld/rpc/detail/RPCCall.cpp
+++ b/src/xrpld/rpc/detail/RPCCall.cpp
@@ -537,9 +537,8 @@ private:
         }
         if (jv.isObject())
         {
-            if (jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0" &&
-                jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0" &&
-                jv.isMember(jss::id) && jv.isMember(jss::method))
+            if (jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0" && jv.isMember(jss::id) &&
+                jv.isMember(jss::method))
             {
                 if (jv.isMember(jss::params) &&
                     !(jv[jss::params].isNull() || jv[jss::params].isArray() ||
@@ -569,7 +568,6 @@ private:
                         jv1[i.key().asString()] = *i;
                 }
                 jv1[jss::jsonrpc] = jv[jss::jsonrpc];
-                jv1[jss::ripplerpc] = jv[jss::ripplerpc];
                 jv1[jss::id] = jv[jss::id];
                 jv1[jss::method] = jv[jss::method];
                 return jv1;
@@ -585,7 +583,6 @@ private:
                         jv1[j][i.key().asString()] = *i;
                 }
                 jv1[j][jss::jsonrpc] = jv[j][jss::jsonrpc];
-                jv1[j][jss::ripplerpc] = jv[j][jss::ripplerpc];
                 jv1[j][jss::id] = jv[j][jss::id];
                 jv1[j][jss::method] = jv[j][jss::method];
             }
@@ -594,8 +591,6 @@ private:
         auto jv_error = rpcError(rpcINVALID_PARAMS);
         if (jv.isMember(jss::jsonrpc))
             jv_error[jss::jsonrpc] = jv[jss::jsonrpc];
-        if (jv.isMember(jss::ripplerpc))
-            jv_error[jss::ripplerpc] = jv[jss::ripplerpc];
         if (jv.isMember(jss::id))
             jv_error[jss::id] = jv[jss::id];
         return jv_error;

--- a/src/xrpld/rpc/detail/ServerHandler.cpp
+++ b/src/xrpld/rpc/detail/ServerHandler.cpp
@@ -832,9 +832,9 @@ ServerHandler::processRequest(
             result[jss::status] = jss::error;
             result["code"] = result[jss::error_code];
             result["message"] = result[jss::error_message];
-            result.removeMember(jss::error_message);
             JLOG(m_journal.debug())
-                << "rpcError: " << result[jss::error] << ": " << result[jss::error_message];
+                << "rpcError: " << result[jss::error] << ": " << result["message"];
+            result.removeMember(jss::error_message);
             r[jss::error] = std::move(result);
         }
         else

--- a/src/xrpld/rpc/detail/ServerHandler.cpp
+++ b/src/xrpld/rpc/detail/ServerHandler.cpp
@@ -409,8 +409,6 @@ ServerHandler::processSession(
                 jr[jss::id] = jv[jss::id];
             if (jv.isMember(jss::jsonrpc))
                 jr[jss::jsonrpc] = jv[jss::jsonrpc];
-            if (jv.isMember(jss::ripplerpc))
-                jr[jss::ripplerpc] = jv[jss::ripplerpc];
             if (jv.isMember(jss::api_version))
                 jr[jss::api_version] = jv[jss::api_version];
 
@@ -505,8 +503,6 @@ ServerHandler::processSession(
         jr[jss::id] = jv[jss::id];
     if (jv.isMember(jss::jsonrpc))
         jr[jss::jsonrpc] = jv[jss::jsonrpc];
-    if (jv.isMember(jss::ripplerpc))
-        jr[jss::ripplerpc] = jv[jss::ripplerpc];
     if (jv.isMember(jss::api_version))
         jr[jss::api_version] = jv[jss::api_version];
 
@@ -773,26 +769,6 @@ ServerHandler::processRequest(
             params = jsonRPC;
         }
 
-        std::string ripplerpc = "1.0";
-        if (params.isMember(jss::ripplerpc))
-        {
-            if (!params[jss::ripplerpc].isString())
-            {
-                usage.charge(Resource::feeMalformedRPC);
-                if (!batch)
-                {
-                    HTTPReply(400, "ripplerpc is not a string", output, rpcJ);
-                    return;
-                }
-
-                Json::Value r = jsonRPC;
-                r[jss::error] = make_json_error(method_not_found, "ripplerpc is not a string");
-                reply.append(r);
-                continue;
-            }
-            ripplerpc = params[jss::ripplerpc].asString();
-        }
-
         /**
          * Clear header-assigned values if not positively identified from a
          * secure_gateway.
@@ -851,61 +827,24 @@ ServerHandler::processRequest(
             result[jss::warning] = jss::load;
 
         Json::Value r(Json::objectValue);
-        if (ripplerpc >= "2.0")
+        if (result.isMember(jss::error))
         {
-            if (result.isMember(jss::error))
-            {
-                result[jss::status] = jss::error;
-                result["code"] = result[jss::error_code];
-                result["message"] = result[jss::error_message];
-                result.removeMember(jss::error_message);
-                JLOG(m_journal.debug())
-                    << "rpcError: " << result[jss::error] << ": " << result[jss::error_message];
-                r[jss::error] = std::move(result);
-            }
-            else
-            {
-                result[jss::status] = jss::success;
-                r[jss::result] = std::move(result);
-            }
+            result[jss::status] = jss::error;
+            result["code"] = result[jss::error_code];
+            result["message"] = result[jss::error_message];
+            result.removeMember(jss::error_message);
+            JLOG(m_journal.debug())
+                << "rpcError: " << result[jss::error] << ": " << result[jss::error_message];
+            r[jss::error] = std::move(result);
         }
         else
         {
-            // Always report "status".  On an error report the request as
-            // received.
-            if (result.isMember(jss::error))
-            {
-                auto rq = params;
-
-                if (rq.isObject())
-                {  // But mask potentially sensitive information.
-                    if (rq.isMember(jss::passphrase.c_str()))
-                        rq[jss::passphrase.c_str()] = "<masked>";
-                    if (rq.isMember(jss::secret.c_str()))
-                        rq[jss::secret.c_str()] = "<masked>";
-                    if (rq.isMember(jss::seed.c_str()))
-                        rq[jss::seed.c_str()] = "<masked>";
-                    if (rq.isMember(jss::seed_hex.c_str()))
-                        rq[jss::seed_hex.c_str()] = "<masked>";
-                }
-
-                result[jss::status] = jss::error;
-                result[jss::request] = rq;
-
-                JLOG(m_journal.debug())
-                    << "rpcError: " << result[jss::error] << ": " << result[jss::error_message];
-            }
-            else
-            {
-                result[jss::status] = jss::success;
-            }
+            result[jss::status] = jss::success;
             r[jss::result] = std::move(result);
         }
 
         if (params.isMember(jss::jsonrpc))
             r[jss::jsonrpc] = params[jss::jsonrpc];
-        if (params.isMember(jss::ripplerpc))
-            r[jss::ripplerpc] = params[jss::ripplerpc];
         if (params.isMember(jss::id))
             r[jss::id] = params[jss::id];
         if (batch)
@@ -926,18 +865,11 @@ ServerHandler::processRequest(
 
     // If we're returning an error_code, use that to determine the HTTP status.
     int const httpStatus = [&reply]() {
-        // This feature is enabled with ripplerpc version 3.0 and above.
-        // Before ripplerpc version 3.0 always return 200.
-        if (reply.isMember(jss::ripplerpc) && reply[jss::ripplerpc].isString() &&
-            reply[jss::ripplerpc].asString() >= "3.0")
+        if (reply.isMember(jss::error) && reply[jss::error].isMember(jss::error_code) &&
+            reply[jss::error][jss::error_code].isInt())
         {
-            // If there's an error_code, use that to determine the HTTP Status.
-            if (reply.isMember(jss::error) && reply[jss::error].isMember(jss::error_code) &&
-                reply[jss::error][jss::error_code].isInt())
-            {
-                int const errCode = reply[jss::error][jss::error_code].asInt();
-                return RPC::error_code_http_status(static_cast<error_code_i>(errCode));
-            }
+            int const errCode = reply[jss::error][jss::error_code].asInt();
+            return RPC::error_code_http_status(static_cast<error_code_i>(errCode));
         }
         // Return OK.
         return 200;


### PR DESCRIPTION
## High Level Overview of Change

This change removes the `ripplerpc` RPC parameter.

### Context of Change

Per [XLS-0095](https://xls.xrpl.org/xls/XLS-0095-rename-rippled-to-xrpld.html), we are taking steps to rename ripple(d) to xrpl(d).

In this case, the `ripplerpc` parameter is not renamed but directly removed, and the behavior of the latest version 3.0 (introduced 4 years ago in https://github.com/XRPLF/rippled/pull/4143 and released 3 years ago in [1.10.0](https://xrpl.org/blog/2023/rippled-1.10.0)) made the default. If different functionality is needed in the future, then the also-existing API version can be leveraged instead.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [X] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)