### PR TITLE
test: Improve test coverage for tecDIR_FULL error in xrpld

### DIFF
--- a/src/libxrpl/ledger/View.cpp
+++ b/src/libxrpl/ledger/View.cpp
@@ -341,7 +341,7 @@ dirLink(
     auto const page =
         view.dirInsert(keylet::ownerDir(owner), object->key(), describeOwnerDir(owner));
     if (!page)
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
     object->setFieldU64(node, *page);
     return tesSUCCESS;
 }

--- a/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
@@ -904,7 +904,7 @@ createMPToken(
         view.dirInsert(keylet::ownerDir(account), mptokenKey, describeOwnerDir(account));
 
     if (!ownerNode)
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
 
     auto mptoken = std::make_shared<SLE>(mptokenKey);
     (*mptoken)[sfAccount] = account;

--- a/src/libxrpl/ledger/helpers/NFTokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/NFTokenHelpers.cpp
@@ -12,6 +12,7 @@
 #include <xrpl/ledger/helpers/RippleStateHelpers.h>
 #include <xrpl/ledger/helpers/TokenHelpers.h>
 #include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/Asset.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Issue.h>
@@ -947,7 +948,7 @@ tokenOfferCreateApply(
             view.dirInsert(keylet::ownerDir(acctID), offerID, describeOwnerDir(acctID));
 
         if (!ownerNode)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         bool const isSellOffer = (txFlags & tfSellNFToken) != 0u;
 
@@ -962,7 +963,7 @@ tokenOfferCreateApply(
             });
 
         if (!offerNode)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         std::uint32_t sleFlags = 0;
 

--- a/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
@@ -218,13 +218,13 @@ trustCreate(
         keylet::ownerDir(uLowAccountID), sleRippleState->key(), describeOwnerDir(uLowAccountID));
 
     if (!lowNode)
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
 
     auto highNode = view.dirInsert(
         keylet::ownerDir(uHighAccountID), sleRippleState->key(), describeOwnerDir(uHighAccountID));
 
     if (!highNode)
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
 
     bool const bSetDst = saLimit.getIssuer() == uDstAccountID;
     bool const bSetHigh = bSrcHigh ^ bSetDst;

--- a/src/libxrpl/tx/transactors/account/SignerListSet.cpp
+++ b/src/libxrpl/tx/transactors/account/SignerListSet.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <tuple>
 #include <utility>
@@ -343,7 +344,7 @@ SignerListSet::replaceSignerList()
                      << (page ? "success" : "failure");
 
     if (!page)
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
 
     signerList->setFieldU64(sfOwnerNode, *page);
 

--- a/src/libxrpl/tx/transactors/bridge/XChainBridge.cpp
+++ b/src/libxrpl/tx/transactors/bridge/XChainBridge.cpp
@@ -1130,7 +1130,7 @@ applyCreateAccountAttestations(
         auto const page = psb.dirInsert(
             keylet::ownerDir(doorAccount), claimIDKeylet, describeOwnerDir(doorAccount));
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
         (*createdSleClaimID)[sfOwnerNode] = *page;
 
         auto const sleDoor = psb.peek(doorK);
@@ -1477,7 +1477,7 @@ XChainCreateBridge::doApply()
         auto const page = ctx_.view().dirInsert(
             keylet::ownerDir(account), bridgeKeylet, describeOwnerDir(account));
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
         (*sleBridge)[sfOwnerNode] = *page;
     }
 
@@ -2039,7 +2039,7 @@ XChainCreateClaimID::doApply()
         auto const page = ctx_.view().dirInsert(
             keylet::ownerDir(account), claimIDKeylet, describeOwnerDir(account));
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
         (*sleClaimID)[sfOwnerNode] = *page;
     }
 

--- a/src/libxrpl/tx/transactors/check/CheckCreate.cpp
+++ b/src/libxrpl/tx/transactors/check/CheckCreate.cpp
@@ -235,7 +235,7 @@ CheckCreate::doApply()
                          << ": " << (page ? "success" : "failure");
 
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         sleCheck->setFieldU64(sfDestinationNode, *page);
     }
@@ -248,7 +248,7 @@ CheckCreate::doApply()
                          << (page ? "success" : "failure");
 
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         sleCheck->setFieldU64(sfOwnerNode, *page);
     }

--- a/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
+++ b/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
@@ -111,7 +111,7 @@ DelegateSet::doApply()
         keylet::ownerDir(accountID_), delegateKey, describeOwnerDir(accountID_));
 
     if (!page)
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
 
     (*sle)[sfOwnerNode] = *page;
 

--- a/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
+++ b/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
@@ -581,7 +581,7 @@ OfferCreate::applyHybrid(
     if (!bookNode)
     {
         JLOG(j_.debug()) << "final result: failed to add hybrid offer to open book";
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
     }
 
     STArray bookArr(sfAdditionalBooks, 1);
@@ -855,10 +855,8 @@ OfferCreate::applyGuts(Sandbox& sb, Sandbox& sbCancel)
 
     if (!ownerNode)
     {
-        // LCOV_EXCL_START
         JLOG(j_.debug()) << "final result: failed to add offer to owner's directory";
         return {tecDIR_FULL, true};
-        // LCOV_EXCL_STOP
     }
 
     // Update owner count.
@@ -909,10 +907,8 @@ OfferCreate::applyGuts(Sandbox& sb, Sandbox& sbCancel)
 
     if (!bookNode)
     {
-        // LCOV_EXCL_START
         JLOG(j_.debug()) << "final result: failed to add offer to book";
         return {tecDIR_FULL, true};
-        // LCOV_EXCL_STOP
     }
 
     auto sleOffer = std::make_shared<SLE>(offerIndex);

--- a/src/libxrpl/tx/transactors/did/DIDSet.cpp
+++ b/src/libxrpl/tx/transactors/did/DIDSet.cpp
@@ -86,7 +86,7 @@ addSLE(ApplyContext& ctx, std::shared_ptr<SLE> const& sle, AccountID const& owne
         auto page =
             ctx.view().dirInsert(keylet::ownerDir(owner), sle->key(), describeOwnerDir(owner));
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
         (*sle)[sfOwnerNode] = *page;
     }
     adjustOwnerCount(ctx.view(), sleAccount, 1, ctx.journal);

--- a/src/libxrpl/tx/transactors/oracle/OracleSet.cpp
+++ b/src/libxrpl/tx/transactors/oracle/OracleSet.cpp
@@ -313,7 +313,7 @@ OracleSet::doApply()
         auto page = ctx_.view().dirInsert(
             keylet::ownerDir(accountID_), sle->key(), describeOwnerDir(accountID_));
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         (*sle)[sfOwnerNode] = *page;
 

--- a/src/libxrpl/tx/transactors/payment/DepositPreauth.cpp
+++ b/src/libxrpl/tx/transactors/payment/DepositPreauth.cpp
@@ -185,7 +185,7 @@ DepositPreauth::doApply()
                          << to_string(preauthKeylet.key) << ": " << (page ? "success" : "failure");
 
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         slePreauth->setFieldU64(sfOwnerNode, *page);
 
@@ -246,7 +246,7 @@ DepositPreauth::doApply()
                          << ": " << (page ? "success" : "failure");
 
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         slePreauth->setFieldU64(sfOwnerNode, *page);
 

--- a/src/libxrpl/tx/transactors/permissioned_domain/PermissionedDomainSet.cpp
+++ b/src/libxrpl/tx/transactors/permissioned_domain/PermissionedDomainSet.cpp
@@ -121,7 +121,7 @@ PermissionedDomainSet::doApply()
         auto const page =
             view().dirInsert(keylet::ownerDir(accountID_), pdKeylet, describeOwnerDir(accountID_));
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         slePd->setFieldU64(sfOwnerNode, *page);
         // If we succeeded, the new entry counts against the creator's reserve.

--- a/src/libxrpl/tx/transactors/system/TicketCreate.cpp
+++ b/src/libxrpl/tx/transactors/system/TicketCreate.cpp
@@ -114,7 +114,7 @@ TicketCreate::doApply()
                          << (page ? "success" : "failure");
 
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         sleTicket->setFieldU64(sfOwnerNode, *page);
     }

--- a/src/libxrpl/tx/transactors/token/MPTokenIssuanceCreate.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenIssuanceCreate.cpp
@@ -120,7 +120,7 @@ MPTokenIssuanceCreate::create(ApplyView& view, beast::Journal journal, MPTCreate
             keylet::ownerDir(args.account), mptIssuanceKeylet, describeOwnerDir(args.account));
 
         if (!ownerNode)
-            return Unexpected(tecDIR_FULL);  // LCOV_EXCL_LINE
+            return Unexpected(tecDIR_FULL);
 
         auto mptIssuance = std::make_shared<SLE>(mptIssuanceKeylet);
         (*mptIssuance)[sfFlags] = args.flags & ~tfUniversal;

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -5,6 +5,7 @@
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>
 #include <test/jtx/check.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
 #include <test/jtx/invoice_id.h>
@@ -316,7 +317,7 @@ class Check_test : public beast::unit_test::Suite
 
         Env env{*this, features};
 
-        STAmount const startBalance{XRP(1000).value()};
+        STAmount const startBalance{XRP(5000).value()};
         env.fund(startBalance, gw1, gwF, alice, bob);
         env.close();
 
@@ -484,6 +485,30 @@ class Check_test : public beast::unit_test::Suite
 
         env(check::create(cheri, bob, usd(50)));
         env.close();
+    }
+
+    void
+    testDirectoryFull(FeatureBitset features)
+    {
+        testcase("Directory full");
+
+        using namespace test::jtx;
+        using namespace ::xrpl::test::jtx::directory;
+
+        Account const alice{"alice"};
+        Account const bob{"bob"};
+
+        Env env{*this, features};
+        env.fund(XRP(10000), alice, bob);
+        env.close();
+
+        auto const bobDir = keylet::ownerDir(bob.id());
+        auto const n1 = getIndexCountToBump(env, bobDir);
+        env(ticket::create(bob, n1));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), bobDir, adjustOwnerNode));
+
+        env(check::create(alice, bob, XRP(1)), Ter(tecDIR_FULL));
+        env(check::create(bob, alice, XRP(1)), Ter(tecDIR_FULL));
     }
 
     void
@@ -2481,6 +2506,7 @@ class Check_test : public beast::unit_test::Suite
         testCreateValid(features);
         testCreateDisallowIncoming(features);
         testCreateInvalid(features);
+        testDirectoryFull(features);
         testCashXRP(features);
         testCashIOU(features);
         testCashXferFee(features);

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -536,16 +536,18 @@ struct Credentials_test : public beast::unit_test::Suite
             {
                 testcase("Credentials fail, directory full");
                 std::uint32_t const issuerSeq{env.seq(issuer) + 1};
-                env(ticket::create(issuer, 63));
-                env.close();
 
+                auto const issuerDir = keylet::ownerDir(issuer.id());
+                auto const n1 = directory::getIndexCountToBump(env, issuerDir);
+                env(ticket::create(issuer, n1));
+                env.close();
                 // Everything below can only be tested on open ledger.
-                auto const res1 = directory::bumpLastPage(
-                    env,
-                    directory::maximumPageIndex(env),
-                    keylet::ownerDir(issuer.id()),
-                    directory::adjustOwnerNode);
-                BEAST_EXPECT(res1);
+                BEAST_EXPECT(
+                    directory::bumpLastPage(
+                        env,
+                        directory::maximumPageIndex(env),
+                        issuerDir,
+                        directory::adjustOwnerNode));
 
                 // NOLINTNEXTLINE(readability-suspicious-call-argument)
                 auto const jv = credentials::create(issuer, subject, credType);
@@ -553,14 +555,15 @@ struct Credentials_test : public beast::unit_test::Suite
                 // Free one directory entry by using a ticket
                 env(noop(issuer), ticket::Use(issuerSeq + 40));
 
-                // Fill subject directory
-                env(ticket::create(subject, 63));
-                auto const res2 = directory::bumpLastPage(
-                    env,
-                    directory::maximumPageIndex(env),
-                    keylet::ownerDir(subject.id()),
-                    directory::adjustOwnerNode);
-                BEAST_EXPECT(res2);
+                auto const subjectDir = keylet::ownerDir(subject.id());
+                auto const n2 = directory::getIndexCountToBump(env, subjectDir);
+                env(ticket::create(subject, n2));
+                BEAST_EXPECT(
+                    directory::bumpLastPage(
+                        env,
+                        directory::maximumPageIndex(env),
+                        subjectDir,
+                        directory::adjustOwnerNode));
                 env(jv, Ter(tecDIR_FULL));
 
                 // End test

--- a/src/test/app/DID_test.cpp
+++ b/src/test/app/DID_test.cpp
@@ -5,8 +5,10 @@
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>  // IWYU pragma: keep
 #include <test/jtx/did.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/pay.h>
 #include <test/jtx/ter.h>
+#include <test/jtx/ticket.h>
 #include <test/jtx/txflags.h>
 
 #include <xrpl/beast/unit_test/suite.h>
@@ -355,6 +357,29 @@ struct DID_test : public beast::unit_test::Suite
     }
 
     void
+    testDirectoryFull(FeatureBitset features)
+    {
+        testcase("Directory full");
+
+        using namespace jtx;
+        using namespace ::xrpl::test::jtx::directory;
+
+        Account const alice{"alice"};
+
+        Env env{*this, features};
+        env.fund(XRP(10000), alice);
+        env.close();
+
+        auto const aliceDir = keylet::ownerDir(alice.id());
+        auto const n1 = getIndexCountToBump(env, aliceDir);
+        env(ticket::create(alice, n1));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+
+        env(did::setValid(alice), Ter(tecDIR_FULL));
+        env.close();
+    }
+
+    void
     run() override
     {
         using namespace test::jtx;
@@ -366,6 +391,7 @@ struct DID_test : public beast::unit_test::Suite
         testDeleteInvalid(all);
         testSetValidInitial(all);
         testSetModify(all);
+        testDirectoryFull(all);
 
         testEnabled(all - emptyDID);
         testAccountReserve(all - emptyDID);

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -7,6 +7,7 @@
 #include <test/jtx/balance.h>
 #include <test/jtx/delegate.h>
 #include <test/jtx/did.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
 #include <test/jtx/mpt.h>
@@ -20,6 +21,7 @@
 #include <test/jtx/sendmax.h>
 #include <test/jtx/sig.h>
 #include <test/jtx/ter.h>
+#include <test/jtx/ticket.h>
 #include <test/jtx/trust.h>
 #include <test/jtx/txflags.h>
 
@@ -238,6 +240,15 @@ class Delegate_test : public beast::unit_test::Suite
             env(delegate::set(gw, alice, {"UNLModify"}), Ter(temMALFORMED));
             env(delegate::set(gw, alice, {"SetFee"}), Ter(temMALFORMED));
             env(delegate::set(gw, alice, {"Batch"}), Ter(temMALFORMED));
+        }
+
+        {
+            using namespace ::xrpl::test::jtx::directory;
+            auto const aliceDir = keylet::ownerDir(alice.id());
+            auto const n = getIndexCountToBump(env, aliceDir);
+            env(ticket::create(alice, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+            env(delegate::set(alice, bob, {"Payment"}), Ter(tecDIR_FULL));
         }
     }
 

--- a/src/test/app/EscrowToken_test.cpp
+++ b/src/test/app/EscrowToken_test.cpp
@@ -3,6 +3,7 @@
 #include <test/jtx/Env.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>  // IWYU pragma: keep
+#include <test/jtx/directory.h>
 #include <test/jtx/escrow.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
@@ -10,6 +11,7 @@
 #include <test/jtx/pay.h>
 #include <test/jtx/rate.h>
 #include <test/jtx/ter.h>
+#include <test/jtx/ticket.h>
 #include <test/jtx/trust.h>
 #include <test/jtx/txflags.h>
 
@@ -2835,6 +2837,46 @@ struct EscrowToken_test : public beast::unit_test::Suite
                 escrow::kFulfillment(escrow::kFb1),
                 Fee(baseFee * 150),
                 Ter(tesSUCCESS));
+            env.close();
+        }
+
+        // tecDir_FULL: bob submits; directory full
+        {
+            Env env{*this, features};
+            auto const baseFee = env.current()->fees().base;
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+            auto const gw = Account("gw");
+            env.fund(XRP(10'000), bob);
+            env.close();
+
+            MPTTester mptGw(env, gw, {.holders = {alice}});
+            mptGw.create(
+                {.ownerCount = 1, .holderCount = 0, .flags = tfMPTCanEscrow | tfMPTCanTransfer});
+            mptGw.authorize({.account = alice});
+            auto const mpt = mptGw["MPT"];
+            env(pay(gw, alice, mpt(10'000)));
+            env.close();
+
+            auto const seq1 = env.seq(alice);
+            env(escrow::create(alice, bob, mpt(10)),
+                escrow::kCondition(escrow::kCb1),
+                escrow::kFinishTime(env.now() + 1s),
+                Fee(baseFee * 150),
+                Ter(tesSUCCESS));
+            env.close();
+
+            using namespace ::xrpl::test::jtx::directory;
+            auto const bobDir = keylet::ownerDir(bob.id());
+            auto const n = getIndexCountToBump(env, bobDir);
+            env(ticket::create(bob, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), bobDir, adjustOwnerNode));
+
+            env(escrow::finish(bob, alice, seq1),
+                escrow::kCondition(escrow::kCb1),
+                escrow::kFulfillment(escrow::kFb1),
+                Fee(baseFee * 150),
+                Ter(tecDIR_FULL));
             env.close();
         }
 

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -4,13 +4,17 @@
 #include <test/jtx/balance.h>
 #include <test/jtx/credentials.h>
 #include <test/jtx/deposit.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/escrow.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
+#include <test/jtx/noop.h>
+#include <test/jtx/pay.h>
 #include <test/jtx/seq.h>
 #include <test/jtx/tag.h>
 #include <test/jtx/ter.h>
 #include <test/jtx/ticket.h>
+#include <test/jtx/trust.h>
 #include <test/jtx/txflags.h>
 
 #include <xrpl/basics/Slice.h>
@@ -1612,6 +1616,72 @@ struct Escrow_test : public beast::unit_test::Suite
     }
 
     void
+    testDirectoryFull(FeatureBitset features)
+    {
+        testcase("Directory full");
+        using namespace jtx;
+        using namespace std::chrono;
+
+        Env env(*this, features);
+        auto const gw = Account{"gateway"};
+        auto const alice = Account{"alice"};
+        auto const bob = Account{"bob"};
+        auto const usd = gw["USD"];
+        auto const eur = gw["EUR"];
+        auto const gbp = gw["GBP"];
+
+        env.fund(XRP(10000), gw, alice, bob);
+        env(fset(gw, asfAllowTrustLineLocking));
+        env.close();
+
+        env.trust(usd(10000), alice);
+        env.close();
+
+        env(pay(gw, alice, usd(10000)));
+
+        std::uint32_t const noopSeq{env.seq(alice) + 1};
+        env.close();
+
+        using namespace ::xrpl::test::jtx::directory;
+        auto const aliceDir = keylet::ownerDir(alice.id());
+        auto const n1 = getIndexCountToBump(env, aliceDir);
+        env(ticket::create(alice, n1));
+        env.close();
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+        env(escrow::create(alice, bob, usd(1000)),
+            escrow::kFinishTime(env.now() + 1h),
+            Ter(tecDIR_FULL));
+
+        env(trust(alice, eur(10000)), Ter(tecDIR_FULL));
+        env.close();
+
+        env(noop(alice), ticket::Use(noopSeq));
+
+        auto const bobDir = keylet::ownerDir(bob.id());
+        auto const n2 = getIndexCountToBump(env, bobDir);
+        env(ticket::create(bob, n2));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), bobDir, adjustOwnerNode));
+
+        env(escrow::create(alice, bob, usd(1000)),
+            escrow::kFinishTime(env.now() + 1h),
+            Ter(tecDIR_FULL));
+        env.close();
+
+        // add issuer somehow
+        env(noop(alice), ticket::Use(noopSeq + 1));
+        auto const gwDir = keylet::ownerDir(gw.id());
+        auto const n3 = getIndexCountToBump(env, gwDir);
+        env(ticket::create(gw, n3));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), gwDir, adjustOwnerNode));
+
+        env(escrow::create(alice, bob, usd(1000)),
+            escrow::kFinishTime(env.now() + 1h),
+            Ter(tecDIR_FULL));
+        env(trust(alice, gbp(10000)), Ter(tecDIR_FULL));
+        env.close();
+    }
+
+    void
     testWithFeats(FeatureBitset features)
     {
         testEnablement(features);
@@ -1634,6 +1704,7 @@ public:
     {
         using namespace test::jtx;
         FeatureBitset const all{testableAmendments()};
+        testDirectoryFull(all);
         testWithFeats(all);
         testWithFeats(all - featureTokenEscrow);
         testTags(all - fixIncludeKeyletFields);

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -9,6 +9,7 @@
 #include <test/jtx/credentials.h>
 #include <test/jtx/delivermin.h>
 #include <test/jtx/deposit.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/domain.h>
 #include <test/jtx/envconfig.h>
 #include <test/jtx/escrow.h>
@@ -23,6 +24,7 @@
 #include <test/jtx/permissioned_domains.h>
 #include <test/jtx/sendmax.h>
 #include <test/jtx/ter.h>
+#include <test/jtx/ticket.h>
 #include <test/jtx/trust.h>
 #include <test/jtx/txflags.h>
 #include <test/jtx/vault.h>
@@ -399,6 +401,19 @@ class MPToken_test : public beast::unit_test::Suite
             mptAlice.authorize({.holder = bob, .id = id, .err = tecOBJECT_NOT_FOUND});
 
             mptAlice.authorize({.account = bob, .id = id, .err = tecOBJECT_NOT_FOUND});
+        }
+
+        {
+            Env env{*this, features};
+            MPTTester const mptAlice(env, alice, {.holders = {bob}});
+
+            using namespace ::xrpl::test::jtx::directory;
+            auto const aliceDir = keylet::ownerDir(alice.id());
+            auto const n = getIndexCountToBump(env, aliceDir);
+            env(ticket::create(alice, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+
+            env(mptAlice.createJV({.issuer = alice, .ownerCount = 1}), Ter(tecDIR_FULL));
         }
 
         // Test bad scenarios without allowlisting in MPTokenAuthorize

--- a/src/test/app/MultiSign_test.cpp
+++ b/src/test/app/MultiSign_test.cpp
@@ -4,6 +4,7 @@
 #include <test/jtx/JTx.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/envconfig.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
@@ -156,7 +157,7 @@ public:
         using namespace jtx;
         Env env{*this, features};
         Account const alice{"alice", KeyType::Ed25519};
-        env.fund(XRP(1000), alice);
+        env.fund(XRP(10000), alice);
         env.close();
 
         // Add alice as a multisigner for herself.  Should fail.
@@ -219,6 +220,13 @@ public:
         // clang-format on
         env.close();
         env.require(Owners(alice, 0));
+
+        using namespace ::xrpl::test::jtx::directory;
+        auto const aliceDir = keylet::ownerDir(alice.id());
+        auto const n2 = getIndexCountToBump(env, aliceDir);
+        env(ticket::create(alice, n2));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+        env(signers(alice, 1, {{bogie_, 1}, {demon_, 1}}), Ter(tecDIR_FULL));
     }
 
     void

--- a/src/test/app/NFToken_test.cpp
+++ b/src/test/app/NFToken_test.cpp
@@ -6,6 +6,7 @@
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>  // IWYU pragma: keep
 #include <test/jtx/check.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
 #include <test/jtx/noop.h>
@@ -836,6 +837,31 @@ class NFTokenBaseUtil_test : public beast::unit_test::Suite
             Ter(tesSUCCESS));
         env.close();
         BEAST_EXPECT(ownerCount(env, buyer) == 2);
+
+        {
+            env(pay(env.master, buyer, XRP(10000)));
+            env.close();
+
+            using namespace ::xrpl::test::jtx::directory;
+            auto const nftDir = keylet::nftBuys(nftAlice0ID);
+            auto const n1 = getIndexCountToBump(env, nftDir);
+            for (auto i = 1; i <= n1; ++i)
+                env(token::createOffer(buyer, nftAlice0ID, gwAUD(i)), token::Owner(alice));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), nftDir, adjustOwnerNode));
+
+            env(token::createOffer(buyer, nftAlice0ID, gwAUD(1)),
+                token::Owner(alice),
+                Ter(tecDIR_FULL));
+
+            auto const buyerDir = keylet::ownerDir(buyer.id());
+            auto const n = getIndexCountToBump(env, buyerDir);
+            env(ticket::create(buyer, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), buyerDir, adjustOwnerNode));
+
+            env(token::createOffer(buyer, nftAlice0ID, gwAUD(1)),
+                token::Owner(alice),
+                Ter(tecDIR_FULL));
+        }
     }
 
     void

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -6,6 +6,7 @@
 #include <test/jtx/acctdelete.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
 #include <test/jtx/jtx_json.h>
@@ -30,6 +31,7 @@
 #include <xrpl/json/to_string.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
 #include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/Book.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Issue.h>
@@ -752,6 +754,59 @@ public:
                 Balance(carol, usdOffer2),
                 Owners(carol, 2));
         }
+    }
+
+    void
+    testDirectoryFull(FeatureBitset features)
+    {
+        testcase("Directory full");
+
+        using namespace jtx;
+
+        Env env{*this, features};
+
+        auto const gw = Account{"gateway"};
+        auto const alice = Account{"alice"};
+        auto const bob = Account{"bob"};
+        auto const usd = gw["USD"];
+        auto const eur = gw["EUR"];
+        auto const gbp = gw["GBP"];
+
+        env.fund(XRP(10000), gw, alice, bob);
+        env.close();
+
+        env(rate(gw, 1.005));
+
+        env.trust(usd(10000), alice);
+        env.trust(eur(10000), alice);
+        env.close();
+        env(pay(gw, alice, usd(10000)));
+        env(pay(gw, alice, eur(10000)));
+
+        std::uint32_t const noopSeq{env.seq(alice) + 1};
+
+        using namespace ::xrpl::test::jtx::directory;
+        auto const aliceDir = keylet::ownerDir(alice.id());
+        auto const n1 = getIndexCountToBump(env, aliceDir);
+        env(ticket::create(alice, n1 + 32));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+
+        auto rate = getRate(eur(50), usd(50));
+        env(offer(alice, usd(50), eur(50)), Ter(tecDIR_FULL));
+
+        env.close();
+
+        Book const book{usd.issue(), eur.issue(), {}};
+        auto dir = keylet::quality(keylet::kBook(book), rate);
+        auto const n2 = getIndexCountToBump(env, dir);
+        for (auto i = 0; i < static_cast<int>(n2); ++i)
+        {
+            env(offer(alice, usd(50), eur(50)), ticket::Use(noopSeq + i + 1));
+            env.close();
+        }
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), dir, adjustOwnerNode));
+
+        env(offer(alice, usd(50), eur(50)), ticket::Use(noopSeq), Ter(tecDIR_FULL));
     }
 
     // Helper function that returns the Offers on an account.
@@ -5113,6 +5168,7 @@ public:
     void
     testAll(FeatureBitset features)
     {
+        testDirectoryFull(features);
         testCanceledOffer(features);
         testRmFundedOffer(features);
         testTinyPayment(features);

--- a/src/test/app/Oracle_test.cpp
+++ b/src/test/app/Oracle_test.cpp
@@ -4,6 +4,7 @@
 #include <test/jtx/TestHelpers.h>
 #include <test/jtx/acctdelete.h>
 #include <test/jtx/amount.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
 #include <test/jtx/multisign.h>
@@ -13,6 +14,7 @@
 #include <test/jtx/sig.h>
 #include <test/jtx/tags.h>
 #include <test/jtx/ter.h>
+#include <test/jtx/ticket.h>
 
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/basics/chrono.h>
@@ -383,6 +385,25 @@ private:
             Oracle const oracle1(
                 env, {.owner = owner, .fee = static_cast<int>(env.current()->fees().base.drops())});
             oracle.set(UpdateArg{.owner = owner, .fee = -1, .err = Ter(temBAD_FEE)});
+        }
+        {
+            Env env(*this);
+            env.fund(XRP(10000), owner);
+
+            CreateArg const arg{
+                .owner = owner,
+                .fee = static_cast<int>(env.current()->fees().base.drops()),
+                .err = Ter(tecDIR_FULL)};
+            // Oracle closes env, which reverts changes made in bumpLastPage
+            Oracle oracle1(env, arg, false);
+
+            using namespace ::xrpl::test::jtx::directory;
+            auto const ownerDir = keylet::ownerDir(owner.id());
+            auto const n = getIndexCountToBump(env, ownerDir);
+            env(ticket::create(owner, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), ownerDir, adjustOwnerNode));
+
+            oracle1.set(arg);
         }
     }
 

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -7,6 +7,7 @@
 #include <test/jtx/balance.h>  // IWYU pragma: keep
 #include <test/jtx/credentials.h>
 #include <test/jtx/deposit.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
 #include <test/jtx/ter.h>
@@ -316,6 +317,17 @@ struct PayChan_test : public beast::unit_test::Suite
             auto const chan = channel(cho, alice, env.seq(cho));
             env(create(cho, alice, XRP(1000), settleDelay, pk), Ter(tesSUCCESS));
             BEAST_EXPECT(channelExists(*env.current(), chan));
+        }
+
+        {
+            using namespace ::xrpl::test::jtx::directory;
+            auto const choDir = keylet::ownerDir(cho.id());
+            auto const n = getIndexCountToBump(env, choDir);
+            env(ticket::create(cho, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), choDir, adjustOwnerNode));
+
+            env(create(cho, alice, XRP(1000), settleDelay, pk), Ter(tecDIR_FULL));
+            env(create(bob, cho, XRP(1000), settleDelay, pk), Ter(tecDIR_FULL));
         }
     }
 

--- a/src/test/app/PermissionedDEX_test.cpp
+++ b/src/test/app/PermissionedDEX_test.cpp
@@ -6,6 +6,7 @@
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>
 #include <test/jtx/credentials.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/domain.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/jtx_json.h>
@@ -992,6 +993,20 @@ class PermissionedDEX_test : public beast::unit_test::Suite
             env(offer(bob_, XRP(10), USD(10)), Txflags(tfHybrid), Domain(domainID));
             env.close();
             BEAST_EXPECT(checkOffer(env, bob_, offerSeq, XRP(10), USD(10), lsfHybrid, true));
+
+            // hybrid offer not created if book directory is full
+            using namespace ::xrpl::test::jtx::directory;
+            Book const book{Issue(XRP), Issue(USD), std::nullopt};
+            auto const bobDir = keylet::quality(keylet::kBook(book), getRate(USD(10), XRP(10)));
+            auto const n = getIndexCountToBump(env, bobDir);
+            for (auto i = 0; i < n; ++i)
+                env(offer(bob_, XRP(10), USD(10)), Txflags(tfHybrid), Domain(domainID));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), bobDir, adjustOwnerNode));
+
+            env(offer(bob_, XRP(10), USD(10)),
+                Txflags(tfHybrid),
+                Domain(domainID),
+                Ter(tecDIR_FULL));
         }
 
         // apply - domain offer can cross with hybrid

--- a/src/test/app/PermissionedDomains_test.cpp
+++ b/src/test/app/PermissionedDomains_test.cpp
@@ -4,16 +4,19 @@
 #include <test/jtx/acctdelete.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>  // IWYU pragma: keep
+#include <test/jtx/directory.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/pay.h>
 #include <test/jtx/permissioned_domains.h>
 #include <test/jtx/ter.h>
+#include <test/jtx/ticket.h>
 #include <test/jtx/txflags.h>
 
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Protocol.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/TxFlags.h>
@@ -526,6 +529,25 @@ class PermissionedDomains_test : public beast::unit_test::Suite
         BEAST_EXPECT(env.ownerCount(alice) == 1);
     }
 
+    void
+    testDirectoryFull(FeatureBitset features)
+    {
+        testcase("Directory full");
+        Account const alice("alice");
+        Env env(*this, features);
+        env.fund(XRP(10000), alice);
+
+        using namespace ::xrpl::test::jtx::directory;
+        auto const aliceDir = keylet::ownerDir(alice.id());
+        auto const n = getIndexCountToBump(env, aliceDir);
+        env(ticket::create(alice, n));
+        env.close();
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+
+        pdomain::Credentials const credentials{{alice, "first credential"}};
+        env(pdomain::setTx(alice, credentials), Ter(tecDIR_FULL));
+    }
+
 public:
     void
     run() override
@@ -540,6 +562,8 @@ public:
         testDelete(withFix_);
         testAccountReserve(withFeature_);
         testAccountReserve(withFix_);
+        testDirectoryFull(withFeature_);
+        testDirectoryFull(withFix_);
     }
 };
 

--- a/src/test/app/Ticket_test.cpp
+++ b/src/test/app/Ticket_test.cpp
@@ -4,6 +4,7 @@
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>  // IWYU pragma: keep
 #include <test/jtx/deposit.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/jtx_json.h>
 #include <test/jtx/noop.h>
@@ -23,6 +24,7 @@
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
 #include <xrpl/protocol/ErrorCodes.h>
+#include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/Seed.h>
@@ -841,6 +843,29 @@ class Ticket_test : public beast::unit_test::Suite
     }
 
     void
+    testDirectoryFull()
+    {
+        testcase("Directory full");
+
+        using namespace test::jtx;
+        using namespace ::xrpl::test::jtx::directory;
+
+        Env env{*this, testableAmendments()};
+        Account const alice{"alice"};
+
+        env.fund(XRP(10000), alice);
+        env.close();
+
+        auto const aliceDir = keylet::ownerDir(alice.id());
+        auto const n1 = getIndexCountToBump(env, aliceDir);
+        env(ticket::create(alice, n1));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+
+        env(ticket::create(alice, 1), Ter(tecDIR_FULL));
+        env.close();
+    }
+
+    void
     testFixBothSeqAndTicket()
     {
         using namespace test::jtx;
@@ -877,6 +902,7 @@ public:
     void
     run() override
     {
+        testDirectoryFull();
         testTicketCreatePreflightFail();
         testTicketCreatePreclaimFail();
         testTicketInsufficientReserve();

--- a/src/test/app/Vault_test.cpp
+++ b/src/test/app/Vault_test.cpp
@@ -5,6 +5,7 @@
 #include <test/jtx/TestHelpers.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/credentials.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/escrow.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
@@ -1342,6 +1343,28 @@ class Vault_test : public beast::unit_test::Suite
                 {
                     auto [tx, keylet] = vault.create({.owner = owner, .asset = asset});
                     env(tx, Ter(terNO_ACCOUNT));
+                    env.close();
+                }
+            }
+
+            {
+                testcase("IOU dir full");
+                Env env{*this, testableAmendments() | featureSingleAssetVault};
+                Account const bob{"issuer"};
+                env.fund(XRP(10000), bob);
+                env.close();
+
+                using namespace ::xrpl::test::jtx::directory;
+                auto const bobDir = keylet::ownerDir(bob.id());
+                auto const n = getIndexCountToBump(env, bobDir);
+                env(ticket::create(bob, n));
+                BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), bobDir, adjustOwnerNode));
+
+                Vault const vault{env};
+                Asset const asset = bob["IOU"].asset();
+                {
+                    auto [tx, keylet] = vault.create({.owner = bob, .asset = asset});
+                    env(tx, Ter(tecDIR_FULL));
                     env.close();
                 }
             }

--- a/src/test/app/XChain_test.cpp
+++ b/src/test/app/XChain_test.cpp
@@ -3,6 +3,7 @@
 #include <test/jtx/acctdelete.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/attester.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/envconfig.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
@@ -10,6 +11,7 @@
 #include <test/jtx/pay.h>
 #include <test/jtx/regkey.h>
 #include <test/jtx/ter.h>
+#include <test/jtx/ticket.h>
 #include <test/jtx/trust.h>
 #include <test/jtx/txflags.h>
 #include <test/jtx/xchain_bridge.h>
@@ -515,6 +517,18 @@ struct XChain_test : public beast::unit_test::Suite, public jtx::XChainBridgeObj
         XEnv(*this)
             .disableFeature(featureXChainBridge)
             .tx(createBridge(mcAlice, jvb), Ter(temDISABLED));
+
+        {
+            XEnv xenv(*this, true);
+            using namespace ::xrpl::test::jtx::directory;
+            auto const masterDir = keylet::ownerDir(Account::kMaster.id());
+            auto n = getIndexCountToBump(xenv.env, masterDir);
+            xenv.tx(ticket::create(Account::kMaster, n));
+            BEAST_EXPECT(
+                bumpLastPage(xenv.env, maximumPageIndex(xenv.env), masterDir, adjustOwnerNode));
+
+            xenv.tx(createBridge(Account::kMaster, jvb), Ter(tecDIR_FULL));
+        }
     }
 
     void
@@ -1261,6 +1275,20 @@ struct XChain_test : public beast::unit_test::Suite, public jtx::XChainBridgeObj
             .close()
             .tx(xchainCreateClaimId(scAlice, jvb, reward, mcAlice), Ter(temDISABLED))
             .close();
+
+        {
+            XEnv xenv(*this, true);
+            using namespace ::xrpl::test::jtx::directory;
+            auto const aliceDir = keylet::ownerDir(scAlice.id());
+            auto const n = getIndexCountToBump(xenv.env, aliceDir);
+            xenv.tx(ticket::create(scAlice, n));
+            BEAST_EXPECT(
+                bumpLastPage(xenv.env, maximumPageIndex(xenv.env), aliceDir, adjustOwnerNode));
+
+            xenv.tx(createBridge(Account::kMaster, jvb))
+                .tx(xchainCreateClaimId(scAlice, jvb, reward, mcAlice), Ter(tecDIR_FULL))
+                .close();
+        }
     }
 
     void
@@ -1861,6 +1889,44 @@ struct XChain_test : public beast::unit_test::Suite, public jtx::XChainBridgeObj
 
                 BEAST_EXPECT(!scEnv.caClaimID(jvb, 3));    // claim id 3 deleted
                 BEAST_EXPECT(scEnv.claimCount(jvb) == 3);  // claim count now 3
+            }
+        }
+
+        {
+            XEnv mcEnv(*this);
+            XEnv scEnv(*this, true);
+            auto const amt = XRP(1000);
+            auto const amtPlusReward = amt + reward;
+
+            {
+                Balance const door(mcEnv, mcDoor);
+                Balance const carol(mcEnv, mcCarol);
+
+                mcEnv.tx(createBridge(mcDoor, jvb, reward, XRP(20)))
+                    .close()
+                    .tx(sidechainXchainAccountCreate(mcAlice, jvb, scuAlice, amt, reward))
+                    .tx(sidechainXchainAccountCreate(mcBob, jvb, scuBob, amt, reward))
+                    .tx(sidechainXchainAccountCreate(mcCarol, jvb, scuCarol, amt, reward))
+                    .close();
+
+                BEAST_EXPECT(
+                    door.diff() == (multiply(amtPlusReward, STAmount(3), xrpIssue()) - txFee()));
+                BEAST_EXPECT(carol.diff() == -(amt + reward + txFee()));
+            }
+
+            scEnv.tx(createBridge(Account::kMaster, jvb, reward, XRP(20)))
+                .tx(jtx::signers(Account::kMaster, quorum, signers))
+                .close();
+
+            {
+                using namespace ::xrpl::test::jtx::directory;
+                auto const masterDir = keylet::ownerDir(Account::kMaster.id());
+                auto const n = getIndexCountToBump(scEnv.env, masterDir);
+                scEnv.tx(ticket::create(Account::kMaster, n));
+                BEAST_EXPECT(bumpLastPage(
+                    scEnv.env, maximumPageIndex(scEnv.env), masterDir, adjustOwnerNode));
+
+                scEnv.multiTx(attCreateAcctVec(1, amt, scuAlice, 2), Ter(tecDIR_FULL)).close();
             }
         }
 

--- a/src/test/jtx/directory.h
+++ b/src/test/jtx/directory.h
@@ -21,6 +21,13 @@ enum class Error {
     AdjustmentError
 };
 
+/// Returns the number of directory entries that must be created so that the
+/// last page of the given directory is full and the directory has at least two
+/// pages. Call this before bumpLastPage to determine how many objects (e.g.
+/// tickets) to create.
+std::size_t
+getIndexCountToBump(Env& env, Keylet directory);
+
 /// Move the position of the last page in the user's directory on open ledger to
 /// newLastPage. Requirements:
 /// - directory must have at least two pages (root and one more)

--- a/src/test/jtx/impl/directory.cpp
+++ b/src/test/jtx/impl/directory.cpp
@@ -14,12 +14,44 @@
 #include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/SField.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
 
 /** Directory operations. */
 namespace xrpl::test::jtx::directory {
+
+std::size_t
+getIndexCountToBump(Env& env, Keylet directory)
+{
+    std::size_t toAdd = 0;
+    env.app().getOpenLedger().modify([&](OpenView& view, beast::Journal j) -> bool {
+        Sandbox sb(&view, TapNone);
+
+        // Find the root page
+        auto sleRoot = sb.peek(directory);
+        if (!sleRoot)
+        {
+            toAdd += 64;
+            return false;
+        }
+
+        auto const lastIndex0 = sleRoot->getFieldU64(sfIndexPrevious);
+        auto slePage0 = sb.peek(keylet::page(directory, lastIndex0));
+        if (!slePage0)
+        {
+            return false;
+        }
+        auto indexes0 = slePage0->getFieldV256(sfIndexes);
+        if (lastIndex0 == 0)
+            toAdd += 32;
+        if (indexes0.size() < 32)
+            toAdd += 32 - indexes0.size();
+        return false;
+    });
+    return toAdd;
+}
 
 auto
 bumpLastPage(

--- a/src/test/jtx/impl/mpt.cpp
+++ b/src/test/jtx/impl/mpt.cpp
@@ -331,7 +331,7 @@ MPTTester::authorize(MPTAuthorize const& arg)
                 return env_.le(keylet::mptoken(*id_, arg.account->id())) != nullptr;
             }));
         }
-        else
+        else if (result != tecDIR_FULL)
         {
             // Verify MPToken doesn't exist if holder failed authorizing(unless
             // it already exists)

--- a/src/test/ledger/Directory_test.cpp
+++ b/src/test/ledger/Directory_test.cpp
@@ -517,8 +517,9 @@ struct Directory_test : public beast::unit_test::Suite
 
             auto const [lastPage, full] = setup(env);
 
-            // Populate root page and last page
-            for (int i = 0; i < 63; ++i)
+            auto const aliceDir = keylet::ownerDir(alice.id());
+            auto const n = directory::getIndexCountToBump(env, aliceDir);
+            for (int i = 0; i < n; ++i)
                 env(credentials::create(alice, alice, std::to_string(i)));
             env.close();
 
@@ -526,32 +527,29 @@ struct Directory_test : public beast::unit_test::Suite
             // there is no transaction type to express what bumpLastPage does.
 
             // Bump position of last page from 1 to highest possible
-            auto const res = directory::bumpLastPage(
-                env,
-                lastPage,
-                keylet::ownerDir(alice.id()),
-                [lastPage, this](ApplyView& view, uint256 key, std::uint64_t page) {
-                    auto sle = view.peek({ltCREDENTIAL, key});
-                    if (!BEAST_EXPECT(sle))
-                        return false;
+            BEAST_EXPECT(
+                directory::bumpLastPage(
+                    env,
+                    lastPage,
+                    aliceDir,
+                    [lastPage, this](ApplyView& view, uint256 const& key, std::uint64_t page) {
+                        auto const sle = view.peek({ltCREDENTIAL, key});
+                        if (!BEAST_EXPECT(sle))
+                            return false;
 
-                    BEAST_EXPECT(page == lastPage);
-                    sle->setFieldU64(sfIssuerNode, page);
-                    // sfSubjectNode is not set in self-issued credentials
-                    view.update(sle);
-                    return true;
-                });
-            BEAST_EXPECT(res);
-
-            // Create one more credential
-            env(credentials::create(alice, alice, std::to_string(63)));
+                        BEAST_EXPECT(page == lastPage);
+                        sle->setFieldU64(sfIssuerNode, page);
+                        // sfSubjectNode is not set in self-issued credentials
+                        view.update(sle);
+                        return true;
+                    }));
 
             // Not enough space for another object if full
             auto const expected = full ? Ter{tecDIR_FULL} : Ter{tesSUCCESS};
             env(credentials::create(alice, alice, "foo"), expected);
 
             // Destroy all objects in directory
-            for (int i = 0; i < 64; ++i)
+            for (int i = 0; i < n; ++i)
                 env(credentials::deleteCred(alice, alice, alice, std::to_string(i)));
 
             if (!full)

--- a/src/test/rpc/DepositAuthorized_test.cpp
+++ b/src/test/rpc/DepositAuthorized_test.cpp
@@ -4,12 +4,17 @@
 #include <test/jtx/amount.h>
 #include <test/jtx/credentials.h>
 #include <test/jtx/deposit.h>
+#include <test/jtx/directory.h>
 #include <test/jtx/flags.h>
+#include <test/jtx/ter.h>
+#include <test/jtx/ticket.h>
 
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/json/json_value.h>
+#include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Protocol.h>
 #include <xrpl/protocol/SField.h>
+#include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/jss.h>
 
@@ -67,9 +72,11 @@ public:
         Account const alice{"alice"};
         Account const becky{"becky"};
         Account const carol{"carol"};
+        Account const bob("bob");
 
         Env env(*this);
         env.fund(XRP(1000), alice, becky, carol);
+        env.fund(XRP(10000), bob);
         env.close();
 
         // becky is authorized to deposit to herself.
@@ -112,6 +119,16 @@ public:
                 "deposit_authorized",
                 depositAuthArgs(becky, alice, "current").toStyledString()),
             true);
+
+        {
+            using namespace ::xrpl::test::jtx::directory;
+            auto const bobDir = keylet::ownerDir(bob.id());
+            auto const n = getIndexCountToBump(env, bobDir);
+            env(ticket::create(bob, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), bobDir, adjustOwnerNode));
+
+            env(deposit::auth(bob, alice), Ter(tecDIR_FULL));
+        }
 
         // becky creates a deposit authorization for alice.
         env(deposit::auth(becky, alice));
@@ -307,9 +324,11 @@ public:
         Account const becky{"becky"};
         Account const diana{"diana"};
         Account const carol{"carol"};
+        Account const bob("bob");
 
         Env env(*this);
         env.fund(XRP(1000), alice, becky, carol, diana);
+        env.fund(XRP(10000), bob);
         env.close();
 
         // carol recognize alice
@@ -322,6 +341,16 @@ public:
         // becky sets the DepositAuth flag in the current ledger.
         env(fset(becky, asfDepositAuth));
         env.close();
+
+        {
+            using namespace ::xrpl::test::jtx::directory;
+            auto const bobDir = keylet::ownerDir(bob.id());
+            auto const n = getIndexCountToBump(env, bobDir);
+            env(ticket::create(bob, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), bobDir, adjustOwnerNode));
+
+            env(deposit::authCredentials(bob, {{carol, credType}}), Ter(tecDIR_FULL));
+        }
 
         // becky authorize any account recognized by carol to make a payment
         env(deposit::authCredentials(becky, {{carol, credType}}));


### PR DESCRIPTION
## High Level Overview of Change

The main goal of this PR is to improve test coverage for the `xrpld` application. 

With the recent ability to simulate the `tecDIR_FULL` error, we can now comprehensively cover all cases where this error is returned. Consequently, this PR modifies production code solely to remove the now-obsolete `LCOV_EXCL_LINE` comments.

### Context of Change

This PR is enabled by the implementation of #5935. 
Once completed, it will resolve issue #5969.

### Type of Change

- [x] `test:` - The changes *only* affect unit tests.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

## Test Plan

Verification is done by running the automated unit test suite. 
Code coverage metrics will reflect the newly covered `tecDIR_FULL` error branches.