### PR TITLE
Fix issue #6798

### DIFF
--- a/src/test/rpc/TransactionEntry_test.cpp
+++ b/src/test/rpc/TransactionEntry_test.cpp
@@ -24,7 +24,7 @@ class TransactionEntry_test : public beast::unit_test::suite
         {
             // no params
             auto const result = env.client().invoke("transaction_entry", {})[jss::result];
-            BEAST_EXPECT(result[jss::error] == "fieldNotFoundTransaction");
+            BEAST_EXPECT(result[jss::error] == "invalidParams");
             BEAST_EXPECT(result[jss::status] == "error");
         }
 
@@ -41,7 +41,7 @@ class TransactionEntry_test : public beast::unit_test::suite
             params[jss::ledger] = "current";
             params[jss::tx_hash] = "DEADBEEF";
             auto const result = env.client().invoke("transaction_entry", params)[jss::result];
-            BEAST_EXPECT(result[jss::error] == "notYetImplemented");
+            BEAST_EXPECT(result[jss::error] == "notImpl");
             BEAST_EXPECT(result[jss::status] == "error");
         }
 
@@ -50,8 +50,7 @@ class TransactionEntry_test : public beast::unit_test::suite
             params[jss::ledger] = "closed";
             params[jss::tx_hash] = "DEADBEEF";
             auto const result = env.client().invoke("transaction_entry", params)[jss::result];
-            BEAST_EXPECT(!result[jss::ledger_hash].asString().empty());
-            BEAST_EXPECT(result[jss::error] == "malformedRequest");
+            BEAST_EXPECT(result[jss::error] == "invalidParams");
             BEAST_EXPECT(result[jss::status] == "error");
         }
 
@@ -112,8 +111,7 @@ class TransactionEntry_test : public beast::unit_test::suite
         {
             // Valid structure, but transaction not found.
             Json::Value const result{env.rpc("transaction_entry", txHash, "closed")};
-            BEAST_EXPECT(!result[jss::result][jss::ledger_hash].asString().empty());
-            BEAST_EXPECT(result[jss::result][jss::error] == "transactionNotFound");
+            BEAST_EXPECT(result[jss::result][jss::error] == "txnNotFound");
             BEAST_EXPECT(result[jss::result][jss::status] == "error");
         }
     }

--- a/src/xrpld/rpc/handlers/transaction/TransactionEntry.cpp
+++ b/src/xrpld/rpc/handlers/transaction/TransactionEntry.cpp
@@ -28,7 +28,7 @@ doTransactionEntry(RPC::JsonContext& context)
 
     if (!context.params.isMember(jss::tx_hash))
     {
-        return rpcError(rpcINVALID_PARAMS);
+        return RPC::missing_field_error(jss::tx_hash);
     }
     else if (jvResult.get(jss::ledger_hash, Json::nullValue).isNull())
     {

--- a/src/xrpld/rpc/handlers/transaction/TransactionEntry.cpp
+++ b/src/xrpld/rpc/handlers/transaction/TransactionEntry.cpp
@@ -5,6 +5,8 @@
 
 #include <xrpl/ledger/ReadView.h>
 #include <xrpl/protocol/jss.h>
+#include <xrpl/protocol/ErrorCodes.h>
+#include <xrpl/protocol/RPCErr.h>
 
 namespace xrpl {
 
@@ -26,14 +28,14 @@ doTransactionEntry(RPC::JsonContext& context)
 
     if (!context.params.isMember(jss::tx_hash))
     {
-        jvResult[jss::error] = "fieldNotFoundTransaction";
+        return rpcError(rpcINVALID_PARAMS);
     }
     else if (jvResult.get(jss::ledger_hash, Json::nullValue).isNull())
     {
         // We don't work on ledger current.
 
         // XXX We don't support any transaction yet.
-        jvResult[jss::error] = "notYetImplemented";
+        return rpcError(rpcNOT_IMPL);
     }
     else
     {
@@ -42,14 +44,13 @@ doTransactionEntry(RPC::JsonContext& context)
         // routine, returning success or failure.
         if (!uTransID.parseHex(context.params[jss::tx_hash].asString()))
         {
-            jvResult[jss::error] = "malformedRequest";
-            return jvResult;
+            return rpcError(rpcINVALID_PARAMS);
         }
 
         auto [sttx, stobj] = lpLedger->txRead(uTransID);
         if (!sttx)
         {
-            jvResult[jss::error] = "transactionNotFound";
+            return rpcError(rpcTXN_NOT_FOUND);
         }
         else
         {


### PR DESCRIPTION
## Summary
Remove legacy rpc error response body and use `rpcError` with predefined errors.