### PR TITLE
refactor: Fix signed/unsigned comparison in lz4Decompress

### DIFF
--- a/include/xrpl/basics/CompressionAlgorithms.h
+++ b/include/xrpl/basics/CompressionAlgorithms.h
@@ -120,10 +120,9 @@ lz4Decompress(
             }
             compressed.resize(inSize);
         }
-	
-        auto const bytesToCopy = std::min(chunkSizeAsSizeT, inSize - copiedInSize);
-        
-	std::copy(chunk, chunk + bytesToCopy, compressed.data() + copiedInSize);
+        auto const bytesToCopy =
+            std::min(chunkSizeAsSizeT, inSize - copiedInSize);
+        std::copy(chunk, chunk + bytesToCopy, compressed.data() + copiedInSize);
 
         copiedInSize += bytesToCopy;
 

--- a/include/xrpl/basics/CompressionAlgorithms.h
+++ b/include/xrpl/basics/CompressionAlgorithms.h
@@ -134,8 +134,15 @@ lz4Decompress(
     }
 
     // Put back unused bytes
-    if (in.ByteCount() > (currentBytes + copiedInSize))
-        in.BackUp(in.ByteCount() - currentBytes - copiedInSize);
+    auto const copiedInByteCount =
+        static_cast<decltype(currentBytes)>(copiedInSize);
+
+    if (in.ByteCount() > currentBytes + copiedInByteCount)
+    {
+        auto const unusedBytes =
+            in.ByteCount() - currentBytes - copiedInByteCount;
+        in.BackUp(static_cast<int>(unusedBytes));
+    }
 
     if (copiedInSize != inSize)
         Throw<std::runtime_error>("lz4 decompress: insufficient input size");

--- a/include/xrpl/basics/CompressionAlgorithms.h
+++ b/include/xrpl/basics/CompressionAlgorithms.h
@@ -98,7 +98,7 @@ lz4Decompress(
     std::vector<std::uint8_t> compressed;
     std::uint8_t const* chunk = nullptr;
     int chunkSize = 0;
-    int copiedInSize = 0;
+    std::size_t copiedInSize = 0;
     auto const currentBytes = in.ByteCount();
 
     // Use the first chunk if it is >= inSize bytes of the compressed message.
@@ -106,21 +106,26 @@ lz4Decompress(
     // use the buffer to decompress.
     while (in.Next(reinterpret_cast<void const**>(&chunk), &chunkSize))
     {
+        if (chunkSize < 0)
+            Throw<std::runtime_error>("lz4 decompress: invalid chunk size");
+
+        auto const chunkSizeAsSizeT = static_cast<std::size_t>(chunkSize);
+
         if (copiedInSize == 0)
         {
-            if (chunkSize >= inSize)
+            if (chunkSizeAsSizeT >= inSize)
             {
                 copiedInSize = inSize;
                 break;
             }
             compressed.resize(inSize);
         }
+	
+        auto const bytesToCopy = std::min(chunkSizeAsSizeT, inSize - copiedInSize);
+        
+	std::copy(chunk, chunk + bytesToCopy, compressed.data() + copiedInSize);
 
-        chunkSize = chunkSize < (inSize - copiedInSize) ? chunkSize : (inSize - copiedInSize);
-
-        std::copy(chunk, chunk + chunkSize, compressed.data() + copiedInSize);
-
-        copiedInSize += chunkSize;
+        copiedInSize += bytesToCopy;
 
         if (copiedInSize == inSize)
         {
@@ -133,7 +138,7 @@ lz4Decompress(
     if (in.ByteCount() > (currentBytes + copiedInSize))
         in.BackUp(in.ByteCount() - currentBytes - copiedInSize);
 
-    if ((copiedInSize == 0 && chunkSize < inSize) || (copiedInSize > 0 && copiedInSize != inSize))
+    if (copiedInSize != inSize)
         Throw<std::runtime_error>("lz4 decompress: insufficient input size");
 
     return lz4Decompress(chunk, inSize, decompressed, decompressedSize);


### PR DESCRIPTION
## High Level Overview of Change

Fixes a signed/unsigned comparison in the stream-based `lz4Decompress` overload.

The stream returns `chunkSize` as an `int`, while the expected input size is represented as `std::size_t`. This change validates `chunkSize` before converting it to `std::size_t`, uses `std::size_t` for copied byte tracking, and simplifies the final insufficient-input check.

Fixes #7521

### Context of Change

The previous implementation compared `chunkSize` directly against `inSize`. Since `chunkSize` is signed and `inSize` is unsigned, a negative `chunkSize` could be converted to a large unsigned value during comparison.

This change checks for a negative `chunkSize` before conversion, then uses a validated `std::size_t` value for size comparisons and copy calculations. It also changes `copiedInSize` to `std::size_t` and simplifies the final insufficient-input check to `copiedInSize != inSize`, so the final validation is based on whether the requested number of compressed input bytes was actually accounted for.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)