### PR TITLE
feat: Add runtime fee_vote CLI/RPC command

### DIFF
--- a/docs/issue-6180-fee-vote-cli.md
+++ b/docs/issue-6180-fee-vote-cli.md
@@ -1,0 +1,156 @@
+# Issue #6180: Fee Voting via CLI/RPC
+
+## Summary
+
+This change adds a new `fee_vote` command that allows reading and updating fee vote targets at runtime (without restarting `rippled`).
+
+Issue: https://github.com/XRPLF/rippled/issues/6180
+
+## Problem
+
+Before this change, fee voting targets were configured from startup config only. Operators could not adjust fee vote targets live through CLI/RPC.
+
+## Solution
+
+Added a new RPC/CLI handler: `fee_vote`.
+
+Behavior:
+
+- Read current fee vote targets:
+  - `fee_vote`
+- Update targets (admin only):
+  - `fee_vote <reference_fee> <account_reserve> <owner_reserve>`
+  - values are applied immediately and returned in the response.
+
+## Interface
+
+### Request
+
+- Command: `fee_vote`
+- Optional fields:
+  - `reference_fee`
+  - `account_reserve`
+  - `owner_reserve`
+
+### Validation
+
+- Each field must be a non-negative integer.
+- `account_reserve` and `owner_reserve` are bounded to `<= 4294967295`.
+
+### Permissions
+
+- Read (`fee_vote` with no fields): allowed.
+- Update (any field present): admin-only (`rpcNO_PERMISSION` for non-admin).
+
+## Implementation Notes
+
+### New files
+
+- `src/xrpld/rpc/handlers/FeeVote.cpp`
+  - Implements `doFeeVote`.
+- `src/test/rpc/FeeVoteRPC_test.cpp`
+  - Covers read/update, permissions, and validation behavior.
+
+### Updated files
+
+- `src/xrpld/app/misc/FeeVote.h`
+  - Added mutable target API:
+    - `setTarget(...)`
+    - `getTarget() const`
+- `src/xrpld/app/misc/FeeVoteImpl.cpp`
+  - Added synchronization for live target updates.
+  - Consensus paths now read from a thread-safe target snapshot.
+- `src/xrpld/app/consensus/RCLConsensus.h`
+- `src/xrpld/app/consensus/RCLConsensus.cpp`
+  - Added passthrough methods for fee vote get/set.
+- `include/xrpl/server/NetworkOPs.h`
+- `src/xrpld/app/misc/NetworkOPs.cpp`
+  - Added public runtime API used by RPC layer.
+- `src/xrpld/rpc/handlers/Handlers.h`
+- `src/xrpld/rpc/detail/Handler.cpp`
+  - Registered `fee_vote` RPC handler.
+- `src/xrpld/rpc/detail/RPCCall.cpp`
+  - Added CLI argument parser for `fee_vote`.
+- `src/xrpld/app/main/Main.cpp`
+  - Added CLI help entry.
+- `include/xrpl/protocol/jss.h`
+  - Added required JSON field keys.
+- `src/test/rpc/RPCCall_test.cpp`
+  - Added parser coverage for `fee_vote`.
+
+## Build and Test Evidence
+
+### Build
+
+```bash
+cd .build
+cmake --build . --target xrpld --parallel 8
+```
+
+### Targeted unit tests
+
+```bash
+./xrpld --unittest FeeVoteRPC,RPCCall --unittest-jobs 1 --quiet
+```
+
+Result: passed (`0 failures`).
+
+## Local Smoke Tests (Standalone)
+
+Environment:
+
+- Standalone node (`--standalone`)
+- Config: `/tmp/xrpld/xrpld.cfg`
+- RPC endpoint: `127.0.0.1:5005`
+
+### 1) Read current fee vote target
+
+```bash
+./.build/xrpld --conf /tmp/xrpld/xrpld.cfg fee_vote
+```
+
+Observed result:
+
+- `status: success`
+- returned current tuple (`reference_fee`, `account_reserve`, `owner_reserve`)
+
+### 2) Update fee vote target
+
+```bash
+./.build/xrpld --conf /tmp/xrpld/xrpld.cfg fee_vote 11 222 33
+```
+
+Observed result:
+
+- `status: success`
+- returned:
+  - `reference_fee: 11`
+  - `account_reserve: 222`
+  - `owner_reserve: 33`
+
+### 3) Read after update (persistence in running process)
+
+```bash
+./.build/xrpld --conf /tmp/xrpld/xrpld.cfg fee_vote
+```
+
+Observed result:
+
+- Returned `11 / 222 / 33`, confirming live update was applied.
+
+### 4) Invalid input handling
+
+```bash
+./.build/xrpld --conf /tmp/xrpld/xrpld.cfg fee_vote foo 222 33
+```
+
+Observed result:
+
+- `status: error`
+- `error: invalidParams`
+- message indicates `reference_fee` must be a non-negative integer.
+
+## Notes
+
+- This feature updates the runtime fee vote target and is aimed at operational convenience.
+- `--standalone` remains isolated from public XRPL networks and is suitable for local testing.

--- a/include/xrpl/protocol/jss.h
+++ b/include/xrpl/protocol/jss.h
@@ -100,6 +100,7 @@ JSS(account_hash);           // out: LedgerToJson
 JSS(account_id);             // out: WalletPropose
 JSS(account_nfts);           // out: AccountNFTs
 JSS(account_objects);        // out: AccountObjects
+JSS(account_reserve);        // in/out: FeeVote
 JSS(account_root);           // in: LedgerEntry
 JSS(account_sequence_next);  // out: SubmitTransaction
 JSS(account_sequence_available);  // out: SubmitTransaction
@@ -260,6 +261,7 @@ JSS(fail_hard);               // in: Sign, Submit
 JSS(failed);                  // out: InboundLedger
 JSS(feature);                 // in: Feature
 JSS(features);                // out: Feature
+JSS(fee_vote);                // in/out: FeeVote
 JSS(fee_base);                // out: NetworkOPs
 JSS(fee_div_max);             // in: TransactionSign
 JSS(fee_level);               // out: AccountInfo
@@ -466,6 +468,7 @@ JSS(oracles);                 // in: get_aggregate_price
 JSS(oracle_document_id);      // in: get_aggregate_price
 JSS(owner);                   // in: LedgerEntry, out: NetworkOPs
 JSS(owner_funds);             // in/out: Ledger, NetworkOPs, AcceptedLedgerTx
+JSS(owner_reserve);           // in/out: FeeVote
 JSS(page_index);
 JSS(params);                  // RPC
 JSS(parent_close_time);       // out: LedgerToJson
@@ -523,6 +526,7 @@ JSS(remote);                  // out: Logic.h
 JSS(request);                 // RPC
 JSS(requested);               // out: Manifest
 JSS(reservations);            // out: Reservations
+JSS(reference_fee);           // in/out: FeeVote
 JSS(reserve_base);            // out: NetworkOPs
 JSS(reserve_base_xrp);        // out: NetworkOPs
 JSS(reserve_inc);             // out: NetworkOPs

--- a/include/xrpl/server/NetworkOPs.h
+++ b/include/xrpl/server/NetworkOPs.h
@@ -3,6 +3,7 @@
 #include <xrpl/core/JobQueue.h>
 #include <xrpl/core/ServiceRegistry.h>
 #include <xrpl/protocol/STValidation.h>
+#include <xrpl/protocol/SystemParameters.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/messages.h>
 #include <xrpl/server/InfoSub.h>
@@ -11,6 +12,7 @@
 #include <boost/asio.hpp>
 
 #include <memory>
+#include <tuple>
 
 namespace xrpl {
 
@@ -227,6 +229,12 @@ public:
 
     virtual void
     reportFeeChange() = 0;
+
+    virtual std::tuple<XRPAmount, XRPAmount, XRPAmount>
+    getFeeVote() const = 0;
+
+    virtual void
+    setFeeVote(XRPAmount referenceFee, XRPAmount accountReserve, XRPAmount ownerReserve) = 0;
 
     virtual void
     updateLocalTx(ReadView const& newValidLedger) = 0;

--- a/src/test/rpc/FeeVoteRPC_test.cpp
+++ b/src/test/rpc/FeeVoteRPC_test.cpp
@@ -1,0 +1,101 @@
+#include <test/jtx.h>
+
+#include <xrpl/beast/unit_test.h>
+#include <xrpl/protocol/ErrorCodes.h>
+#include <xrpl/protocol/jss.h>
+#include <xrpl/server/NetworkOPs.h>
+
+namespace xrpl {
+
+class FeeVoteRPC_test : public beast::unit_test::suite
+{
+public:
+    void
+    testReadAndUpdate()
+    {
+        testcase("Read and Update");
+        using namespace test::jtx;
+
+        Env env{*this};
+
+        Json::Value initial{Json::objectValue};
+        {
+            initial = env.rpc("fee_vote")[jss::result];
+            BEAST_EXPECT(!RPC::contains_error(initial));
+            BEAST_EXPECT(initial.isMember(jss::reference_fee));
+            BEAST_EXPECT(initial.isMember(jss::account_reserve));
+            BEAST_EXPECT(initial.isMember(jss::owner_reserve));
+        }
+
+        Json::Value updated{Json::objectValue};
+        {
+            updated = env.rpc("fee_vote", "12", "11000000", "2100000")[jss::result];
+            BEAST_EXPECT(!RPC::contains_error(updated));
+        }
+
+        auto const [referenceFee, accountReserve, ownerReserve] = env.app().getOPs().getFeeVote();
+        BEAST_EXPECT(updated[jss::reference_fee] == referenceFee.jsonClipped());
+        BEAST_EXPECT(updated[jss::account_reserve] == accountReserve.jsonClipped());
+        BEAST_EXPECT(updated[jss::owner_reserve] == ownerReserve.jsonClipped());
+
+        BEAST_EXPECT(updated[jss::reference_fee] != initial[jss::reference_fee]);
+        BEAST_EXPECT(updated[jss::account_reserve] != initial[jss::account_reserve]);
+        BEAST_EXPECT(updated[jss::owner_reserve] != initial[jss::owner_reserve]);
+    }
+
+    void
+    testNonAdmin()
+    {
+        testcase("Non Admin");
+        using namespace test::jtx;
+
+        Env env{*this, envconfig([](std::unique_ptr<Config> cfg) {
+                    (*cfg)["port_rpc"].set("admin", "");
+                    (*cfg)["port_ws"].set("admin", "");
+                    return cfg;
+                })};
+
+        {
+            auto const result = env.rpc("fee_vote")[jss::result];
+            BEAST_EXPECT(!RPC::contains_error(result));
+        }
+
+        {
+            auto const result = env.rpc("fee_vote", "11")[jss::result];
+            BEAST_EXPECT(result[jss::error] == "noPermission");
+            BEAST_EXPECT(
+                result[jss::error_message] == "You don't have permission for this command.");
+        }
+    }
+
+    void
+    testInvalidParams()
+    {
+        testcase("Invalid Params");
+        using namespace test::jtx;
+
+        Env env{*this};
+
+        {
+            auto const result = env.rpc("fee_vote", "abc")[jss::result];
+            BEAST_EXPECT(result[jss::error] == "invalidParams");
+        }
+
+        {
+            auto const result = env.rpc("fee_vote", "10", "4294967296")[jss::result];
+            BEAST_EXPECT(result[jss::error] == "invalidParams");
+        }
+    }
+
+    void
+    run() override
+    {
+        testReadAndUpdate();
+        testNonAdmin();
+        testInvalidParams();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(FeeVoteRPC, rpc, xrpl);
+
+}  // namespace xrpl

--- a/src/test/rpc/RPCCall_test.cpp
+++ b/src/test/rpc/RPCCall_test.cpp
@@ -2603,6 +2603,52 @@ static RPCCallTestData const rpcCallTestArray[] = {
     ]
     })"},
 
+    // fee_vote
+    // ------------------------------------------------------------------
+    {"fee_vote: minimal.",
+     __LINE__,
+     {
+         "fee_vote",
+     },
+     RPCCallTestData::no_exception,
+     R"({
+    "method" : "fee_vote",
+    "params" : [
+      {
+         "api_version" : %API_VER%,
+      }
+    ]
+    })"},
+    {"fee_vote: with params.",
+     __LINE__,
+     {"fee_vote", "10", "20000000", "3000000"},
+     RPCCallTestData::no_exception,
+     R"({
+    "method" : "fee_vote",
+    "params" : [
+      {
+         "account_reserve" : "20000000",
+         "api_version" : %API_VER%,
+         "owner_reserve" : "3000000",
+         "reference_fee" : "10"
+      }
+    ]
+    })"},
+    {"fee_vote: too many arguments.",
+     __LINE__,
+     {"fee_vote", "10", "20000000", "3000000", "extra"},
+     RPCCallTestData::no_exception,
+     R"({
+    "method" : "fee_vote",
+    "params" : [
+      {
+         "error" : "badSyntax",
+         "error_code" : 1,
+         "error_message" : "Syntax error."
+      }
+    ]
+    })"},
+
     // fetch_info
     // ------------------------------------------------------------------
     {"fetch_info: minimal.",

--- a/src/xrpld/app/consensus/RCLConsensus.cpp
+++ b/src/xrpld/app/consensus/RCLConsensus.cpp
@@ -833,6 +833,21 @@ RCLConsensus::Adaptor::onModeChange(ConsensusMode before, ConsensusMode after)
     mode_ = after;
 }
 
+void
+RCLConsensus::Adaptor::setFeeVote(
+    XRPAmount referenceFee,
+    XRPAmount accountReserve,
+    XRPAmount ownerReserve)
+{
+    feeVote_->setTarget(referenceFee, accountReserve, ownerReserve);
+}
+
+std::tuple<XRPAmount, XRPAmount, XRPAmount>
+RCLConsensus::Adaptor::getFeeVote() const
+{
+    return feeVote_->getTarget();
+}
+
 Json::Value
 RCLConsensus::getJson(bool full) const
 {
@@ -843,6 +858,18 @@ RCLConsensus::getJson(bool full) const
     }
     ret["validating"] = adaptor_.validating();
     return ret;
+}
+
+void
+RCLConsensus::setFeeVote(XRPAmount referenceFee, XRPAmount accountReserve, XRPAmount ownerReserve)
+{
+    adaptor_.setFeeVote(referenceFee, accountReserve, ownerReserve);
+}
+
+std::tuple<XRPAmount, XRPAmount, XRPAmount>
+RCLConsensus::getFeeVote() const
+{
+    return adaptor_.getFeeVote();
 }
 
 void

--- a/src/xrpld/app/consensus/RCLConsensus.h
+++ b/src/xrpld/app/consensus/RCLConsensus.h
@@ -19,6 +19,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <tuple>
 
 namespace xrpl {
 
@@ -109,6 +110,12 @@ class RCLConsensus
         {
             return mode_;
         }
+
+        void
+        setFeeVote(XRPAmount referenceFee, XRPAmount accountReserve, XRPAmount ownerReserve);
+
+        std::tuple<XRPAmount, XRPAmount, XRPAmount>
+        getFeeVote() const;
 
         /** Called before kicking off a new consensus round.
 
@@ -491,6 +498,12 @@ public:
     {
         return adaptor_.parms();
     }
+
+    void
+    setFeeVote(XRPAmount referenceFee, XRPAmount accountReserve, XRPAmount ownerReserve);
+
+    std::tuple<XRPAmount, XRPAmount, XRPAmount>
+    getFeeVote() const;
 
 private:
     // Since Consensus does not provide intrinsic thread-safety, this mutex

--- a/src/xrpld/app/main/Main.cpp
+++ b/src/xrpld/app/main/Main.cpp
@@ -126,6 +126,7 @@ printHelp(po::options_description const& desc)
                  "     deposit_authorized <source_account> <destination_account> "
                  "[<ledger> [<credentials>, ...]]\n"
                  "     feature [<feature> [accept|reject]]\n"
+                 "     fee_vote [<reference_fee> [<account_reserve> [<owner_reserve>]]]\n"
                  "     fetch_info [clear]\n"
                  "     gateway_balances [<ledger>] <issuer_account> [ <hotwallet> [ "
                  "<hotwallet> ]]\n"

--- a/src/xrpld/app/misc/FeeVote.h
+++ b/src/xrpld/app/misc/FeeVote.h
@@ -2,7 +2,10 @@
 
 #include <xrpl/ledger/ReadView.h>
 #include <xrpl/protocol/STValidation.h>
+#include <xrpl/protocol/SystemParameters.h>
 #include <xrpl/shamap/SHAMap.h>
+
+#include <tuple>
 
 namespace xrpl {
 
@@ -30,6 +33,16 @@ public:
         std::shared_ptr<ReadView const> const& lastClosedLedger,
         std::vector<std::shared_ptr<STValidation>> const& parentValidations,
         std::shared_ptr<SHAMap> const& initialPosition) = 0;
+
+    /** Update local fee target used for voting.
+     */
+    virtual void
+    setTarget(XRPAmount referenceFee, XRPAmount accountReserve, XRPAmount ownerReserve) = 0;
+
+    /** Get current local fee vote target.
+     */
+    virtual std::tuple<XRPAmount, XRPAmount, XRPAmount>
+    getTarget() const = 0;
 };
 
 struct FeeSetup;

--- a/src/xrpld/app/misc/FeeVoteImpl.cpp
+++ b/src/xrpld/app/misc/FeeVoteImpl.cpp
@@ -5,6 +5,9 @@
 #include <xrpl/protocol/STValidation.h>
 #include <xrpl/protocol/st.h>
 
+#include <mutex>
+#include <tuple>
+
 namespace xrpl {
 
 namespace detail {
@@ -72,6 +75,7 @@ VotableValue::getVotes() const -> std::pair<value_type, bool>
 class FeeVoteImpl : public FeeVote
 {
 private:
+    mutable std::mutex mutex_;
     FeeSetup target_;
     beast::Journal const journal_;
 
@@ -86,6 +90,12 @@ public:
         std::shared_ptr<ReadView const> const& lastClosedLedger,
         std::vector<std::shared_ptr<STValidation>> const& parentValidations,
         std::shared_ptr<SHAMap> const& initialPosition) override;
+
+    void
+    setTarget(XRPAmount referenceFee, XRPAmount accountReserve, XRPAmount ownerReserve) override;
+
+    std::tuple<XRPAmount, XRPAmount, XRPAmount>
+    getTarget() const override;
 };
 
 //--------------------------------------------------------------------------
@@ -98,6 +108,8 @@ FeeVoteImpl::FeeVoteImpl(FeeSetup const& setup, beast::Journal journal)
 void
 FeeVoteImpl::doValidation(Fees const& lastFees, Rules const& rules, STValidation& v)
 {
+    auto const [referenceFee, accountReserve, ownerReserve] = getTarget();
+
     // Values should always be in a valid range (because the voting process
     // will ignore out-of-range values) but if we detect such a case, we do
     // not send a value.
@@ -112,13 +124,9 @@ FeeVoteImpl::doValidation(Fees const& lastFees, Rules const& rules, STValidation
                     v[sfield] = target;
                 }
             };
-        vote(lastFees.base, target_.reference_fee, "base fee", sfBaseFeeDrops);
-        vote(lastFees.reserve, target_.account_reserve, "base reserve", sfReserveBaseDrops);
-        vote(
-            lastFees.increment,
-            target_.owner_reserve,
-            "reserve increment",
-            sfReserveIncrementDrops);
+        vote(lastFees.base, referenceFee, "base fee", sfBaseFeeDrops);
+        vote(lastFees.reserve, accountReserve, "base reserve", sfReserveBaseDrops);
+        vote(lastFees.increment, ownerReserve, "reserve increment", sfReserveIncrementDrops);
     }
     else
     {
@@ -139,14 +147,9 @@ FeeVoteImpl::doValidation(Fees const& lastFees, Rules const& rules, STValidation
             }
         };
 
-        vote(lastFees.base, target_.reference_fee, to64, "base fee", sfBaseFee);
-        vote(lastFees.reserve, target_.account_reserve, to32, "base reserve", sfReserveBase);
-        vote(
-            lastFees.increment,
-            target_.owner_reserve,
-            to32,
-            "reserve increment",
-            sfReserveIncrement);
+        vote(lastFees.base, referenceFee, to64, "base fee", sfBaseFee);
+        vote(lastFees.reserve, accountReserve, to32, "base reserve", sfReserveBase);
+        vote(lastFees.increment, ownerReserve, to32, "reserve increment", sfReserveIncrement);
     }
 }
 
@@ -156,16 +159,18 @@ FeeVoteImpl::doVoting(
     std::vector<std::shared_ptr<STValidation>> const& set,
     std::shared_ptr<SHAMap> const& initialPosition)
 {
+    auto const [referenceFee, accountReserve, ownerReserve] = getTarget();
+
     // LCL must be flag ledger
     XRPL_ASSERT(
         lastClosedLedger && isFlagLedger(lastClosedLedger->seq()),
         "xrpl::FeeVoteImpl::doVoting : has a flag ledger");
 
-    detail::VotableValue baseFeeVote(lastClosedLedger->fees().base, target_.reference_fee);
+    detail::VotableValue baseFeeVote(lastClosedLedger->fees().base, referenceFee);
 
-    detail::VotableValue baseReserveVote(lastClosedLedger->fees().reserve, target_.account_reserve);
+    detail::VotableValue baseReserveVote(lastClosedLedger->fees().reserve, accountReserve);
 
-    detail::VotableValue incReserveVote(lastClosedLedger->fees().increment, target_.owner_reserve);
+    detail::VotableValue incReserveVote(lastClosedLedger->fees().increment, ownerReserve);
 
     auto const& rules = lastClosedLedger->rules();
     if (rules.enabled(featureXRPFees))
@@ -281,6 +286,22 @@ FeeVoteImpl::doVoting(
             JLOG(journal_.warn()) << "Ledger already had fee change";
         }
     }
+}
+
+void
+FeeVoteImpl::setTarget(XRPAmount referenceFee, XRPAmount accountReserve, XRPAmount ownerReserve)
+{
+    std::lock_guard lock(mutex_);
+    target_.reference_fee = referenceFee;
+    target_.account_reserve = accountReserve;
+    target_.owner_reserve = ownerReserve;
+}
+
+std::tuple<XRPAmount, XRPAmount, XRPAmount>
+FeeVoteImpl::getTarget() const
+{
+    std::lock_guard lock(mutex_);
+    return {target_.reference_fee, target_.account_reserve, target_.owner_reserve};
 }
 
 //------------------------------------------------------------------------------

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -432,6 +432,10 @@ public:
     acceptLedger(std::optional<std::chrono::milliseconds> consensusDelay) override;
     void
     reportFeeChange() override;
+    std::tuple<XRPAmount, XRPAmount, XRPAmount>
+    getFeeVote() const override;
+    void
+    setFeeVote(XRPAmount referenceFee, XRPAmount accountReserve, XRPAmount ownerReserve) override;
     void
     reportConsensusStateChange(ConsensusPhase phase);
 
@@ -3021,6 +3025,18 @@ NetworkOPsImp::reportFeeChange()
     {
         m_job_queue.addJob(jtCLIENT_FEE_CHANGE, "PubFee", [this]() { pubServer(); });
     }
+}
+
+std::tuple<XRPAmount, XRPAmount, XRPAmount>
+NetworkOPsImp::getFeeVote() const
+{
+    return mConsensus.getFeeVote();
+}
+
+void
+NetworkOPsImp::setFeeVote(XRPAmount referenceFee, XRPAmount accountReserve, XRPAmount ownerReserve)
+{
+    mConsensus.setFeeVote(referenceFee, accountReserve, ownerReserve);
 }
 
 void

--- a/src/xrpld/rpc/detail/Handler.cpp
+++ b/src/xrpld/rpc/detail/Handler.cpp
@@ -84,6 +84,7 @@ Handler const handlerArray[]{
     {"deposit_authorized", byRef(&doDepositAuthorized), Role::USER, NO_CONDITION},
     {"feature", byRef(&doFeature), Role::USER, NO_CONDITION},
     {"fee", byRef(&doFee), Role::USER, NEEDS_CURRENT_LEDGER},
+    {"fee_vote", byRef(&doFeeVote), Role::USER, NO_CONDITION},
     {"fetch_info", byRef(&doFetchInfo), Role::ADMIN, NO_CONDITION},
     {"gateway_balances", byRef(&doGatewayBalances), Role::USER, NO_CONDITION},
     {"get_counts", byRef(&doGetCounts), Role::ADMIN, NO_CONDITION},

--- a/src/xrpld/rpc/detail/RPCCall.cpp
+++ b/src/xrpld/rpc/detail/RPCCall.cpp
@@ -457,6 +457,22 @@ private:
         return jvRequest;
     }
 
+    // fee_vote [<reference_fee> [<account_reserve> [<owner_reserve>]]]
+    Json::Value
+    parseFeeVote(Json::Value const& jvParams)
+    {
+        Json::Value jvRequest(Json::objectValue);
+
+        if (jvParams.size() > 0)
+            jvRequest[jss::reference_fee] = jvParams[0u].asString();
+        if (jvParams.size() > 1)
+            jvRequest[jss::account_reserve] = jvParams[1u].asString();
+        if (jvParams.size() > 2)
+            jvRequest[jss::owner_reserve] = jvParams[2u].asString();
+
+        return jvRequest;
+    }
+
     // get_counts [<min_count>]
     Json::Value
     parseGetCounts(Json::Value const& jvParams)
@@ -1220,6 +1236,7 @@ public:
             {"consensus_info", &RPCParser::parseAsIs, 0, 0},
             {"deposit_authorized", &RPCParser::parseDepositAuthorized, 2, 11},
             {"feature", &RPCParser::parseFeature, 0, 2},
+            {"fee_vote", &RPCParser::parseFeeVote, 0, 3},
             {"fetch_info", &RPCParser::parseFetchInfo, 0, 1},
             {"gateway_balances", &RPCParser::parseGatewayBalances, 1, -1},
             {"get_counts", &RPCParser::parseGetCounts, 0, 1},

--- a/src/xrpld/rpc/handlers/FeeVote.cpp
+++ b/src/xrpld/rpc/handlers/FeeVote.cpp
@@ -1,0 +1,114 @@
+#include <xrpld/app/main/Application.h>
+#include <xrpld/rpc/Context.h>
+
+#include <xrpl/beast/core/LexicalCast.h>
+#include <xrpl/protocol/ErrorCodes.h>
+#include <xrpl/protocol/RPCErr.h>
+#include <xrpl/protocol/jss.h>
+#include <xrpl/server/NetworkOPs.h>
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <string>
+
+namespace xrpl {
+
+namespace {
+
+std::optional<XRPAmount>
+parseDrops(Json::Value const& value)
+{
+    std::int64_t drops;
+    if (value.isInt())
+    {
+        drops = value.asInt();
+    }
+    else if (value.isUInt())
+    {
+        drops = value.asUInt();
+    }
+    else if (value.isString())
+    {
+        try
+        {
+            drops = beast::lexicalCastThrow<std::int64_t>(value.asString());
+        }
+        catch (...)
+        {
+            return std::nullopt;
+        }
+    }
+    else
+    {
+        return std::nullopt;
+    }
+
+    if (drops < 0)
+        return std::nullopt;
+
+    return XRPAmount{drops};
+}
+
+Json::Value
+makeFeeVoteResult(XRPAmount referenceFee, XRPAmount accountReserve, XRPAmount ownerReserve)
+{
+    Json::Value result{Json::objectValue};
+    result[jss::reference_fee] = referenceFee.jsonClipped();
+    result[jss::account_reserve] = accountReserve.jsonClipped();
+    result[jss::owner_reserve] = ownerReserve.jsonClipped();
+    return result;
+}
+
+}  // namespace
+
+Json::Value
+doFeeVote(RPC::JsonContext& context)
+{
+    auto [referenceFee, accountReserve, ownerReserve] = context.app.getOPs().getFeeVote();
+
+    auto const hasReference = context.params.isMember(jss::reference_fee);
+    auto const hasAccount = context.params.isMember(jss::account_reserve);
+    auto const hasOwner = context.params.isMember(jss::owner_reserve);
+    auto const updateVote = hasReference || hasAccount || hasOwner;
+
+    if (updateVote && context.role != Role::ADMIN)
+        return rpcError(rpcNO_PERMISSION);
+
+    if (hasReference)
+    {
+        auto const parsed = parseDrops(context.params[jss::reference_fee]);
+        if (!parsed)
+            return RPC::make_param_error("Field 'reference_fee' must be a non-negative integer.");
+        referenceFee = *parsed;
+    }
+
+    if (hasAccount)
+    {
+        auto const parsed = parseDrops(context.params[jss::account_reserve]);
+        if (!parsed)
+            return RPC::make_param_error("Field 'account_reserve' must be a non-negative integer.");
+        if (!parsed->dropsAs<std::uint32_t>())
+            return RPC::make_param_error(
+                "Field 'account_reserve' must be less than or equal to 4294967295.");
+        accountReserve = *parsed;
+    }
+
+    if (hasOwner)
+    {
+        auto const parsed = parseDrops(context.params[jss::owner_reserve]);
+        if (!parsed)
+            return RPC::make_param_error("Field 'owner_reserve' must be a non-negative integer.");
+        if (!parsed->dropsAs<std::uint32_t>())
+            return RPC::make_param_error(
+                "Field 'owner_reserve' must be less than or equal to 4294967295.");
+        ownerReserve = *parsed;
+    }
+
+    if (updateVote)
+        context.app.getOPs().setFeeVote(referenceFee, accountReserve, ownerReserve);
+
+    return makeFeeVoteResult(referenceFee, accountReserve, ownerReserve);
+}
+
+}  // namespace xrpl

--- a/src/xrpld/rpc/handlers/Handlers.h
+++ b/src/xrpld/rpc/handlers/Handlers.h
@@ -45,6 +45,8 @@ doFeature(RPC::JsonContext&);
 Json::Value
 doFee(RPC::JsonContext&);
 Json::Value
+doFeeVote(RPC::JsonContext&);
+Json::Value
 doFetchInfo(RPC::JsonContext&);
 Json::Value
 doGatewayBalances(RPC::JsonContext&);


### PR DESCRIPTION
Fixes #6180

## High Level Overview of Change

Adds a new `fee_vote` RPC/CLI command to read and update local fee vote targets at runtime, without restarting `rippled`.

### Context of Change

Before this change, fee vote targets were configured at startup from config and could not be changed live through RPC/CLI.  
This adds operational flexibility for validators/operators by allowing runtime updates to:
- `reference_fee`
- `account_reserve`
- `owner_reserve`

The change wires this through RPC -> NetworkOPs -> consensus fee voting target state and adds validation/permission checks.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [x] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

- [x] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

## Before / After

### Before
No `fee_vote` RPC method existed for runtime fee vote target updates.

### After
New method: `fee_vote`

- Read current values (all roles):
  - `fee_vote`
- Update values (admin only):
  - `fee_vote <reference_fee> <account_reserve> <owner_reserve>`

Validation:
- Values must be non-negative integers.
- `account_reserve` and `owner_reserve` must be `<= 4294967295`.

## Test Plan

- `./.build/xrpld --unittest FeeVoteRPC,RPCCall --unittest-jobs 1 --quiet`
- `./.build/xrpld --unittest FeeVote --unittest-jobs 1 --quiet`
