### PR TITLE
Fixed logLevel missing type validation on severity and partition parameters

### DIFF
--- a/src/xrpld/rpc/handlers/admin/log/LogLevel.cpp
+++ b/src/xrpld/rpc/handlers/admin/log/LogLevel.cpp
@@ -35,6 +35,9 @@ doLogLevel(RPC::JsonContext& context)
         return ret;
     }
 
+    if (!context.params[jss::severity].isString())
+        return rpcError(RpcInvalidParams);
+
     auto const severity = Logs::fromString(context.params[jss::severity].asString());
 
     if (not severity.has_value())
@@ -51,6 +54,8 @@ doLogLevel(RPC::JsonContext& context)
     // log_level partition severity base?
     if (context.params.isMember(jss::partition))
     {
+        if (!context.params[jss::partition].isString())
+            return rpcError(RpcInvalidParams);
         // set partition threshold
         std::string const partition(context.params[jss::partition].asString());
 


### PR DESCRIPTION
Fixed missing input type validation for severity and partition parameters in log_level RPC by adding isString() checks before calling asString(), preventing invalid JSON types from causing exceptions or rpcINTERNAL errors.