### PR TITLE
fix: Set load type for noripple_check handler

### DIFF
--- a/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
+++ b/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
@@ -17,6 +17,7 @@
 #include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/UintTypes.h>
 #include <xrpl/protocol/jss.h>
+#include <xrpl/resource/Fees.h>
 #include <xrpl/server/LoadFeeTrack.h>
 
 #include <cstdint>

--- a/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
+++ b/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
@@ -51,7 +51,7 @@ fillTransaction(
 json::Value
 doNoRippleCheck(RPC::JsonContext& context)
 {
-    context.loadType = Resource::feeMediumBurdenRPC;
+    context.loadType = Resource::kFeeMediumBurdenRpc;
 
     auto const& params(context.params);
     if (!params.isMember(jss::account))

--- a/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
+++ b/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
@@ -52,8 +52,6 @@ fillTransaction(
 json::Value
 doNoRippleCheck(RPC::JsonContext& context)
 {
-    context.loadType = Resource::kFeeMediumBurdenRpc;
-
     auto const& params(context.params);
     if (!params.isMember(jss::account))
         return RPC::missingFieldError("account");
@@ -185,6 +183,7 @@ doNoRippleCheck(RPC::JsonContext& context)
         return false;
     });
 
+    context.loadType = Resource::kFeeMediumBurdenRpc;
     return result;
 }
 

--- a/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
+++ b/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
@@ -51,6 +51,8 @@ fillTransaction(
 json::Value
 doNoRippleCheck(RPC::JsonContext& context)
 {
+    context.loadType = Resource::feeMediumBurdenRPC;
+
     auto const& params(context.params);
     if (!params.isMember(jss::account))
         return RPC::missingFieldError("account");


### PR DESCRIPTION
## High Level Overview of Change

This change updates the `noripple_check` RPC handler to assign `Resource::feeMediumBurdenRPC` to `context.loadType`.

The handler can iterate through trust lines using the configured limit and may optionally generate transaction recommendations, so it should use a medium burden RPC load charge instead of falling back to the default reference RPC charge.

Fixes #7506

### Context of Change

The `noripple_check` handler previously did not set `context.loadType`, which caused the request to use the default `feeReferenceRPC` cost.

This handler performs work comparable to other paginated account RPC handlers because it can scan multiple trust lines and optionally build transaction JSON for problematic lines. Assigning `Resource::feeMediumBurdenRPC` makes the load charge better match the amount of work performed by the handler.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)