### PR TITLE
fixed missing type validation on peer parameter

### DIFF
--- a/src/xrpld/rpc/handlers/account/AccountLines.cpp
+++ b/src/xrpld/rpc/handlers/account/AccountLines.cpp
@@ -108,6 +108,9 @@ doAccountLines(RPC::JsonContext& context)
         return rpcError(RpcActNotFound);
 
     std::string strPeer;
+    if(params.isMember(jss::peer) && !params[jss::peer].isString())
+        return RPC::invalidFieldError(jss::peer);
+    
     if (params.isMember(jss::peer))
         strPeer = params[jss::peer].asString();
 


### PR DESCRIPTION
#6760
Fixed missing type validation for the peer parameter by checking its presence using isMember() and validating its type using isString() before calling asString().