### PR TITLE
fix: Skip null SLEs in directory item iteration

### DIFF
--- a/src/libxrpl/ledger/helpers/DirectoryHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/DirectoryHelpers.cpp
@@ -5,6 +5,7 @@
 #include <xrpl/ledger/ApplyView.h>
 #include <xrpl/ledger/ReadView.h>
 #include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Keylet.h>
 #include <xrpl/protocol/LedgerFormats.h>
@@ -67,6 +68,8 @@ forEachItem(ReadView const& view, Keylet const& root, std::function<void(SLE::co
     if (root.type != ltDIR_NODE)
         return;
 
+    bool const fixNullDirectoryEntries = view.rules().enabled(fixCleanup3_4_0);
+
     auto pos = root;
 
     while (true)
@@ -75,7 +78,18 @@ forEachItem(ReadView const& view, Keylet const& root, std::function<void(SLE::co
         if (!sle)
             return;
         for (auto const& key : sle->getFieldV256(sfIndexes))
-            f(view.read(keylet::child(key)));
+        {
+            auto const child = view.read(keylet::child(key));
+            if (!child)
+            {
+                // LCOV_EXCL_START
+                UNREACHABLE("xrpl::forEachItem : null child SLE");
+                // LCOV_EXCL_STOP
+                if (fixNullDirectoryEntries)
+                    continue;
+            }
+            f(child);
+        }
         auto const next = sle->getFieldU64(sfIndexNext);
         if (next == 0u)
             return;
@@ -96,6 +110,8 @@ forEachItemAfter(
 
     if (root.type != ltDIR_NODE)
         return false;
+
+    bool const fixNullDirectoryEntries = view.rules().enabled(fixCleanup3_4_0);
 
     auto currentIndex = root;
 
@@ -130,9 +146,19 @@ forEachItemAfter(
                     if (key == after)
                         found = true;
                 }
-                else if (f(view.read(keylet::child(key))) && limit-- <= 1)
+                else
                 {
-                    return found;
+                    auto const sle = view.read(keylet::child(key));
+                    if (!sle)
+                    {
+                        // LCOV_EXCL_START
+                        UNREACHABLE("xrpl::forEachItemAfter : null child SLE");
+                        // LCOV_EXCL_STOP
+                        if (fixNullDirectoryEntries)
+                            continue;
+                    }
+                    if (f(sle) && limit-- <= 1)
+                        return found;
                 }
             }
 
@@ -151,7 +177,16 @@ forEachItemAfter(
                 return true;
             for (auto const& key : ownerDir->getFieldV256(sfIndexes))
             {
-                if (f(view.read(keylet::child(key))) && limit-- <= 1)
+                auto const sle = view.read(keylet::child(key));
+                if (!sle)
+                {
+                    // LCOV_EXCL_START
+                    UNREACHABLE("xrpl::forEachItemAfter : null child SLE");
+                    // LCOV_EXCL_STOP
+                    if (fixNullDirectoryEntries)
+                        continue;
+                }
+                if (f(sle) && limit-- <= 1)
                     return true;
             }
             auto const uNodeNext = ownerDir->getFieldU64(sfIndexNext);


### PR DESCRIPTION
## High Level Overview of Change

This PR adds defensive null checks when reading child ledger entries during directory item iteration.

Specifically, `forEachItem` and `forEachItemAfter` now check the result of `view.read(keylet::child(key))` and mark null child SLE reads as `UNREACHABLE`.

When `fixCleanup3_4_0` is enabled, null child directory entries are skipped before invoking callbacks. Before that amendment is enabled, the existing callback behavior is preserved.

Fixes #7512.

### Context of Change

`view.read(keylet::child(key))` can theoretically return `nullptr` if a directory contains a dangling reference to a missing ledger entry. Under normal ledger operation this should not occur, because directory entries and their referenced objects are maintained atomically.

However, if ledger corruption or an internal invariant violation ever produced a dangling directory entry, the previous implementation could pass a null `SLE` to callback code. Some callbacks dereference the received `SLE`, which could result in a crash.

This change adds defense-in-depth by skipping null child entries inside the shared directory iteration helpers before callbacks are invoked.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

## Before / After

Before this change, `forEachItem` and `forEachItemAfter` could pass the result of `view.read(keylet::child(key))` directly to the callback without checking whether the read succeeded.

After this change, null child `SLE` values are skipped .