### PR TITLE
Fix removeDeletedTrustLines

### DIFF
--- a/src/libxrpl/tx/Transactor.cpp
+++ b/src/libxrpl/tx/Transactor.cpp
@@ -981,12 +981,7 @@ removeDeletedTrustLines(
     std::vector<uint256> const& trustLines,
     beast::Journal viewJ)
 {
-    if (trustLines.size() > maxDeletableAMMTrustLines)
-    {
-        JLOG(viewJ.error()) << "removeDeletedTrustLines: deleted trustlines exceed max "
-                            << trustLines.size();
-        return;
-    }
+    std::size_t removed = 0;
 
     for (auto const& index : trustLines)
     {
@@ -995,6 +990,8 @@ removeDeletedTrustLines(
         {
             JLOG(viewJ.error()) << "removeDeletedTrustLines: failed to delete AMM trustline";
         }
+        if (++removed == maxDeletableAMMTrustLines)
+            return;
     }
 }
 


### PR DESCRIPTION
## High Level Overview of Change

  Replace the all-or-nothing size guard in `removeDeletedTrustLines` with an
  iterate-up-to-limit loop, so each `AMMDelete` transaction cleans up as many
  AMM trust lines as the per-transaction cap allows instead of abandoning
  cleanup entirely when that cap is exceeded.

  Fixes https://github.com/XRPLF/rippled/issues/6614

  ---

  ### Context of Change

  `removeDeletedTrustLines` is called at the end of `Transactor::operator()`
  when a transaction returns `tecINCOMPLETE`. Its job is to finalize deletion
  of AMM trust lines that were marked for removal during transaction processing.

  The previous implementation contained this guard:

  ```cpp
  if (trustLines.size() > maxDeletableAMMTrustLines)
  {
      JLOG(viewJ.error()) << "removeDeletedTrustLines: deleted trustlines exceed max "
                          << trustLines.size();
      return;
  }

  When an AMM account held more than 512 trust lines (maxDeletableAMMTrustLines),
  this guard caused the function to return immediately without deleting any of
  them. The stale trust line objects then accumulated on the ledger indefinitely
  with no path to cleanup, because each subsequent AMMDelete attempt hit the
  same guard and bailed out the same way.

  The fix removes the guard and replaces the plain loop with a counter-based
  loop that stops after maxDeletableAMMTrustLines attempts — identical in
  structure to removeUnfundedOffers and removeExpiredNFTokenOffers in the
  same file. Each AMMDelete transaction now deletes up to 512 trust lines;
  when more remain the transaction returns tecINCOMPLETE and the next
  invocation continues where the previous one left off, eventually completing
  the full cleanup.

  API Impact

  - Public API: New feature (new methods and/or new fields)
  - Public API: Breaking change
  - libxrpl change
  - Peer protocol change

  No API impact. The change is entirely internal to Transactor.cpp. No new
  fields, methods, configuration values, or protocol messages are introduced.
  Transaction semantics (tecINCOMPLETE for oversized cleanup, eventual
  success) remain unchanged — only the number of trust lines processed per
  invocation improves.

  ---
  Before / After

  Before — if trustLines.size() > 512:
  - Function logs an error and returns immediately
  - Zero trust lines are deleted
  - Stale AMM trust line objects accumulate on the ledger with no cleanup path

  After — regardless of trustLines.size():
  - Function deletes up to 512 trust lines per invocation
  - Returns after the limit is reached, leaving the rest for the next transaction
  - AMM accounts with any number of trust lines can be fully cleaned up across
  one or more AMMDelete transactions

  ---
  Test Plan

  Existing tests in src/test/app/AMM_test.cpp — testAutoDelete() — cover
  both boundary cases:

  1. Slightly over limit (maxDeletableAMMTrustLines + 10 = 522 trust lines):
  first AMMDelete returns tecINCOMPLETE, second call completes the AMM
  deletion successfully.
  2. Well over limit (maxDeletableAMMTrustLines * 2 + 10 = 1034 trust lines):
  two AMMDelete transactions are required to finish cleanup; both complete
  without error.

  Run from the build directory:

  ./xrpld --unittest=AMM

  All tests must pass.