### PR TITLE
fix: Validate JSON string types in parseVault

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -50,7 +50,8 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
-
+- `vault_info`: The `vault_id` and `owner` parameters now correctly return RpcInvalidParams error if provided as non-string JSON types. [#7097](https://github.com/XRPLF/rippled/pull/7097)
+ 
 ## XRP Ledger server version 3.1.0
 
 [Version 3.1.0](https://github.com/XRPLF/rippled/releases/tag/3.1.0) was released on Jan 27, 2026.

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -50,7 +50,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
-- `vault_info`: The `vault_id` and `owner` parameters now correctly return RpcInvalidParams error if provided as non-string JSON types. [#7097](https://github.com/XRPLF/rippled/pull/7097)
+- `vault_info`: The `vault_id` and `owner` parameters now correctly return expectedFieldError error if provided as non-string JSON types. [#7097](https://github.com/XRPLF/rippled/pull/7097)
  
 ## XRP Ledger server version 3.1.0
 

--- a/src/xrpld/rpc/handlers/VaultInfo.cpp
+++ b/src/xrpld/rpc/handlers/VaultInfo.cpp
@@ -25,6 +25,11 @@ parseVault(json::Value const& params, json::Value& jvResult)
     uint256 uNodeIndex = beast::kZERO;
     if (hasVaultId && !hasOwner && !hasSeq)
     {
+        if (!params[jss::vault_id].isString())
+        {
+            RPC::injectError(RpcInvalidParams, jvResult);
+            return std::nullopt;
+        }
         if (!uNodeIndex.parseHex(params[jss::vault_id].asString()))
         {
             RPC::injectError(RpcInvalidParams, jvResult);
@@ -34,6 +39,11 @@ parseVault(json::Value const& params, json::Value& jvResult)
     }
     else if (!hasVaultId && hasOwner && hasSeq)
     {
+        if (!params[jss::owner].isString())
+        {
+            RPC::injectError(RpcInvalidParams, jvResult);
+            return std::nullopt;
+        }
         auto const id = parseBase58<AccountID>(params[jss::owner].asString());
         if (!id)
         {

--- a/src/xrpld/rpc/handlers/VaultInfo.cpp
+++ b/src/xrpld/rpc/handlers/VaultInfo.cpp
@@ -27,7 +27,8 @@ parseVault(json::Value const& params, json::Value& jvResult)
     {
         if (!params[jss::vault_id].isString())
         {
-            return RPC::expectedFieldError(jss::vault_id, "string");
+            jvResult = RPC::expectedFieldError(jss::vault_id, "string");
+            return std::nullopt;
         }
         if (!uNodeIndex.parseHex(params[jss::vault_id].asString()))
         {
@@ -40,7 +41,8 @@ parseVault(json::Value const& params, json::Value& jvResult)
     {
         if (!params[jss::owner].isString())
         {
-            return RPC::expectedFieldError(jss::owner, "string");
+            jvResult = RPC::expectedFieldError(jss::owner, "string");
+            return std::nullopt;
         }
         auto const id = parseBase58<AccountID>(params[jss::owner].asString());
         if (!id)

--- a/src/xrpld/rpc/handlers/VaultInfo.cpp
+++ b/src/xrpld/rpc/handlers/VaultInfo.cpp
@@ -27,8 +27,7 @@ parseVault(json::Value const& params, json::Value& jvResult)
     {
         if (!params[jss::vault_id].isString())
         {
-            RPC::injectError(RpcInvalidParams, jvResult);
-            return std::nullopt;
+            return RPC::expectedFieldError(jss::vault_id, "string");
         }
         if (!uNodeIndex.parseHex(params[jss::vault_id].asString()))
         {
@@ -41,8 +40,7 @@ parseVault(json::Value const& params, json::Value& jvResult)
     {
         if (!params[jss::owner].isString())
         {
-            RPC::injectError(RpcInvalidParams, jvResult);
-            return std::nullopt;
+            return RPC::expectedFieldError(jss::owner, "string");
         }
         auto const id = parseBase58<AccountID>(params[jss::owner].asString());
         if (!id)


### PR DESCRIPTION
## High Level Overview of Change

Add `isString()` validation for `vault_id` and `owner` in `parseVault()` before calling `asString()`.

Invalid JSON types now return `RpcInvalidParams`
instead of propagating `Json::LogicError`.

Changes:
- Validate vault_id with `isString()`
- Validate owner with `isString()`
- Return RpcInvalidParams for invalid JSON types

### Context of Change

`parseVault()` previously checked whether `vault_id` and `owner` existed using `isMember()`, but did not validate that
the values were JSON strings before calling `asString()`.

If a client supplied a non-string JSON value such as an object,array, or null, JsonCpp could throw `Json::LogicError`. The
RPC framework catches the exception, but the client receives a generic internal error instead of a proper`RpcInvalidParams` response.

This change adds explicit `isString()` validation before calling `asString()` so malformed requests are rejected early
with consistent RPC error handling.


### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)