### PR TITLE
fix: AMMClawback exact LP token boundary

### DIFF
--- a/src/libxrpl/tx/transactors/dex/AMMClawback.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMClawback.cpp
@@ -324,11 +324,13 @@ AMMClawback::equalWithdrawMatchingOneAmount(
     auto amount2Withdraw = amount2Balance * frac;
 
     auto const lpTokensWithdraw = toSTAmount(lptAMMBalance.asset(), lptAMMBalance * frac);
-    if (lpTokensWithdraw >= holdLPtokens)
+    auto const& rules = sb.rules();
+    // Pre-fixCleanup3_4_0 only a strictly greater computed LP amount takes
+    // the withdraw-all path. Equality left the last holder unable to be
+    // fully clawed. The amendment treats equality as withdraw-all.
+    if (rules.enabled(fixCleanup3_4_0) ? lpTokensWithdraw >= holdLPtokens
+                                       : lpTokensWithdraw > holdLPtokens)
     {
-        // if lptoken balance less and equal to what the issuer intended to clawback,
-        // clawback all the tokens. Because we are doing a two-asset withdrawal,
-        // tfee is actually not used, so pass tfee as 0.
         return AMMWithdraw::equalWithdrawTokens(
             sb,
             ammSle,
@@ -348,7 +350,6 @@ AMMClawback::equalWithdrawMatchingOneAmount(
             ctx_.journal);
     }
 
-    auto const& rules = sb.rules();
     if (rules.enabled(fixAMMClawbackRounding))
     {
         auto tokensAdj = getRoundedLPTokens(rules, lptAMMBalance, frac, IsDeposit::No);

--- a/src/libxrpl/tx/transactors/dex/AMMClawback.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMClawback.cpp
@@ -324,9 +324,9 @@ AMMClawback::equalWithdrawMatchingOneAmount(
     auto amount2Withdraw = amount2Balance * frac;
 
     auto const lpTokensWithdraw = toSTAmount(lptAMMBalance.asset(), lptAMMBalance * frac);
-    if (lpTokensWithdraw > holdLPtokens)
+    if (lpTokensWithdraw >= holdLPtokens)
     {
-        // if lptoken balance less than what the issuer intended to clawback,
+        // if lptoken balance less and equal to what the issuer intended to clawback,
         // clawback all the tokens. Because we are doing a two-asset withdrawal,
         // tfee is actually not used, so pass tfee as 0.
         return AMMWithdraw::equalWithdrawTokens(

--- a/src/test/app/AMMClawback_test.cpp
+++ b/src/test/app/AMMClawback_test.cpp
@@ -2481,9 +2481,21 @@ class AMMClawback_test : public beast::unit_test::Suite
             auto const unit = STAmount(usd, UINT64_C(1), -15);
             auto const amount = amountExceedsBalance ? amountBalance + unit : amountBalance;
 
-            env(amm::ammClawback(gw, alice, usd, XRP, amount), Ter(tesSUCCESS));
-            env.close();
-            BEAST_EXPECT(!amm.ammExists());
+            // Exceeding the holder's LP tokens already took withdraw-all
+            // pre-amendment. Exact equality does so only after
+            // fixCleanup3_4_0.
+            if (amountExceedsBalance || features[fixCleanup3_4_0])
+            {
+                env(amm::ammClawback(gw, alice, usd, XRP, amount), Ter(tesSUCCESS));
+                env.close();
+                BEAST_EXPECT(!amm.ammExists());
+            }
+            else
+            {
+                env(amm::ammClawback(gw, alice, usd, XRP, amount), Ter(tecAMM_BALANCE));
+                env.close();
+                BEAST_EXPECT(amm.ammExists());
+            }
         };
 
         // IOU/XRP pool. AMMClawback almost last holder's USD balance

--- a/src/test/app/AMMClawback_test.cpp
+++ b/src/test/app/AMMClawback_test.cpp
@@ -13,7 +13,9 @@
 
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/ledger/helpers/AMMHelpers.h>
+#include <xrpl/protocol/AmountConversions.h>
 #include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/STAmount.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/XRPAmount.h>
@@ -2461,43 +2463,6 @@ class AMMClawback_test : public beast::unit_test::Suite
             return {lpToken, lpTokenBalance};
         };
 
-        auto testClawbackAllWithAmount = [&](bool amountExceedsBalance) {
-            Env env(*this, features, std::make_unique<CaptureLogs>(&logs));
-            Account const gw{"gateway"}, alice{"alice"}, bob{"bob"};
-            auto const usd = setupAccounts(env, gw, alice, bob);
-
-            AMM amm(env, alice, XRP(2), usd(1));
-            amm.deposit(alice, IOUAmount{1'876123487565916, -15});
-            amm.deposit(bob, IOUAmount{1'000'000});
-            amm.withdraw(alice, IOUAmount{1'876123487565916, -15});
-            amm.withdrawAll(bob);
-
-            auto const [amountBalance, amount2Balance, lptAMMBalance] = amm.balances(usd, XRP);
-            BEAST_EXPECT(amountBalance.asset() == usd);
-            BEAST_EXPECT(amount2Balance.native());
-            auto const holderLPTokens = STAmount{amm.getLPTokensBalance(alice), amm.lptIssue()};
-            BEAST_EXPECT(lptAMMBalance >= holderLPTokens);
-
-            auto const unit = STAmount(usd, UINT64_C(1), -15);
-            auto const amount = amountExceedsBalance ? amountBalance + unit : amountBalance;
-
-            // Exceeding the holder's LP tokens already took withdraw-all
-            // pre-amendment. Exact equality does so only after
-            // fixCleanup3_4_0.
-            if (amountExceedsBalance || features[fixCleanup3_4_0])
-            {
-                env(amm::ammClawback(gw, alice, usd, XRP, amount), Ter(tesSUCCESS));
-                env.close();
-                BEAST_EXPECT(!amm.ammExists());
-            }
-            else
-            {
-                env(amm::ammClawback(gw, alice, usd, XRP, amount), Ter(tecAMM_BALANCE));
-                env.close();
-                BEAST_EXPECT(amm.ammExists());
-            }
-        };
-
         // IOU/XRP pool. AMMClawback almost last holder's USD balance
         {
             Env env(*this, features, std::make_unique<CaptureLogs>(&logs));
@@ -2607,12 +2572,6 @@ class AMMClawback_test : public beast::unit_test::Suite
             {
                 env(amm::ammClawback(gw, alice, usd, XRP, std::nullopt));
                 BEAST_EXPECT(!amm.ammExists());
-            }
-
-            if (features[fixAMMv1_3] && features[fixAMMClawbackRounding])
-            {
-                testClawbackAllWithAmount(true);
-                testClawbackAllWithAmount(false);
             }
         }
 
@@ -2757,6 +2716,67 @@ class AMMClawback_test : public beast::unit_test::Suite
     }
 
     void
+    testExactLPTokenEquality(FeatureBitset features)
+    {
+        using namespace jtx;
+
+        if (!features[fixAMMv1_3] || !features[fixAMMClawbackRounding])
+            return;
+
+        testcase("test exact LP token equality boundary");
+
+        Env env(*this, features);
+        Account const gw{"gateway"}, alice{"alice"}, bob{"bob"};
+        env.fund(XRP(100000), gw, alice, bob);
+        env.close();
+        env(fset(gw, asfAllowTrustLineClawback));
+        env.close();
+
+        auto const usd = gw["USD"];
+        env.trust(usd(100000), alice);
+        env(pay(gw, alice, usd(50000)));
+        env.trust(usd(100000), bob);
+        env(pay(gw, bob, usd(40000)));
+        env.close();
+
+        // bob keeps alice from being the sole LP, otherwise the clawback
+        // first rewrites the AMM's LP balance to alice's tokens and the
+        // boundary is no longer distinguishable.
+        AMM amm(env, alice, XRP(2), usd(1));
+        amm.deposit(alice, IOUAmount{1'876123487565916, -15});
+        amm.deposit(bob, IOUAmount{1'000'000});
+
+        auto const [amountBalance, amount2Balance, lptAMMBalance] = amm.balances(usd, XRP);
+        auto const aliceLP = amm.getLPTokensBalance(alice);
+        auto const holderLPTokens = STAmount{aliceLP, amm.lptIssue()};
+        BEAST_EXPECT(lptAMMBalance > holderLPTokens);
+
+        // Clawing alice's pro-rata share lands the transactor's computed LP
+        // amount exactly on her balance.
+        auto const amount = toSTAmount(usd, Number{amountBalance} * holderLPTokens / lptAMMBalance);
+        BEAST_EXPECT(
+            toSTAmount(lptAMMBalance.asset(), lptAMMBalance * (Number{amount} / amountBalance)) ==
+            holderLPTokens);
+
+        env(amm::ammClawback(gw, alice, usd, XRP, amount));
+        env.close();
+
+        auto const aliceLPAfter = amm.getLPTokensBalance(alice);
+        if (features[fixCleanup3_4_0])
+        {
+            // Equality takes the withdraw-all path, redeeming alice's tokens
+            // exactly.
+            BEAST_EXPECT(aliceLPAfter == IOUAmount(0));
+        }
+        else
+        {
+            // The fall-through re-rounds the LP amount against the much
+            // larger pool balance, leaving alice with dust.
+            BEAST_EXPECT(aliceLPAfter != IOUAmount(0) && aliceLPAfter < aliceLP);
+        }
+    }
+
+    void
     run() override
     {
         // For now, just disable SAV entirely, which locks in the small Number
@@ -2789,6 +2809,7 @@ class AMMClawback_test : public beast::unit_test::Suite
             testAssetFrozen(features);
             testSingleDepositAndClawback(features);
             testLastHolderLPTokenBalance(features);
+            testExactLPTokenEquality(features);
         }
     }
 };

--- a/src/test/app/AMMClawback_test.cpp
+++ b/src/test/app/AMMClawback_test.cpp
@@ -2461,6 +2461,31 @@ class AMMClawback_test : public beast::unit_test::Suite
             return {lpToken, lpTokenBalance};
         };
 
+        auto testClawbackAllWithAmount = [&](bool amountExceedsBalance) {
+            Env env(*this, features, std::make_unique<CaptureLogs>(&logs));
+            Account const gw{"gateway"}, alice{"alice"}, bob{"bob"};
+            auto const usd = setupAccounts(env, gw, alice, bob);
+
+            AMM amm(env, alice, XRP(2), usd(1));
+            amm.deposit(alice, IOUAmount{1'876123487565916, -15});
+            amm.deposit(bob, IOUAmount{1'000'000});
+            amm.withdraw(alice, IOUAmount{1'876123487565916, -15});
+            amm.withdrawAll(bob);
+
+            auto const [amountBalance, amount2Balance, lptAMMBalance] = amm.balances(usd, XRP);
+            BEAST_EXPECT(amountBalance.asset() == usd);
+            BEAST_EXPECT(amount2Balance.native());
+            auto const holderLPTokens = STAmount{amm.getLPTokensBalance(alice), amm.lptIssue()};
+            BEAST_EXPECT(lptAMMBalance >= holderLPTokens);
+
+            auto const unit = STAmount(usd, UINT64_C(1), -15);
+            auto const amount = amountExceedsBalance ? amountBalance + unit : amountBalance;
+
+            env(amm::ammClawback(gw, alice, usd, XRP, amount), Ter(tesSUCCESS));
+            env.close();
+            BEAST_EXPECT(!amm.ammExists());
+        };
+
         // IOU/XRP pool. AMMClawback almost last holder's USD balance
         {
             Env env(*this, features, std::make_unique<CaptureLogs>(&logs));
@@ -2570,6 +2595,12 @@ class AMMClawback_test : public beast::unit_test::Suite
             {
                 env(amm::ammClawback(gw, alice, usd, XRP, std::nullopt));
                 BEAST_EXPECT(!amm.ammExists());
+            }
+
+            if (features[fixAMMv1_3] && features[fixAMMClawbackRounding])
+            {
+                testClawbackAllWithAmount(true);
+                testClawbackAllWithAmount(false);
             }
         }
 


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change
Fixes an AMMClawback boundary case where a requested clawback amount maps to exactly all of the holder’s LP tokens.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change
Previously, AMMClawback::equalWithdrawMatchingOneAmount() only took the full-clawback path when `lpTokensWithdraw > holdLPtokens` If the computed LP token amount was exactly equal to the holder’s LP token balance, the code fell through to the partial-withdraw path, which could fail with `tecAMM_BALANCE` in last-holder rounding scenarios.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
