### PR TITLE
fix: Assert PeerReservationTable connection is initialized

### DIFF
--- a/src/xrpld/overlay/detail/PeerReservationTable.cpp
+++ b/src/xrpld/overlay/detail/PeerReservationTable.cpp
@@ -102,7 +102,7 @@ PeerReservationTable::erase(PublicKey const& nodeId)
 
     std::scoped_lock const lock(mutex_);
 
-    XRPL_ASSERT(connection_ != nullptr, "PeerReservationTable::erase: connection must be initialized");
+    XRPL_ASSERT(connection_ != nullptr, "xrpl::PeerReservationTable::erase : connection must be initialized");
     
     auto const it = table_.find({.nodeId = nodeId});
     if (it != table_.end())

--- a/src/xrpld/overlay/detail/PeerReservationTable.cpp
+++ b/src/xrpld/overlay/detail/PeerReservationTable.cpp
@@ -62,14 +62,12 @@ PeerReservationTable::load(DatabaseCon& connection)
 std::optional<PeerReservation>
 PeerReservationTable::insertOrAssign(PeerReservation const& reservation)
 {
-    XRPL_ASSERT(
-        connection_ != nullptr,
-	"PeerReservationTable::insertOrAssign: connection must be initialized");
-    
     std::optional<PeerReservation> previous;
 
     std::scoped_lock const lock(mutex_);
 
+    XRPL_ASSERT(connection_ != nullptr, "PeerReservationTable::insertOrAssign: connection must be initialized");
+    
     auto hint = table_.find(reservation);
     if (hint != table_.end())
     {
@@ -100,14 +98,12 @@ PeerReservationTable::insertOrAssign(PeerReservation const& reservation)
 std::optional<PeerReservation>
 PeerReservationTable::erase(PublicKey const& nodeId)
 {
-    XRPL_ASSERT(
-        connection_ != nullptr,
-	"PeerReservationTable::erase: connection must be initialized");
- 
     std::optional<PeerReservation> previous;
 
     std::scoped_lock const lock(mutex_);
 
+    XRPL_ASSERT(connection_ != nullptr, "PeerReservationTable::erase: connection must be initialized");
+    
     auto const it = table_.find({.nodeId = nodeId});
     if (it != table_.end())
     {

--- a/src/xrpld/overlay/detail/PeerReservationTable.cpp
+++ b/src/xrpld/overlay/detail/PeerReservationTable.cpp
@@ -66,8 +66,8 @@ PeerReservationTable::insertOrAssign(PeerReservation const& reservation)
 
     std::scoped_lock const lock(mutex_);
 
-    XRPL_ASSERT(connection_ != nullptr, "PeerReservationTable::insertOrAssign: connection must be initialized");
-    
+    XRPL_ASSERT(connection_ != nullptr, "xrpl::PeerReservationTable::insertOrAssign : connection must be initialized");
+
     auto hint = table_.find(reservation);
     if (hint != table_.end())
     {

--- a/src/xrpld/overlay/detail/PeerReservationTable.cpp
+++ b/src/xrpld/overlay/detail/PeerReservationTable.cpp
@@ -62,6 +62,10 @@ PeerReservationTable::load(DatabaseCon& connection)
 std::optional<PeerReservation>
 PeerReservationTable::insertOrAssign(PeerReservation const& reservation)
 {
+    XRPL_ASSERT(
+        connection_ != nullptr,
+	"PeerReservationTable::insertOrAssign: connection must be initialized");
+    
     std::optional<PeerReservation> previous;
 
     std::scoped_lock const lock(mutex_);
@@ -96,6 +100,10 @@ PeerReservationTable::insertOrAssign(PeerReservation const& reservation)
 std::optional<PeerReservation>
 PeerReservationTable::erase(PublicKey const& nodeId)
 {
+    XRPL_ASSERT(
+        connection_ != nullptr,
+	"PeerReservationTable::erase: connection must be initialized");
+ 
     std::optional<PeerReservation> previous;
 
     std::scoped_lock const lock(mutex_);


### PR DESCRIPTION
## High Level Overview of Change

Adds defensive `XRPL_ASSERT` checks in `PeerReservationTable::insertOrAssign` and `PeerReservationTable::erase` to ensure `connection_` has been initialized before it is dereferenced.

Fixes #7509.

### Context of Change

`PeerReservationTable::connection_` is initialized to `nullptr` and is set during `PeerReservationTable::load()`. The normal application startup path calls `load()` before these methods are reachable, but `insertOrAssign()` and `erase()` previously dereferenced `connection_` without guarding that initialization invariant.

This change adds explicit assertions before calling `connection_->checkoutDb()`, making the expected initialization order clear and preventing use-before-initialization from going unchecked.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)