### PR TITLE
fixed missing type validation on account/ident parameter

### DIFF
--- a/src/xrpld/rpc/handlers/account/OwnerInfo.cpp
+++ b/src/xrpld/rpc/handlers/account/OwnerInfo.cpp
@@ -10,9 +10,7 @@
 
 #include <optional>
 #include <string>
-
 namespace xrpl {
-
 // {
 //   'ident' : <indent>,
 // }
@@ -23,7 +21,15 @@ doOwnerInfo(RPC::JsonContext& context)
     {
         return RPC::missingFieldError(jss::account);
     }
+    if (context.params.isMember(jss::account) && !context.params[jss::account].isString())
+    {
+        return RPC::invalidFieldError(jss::account);
+    }
 
+    if (context.params.isMember(jss::ident) && !context.params[jss::ident].isString())
+    {
+        return RPC::invalidFieldError(jss::ident);
+    }
     std::string const strIdent = context.params.isMember(jss::account)
         ? context.params[jss::account].asString()
         : context.params[jss::ident].asString();


### PR DESCRIPTION
#6761
Fixed missing type validation for the account and ident parameters using isMember() and isString() before calling asString().