### PR TITLE
fix: Add null SLE checks in directory callbacks

### DIFF
--- a/src/xrpld/rpc/handlers/account/GatewayBalances.cpp
+++ b/src/xrpld/rpc/handlers/account/GatewayBalances.cpp
@@ -146,8 +146,12 @@ doGatewayBalances(RPC::JsonContext& context)
     {
         forEachItem(*ledger, accountID, [&](SLE::const_ref sle) {
             if (!sle)
-	    	return;
-
+            {
+                // LCOV_EXCL_START
+                UNREACHABLE("xrpl::doGatewayBalances : null SLE");
+	    	    return;
+                // LCOV_EXCL_STOP
+            }
 	    if (sle->getType() == ltESCROW)
             {
                 auto const& escrow = sle->getFieldAmount(sfAmount);

--- a/src/xrpld/rpc/handlers/account/GatewayBalances.cpp
+++ b/src/xrpld/rpc/handlers/account/GatewayBalances.cpp
@@ -152,7 +152,7 @@ doGatewayBalances(RPC::JsonContext& context)
                 return;
                 // LCOV_EXCL_STOP
             }
-	    if (sle->getType() == ltESCROW)
+            if (sle->getType() == ltESCROW)
             {
                 auto const& escrow = sle->getFieldAmount(sfAmount);
                 // Gateway Balance should not include MPTs

--- a/src/xrpld/rpc/handlers/account/GatewayBalances.cpp
+++ b/src/xrpld/rpc/handlers/account/GatewayBalances.cpp
@@ -149,7 +149,7 @@ doGatewayBalances(RPC::JsonContext& context)
             {
                 // LCOV_EXCL_START
                 UNREACHABLE("xrpl::doGatewayBalances : null SLE");
-	    	    return;
+                return;
                 // LCOV_EXCL_STOP
             }
 	    if (sle->getType() == ltESCROW)

--- a/src/xrpld/rpc/handlers/account/GatewayBalances.cpp
+++ b/src/xrpld/rpc/handlers/account/GatewayBalances.cpp
@@ -145,7 +145,10 @@ doGatewayBalances(RPC::JsonContext& context)
     // Traverse the cold wallet's trust lines
     {
         forEachItem(*ledger, accountID, [&](SLE::const_ref sle) {
-            if (sle->getType() == ltESCROW)
+            if (!sle)
+	    	return;
+
+	    if (sle->getType() == ltESCROW)
             {
                 auto const& escrow = sle->getFieldAmount(sfAmount);
                 // Gateway Balance should not include MPTs

--- a/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
+++ b/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
@@ -138,16 +138,15 @@ doNoRippleCheck(RPC::JsonContext& context)
     }
 
     forEachItemAfter(*ledger, accountID, uint256(), 0, limit, [&](SLE::const_ref ownedItem) {
-        
-	if (!ownedItem)
-    {
-        // LCOV_EXCL_START
-        UNREACHABLE("xrpl::doNoRippleCheck : null SLE");
-	    return false;
-        // LCOV_EXCL_STOP
-    }
+        if (!ownedItem)
+        {
+            // LCOV_EXCL_START
+            UNREACHABLE("xrpl::doNoRippleCheck : null SLE");
+            return false;
+            // LCOV_EXCL_STOP
+        }
 
-	if (ownedItem->getType() == ltRIPPLE_STATE)
+        if (ownedItem->getType() == ltRIPPLE_STATE)
         {
             bool const bLow = accountID == ownedItem->getFieldAmount(sfLowLimit).getIssuer();
 

--- a/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
+++ b/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
@@ -140,7 +140,12 @@ doNoRippleCheck(RPC::JsonContext& context)
     forEachItemAfter(*ledger, accountID, uint256(), 0, limit, [&](SLE::const_ref ownedItem) {
         
 	if (!ownedItem)
+    {
+        // LCOV_EXCL_START
+        UNREACHABLE("xrpl::doNoRippleCheck : null SLE");
 	    return false;
+        // LCOV_EXCL_STOP
+    }
 
 	if (ownedItem->getType() == ltRIPPLE_STATE)
         {

--- a/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
+++ b/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
@@ -138,7 +138,11 @@ doNoRippleCheck(RPC::JsonContext& context)
     }
 
     forEachItemAfter(*ledger, accountID, uint256(), 0, limit, [&](SLE::const_ref ownedItem) {
-        if (ownedItem->getType() == ltRIPPLE_STATE)
+        
+	if (!ownedItem)
+	    return false;
+
+	if (ownedItem->getType() == ltRIPPLE_STATE)
         {
             bool const bLow = accountID == ownedItem->getFieldAmount(sfLowLimit).getIssuer();
 


### PR DESCRIPTION
## High Level Overview of Change

Adds null `SLE` checks in directory iteration callbacks for `NoRippleCheck` and `GatewayBalances`.

This prevents possible null pointer dereferences if directory iteration passes a null ledger entry to the callback.

Fixes #7510.

### Context of Change

`forEachItemAfter` in `NoRippleCheck` and `forEachItem` in `GatewayBalances` both receive `std::shared_ptr<SLE const>` values from directory iteration.

This change adds the missing checks before calling `getType()` in both affected callbacks:

- `NoRippleCheck`: returns `false` when `ownedItem` is null
- `GatewayBalances`: returns early when `sle` is null

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)