### PR TITLE
fix: Charge fee for malformed websocket json

### DIFF
--- a/src/xrpld/rpc/detail/ServerHandler.cpp
+++ b/src/xrpld/rpc/detail/ServerHandler.cpp
@@ -340,8 +340,13 @@ ServerHandler::onWSMessage(
     if (size > rpc::tuning::kMaxRequestSize || !json::Reader{}.parse(jv, buffers) || !jv.isObject())
     {
         auto const wsInfoSub = std::static_pointer_cast<WSInfoSub>(session->appDefined);
-        wsInfoSub->getConsumer().charge(resource::kFeeMalformedRpc);
-
+        auto& consumer = wsInfoSub->getConsumer();
+        consumer.charge(resource::kFeeMalformedRpc);
+        if (consumer.disconnect(journal_))
+        {
+            session->close({boost::beast::websocket::policy_error, "threshold exceeded"});
+            return;
+        }
         json::Value jvResult(json::ValueType::Object);
         jvResult[jss::type] = jss::error;
         jvResult[jss::error] = "jsonInvalid";

--- a/src/xrpld/rpc/detail/ServerHandler.cpp
+++ b/src/xrpld/rpc/detail/ServerHandler.cpp
@@ -340,7 +340,7 @@ ServerHandler::onWSMessage(
     if (size > rpc::tuning::kMaxRequestSize || !json::Reader{}.parse(jv, buffers) || !jv.isObject())
     {
         auto const wsInfoSub = std::static_pointer_cast<WSInfoSub>(session->appDefined);
-        wsInfoSub->getConsumer().charge(Resource::kFeeMalformedRpc);
+        wsInfoSub->getConsumer().charge(resource::kFeeMalformedRpc);
 
         json::Value jvResult(json::ValueType::Object);
         jvResult[jss::type] = jss::error;

--- a/src/xrpld/rpc/detail/ServerHandler.cpp
+++ b/src/xrpld/rpc/detail/ServerHandler.cpp
@@ -339,6 +339,9 @@ ServerHandler::onWSMessage(
     auto const size = boost::asio::buffer_size(buffers);
     if (size > rpc::tuning::kMaxRequestSize || !json::Reader{}.parse(jv, buffers) || !jv.isObject())
     {
+        auto const wsInfoSub = std::static_pointer_cast<WSInfoSub>(session->appDefined);
+        wsInfoSub->getConsumer().charge(Resource::kFeeMalformedRpc);
+
         json::Value jvResult(json::ValueType::Object);
         jvResult[jss::type] = jss::error;
         jvResult[jss::error] = "jsonInvalid";


### PR DESCRIPTION
## High Level Overview of Change

Charges `Resource::feeMalformedRPC` when a WebSocket message fails JSON parsing, exceeds `RPC::Tuning::kMaxRequestSize`, or does not parse to a JSON object.

Fixes #7505

### Context of Change

Malformed WebSocket messages are handled directly in `ServerHandler::onWSMessage`. Before this change, those messages returned a `jsonInvalid` error immediately and never reached `processSession`, where normal WebSocket request resource charging occurs.

This meant malformed WebSocket traffic could consume JSON parsing and error-response work without accumulating resource charges.

This change retrieves the connection’s `WSInfoSub` from `session->appDefined` and charges the associated `Resource::Consumer` with `Resource::feeMalformedRPC` before returning the existing `jsonInvalid` response.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)