### PR TITLE
fix: Fix flaky TxQ test

### DIFF
--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -624,7 +624,7 @@ private:
         TER result);
 
     void
-    pubServer();
+    pubServer(bool force = true);
     void
     pubConsensus(ConsensusPhase phase);
 
@@ -2171,7 +2171,7 @@ trunc32(std::uint64_t v)
 };
 
 void
-NetworkOPsImp::pubServer()
+NetworkOPsImp::pubServer(bool force)
 {
     // VFALCO TODO Don't hold the lock across calls to send...make a copy of the
     //             list into a local array while holding the lock then release
@@ -2187,6 +2187,13 @@ NetworkOPsImp::pubServer()
             registry_.openLedger().current()->fees().base,
             registry_.getTxQ().getMetrics(*registry_.openLedger().current()),
             registry_.getFeeTrack()};
+
+        // Skip sending if the fee state hasn't changed since the last
+        // notification, unless forced (e.g. by an operating mode change).
+        // This prevents duplicate notifications when multiple pubServer jobs
+        // are queued before any of them run.
+        if (!force && f == mLastFeeSummary)
+            return;
 
         jvObj[jss::type] = "serverStatus";
         jvObj[jss::server_status] = strOperatingMode();
@@ -3069,7 +3076,7 @@ NetworkOPsImp::reportFeeChange()
     // only schedule the job if something has changed
     if (f != mLastFeeSummary)
     {
-        m_job_queue.addJob(jtCLIENT_FEE_CHANGE, "PubFee", [this]() { pubServer(); });
+        m_job_queue.addJob(jtCLIENT_FEE_CHANGE, "PubFee", [this]() { pubServer(false); });
     }
 }
 


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

This PR fixes flaky TxQ test. [Failure example](https://github.com/XRPLF/rippled/actions/runs/23305953982/job/67780056769).

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->
**The root cause of the flakiness:** Multiple `reportFeeChange()` calls can happen while a `pubServer` job is still pending in the job queue (e.g., one from a fund transaction's `apply()` and one from `doAccept()` — or multiple from successive fund tx applications). Each call sees `f != mLastFeeSummary` (since `mLastFeeSummary` is only updated when a job actually runs) and schedules a *separate* `pubServer` job. Under slow debug/coverage builds, jobs take much longer to execute, making it far more likely for multiple jobs to pile up before any runs.

When multiple jobs finally execute, they all read the *current* fee state. If the fee is the same for all of them (e.g., all read `256` after the queue drains), they all send identical notifications. `findMsg` at line 3474 consumes one; the duplicate sits in the buffer and causes line 3486 to fail.

**The fix:** Add a `force` parameter (default `false`) to `pubServer()`. When called from the job queue (no `force`), it now returns early if the fee summary hasn't changed since the last notification — eliminating duplicate sends. When called from `setMode()` (mode changes), it passes `force=true` so those notifications are always sent regardless of fee state.

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
