### PR TITLE
fix: Implicit narrowing in tx metrics

### DIFF
--- a/src/xrpld/overlay/detail/TxMetrics.cpp
+++ b/src/xrpld/overlay/detail/TxMetrics.cpp
@@ -14,9 +14,9 @@
 namespace xrpl::metrics {
 
 void
-TxMetrics::addMetrics(protocol::MessageType type, std::uint32_t val)
+TxMetrics::addMetrics(protocol::MessageType type, std::uint64_t val)
 {
-    auto add = [&](auto& m, std::uint32_t val) {
+    auto add = [&](auto& m, std::uint64_t val) {
         std::scoped_lock const lock(mutex);
         m.addMetrics(val);
     };
@@ -60,20 +60,20 @@ TxMetrics::addMetrics(std::uint32_t missing)
 }
 
 void
-MultipleMetrics::addMetrics(std::uint32_t val2)
+MultipleMetrics::addMetrics(std::uint64_t val2)
 {
     addMetrics(1, val2);
 }
 
 void
-MultipleMetrics::addMetrics(std::uint32_t val1, std::uint32_t val2)
+MultipleMetrics::addMetrics(std::uint64_t val1, std::uint64_t val2)
 {
     m1.addMetrics(val1);
     m2.addMetrics(val2);
 }
 
 void
-SingleMetrics::addMetrics(std::uint32_t val)
+SingleMetrics::addMetrics(std::uint64_t val)
 {
     using namespace std::chrono_literals;
     accum += val;

--- a/src/xrpld/overlay/detail/TxMetrics.h
+++ b/src/xrpld/overlay/detail/TxMetrics.h
@@ -41,7 +41,7 @@ struct SingleMetrics
      * @param val metrics value, either bytes or count
      */
     void
-    addMetrics(std::uint32_t val);
+    addMetrics(std::uint64_t val);
 };
 
 /**
@@ -61,14 +61,14 @@ struct MultipleMetrics
      * @param val2 m2 metrics value
      */
     void
-    addMetrics(std::uint32_t val2);
+    addMetrics(std::uint64_t val2);
     /**
      * Add metrics to m1 and m2.
      * @param val1 m1 metrics value
      * @param val2 m2 metrics value
      */
     void
-    addMetrics(std::uint32_t val1, std::uint32_t val2);
+    addMetrics(std::uint64_t val1, std::uint64_t val2);
 };
 
 /**
@@ -101,7 +101,7 @@ struct TxMetrics
      * @param val message size in bytes
      */
     void
-    addMetrics(protocol::MessageType type, std::uint32_t val);
+    addMetrics(protocol::MessageType type, std::uint64_t val);
     /**
      * Add peers selected for relaying and suppressed peers metrics.
      * @param selected number of selected peers to relay


### PR DESCRIPTION
## High Level Overview of Change

Fixes #7480.

This PR removes an implicit narrowing conversion in transaction reduce-relay metrics by changing the `TxMetrics::addMetrics(protocol::MessageType, ...)` overload to accept `std::uint64_t` instead of `std::uint32_t`.

`PeerImp::onMessageBegin` already passes the message size as `std::uint64_t`, but the destination overload accepted `std::uint32_t`, which allowed the value to be silently narrowed.

### Context of Change

In `PeerImp::onMessageBegin`, the message size is passed through `overlay_.addTxMetrics(...)` as a `std::uint64_t`.

Before this change, the variadic `addTxMetrics` wrapper forwarded that value to:

`TxMetrics::addMetrics(protocol::MessageType type, std::uint32_t val)`

That caused an implicit conversion from `std::uint64_t` to `std::uint32_t`. While protocol messages are not expected to exceed the 32-bit range in normal operation, accepting `std::uint64_t` here better matches the caller and avoids possible silent truncation in the metrics path.

This PR updates both the declaration and definition of that overload to preserve the full value width.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)