### PR TITLE
cfg: document /dev/stdout for [debug_logfile] and its interaction with --silent

### DIFF
--- a/cfg/xrpld-example.cfg
+++ b/cfg/xrpld-example.cfg
@@ -1192,6 +1192,11 @@
 #
 #   Example: debug.log
 #
+#   In a container, you can set this to /dev/stdout (or /proc/1/fd/1, which is
+#   more portable) to route the server's logs to the container log driver. With
+#   --silent, the console (stderr) log sink is disabled, so the [debug_logfile]
+#   sink is the only one that keeps receiving ongoing logs.
+#
 #
 #
 # [insight]


### PR DESCRIPTION
## High Level Overview of Change

Adds a short comment to the `[debug_logfile]` stanza in `cfg/xrpld-example.cfg` explaining that, in a container, the debug log file can be set to `/dev/stdout` (or `/proc/1/fd/1`) to route logs to the container log driver, and that when `--silent` is used the file sink is the only sink that keeps receiving ongoing logs.

### Context of Change

`xrpld` has two log sinks: the console (stderr) and the optional `[debug_logfile]` file sink. The `--silent` flag disables the console sink for the entire run of the process, so under a process supervisor or in a container that captures stdout/stderr, no ongoing logs are emitted after the startup banner. The file sink is independent of `--silent`, so pointing `[debug_logfile]` at `/dev/stdout` restores log visibility to the container log driver. The example config did not mention either the container pattern or the `--silent` interaction; this comment closes that gap for operators reading the example config.

This is a comments-only change to the example config; no behavior changes.

### Type of Change

- [x] Documentation update

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change
- [ ] `libxrpl` change
- [ ] Peer protocol change

None — documentation/comment change to the example config only.