### PR TITLE
fix: Incorrect IPv6 public/private classification bypasses peer IP limit enforcement

### DIFF
--- a/src/libxrpl/beast/net/IPAddressV6.cpp
+++ b/src/libxrpl/beast/net/IPAddressV6.cpp
@@ -9,11 +9,18 @@ namespace beast::IP {
 bool
 isPrivate(AddressV6 const& addr)
 {
-    // fc00::/7 - Unique Local Address (ULA), covers fc00:: and fd00::
-    if ((addr.to_bytes()[0] & 0xfe) == 0xfc)
+    if (addr.is_loopback() || addr.is_unspecified())
         return true;
     if (addr.is_v4_mapped())
         return isPrivate(boost::asio::ip::make_address_v4(boost::asio::ip::v4_mapped, addr));
+
+    auto const b = addr.to_bytes();
+
+    // fc00::/7 - Unique Local Address (ULA), covers fc00:: and fd00::
+    if ((b[0] & 0xfe) == 0xfc)
+        return true;
+    if (b[0] == 0xfe && (b[1] & 0xc0) == 0x80)
+        return true;
     return false;
 }
 


### PR DESCRIPTION
## Summary

Automated security fix for **Incorrect IPv6 public/private classification bypasses peer IP limit enforcement** (Medium).

**CWE**: CWE-CWE-697
**OWASP**: A05:2021-Security Misconfiguration
**Fix Confidence**: medium

## What Changed
Updated IPv6 private classification to use explicit prefix comparisons and to treat loopback, unspecified, unique-local, and link-local IPv6 addresses as non-public/private while preserving public classification for normal global IPv6 addresses and IPv4-mapped delegation.

## Caveats
- IPv6 isPublic already contained separate checks for several non-public ranges; those were left unchanged to keep the patch surgical.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
