### PR TITLE
fix: Validate account_lines peer field type

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -54,6 +54,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
+- `account_lines`: The `peer` field now returns an error if the value is not a string. [#7728](https://github.com/XRPLF/rippled/pull/7728)
 
 ## XRP Ledger server version 3.1.0
 

--- a/src/test/rpc/AccountLines_test.cpp
+++ b/src/test/rpc/AccountLines_test.cpp
@@ -808,7 +808,7 @@ public:
                 request[jss::params] = params;
 
                 auto const lines = env.rpc("json2", to_string(request));
-                BEAST_EXPECT(lines[jss::error][jss::code] == "invalidParams");
+                BEAST_EXPECT(lines[jss::error][jss::error] == "invalidParams");
                 BEAST_EXPECT(lines[jss::error][jss::message] == "Invalid field 'peer'.");
                 BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
                 BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");

--- a/src/test/rpc/AccountLines_test.cpp
+++ b/src/test/rpc/AccountLines_test.cpp
@@ -81,6 +81,20 @@ public:
         }
         Account const alice{"alice"};
         {
+            // account_lines on an unfunded account.
+            json::Value params;
+            params[jss::account] = alice.human();
+            auto const lines = env.rpc("json", "account_lines", to_string(params));
+            BEAST_EXPECT(
+                lines[jss::result][jss::error_message] ==
+                rpc::makeError(RpcActNotFound)[jss::error_message]);
+        }
+        env.fund(XRP(10000), alice);
+        env.close();
+        LedgerHeader const ledger3Info = env.closed()->header();
+        BEAST_EXPECT(ledger3Info.seq == 3);
+
+        {
             // test peer non-string
             auto testInvalidPeerParam = [&](auto const& param) {
                 json::Value params;
@@ -98,20 +112,6 @@ public:
             testInvalidPeerParam(json::Value(json::ValueType::Object));
             testInvalidPeerParam(json::Value(json::ValueType::Array));
         }
-        {
-            // account_lines on an unfunded account.
-            json::Value params;
-            params[jss::account] = alice.human();
-            auto const lines = env.rpc("json", "account_lines", to_string(params));
-            BEAST_EXPECT(
-                lines[jss::result][jss::error_message] ==
-                rpc::makeError(RpcActNotFound)[jss::error_message]);
-        }
-        env.fund(XRP(10000), alice);
-        env.close();
-        LedgerHeader const ledger3Info = env.closed()->header();
-        BEAST_EXPECT(ledger3Info.seq == 3);
-
         {
             // alice is funded but has no lines.  An empty array is returned.
             json::Value params;
@@ -771,6 +771,29 @@ public:
         }
         Account const alice{"alice"};
         {
+            // account_lines on an unfunded account.
+            json::Value params;
+            params[jss::account] = alice.human();
+            json::Value request;
+            request[jss::method] = "account_lines";
+            request[jss::jsonrpc] = "2.0";
+            request[jss::ripplerpc] = "2.0";
+            request[jss::id] = 5;
+            request[jss::params] = params;
+            auto const lines = env.rpc("json2", to_string(request));
+            BEAST_EXPECT(
+                lines[jss::error][jss::message] ==
+                rpc::makeError(RpcActNotFound)[jss::error_message]);
+            BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
+            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
+            BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
+        }
+        env.fund(XRP(10000), alice);
+        env.close();
+        LedgerHeader const ledger3Info = env.closed()->header();
+        BEAST_EXPECT(ledger3Info.seq == 3);
+
+        {
             // test peer non-string
             auto testInvalidPeerParam = [&](auto const& param) {
                 json::Value params;
@@ -799,29 +822,6 @@ public:
             testInvalidPeerParam(json::Value(json::ValueType::Object));
             testInvalidPeerParam(json::Value(json::ValueType::Array));
         }
-        {
-            // account_lines on an unfunded account.
-            json::Value params;
-            params[jss::account] = alice.human();
-            json::Value request;
-            request[jss::method] = "account_lines";
-            request[jss::jsonrpc] = "2.0";
-            request[jss::ripplerpc] = "2.0";
-            request[jss::id] = 5;
-            request[jss::params] = params;
-            auto const lines = env.rpc("json2", to_string(request));
-            BEAST_EXPECT(
-                lines[jss::error][jss::message] ==
-                rpc::makeError(RpcActNotFound)[jss::error_message]);
-            BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
-            BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
-        }
-        env.fund(XRP(10000), alice);
-        env.close();
-        LedgerHeader const ledger3Info = env.closed()->header();
-        BEAST_EXPECT(ledger3Info.seq == 3);
-
         {
             // alice is funded but has no lines.  An empty array is returned.
             json::Value params;

--- a/src/test/rpc/AccountLines_test.cpp
+++ b/src/test/rpc/AccountLines_test.cpp
@@ -81,6 +81,24 @@ public:
         }
         Account const alice{"alice"};
         {
+            // test peer non-string
+            auto testInvalidPeerParam = [&](auto const& param) {
+                json::Value params;
+                params[jss::account] = alice.human();
+                params[jss::peer] = param;
+                auto jrr = env.rpc("json", "account_lines", to_string(params))[jss::result];
+                BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+                BEAST_EXPECT(jrr[jss::error_message] == "Invalid field 'peer'.");
+            };
+
+            testInvalidPeerParam(1);
+            testInvalidPeerParam(1.1);
+            testInvalidPeerParam(true);
+            testInvalidPeerParam(json::Value(json::ValueType::Null));
+            testInvalidPeerParam(json::Value(json::ValueType::Object));
+            testInvalidPeerParam(json::Value(json::ValueType::Array));
+        }
+        {
             // account_lines on an unfunded account.
             json::Value params;
             params[jss::account] = alice.human();
@@ -752,6 +770,35 @@ public:
             BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
         }
         Account const alice{"alice"};
+        {
+            // test peer non-string
+            auto testInvalidPeerParam = [&](auto const& param) {
+                json::Value params;
+                params[jss::account] = alice.human();
+                params[jss::peer] = param;
+
+                json::Value request;
+                request[jss::method] = "account_lines";
+                request[jss::jsonrpc] = "2.0";
+                request[jss::ripplerpc] = "2.0";
+                request[jss::id] = 5;
+                request[jss::params] = params;
+
+                auto const lines = env.rpc("json2", to_string(request));
+                BEAST_EXPECT(lines[jss::error][jss::code] == "invalidParams");
+                BEAST_EXPECT(lines[jss::error][jss::message] == "Invalid field 'peer'.");
+                BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
+                BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
+                BEAST_EXPECT(lines.isMember(jss::id) && lines[jss::id] == 5);
+            };
+
+            testInvalidPeerParam(1);
+            testInvalidPeerParam(1.1);
+            testInvalidPeerParam(true);
+            testInvalidPeerParam(json::Value(json::ValueType::Null));
+            testInvalidPeerParam(json::Value(json::ValueType::Object));
+            testInvalidPeerParam(json::Value(json::ValueType::Array));
+        }
         {
             // account_lines on an unfunded account.
             json::Value params;

--- a/src/xrpld/rpc/handlers/account/AccountLines.cpp
+++ b/src/xrpld/rpc/handlers/account/AccountLines.cpp
@@ -109,11 +109,11 @@ doAccountLines(rpc::JsonContext& context)
     if (params.isMember(jss::peer))
     {
         if (!params[jss::peer].isString())
-            return RPC::invalid_field_error(jss::peer);
+            return rpc::invalidFieldError(jss::peer);
 
         strPeer = params[jss::peer].asString();
     }
-    
+
     auto const raPeerAccount = [&]() -> std::optional<AccountID> {
         return strPeer.empty() ? std::nullopt : parseBase58<AccountID>(strPeer);
     }();

--- a/src/xrpld/rpc/handlers/account/AccountLines.cpp
+++ b/src/xrpld/rpc/handlers/account/AccountLines.cpp
@@ -107,8 +107,13 @@ doAccountLines(rpc::JsonContext& context)
 
     std::string strPeer;
     if (params.isMember(jss::peer))
-        strPeer = params[jss::peer].asString();
+    {
+        if (!params[jss::peer].isString())
+            return RPC::invalid_field_error(jss::peer);
 
+        strPeer = params[jss::peer].asString();
+    }
+    
     auto const raPeerAccount = [&]() -> std::optional<AccountID> {
         return strPeer.empty() ? std::nullopt : parseBase58<AccountID>(strPeer);
     }();


### PR DESCRIPTION
## High Level Overview of Change

Adds type validation for the optional `peer` field in the `account_lines` RPC handler before calling `asString()`.

Fixes #7507.

### Context of Change

The `account_lines` handler already validates that the required `account` field is a string before using it. However, the optional `peer` field was being passed to `asString()` without first checking that it was actually a string.

This change adds the missing `isString()` check and returns `RPC::invalid_field_error(jss::peer)` when `peer` is present but not a string. This keeps input validation consistent with the nearby `account` field validation and prevents jsoncpp from silently converting non-string values.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [x] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)