### PR TITLE
fix: Charge malformed HTTP parse failures

### DIFF
--- a/src/xrpld/rpc/detail/ServerHandler.cpp
+++ b/src/xrpld/rpc/detail/ServerHandler.cpp
@@ -608,15 +608,20 @@ ServerHandler::processRequest(
     std::string_view user)
 {
     auto rpcJ = app_.getJournal("RPC");
-    Resource::Consumer parseFailureUsage =
-        resourceManager_.newInboundEndpoint(remoteIPAddress, false, forwardedFor);
     json::Value jsonOrig;
     {
         json::Reader reader;
         if ((request.size() > RPC::Tuning::kMaxRequestSize) || !reader.parse(request, jsonOrig) ||
             !jsonOrig || !jsonOrig.isObject())
         {
+            auto const role = requestRole(
+                Role::GUEST, port, json::Value(), remoteIPAddress, user);
+
+            auto parseFailureUsage = requestInboundEndpoint(
+                resourceManager_, remoteIPAddress, role, user, forwardedFor);
+
             parseFailureUsage.charge(Resource::kFeeMalformedRpc);
+
             httpReply(
                 400,
                 "Unable to parse request: " + reader.getFormattedErrorMessages(),

--- a/src/xrpld/rpc/detail/ServerHandler.cpp
+++ b/src/xrpld/rpc/detail/ServerHandler.cpp
@@ -608,13 +608,15 @@ ServerHandler::processRequest(
     std::string_view user)
 {
     auto rpcJ = app_.getJournal("RPC");
-
+    Resource::Consumer parseFailureUsage =
+        resourceManager_.newInboundEndpoint(remoteIPAddress, false, forwardedFor);
     json::Value jsonOrig;
     {
         json::Reader reader;
         if ((request.size() > RPC::Tuning::kMaxRequestSize) || !reader.parse(request, jsonOrig) ||
             !jsonOrig || !jsonOrig.isObject())
         {
+            parseFailureUsage.charge(Resource::kFeeMalformedRpc);
             httpReply(
                 400,
                 "Unable to parse request: " + reader.getFormattedErrorMessages(),


### PR DESCRIPTION
## High Level Overview of Change

Charges malformed HTTP requests that fail before JSON parsing completes.

This creates an IP-based `Resource::Consumer` before the HTTP JSON parse check in `ServerHandler::processRequest`, then charges `Resource::kFeeMalformedRpc` when the request body is oversized, invalid JSON, empty, or not a JSON object.

Fixes #7504

### Context of Change

Previously, HTTP requests that exceeded `RPC::Tuning::kMaxRequestSize` or failed JSON parsing returned `400 Bad Request` before any `Resource::Consumer` was created. As a result, repeated malformed HTTP requests could consume request parsing resources without accumulating resource charges.

The HTTP request path now creates a resource consumer from the remote IP address before the parse-failure return path. The HTTP request path already charges `Resource::kFeeMalformedRpc` for malformed requests after JSON parsing succeeds. This change adds the same charge to requests that fail during the earlier JSON parse check.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)