### PR TITLE
fix: Add feePayer logic in txQ

### DIFF
--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -5,6 +5,7 @@
 #include <test/jtx/WSClient.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>
+#include <test/jtx/delegate.h>
 #include <test/jtx/envconfig.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
@@ -2336,6 +2337,138 @@ public:
     }
 
     void
+    testDelegatedFeePayerInFlightBalance()
+    {
+        using namespace jtx;
+        testcase("delegated fee payer in-flight balance");
+
+        Env env(
+            *this,
+            makeConfig(
+                {{Keys::kMinimumTxnInLedgerStandalone, "3"}},
+                {{Keys::kAccountReserve, "200"}, {Keys::kOwnerReserve, "50"}}));
+
+        auto const alice = Account("alice");
+        auto const bob = Account("bob");
+        auto const carol = Account("carol");
+        auto const filler = Account("filler");
+
+        env.fund(XRP(50000), alice, bob);
+        env.close();
+        env.fund(XRP(50000), carol, filler);
+        env.close();
+
+        auto const initQueueMax = initFee(env, 3, 2, 10, 200, 50);
+        checkMetrics(*this, env, 0, initQueueMax, 0, 3);
+
+        env(delegate::set(alice, bob, {"Payment"}));
+        env.close();
+
+        auto const currentQueueMax = 6;
+        fillQueue(env, filler);
+        checkMetrics(*this, env, 0, currentQueueMax, 4, 3);
+
+        auto const aliceSeq = env.seq(alice);
+        env(pay(alice, carol, drops(1)),
+            Seq(aliceSeq),
+            Fee(drops(300)),
+            delegate::As(bob),
+            Ter(terQUEUED));
+
+        {
+            json::Value params;
+            params[jss::account] = alice.human();
+            params[jss::queue] = true;
+            auto const result = env.rpc("json", "account_info", to_string(params))[jss::result];
+            auto const& queueData = result[jss::queue_data];
+            BEAST_EXPECT(queueData[jss::txn_count] == 1u);
+            BEAST_EXPECT(queueData[jss::max_spend_drops_total] == "1");
+            BEAST_EXPECT(queueData[jss::transactions][0u][jss::max_spend_drops] == "1");
+        }
+
+        // Bob's delegated fee must not consume Alice's queued-fee budget
+        // and this transaction should be queued successfully.
+        env(noop(alice), Seq(aliceSeq + 1), Fee(drops(50)), Ter(terQUEUED));
+        checkMetrics(*this, env, 2, currentQueueMax, 4, 3);
+    }
+
+    void
+    testDelegateFeePayerAggregateInFlightFees()
+    {
+        using namespace jtx;
+        testcase("delegate fee payer aggregate in-flight fees");
+
+        Env env(
+            *this,
+            makeConfig(
+                {{Keys::kMinimumTxnInLedgerStandalone, "3"}},
+                {{Keys::kAccountReserve, "200"}, {Keys::kOwnerReserve, "50"}}));
+
+        auto const alice = Account("alice");
+        auto const bob = Account("bob");
+        auto const carol = Account("carol");
+        auto const dave = Account("dave");
+        auto const ed = Account("ed");
+        auto const filler = Account("filler");
+
+        env.fund(XRP(50000), alice, bob);
+        env.close();
+        env.fund(XRP(50000), carol, dave);
+        env.close();
+        env.fund(XRP(50000), ed, filler);
+        env.close();
+
+        auto const initQueueMax = initFee(env, 3, 2, 10, 200, 50);
+        checkMetrics(*this, env, 0, initQueueMax, 0, 3);
+
+        env(delegate::set(alice, bob, {"Payment"}));
+        env(delegate::set(carol, bob, {"Payment"}));
+        env(delegate::set(dave, bob, {"Payment"}));
+        env.close();
+
+        auto const currentQueueMax = 6;
+        fillQueue(env, filler);
+        checkMetrics(*this, env, 0, currentQueueMax, 4, 3);
+
+        // bob sends tx on behalf of others. Bob will pay the fee for those
+        // transactions. We will test when bob does not have enough
+        // balance to pay for all the fees of the queued transactions.
+        env(pay(alice, ed, drops(1)),
+            Seq(env.seq(alice)),
+            Fee(drops(100)),
+            delegate::As(bob),
+            Ter(terQUEUED));
+        env(pay(carol, ed, drops(1)),
+            Seq(env.seq(carol)),
+            Fee(drops(90)),
+            delegate::As(bob),
+            Ter(terQUEUED));
+        auto const daveSeq = env.seq(dave);
+        env(pay(dave, ed, drops(1)),
+            Seq(daveSeq),
+            Fee(drops(20)),
+            delegate::As(bob),
+            Ter(terQUEUED));
+        checkMetrics(*this, env, 3, currentQueueMax, 4, 3);
+        {
+            auto const queuedTxs = env.app().getTxQ().getTxs();
+            BEAST_EXPECT(queuedTxs.size() == 3);
+            BEAST_EXPECT(std::all_of(queuedTxs.begin(), queuedTxs.end(), [&](auto const& tx) {
+                return tx.feePayer == bob.id();
+            }));
+        }
+
+        // The first three queued transactions already put 210 drops of Bob-paid fees in
+        // flight, which is above this test's 200-drop limit. This will be rejected.
+        env(pay(dave, ed, drops(1)),
+            Seq(daveSeq + 1),
+            Fee(drops(50)),
+            delegate::As(bob),
+            Ter(telCAN_NOT_QUEUE_BALANCE));
+        checkMetrics(*this, env, 3, currentQueueMax, 4, 3);
+    }
+
+    void
     testConsequences()
     {
         using namespace jtx;
@@ -4662,6 +4795,8 @@ public:
         testBlockersSeq();
         testBlockersTicket();
         testInFlightBalance();
+        testDelegatedFeePayerInFlightBalance();
+        testDelegateFeePayerAggregateInFlightFees();
         testConsequences();
     }
 

--- a/src/xrpld/app/misc/TxQ.h
+++ b/src/xrpld/app/misc/TxQ.h
@@ -178,6 +178,7 @@ public:
             std::optional<LedgerIndex> const& lastValid,
             TxConsequences const& consequences,
             AccountID const& account,
+            AccountID const& feePayer,
             SeqProxy seqProxy,
             std::shared_ptr<STTx const> const& txn,
             int retriesRemaining,
@@ -187,6 +188,7 @@ public:
             , lastValid(lastValid)
             , consequences(consequences)
             , account(account)
+            , feePayer(feePayer)
             , seqProxy(seqProxy)
             , txn(txn)
             , retriesRemaining(retriesRemaining)
@@ -205,6 +207,8 @@ public:
         TxConsequences consequences;
         /// The account the transaction is queued for
         AccountID account;
+        /// The account that pays the transaction fee
+        AccountID feePayer;
         /// SeqProxy of the transaction
         SeqProxy seqProxy;
         /// The full transaction
@@ -494,8 +498,10 @@ private:
         FeeLevel64 const feeLevel;
         /// Transaction ID.
         TxID const txID;
-        /// Account submitting the transaction.
+        /// Account the transaction acts on.
         AccountID const account;
+        /// Account that pays the transaction fee.
+        AccountID const feePayer;
         /// Expiration ledger for the transaction
         /// (`sfLastLedgerSequence` field).
         std::optional<LedgerIndex> const lastValid;
@@ -589,6 +595,7 @@ private:
                 lastValid,
                 consequences(),
                 account,
+                feePayer,
                 seqProxy,
                 txn,
                 retriesRemaining,

--- a/src/xrpld/app/misc/TxQ.h
+++ b/src/xrpld/app/misc/TxQ.h
@@ -9,6 +9,7 @@
 #include <xrpl/tx/applySteps.h>
 
 #include <boost/circular_buffer.hpp>
+#include <boost/intrusive/list.hpp>
 #include <boost/intrusive/set.hpp>
 
 #include <optional>
@@ -490,6 +491,7 @@ private:
         /// to put each MaybeTx object into more than one
         /// set without copies, pointers, etc.
         boost::intrusive::set_member_hook<> byFeeListHook;
+        boost::intrusive::list_member_hook<> byPayerListHook;
 
         /// The complete transaction.
         std::shared_ptr<STTx const> txn;
@@ -724,11 +726,21 @@ private:
         std::optional<TxQAccount::TxMap::iterator> const& replacedTxIter,
         std::shared_ptr<STTx const> const& tx);
 
+    void
+    removeFromByPayer(MaybeTx const& txn);
+
     using FeeHook = boost::intrusive::
         member_hook<MaybeTx, boost::intrusive::set_member_hook<>, &MaybeTx::byFeeListHook>;
 
     using FeeMultiSet =
         boost::intrusive::multiset<MaybeTx, FeeHook, boost::intrusive::compare<OrderCandidates>>;
+
+    using PayerHook = boost::intrusive::
+        member_hook<MaybeTx, boost::intrusive::list_member_hook<>, &MaybeTx::byPayerListHook>;
+
+    using PayerList = boost::intrusive::list<MaybeTx, PayerHook>;
+
+    using PayerMap = std::map<AccountID, PayerList>;
 
     using AccountMap = std::map<AccountID, TxQAccount>;
 
@@ -748,6 +760,13 @@ private:
         locked mutex_
     */
     FeeMultiSet byFee_;
+    /** Queued transactions grouped by the account that pays their fee.
+        The transaction objects are owned by byAccount_; this is only an
+        intrusive index over those same objects.
+        @note This member must always and only be accessed under
+        locked mutex_
+    */
+    PayerMap byPayer_;
     /** All of the accounts which currently have any transactions
         in the queue. Entries are created and destroyed dynamically
         as transactions are added and removed.

--- a/src/xrpld/app/misc/detail/TxQ.cpp
+++ b/src/xrpld/app/misc/detail/TxQ.cpp
@@ -292,6 +292,7 @@ TxQ::MaybeTx::MaybeTx(
     , feeLevel(feeLevel)
     , txID(txId)
     , account(txn->getAccountID(sfAccount))
+    , feePayer(txn->getFeePayer())
     , lastValid(getLastLedgerSequence(*txn))
     , seqProxy(txn->getSeqProxy())
     , flags(flags)
@@ -757,6 +758,12 @@ TxQ::apply(
     if (!sleAccount)
         return {terNO_ACCOUNT, false};
 
+    auto const feePayer = tx->getFeePayer();
+    Keylet const feePayerKey{keylet::account(feePayer)};
+    auto const sleFeePayer = feePayer == account ? sleAccount : view.read(feePayerKey);
+    if (!sleFeePayer)
+        return {terNO_ACCOUNT, false};
+
     // If the transaction needs a Ticket is that Ticket in the ledger?
     SeqProxy const acctSeqProx = SeqProxy::sequence((*sleAccount)[sfSequence]);
     SeqProxy const txSeqProx = tx->getSeqProxy();
@@ -1027,7 +1034,6 @@ TxQ::apply(
             // so we know how much to remove from the account balance
             // for the trial preclaim.
             XRPAmount potentialSpend = beast::kZero;
-            XRPAmount totalFee = beast::kZero;
             for (auto iter = txIter->first; iter != txIter->end; ++iter)
             {
                 // If we're replacing this transaction don't include
@@ -1035,17 +1041,27 @@ TxQ::apply(
                 // it to potentialSpend.
                 if (iter->first != txSeqProx)
                 {
-                    totalFee += iter->second.consequences().fee();
                     potentialSpend += iter->second.consequences().potentialSpend();
                 }
                 else if (std::next(iter) != txIter->end)
                 {
-                    // The fee for the candidate transaction _should_ be
-                    // counted if it's replacing a transaction in the middle
-                    // of the queue.
-                    totalFee += pfResult.consequences.fee();
                     potentialSpend += pfResult.consequences.potentialSpend();
                 }
+            }
+            XRPAmount totalFee{beast::kZero};
+            for (auto const& txn : byFee_)
+            {
+                if (txn.feePayer != feePayer)
+                    continue;
+
+                if (replacedTxIter && &txn == &(*replacedTxIter)->second)
+                    continue;
+
+                totalFee += txn.consequences().fee();
+            }
+            if (replacedTxIter && std::next(*replacedTxIter) != txIter->end)
+            {
+                totalFee += pfResult.consequences.fee();
             }
             // NOLINTEND(bugprone-unchecked-optional-access)
 
@@ -1078,7 +1094,7 @@ TxQ::apply(
                 Transactions stuck in the queue are mitigated by
                 LastLedgerSeq and MaybeTx::retriesRemaining.
             */
-            auto const balance = (*sleAccount)[sfBalance].xrp();
+            auto const balance = (*sleFeePayer)[sfBalance].xrp();
             /* Get the minimum possible account reserve. If it
                is at least 10 * the base fee, and fees exceed
                this amount, the transaction can't be queued.
@@ -1109,26 +1125,38 @@ TxQ::apply(
             // Create the test view from the current view.
             multiTxn.emplace(view, flags);
 
-            auto const sleBump = multiTxn->applyView.peek(accountKey);
-            if (!sleBump)
+            auto const sleAccountBump = multiTxn->applyView.peek(accountKey);
+            auto const sleFeePayerBump =
+                feePayer == account ? sleAccountBump : multiTxn->applyView.peek(feePayerKey);
+            if (!sleAccountBump || !sleFeePayerBump)
                 return {tefINTERNAL, false};
 
             // Subtract the fees and XRP spend from all of the other
             // transactions in the queue.  That prevents a transaction
             // inserted in the middle from fouling up later transactions.
-            auto const potentialTotalSpend =
-                totalFee + std::min(balance - std::min(balance, reserve), potentialSpend);
+            auto const accountBalance = (*sleAccount)[sfBalance].xrp();
+            auto const potentialAccountSpend =
+                std::min(accountBalance - std::min(accountBalance, reserve), potentialSpend);
+            auto const potentialTotalSpend = totalFee + potentialAccountSpend;
             XRPL_ASSERT(
                 potentialTotalSpend > XRPAmount{0} ||
                     (potentialTotalSpend == XRPAmount{0} && multiTxn->applyView.fees().base == 0),
                 "xrpl::TxQ::apply : total spend check");
-            sleBump->setFieldAmount(sfBalance, balance - potentialTotalSpend);
+            if (feePayer == account)
+            {
+                sleAccountBump->setFieldAmount(sfBalance, accountBalance - potentialTotalSpend);
+            }
+            else
+            {
+                sleAccountBump->setFieldAmount(sfBalance, accountBalance - potentialAccountSpend);
+                sleFeePayerBump->setFieldAmount(sfBalance, balance - totalFee);
+            }
             // The transaction's sequence/ticket will be valid when the other
             // transactions in the queue have been processed. If the tx has a
             // sequence, set the account to match it. If it has a ticket, use
             // the next queueable sequence, which is the closest approximation
             // to the most successful case.
-            sleBump->at(sfSequence) = txSeqProx.isSeq()
+            sleAccountBump->at(sfSequence) = txSeqProx.isSeq()
                 ? txSeqProx.value()
                 : nextQueuableSeqImpl(sleAccount, lock).value();
         }

--- a/src/xrpld/app/misc/detail/TxQ.cpp
+++ b/src/xrpld/app/misc/detail/TxQ.cpp
@@ -371,6 +371,9 @@ TxQ::TxQ(Setup const& setup, beast::Journal j)
 TxQ::~TxQ()
 {
     byFee_.clear();
+    for (auto& [_, payerTxs] : byPayer_)
+        payerTxs.clear();
+    byPayer_.clear();
 }
 
 template <size_t FillPercentage>
@@ -457,6 +460,8 @@ TxQ::erase(TxQ::FeeMultiSet::const_iterator_type candidateIter) -> FeeMultiSet::
 {
     auto& txQAccount = byAccount_.at(candidateIter->account);
     auto const seqProx = candidateIter->seqProxy;
+    auto& txn = txQAccount.transactions.at(seqProx);
+    removeFromByPayer(txn);
     auto const newCandidateIter = byFee_.erase(candidateIter);
     // Now that the candidate has been removed from the
     // intrusive list remove it from the TxQAccount
@@ -494,6 +499,7 @@ TxQ::eraseAndAdvance(TxQ::FeeMultiSet::const_iterator_type candidateIter)
         accountNextIter->first > candidateIter->seqProxy &&
         (feeNextIter == byFee_.end() || byFee_.value_comp()(accountNextIter->second, *feeNextIter));
 
+    removeFromByPayer(accountIter->second);
     auto const candidateNextIter = byFee_.erase(candidateIter);
     txQAccount.transactions.erase(accountIter);
 
@@ -508,6 +514,7 @@ TxQ::erase(
 {
     for (auto it = begin; it != end; ++it)
     {
+        removeFromByPayer(it->second);
         byFee_.erase(byFee_.iterator_to(it->second));
     }
     return txQAccount.transactions.erase(begin, end);
@@ -1049,15 +1056,15 @@ TxQ::apply(
                 }
             }
             XRPAmount totalFee{beast::kZero};
-            for (auto const& txn : byFee_)
+            if (auto const payerIter = byPayer_.find(feePayer); payerIter != byPayer_.end())
             {
-                if (txn.feePayer != feePayer)
-                    continue;
+                for (auto const& txn : payerIter->second)
+                {
+                    if (replacedTxIter && &txn == &(*replacedTxIter)->second)
+                        continue;
 
-                if (replacedTxIter && &txn == &(*replacedTxIter)->second)
-                    continue;
-
-                totalFee += txn.consequences().fee();
+                    totalFee += txn.consequences().fee();
+                }
             }
             if (replacedTxIter && std::next(*replacedTxIter) != txIter->end)
             {
@@ -1333,8 +1340,9 @@ TxQ::apply(
 
     auto& candidate = accountIter->second.add({tx, transactionID, feeLevelPaid, flags, pfResult});
 
-    // Then index it into the byFee lookup.
+    // Then index it into the non-owning lookups.
     byFee_.insert(candidate);
+    byPayer_[candidate.feePayer].push_back(candidate);
     JLOG(j_.debug()) << "Added transaction " << candidate.txID << " with result "
                      << transToken(pfResult.ter) << " from "
                      << (accountIsInQueue ? "existing" : "new") << " account " << candidate.account
@@ -1757,6 +1765,18 @@ TxQ::removeFromByFee(
         erase(deleteIter);
     }
     return std::nullopt;
+}
+
+void
+TxQ::removeFromByPayer(MaybeTx const& txn)
+{
+    auto payerIter = byPayer_.find(txn.feePayer);
+    XRPL_ASSERT(payerIter != byPayer_.end(), "xrpl::TxQ::removeFromByPayer : payer found");
+
+    auto& payerTxs = payerIter->second;
+    payerTxs.erase(payerTxs.iterator_to(const_cast<MaybeTx&>(txn)));
+    if (payerTxs.empty())
+        byPayer_.erase(payerIter);
 }
 
 TxQ::Metrics

--- a/src/xrpld/rpc/handlers/account/AccountInfo.cpp
+++ b/src/xrpld/rpc/handlers/account/AccountInfo.cpp
@@ -296,7 +296,9 @@ doAccountInfo(RPC::JsonContext& context)
                         jvTx[jss::LastLedgerSequence] = *tx.lastValid;
 
                     jvTx[jss::fee] = to_string(tx.consequences.fee());
-                    auto const spend = tx.consequences.potentialSpend() + tx.consequences.fee();
+                    auto const spend = tx.consequences.potentialSpend() +
+                        (tx.feePayer == accountID ? tx.consequences.fee()
+                                                  : XRPAmount{beast::kZero});
                     jvTx[jss::max_spend_drops] = to_string(spend);
                     totalSpend += spend;
                     bool const authChanged = tx.consequences.isBlocker();


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Because the delegated transactions are paid by the `sfDelegate`, but not `sfAccount`:
- TxQ might reject some transactions that should be queueable by incorrectly counting delegate-paid fees against the principal account.
- It may also undercount the total queued fees owed by a delegate across different accounts, allowing transactions into the queue that the actual fee payer may not be able to cover later.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
