### PR TITLE
AMMHelpers: Add defensive XRPL_ASSERT for denominator in ammAssetOut

### DIFF
--- a/src/libxrpl/tx/transactors/dex/AMMHelpers.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMHelpers.cpp
@@ -120,14 +120,17 @@ ammAssetOut(
 {
     auto const f = getFee(tfee);
     Number const t1 = lpTokens / lptAMMBalance;
+    auto const denom = t1 * f - 1;
+    XRPL_ASSERT(denom != Number{0}, "xrpl::ammAssetOut : denominator is non-zero");
+
     if (!isFeatureEnabled(fixAMMv1_3))
     {
-        auto const b = assetBalance * (t1 * t1 - t1 * (2 - f)) / (t1 * f - 1);
+        auto const b = assetBalance * (t1 * t1 - t1 * (2 - f)) / denom;
         return toSTAmount(assetBalance.issue(), b);
     }
 
     // minimize withdraw
-    auto const frac = (t1 * t1 - t1 * (2 - f)) / (t1 * f - 1);
+    auto const frac = (t1 * t1 - t1 * (2 - f)) / denom;
     return multiply(assetBalance, frac, Number::downward);
 }
 


### PR DESCRIPTION
## High Level Overview of Change

Add a defensive `XRPL_ASSERT` for the denominator `(t1 * f - 1)` 
in `ammAssetOut` to document and enforce the invariant that it 
cannot be zero.

### Context of Change

The denominator `(t1 * f - 1)` in `ammAssetOut` cannot be zero 
given valid input constraints:
- `f = getFee(tfee)` ranges [0, 0.01] (max tfee is 1000)
- `t1 = lpTokens / lptAMMBalance` ranges (0, 1]
- Therefore `t1 * f` ranges [0, 0.01], making the denominator 
  range [-1, -0.99]

However, this invariant was implicit and undocumented. This PR 
extracts the denominator into a named variable `denom` and adds 
a defensive `XRPL_ASSERT` before the division, making the 
invariant self-documenting and protecting against future changes 
that might widen the input ranges.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)


## Test Plan

The invariant cannot be violated with valid inputs — the denominator 
cannot be zero given the current input constraints. No new test is 
added for this reason.

Existing AMM tests in `src/test/app/AMM_test.cpp` cover the normal 
behavior of `ammAssetOut` and were not affected by this change.

