### PR TITLE
fix: Validate AMM state changes in invariant default case

### DIFF
--- a/src/libxrpl/tx/invariants/AMMInvariant.cpp
+++ b/src/libxrpl/tx/invariants/AMMInvariant.cpp
@@ -349,6 +349,7 @@ ValidAMM::finalize(
 
     bool const enforce = view.rules().enabled(fixAMMv1_3);
     bool const enforceAMMDelete = view.rules().enabled(fixCleanup3_3_0);
+    bool const enforceUnexpectedAMMChange = view.rules().enabled(fixCleanup3_4_0);
 
     // AMM can only be deleted by AMMWithdraw, AMMClawback, and AMMDelete
     if (enforceAMMDelete && ammDeleted_)
@@ -388,6 +389,13 @@ ValidAMM::finalize(
         case ttPAYMENT:
             return finalizeDEX(enforce, j);
         default:
+            if (ammAccount_ || ammPoolChanged_)
+            {
+                JLOG(j.error()) << "Invariant failed: AMM failed, unexpected AMM state change by "
+                                << tx.getTxnType();
+                if (enforceUnexpectedAMMChange)
+                    return false;
+            }
             break;
     }
 


### PR DESCRIPTION
## High Level Overview of Change

Adds validation to the `ValidAMM::finalize` default case so unlisted transaction types no longer silently pass after modifying AMM-related state.

Fixes #7489.

### Context of Change

`ValidAMM::finalize` handles known AMM transaction types. Previously, any transaction type not listed in the switch statement would fall through the default case and eventually return `true`.

This change updates the default case to check whether `ammAccount_` or `ammPoolChanged_` is set. If AMM state was modified by an unexpected transaction type, the invariant logs an error and fails when AMM invariant enforcement is active.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields) 
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version) 
- [x] libxrpl change (any change that may affect libxrpl or dependents of libxrpl) 
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

