### PR TITLE
refactor: Expand AccountSetFlags macro with `account_info` data

### DIFF
--- a/include/xrpl/protocol/TxFlags.h
+++ b/include/xrpl/protocol/TxFlags.h
@@ -414,33 +414,40 @@ inline constexpr FlagValue tfWithdrawSubTx = tfLPToken | tfSingleAsset | tfTwoAs
 inline constexpr FlagValue tfDepositSubTx =
     tfLPToken | tfSingleAsset | tfTwoAsset | tfOneAssetLPToken | tfLimitLPToken | tfTwoAssetIfEmpty;
 
-#pragma push_macro("ACCOUNTSET_FLAGS")
+// AccountSet SetFlag/ClearFlag values.
+// Format: ASF_FLAG(name, asf_value, lsf_value)
+//   lsf_value is 0 when there is no corresponding ledger-state flag:
+//   - asfAccountTxnID, asfAuthorizedNFTokenMinter: stored as account fields, not flags
+//   - asfAllowTrustLineLocking: has an lsf but is feature-gated (featureTokenEscrow);
+//     callers that need it must handle it separately
+// The JSON key for account_info's account_flags is derived from the name by
+// stripping the "asf" prefix and lowercasing the first character.
+// clang-format off
+#define ACCOUNTSET_FLAGS(ASF_FLAG)                                                         \
+    ASF_FLAG(asfRequireDestinationTag,    1,  lsfRequireDestTag)                           \
+    ASF_FLAG(asfRequireAuthorization,     2,  lsfRequireAuth)                              \
+    ASF_FLAG(asfDisallowIncomingXRP,      3,  lsfDisallowXRP)                              \
+    ASF_FLAG(asfDisableMasterKey,         4,  lsfDisableMaster)                            \
+    ASF_FLAG(asfAccountTxnID,            5,  0) /* no lsf: stored as field */              \
+    ASF_FLAG(asfNoFreeze,                6,  lsfNoFreeze)                                  \
+    ASF_FLAG(asfGlobalFreeze,            7,  lsfGlobalFreeze)                              \
+    ASF_FLAG(asfDefaultRipple,           8,  lsfDefaultRipple)                             \
+    ASF_FLAG(asfDepositAuth,             9,  lsfDepositAuth)                               \
+    ASF_FLAG(asfAuthorizedNFTokenMinter, 10, 0) /* no lsf: stored as field */              \
+    /*  11 is unused */                                                                    \
+    ASF_FLAG(asfDisallowIncomingNFTokenOffer, 12, lsfDisallowIncomingNFTokenOffer)         \
+    ASF_FLAG(asfDisallowIncomingCheck,   13, lsfDisallowIncomingCheck)                     \
+    ASF_FLAG(asfDisallowIncomingPayChan, 14, lsfDisallowIncomingPayChan)                   \
+    ASF_FLAG(asfDisallowIncomingTrustline, 15, lsfDisallowIncomingTrustline)               \
+    ASF_FLAG(asfAllowTrustLineClawback,  16, lsfAllowTrustLineClawback)                    \
+    ASF_FLAG(asfAllowTrustLineLocking,   17, 0) /* feature-gated: featureTokenEscrow */
+// clang-format on
+
 #pragma push_macro("ACCOUNTSET_FLAG_TO_VALUE")
 #pragma push_macro("ACCOUNTSET_FLAG_TO_MAP")
 
-// AccountSet SetFlag/ClearFlag values
-#define ACCOUNTSET_FLAGS(ASF_FLAG)                \
-    ASF_FLAG(asfRequireDest, 1)                   \
-    ASF_FLAG(asfRequireAuth, 2)                   \
-    ASF_FLAG(asfDisallowXRP, 3)                   \
-    ASF_FLAG(asfDisableMaster, 4)                 \
-    ASF_FLAG(asfAccountTxnID, 5)                  \
-    ASF_FLAG(asfNoFreeze, 6)                      \
-    ASF_FLAG(asfGlobalFreeze, 7)                  \
-    ASF_FLAG(asfDefaultRipple, 8)                 \
-    ASF_FLAG(asfDepositAuth, 9)                   \
-    ASF_FLAG(asfAuthorizedNFTokenMinter, 10)      \
-    /*  11 is reserved for Hooks amendment */     \
-    /* ASF_FLAG(asfTshCollect, 11) */             \
-    ASF_FLAG(asfDisallowIncomingNFTokenOffer, 12) \
-    ASF_FLAG(asfDisallowIncomingCheck, 13)        \
-    ASF_FLAG(asfDisallowIncomingPayChan, 14)      \
-    ASF_FLAG(asfDisallowIncomingTrustline, 15)    \
-    ASF_FLAG(asfAllowTrustLineClawback, 16)       \
-    ASF_FLAG(asfAllowTrustLineLocking, 17)
-
-#define ACCOUNTSET_FLAG_TO_VALUE(name, value) inline constexpr FlagValue name = value;
-#define ACCOUNTSET_FLAG_TO_MAP(name, value) {#name, value},
+#define ACCOUNTSET_FLAG_TO_VALUE(name, value, lsf) inline constexpr FlagValue name = value;
+#define ACCOUNTSET_FLAG_TO_MAP(name, value, lsf) {#name, value},
 
 ACCOUNTSET_FLAGS(ACCOUNTSET_FLAG_TO_VALUE)
 
@@ -454,11 +461,9 @@ getAsfFlagMap()
 
 #undef ACCOUNTSET_FLAG_TO_VALUE
 #undef ACCOUNTSET_FLAG_TO_MAP
-#undef ACCOUNTSET_FLAGS
 
 #pragma pop_macro("ACCOUNTSET_FLAG_TO_VALUE")
 #pragma pop_macro("ACCOUNTSET_FLAG_TO_MAP")
-#pragma pop_macro("ACCOUNTSET_FLAGS")
 
 // Sponsor flags (spf)
 

--- a/src/libxrpl/tx/Transactor.cpp
+++ b/src/libxrpl/tx/Transactor.cpp
@@ -1139,7 +1139,7 @@ Transactor::checkMultiSign(
         //      A. signingAcctID == signingAcctIDFromPubKey, and signingAcctID
         //         is in the ledger.
         //      B. If the signingAcctID in the ledger does not have the
-        //         asfDisableMaster flag set, then the signature is allowed.
+        //         asfDisableMasterKey flag set, then the signature is allowed.
         //
         //   3. "Regular Key"
         //      A. signingAcctID != signingAcctIDFromPubKey, and signingAcctID
@@ -1158,7 +1158,7 @@ Transactor::checkMultiSign(
             // Either Phantom or Master.  Phantoms automatically pass.
             if (sleTxSignerRoot)
             {
-                // Master Key.  Account may not have asfDisableMaster set.
+                // Master Key.  Account may not have asfDisableMasterKey set.
                 std::uint32_t const signerAccountFlags = sleTxSignerRoot->getFieldU32(sfFlags);
 
                 if ((signerAccountFlags & lsfDisableMaster) != 0u)

--- a/src/libxrpl/tx/transactors/account/AccountSet.cpp
+++ b/src/libxrpl/tx/transactors/account/AccountSet.cpp
@@ -38,12 +38,12 @@ AccountSet::makeTxConsequences(PreflightContext const& ctx)
             return TxConsequences::Category::Blocker;
 
         if (auto const uSetFlag = tx[~sfSetFlag]; uSetFlag &&
-            (*uSetFlag == asfRequireAuth || *uSetFlag == asfDisableMaster ||
+            (*uSetFlag == asfRequireAuthorization || *uSetFlag == asfDisableMasterKey ||
              *uSetFlag == asfAccountTxnID))
             return TxConsequences::Category::Blocker;
 
         if (auto const uClearFlag = tx[~sfClearFlag]; uClearFlag &&
-            (*uClearFlag == asfRequireAuth || *uClearFlag == asfDisableMaster ||
+            (*uClearFlag == asfRequireAuthorization || *uClearFlag == asfDisableMasterKey ||
              *uClearFlag == asfAccountTxnID))
             return TxConsequences::Category::Blocker;
 
@@ -77,8 +77,9 @@ AccountSet::preflight(PreflightContext const& ctx)
     //
     // RequireAuth
     //
-    bool const bSetRequireAuth = tx.isFlag(tfRequireAuth) || (uSetFlag == asfRequireAuth);
-    bool const bClearRequireAuth = tx.isFlag(tfOptionalAuth) || (uClearFlag == asfRequireAuth);
+    bool const bSetRequireAuth = tx.isFlag(tfRequireAuth) || (uSetFlag == asfRequireAuthorization);
+    bool const bClearRequireAuth =
+        tx.isFlag(tfOptionalAuth) || (uClearFlag == asfRequireAuthorization);
 
     if (bSetRequireAuth && bClearRequireAuth)
     {
@@ -89,8 +90,10 @@ AccountSet::preflight(PreflightContext const& ctx)
     //
     // RequireDestTag
     //
-    bool const bSetRequireDest = tx.isFlag(tfRequireDestTag) || (uSetFlag == asfRequireDest);
-    bool const bClearRequireDest = tx.isFlag(tfOptionalDestTag) || (uClearFlag == asfRequireDest);
+    bool const bSetRequireDest =
+        tx.isFlag(tfRequireDestTag) || (uSetFlag == asfRequireDestinationTag);
+    bool const bClearRequireDest =
+        tx.isFlag(tfOptionalDestTag) || (uClearFlag == asfRequireDestinationTag);
 
     if (bSetRequireDest && bClearRequireDest)
     {
@@ -101,8 +104,8 @@ AccountSet::preflight(PreflightContext const& ctx)
     //
     // DisallowXRP
     //
-    bool const bSetDisallowXRP = tx.isFlag(tfDisallowXRP) || (uSetFlag == asfDisallowXRP);
-    bool const bClearDisallowXRP = tx.isFlag(tfAllowXRP) || (uClearFlag == asfDisallowXRP);
+    bool const bSetDisallowXRP = tx.isFlag(tfDisallowXRP) || (uSetFlag == asfDisallowIncomingXRP);
+    bool const bClearDisallowXRP = tx.isFlag(tfAllowXRP) || (uClearFlag == asfDisallowIncomingXRP);
 
     if (bSetDisallowXRP && bClearDisallowXRP)
     {
@@ -177,7 +180,8 @@ AccountSet::preclaim(PreclaimContext const& ctx)
     std::uint32_t const uSetFlag = ctx.tx.getFieldU32(sfSetFlag);
 
     // legacy AccountSet flags
-    bool const bSetRequireAuth = ctx.tx.isFlag(tfRequireAuth) || (uSetFlag == asfRequireAuth);
+    bool const bSetRequireAuth =
+        ctx.tx.isFlag(tfRequireAuth) || (uSetFlag == asfRequireAuthorization);
 
     //
     // RequireAuth
@@ -236,12 +240,15 @@ AccountSet::doApply()
     std::uint32_t const uClearFlag{tx.getFieldU32(sfClearFlag)};
 
     // legacy AccountSet flags
-    bool const bSetRequireDest{tx.isFlag(tfRequireDestTag) || (uSetFlag == asfRequireDest)};
-    bool const bClearRequireDest{tx.isFlag(tfOptionalDestTag) || (uClearFlag == asfRequireDest)};
-    bool const bSetRequireAuth{tx.isFlag(tfRequireAuth) || (uSetFlag == asfRequireAuth)};
-    bool const bClearRequireAuth{tx.isFlag(tfOptionalAuth) || (uClearFlag == asfRequireAuth)};
-    bool const bSetDisallowXRP{tx.isFlag(tfDisallowXRP) || (uSetFlag == asfDisallowXRP)};
-    bool const bClearDisallowXRP{tx.isFlag(tfAllowXRP) || (uClearFlag == asfDisallowXRP)};
+    bool const bSetRequireDest{
+        tx.isFlag(tfRequireDestTag) || (uSetFlag == asfRequireDestinationTag)};
+    bool const bClearRequireDest{
+        tx.isFlag(tfOptionalDestTag) || (uClearFlag == asfRequireDestinationTag)};
+    bool const bSetRequireAuth{tx.isFlag(tfRequireAuth) || (uSetFlag == asfRequireAuthorization)};
+    bool const bClearRequireAuth{
+        tx.isFlag(tfOptionalAuth) || (uClearFlag == asfRequireAuthorization)};
+    bool const bSetDisallowXRP{tx.isFlag(tfDisallowXRP) || (uSetFlag == asfDisallowIncomingXRP)};
+    bool const bClearDisallowXRP{tx.isFlag(tfAllowXRP) || (uClearFlag == asfDisallowIncomingXRP)};
 
     bool const sigWithMaster{[&tx, &acct = accountID_]() {
         auto const spk = tx.getSigningPubKey();
@@ -304,7 +311,7 @@ AccountSet::doApply()
     //
     // DisableMaster
     //
-    if ((uSetFlag == asfDisableMaster) && !sle->isFlag(lsfDisableMaster))
+    if ((uSetFlag == asfDisableMasterKey) && !sle->isFlag(lsfDisableMaster))
     {
         if (!sigWithMaster)
         {
@@ -322,7 +329,7 @@ AccountSet::doApply()
         uFlagsOut |= lsfDisableMaster;
     }
 
-    if ((uClearFlag == asfDisableMaster) && sle->isFlag(lsfDisableMaster))
+    if ((uClearFlag == asfDisableMasterKey) && sle->isFlag(lsfDisableMaster))
     {
         JLOG(j_.trace()) << "Clear lsfDisableMaster.";
         uFlagsOut &= ~lsfDisableMaster;

--- a/src/test/app/AMMExtendedMPT_test.cpp
+++ b/src/test/app/AMMExtendedMPT_test.cpp
@@ -3333,7 +3333,7 @@ private:
         // alice uses a regular key with the master disabled.
         Account const alie{"alie", KeyType::Secp256k1};
         env(regkey(alice, alie));
-        env(fset(alice, asfDisableMaster), Sig(alice));
+        env(fset(alice, asfDisableMasterKey), Sig(alice));
 
         // Attach signers to alice.
         env(signers(alice, 2, {{becky, 1}, {bogie, 1}}), Sig(alie));

--- a/src/test/app/AMMExtended_test.cpp
+++ b/src/test/app/AMMExtended_test.cpp
@@ -1252,7 +1252,7 @@ private:
         env.close();
 
         // GW requires authorization for holders of its IOUs
-        env(fset(gw_, asfRequireAuth));
+        env(fset(gw_, asfRequireAuthorization));
         env.close();
 
         // Properly set trust and have gw_ authorize bob_ and alice_
@@ -1301,7 +1301,7 @@ private:
             AMM const ammAlice(env, alice_, USD(1'000), XRP(1'000), Ter(tecUNFUNDED_AMM));
         }
 
-        env(fset(gw_, asfRequireAuth));
+        env(fset(gw_, asfRequireAuthorization));
         env.close();
 
         env(trust(gw_, bob_["USD"](50)), Txflags(tfSetfAuth));
@@ -3319,7 +3319,7 @@ private:
         // alice_ uses a regular key with the master disabled.
         Account const alie{"alie", KeyType::Secp256k1};
         env(regkey(alice, alie));
-        env(fset(alice, asfDisableMaster), Sig(alice));
+        env(fset(alice, asfDisableMasterKey), Sig(alice));
 
         // Attach signers to alice_.
         env(signers(alice, 2, {{becky, 1}, {bogie, 1}}), Sig(alie));

--- a/src/test/app/AMMMPT_test.cpp
+++ b/src/test/app/AMMMPT_test.cpp
@@ -121,7 +121,7 @@ private:
             Env env{*this};
             env.fund(XRP(30'000), gw_, alice_);
             env.close();
-            env(fset(gw_, asfRequireAuth));
+            env(fset(gw_, asfRequireAuthorization));
             env(trust(alice_, gw_["USD"](30'000), 0));
             env(trust(gw_, alice_["USD"](0), tfSetfAuth));
             env(pay(gw_, alice_, USD(10'000)));
@@ -328,7 +328,7 @@ private:
             Env env{*this};
             env.fund(XRP(30'000), gw_, alice_);
             env.close();
-            env(fset(gw_, asfRequireAuth));
+            env(fset(gw_, asfRequireAuthorization));
             env(trust(alice_, gw_["USD"](30'000), 0));
             env(trust(gw_, alice_["USD"](0), tfSetfAuth));
             env.close();

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -149,7 +149,7 @@ private:
             Env env{*this};
             env.fund(XRP(30'000), gw_, alice_);
             env.close();
-            env(fset(gw_, asfRequireAuth));
+            env(fset(gw_, asfRequireAuthorization));
             env(trust(alice_, gw_["USD"](30'000), 0));
             env(trust(gw_, alice_["USD"](0), tfSetfAuth));
             env.close();
@@ -322,7 +322,7 @@ private:
             Env env{*this};
             env.fund(XRP(30'000), gw_, alice_);
             env.close();
-            env(fset(gw_, asfRequireAuth));
+            env(fset(gw_, asfRequireAuthorization));
             env.close();
             env(trust(gw_, alice_["USD"](30'000)));
             env.close();
@@ -869,7 +869,7 @@ private:
         {
             Env env(*this, features);
             env.fund(XRP(1000), gw_, alice_, bob_);
-            env(fset(gw_, asfRequireAuth));
+            env(fset(gw_, asfRequireAuthorization));
             env.close();
             env(trust(gw_, alice_["USD"](100)), Txflags(tfSetfAuth));
             env(trust(alice_, gw_["USD"](20)));
@@ -1503,7 +1503,7 @@ private:
             Env env{*this};
             env.fund(XRP(30'000), gw_, alice_, bob_);
             env.close();
-            env(fset(gw_, asfRequireAuth));
+            env(fset(gw_, asfRequireAuthorization));
             env.close();
             env(trust(alice_, gw_["USD"](30'000), 0));
             env(trust(gw_, alice_["USD"](0), tfSetfAuth));

--- a/src/test/app/AccountDelete_test.cpp
+++ b/src/test/app/AccountDelete_test.cpp
@@ -708,7 +708,7 @@ public:
         env(fset(alice, asfDepositAuth));
 
         // carol requires a destination tag.
-        env(fset(carol, asfRequireDest));
+        env(fset(carol, asfRequireDestinationTag));
         env.close();
 
         // Close enough ledgers to be able to delete becky's account.

--- a/src/test/app/AccountSet_test.cpp
+++ b/src/test/app/AccountSet_test.cpp
@@ -79,7 +79,7 @@ public:
         env.fund(XRP(10000), noripple(alice));
 
         // Give alice a regular key so she can legally set and clear
-        // her asfDisableMaster flag.
+        // her asfDisableMasterKey flag.
         Account const alie{"alie", KeyType::Secp256k1};
         env(regkey(alice, alie));
         env.close();
@@ -151,11 +151,11 @@ public:
             }
         };
         testFlags(
-            {asfRequireDest,
-             asfRequireAuth,
-             asfDisallowXRP,
+            {asfRequireDestinationTag,
+             asfRequireAuthorization,
+             asfDisallowIncomingXRP,
              asfGlobalFreeze,
-             asfDisableMaster,
+             asfDisableMasterKey,
              asfDefaultRipple,
              asfDepositAuth});
     }
@@ -481,35 +481,35 @@ public:
         Account const alice("alice");
         env.fund(XRP(10000), alice);
 
-        auto jt = fset(alice, asfDisallowXRP);
-        jt[jss::ClearFlag] = asfDisallowXRP;
+        auto jt = fset(alice, asfDisallowIncomingXRP);
+        jt[jss::ClearFlag] = asfDisallowIncomingXRP;
         env(jt, Ter(temINVALID_FLAG));
 
-        jt = fset(alice, asfRequireAuth);
-        jt[jss::ClearFlag] = asfRequireAuth;
+        jt = fset(alice, asfRequireAuthorization);
+        jt[jss::ClearFlag] = asfRequireAuthorization;
         env(jt, Ter(temINVALID_FLAG));
 
-        jt = fset(alice, asfRequireDest);
-        jt[jss::ClearFlag] = asfRequireDest;
+        jt = fset(alice, asfRequireDestinationTag);
+        jt[jss::ClearFlag] = asfRequireDestinationTag;
         env(jt, Ter(temINVALID_FLAG));
 
-        jt = fset(alice, asfDisallowXRP);
+        jt = fset(alice, asfDisallowIncomingXRP);
         jt[sfFlags.fieldName] = tfAllowXRP;
         env(jt, Ter(temINVALID_FLAG));
 
-        jt = fset(alice, asfRequireAuth);
+        jt = fset(alice, asfRequireAuthorization);
         jt[sfFlags.fieldName] = tfOptionalAuth;
         env(jt, Ter(temINVALID_FLAG));
 
-        jt = fset(alice, asfRequireDest);
+        jt = fset(alice, asfRequireDestinationTag);
         jt[sfFlags.fieldName] = tfOptionalDestTag;
         env(jt, Ter(temINVALID_FLAG));
 
-        jt = fset(alice, asfRequireDest);
+        jt = fset(alice, asfRequireDestinationTag);
         jt[sfFlags.fieldName] = tfAccountSetMask;
         env(jt, Ter(temINVALID_FLAG));
 
-        env(fset(alice, asfDisableMaster), Sig(alice), Ter(tecNO_ALTERNATIVE_KEY));
+        env(fset(alice, asfDisableMasterKey), Sig(alice), Ter(tecNO_ALTERNATIVE_KEY));
     }
 
     void
@@ -533,14 +533,14 @@ public:
         env.close();
         BEAST_EXPECT(!dirIsEmpty(*env.closed(), keylet::ownerDir(alice)));
 
-        env(fset(alice, asfRequireAuth), Ter(tecOWNERS));
+        env(fset(alice, asfRequireAuthorization), Ter(tecOWNERS));
 
-        // Remove the signer list.  After that asfRequireAuth should succeed.
+        // Remove the signer list.  After that asfRequireAuthorization should succeed.
         env(signers(alice, test::jtx::kNone));
         env.close();
         BEAST_EXPECT(dirIsEmpty(*env.closed(), keylet::ownerDir(alice)));
 
-        env(fset(alice, asfRequireAuth));
+        env(fset(alice, asfRequireAuthorization));
     }
 
     void

--- a/src/test/app/Batch_test.cpp
+++ b/src/test/app/Batch_test.cpp
@@ -767,7 +767,7 @@ class Batch_test : public beast::unit_test::Suite
         // tefMASTER_DISABLED: Master key disabled
         {
             env(regkey(elsa, frank));
-            env(fset(elsa, asfDisableMaster), Sig(elsa));
+            env(fset(elsa, asfDisableMasterKey), Sig(elsa));
             auto const seq = env.seq(alice);
             auto const batchFee = batch::calcBatchFee(env, 3, 2);
             env(batch::outer(alice, seq, batchFee, tfAllOrNothing),
@@ -911,7 +911,7 @@ class Batch_test : public beast::unit_test::Suite
         // tefMASTER_DISABLED: Signed With Master Key Disabled
         {
             env(regkey(bob, carol));
-            env(fset(bob, asfDisableMaster), Sig(bob));
+            env(fset(bob, asfDisableMasterKey), Sig(bob));
             auto const seq = env.seq(alice);
             auto const batchFee = batch::calcBatchFee(env, 1, 2);
             env(batch::outer(alice, seq, batchFee, tfAllOrNothing),
@@ -3390,7 +3390,7 @@ class Batch_test : public beast::unit_test::Suite
 
         // failure
         {
-            env(fset(alice, asfRequireDest));
+            env(fset(alice, asfRequireDestinationTag));
             env.close();
 
             auto const aliceSeq = env.seq(alice);
@@ -3406,7 +3406,7 @@ class Batch_test : public beast::unit_test::Suite
                 env,
                 tesSUCCESS,
                 batch::outer(alice, aliceSeq, batchFee, tfIndependent),
-                // tecDST_TAG_NEEDED - alice has enabled asfRequireDest
+                // tecDST_TAG_NEEDED - alice has enabled asfRequireDestinationTag
                 batch::Inner(check::create(bob, alice, usd(10)), bobSeq),
                 batch::Inner(check::cash(alice, chkID, usd(10)), aliceSeq + 1),
                 batch::Sig(bob));
@@ -5328,7 +5328,7 @@ class Batch_test : public beast::unit_test::Suite
             Account const alice{"alice"};
             Account const bob{"bob"};
             env.fund(XRP(10000), gw, alice, bob);
-            env(fset(gw, asfRequireAuth));
+            env(fset(gw, asfRequireAuthorization));
             env.close();
             env(trust(alice, gw["USD"](50)));
             env.close();
@@ -5382,7 +5382,7 @@ class Batch_test : public beast::unit_test::Suite
             Account const alice{"alice"};
             Account const bob{"bob"};
             env.fund(XRP(10000), gw, alice, bob);
-            env(fset(gw, asfRequireAuth));
+            env(fset(gw, asfRequireAuthorization));
             env.close();
             env(trust(alice, gw["USD"](50)));
             env.close();
@@ -5469,7 +5469,7 @@ class Batch_test : public beast::unit_test::Suite
         {
             auto const baseFee = env.current()->fees().base;
             auto const aliceSeq = env.seq(alice);
-            env(fset(bob, asfRequireDest));
+            env(fset(bob, asfRequireDestinationTag));
             auto jtx = env.jt(pay(alice, bob, XRP(1)), Seq(aliceSeq));
 
             Serializer s;

--- a/src/test/app/CheckMPT_test.cpp
+++ b/src/test/app/CheckMPT_test.cpp
@@ -333,7 +333,7 @@ class CheckMPT_test : public beast::unit_test::Suite
         env.close();
 
         // Require destination tag.
-        env(fset(bob, asfRequireDest));
+        env(fset(bob, asfRequireDestinationTag));
         env.close();
 
         env(check::create(alice, bob, usd(50)), Ter(tecDST_TAG_NEEDED));
@@ -342,7 +342,7 @@ class CheckMPT_test : public beast::unit_test::Suite
         env(check::create(alice, bob, usd(50)), DestTag(11));
         env.close();
 
-        env(fclear(bob, asfRequireDest));
+        env(fclear(bob, asfRequireDestinationTag));
         env.close();
         {
             // Globally frozen asset.
@@ -654,7 +654,7 @@ class CheckMPT_test : public beast::unit_test::Suite
             BEAST_EXPECT(ownerCount(env, bob) == 1);
         }
         {
-            // Examine the effects of the asfRequireAuth flag.
+            // Examine the effects of the asfRequireAuthorization flag.
             Env env(*this, features);
 
             env.fund(XRP(1000), gw, alice, bob);
@@ -1052,7 +1052,7 @@ class CheckMPT_test : public beast::unit_test::Suite
         {
             // Set the RequireDest flag on bob's account (after the check
             // was created) then cash a check without a destination tag.
-            env(fset(bob, asfRequireDest));
+            env(fset(bob, asfRequireDestinationTag));
             env.close();
             env(check::cash(bob, chkIdNoDest1, usd(1)), Ter(tecDST_TAG_NEEDED));
             env.close();
@@ -1068,7 +1068,7 @@ class CheckMPT_test : public beast::unit_test::Suite
 
             // Clear the RequireDest flag on bob's account so he can
             // cash the check with no DestinationTag.
-            env(fclear(bob, asfRequireDest));
+            env(fclear(bob, asfRequireDestinationTag));
             env.close();
             env(check::cash(bob, chkIdNoDest1, usd(1)));
             env.close();
@@ -1998,7 +1998,7 @@ class CheckMPT_test : public beast::unit_test::Suite
 
             // Set lsfRequireAuth on gw2.  That should not stop any automatic
             // MPT from being created.
-            env(fset(gw2, asfRequireAuth));
+            env(fset(gw2, asfRequireAuthorization));
             env.close();
 
             // Use offers to automatically create MPT.

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -367,7 +367,7 @@ class Check_test : public beast::unit_test::Suite
         env.close();
 
         // Require destination tag.
-        env(fset(bob, asfRequireDest));
+        env(fset(bob, asfRequireDestinationTag));
         env.close();
 
         env(check::create(alice, bob, usd(50)), Ter(tecDST_TAG_NEEDED));
@@ -376,7 +376,7 @@ class Check_test : public beast::unit_test::Suite
         env(check::create(alice, bob, usd(50)), DestTag(11));
         env.close();
 
-        env(fclear(bob, asfRequireDest));
+        env(fclear(bob, asfRequireDestinationTag));
         env.close();
         {
             // Globally frozen asset.
@@ -835,11 +835,11 @@ class Check_test : public beast::unit_test::Suite
             BEAST_EXPECT(ownerCount(env, bob) == 1);
         }
         {
-            // Examine the effects of the asfRequireAuth flag.
+            // Examine the effects of the asfRequireAuthorization flag.
             Env env(*this, features);
 
             env.fund(XRP(1000), gw, alice, bob);
-            env(fset(gw, asfRequireAuth));
+            env(fset(gw, asfRequireAuthorization));
             env.close();
             env(trust(gw, alice["USD"](100)), Txflags(tfSetfAuth));
             env(trust(alice, usd(20)));
@@ -1492,7 +1492,7 @@ class Check_test : public beast::unit_test::Suite
         {
             // Set the RequireDest flag on bob's account (after the check
             // was created) then cash a check without a destination tag.
-            env(fset(bob, asfRequireDest));
+            env(fset(bob, asfRequireDestinationTag));
             env.close();
             env(check::cash(bob, chkIdNoDest1, usd(1)), Ter(tecDST_TAG_NEEDED));
             env.close();
@@ -1508,7 +1508,7 @@ class Check_test : public beast::unit_test::Suite
 
             // Clear the RequireDest flag on bob's account so he can
             // cash the check with no DestinationTag.
-            env(fclear(bob, asfRequireDest));
+            env(fclear(bob, asfRequireDestinationTag));
             env.close();
             env(check::cash(bob, chkIdNoDest1, usd(1)));
             env.close();
@@ -2378,7 +2378,7 @@ class Check_test : public beast::unit_test::Suite
 
             // Set lsfRequireAuth on gw2.  That should stop any automatic
             // trust lines from being created.
-            env(fset(gw2, asfRequireAuth));
+            env(fset(gw2, asfRequireAuthorization));
             env.close();
 
             // Use offers to automatically create the trust line.

--- a/src/test/app/ConfidentialTransferExtended_test.cpp
+++ b/src/test/app/ConfidentialTransferExtended_test.cpp
@@ -813,7 +813,7 @@ class ConfidentialTransferExtended_test : public ConfidentialTransferTestBase
         auto& mptAlice = confEnv.mpt;
 
         // Set RequireDest on carol
-        env(fset(carol, asfRequireDest));
+        env(fset(carol, asfRequireDestinationTag));
         env.close();
 
         // Send without destination tag — rejected
@@ -840,7 +840,7 @@ class ConfidentialTransferExtended_test : public ConfidentialTransferTestBase
         BEAST_EXPECT(tx->isFieldPresent(sfDestinationTag));
         BEAST_EXPECT((*tx)[sfDestinationTag] == 42);
 
-        env(fclear(carol, asfRequireDest));
+        env(fclear(carol, asfRequireDestinationTag));
         env.close();
 
         // Send without destination tag when not required — succeeds

--- a/src/test/app/ConfidentialTransfer_test.cpp
+++ b/src/test/app/ConfidentialTransfer_test.cpp
@@ -2539,7 +2539,7 @@ class ConfidentialTransfer_test : public ConfidentialTransferTestBase
 
         // destination requires destination tag but none provided
         {
-            env(fset(carol, asfRequireDest));
+            env(fset(carol, asfRequireDestinationTag));
             env.close();
 
             mptAlice.send({
@@ -2555,7 +2555,7 @@ class ConfidentialTransfer_test : public ConfidentialTransferTestBase
                 .err = tecDST_TAG_NEEDED,
             });
 
-            env(fclear(carol, asfRequireDest));
+            env(fclear(carol, asfRequireDestinationTag));
             env.close();
         }
 

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -1518,7 +1518,7 @@ class Delegate_test : public beast::unit_test::Suite
             Account const alice{"alice"};
             Account const bob{"bob"};
             env.fund(XRP(10000), gw, alice, bob);
-            env(fset(gw, asfRequireAuth));
+            env(fset(gw, asfRequireAuthorization));
             env.close();
 
             env(delegate::set(alice, bob, {"TrustlineUnfreeze"}));
@@ -1630,7 +1630,7 @@ class Delegate_test : public beast::unit_test::Suite
             Account const alice{"alice"};
             Account const bob{"bob"};
             env.fund(XRP(10000), gw, alice, bob);
-            env(fset(gw, asfRequireAuth));
+            env(fset(gw, asfRequireAuthorization));
             env.close();
 
             // bob does not have permission
@@ -1675,7 +1675,7 @@ class Delegate_test : public beast::unit_test::Suite
             Account const alice{"alice"};
             Account const bob{"bob"};
             env.fund(XRP(10000), gw, alice, bob);
-            env(fset(gw, asfRequireAuth));
+            env(fset(gw, asfRequireAuthorization));
             env.close();
             env(trust(alice, gw["USD"](50)));
             env.close();
@@ -1693,7 +1693,7 @@ class Delegate_test : public beast::unit_test::Suite
             Account const bob{"bob"};
             env.fund(XRP(10000), gw, alice, bob);
 
-            env(fset(gw, asfRequireAuth));
+            env(fset(gw, asfRequireAuthorization));
             env.close();
             env(trust(alice, gw["USD"](50)));
             env.close();
@@ -1835,18 +1835,22 @@ class Delegate_test : public beast::unit_test::Suite
             env(jt);
             BEAST_EXPECT((*env.le(alice))[sfTickSize] == 8);
 
-            // can not set asfRequireAuth flag for alice
-            env(fset(alice, asfRequireAuth), delegate::As(bob), Ter(terNO_DELEGATE_PERMISSION));
+            // can not set asfRequireAuthorization flag for alice
+            env(fset(alice, asfRequireAuthorization),
+                delegate::As(bob),
+                Ter(terNO_DELEGATE_PERMISSION));
 
             // reset Delegate will delete the Delegate
             // object
             env(delegate::set(alice, bob, {}));
-            // bib still does not have permission to set asfRequireAuth for
+            // bib still does not have permission to set asfRequireAuthorization for
             // alice
-            env(fset(alice, asfRequireAuth), delegate::As(bob), Ter(terNO_DELEGATE_PERMISSION));
+            env(fset(alice, asfRequireAuthorization),
+                delegate::As(bob),
+                Ter(terNO_DELEGATE_PERMISSION));
             // alice can set for herself
-            env(fset(alice, asfRequireAuth));
-            env.require(Flags(alice, asfRequireAuth));
+            env(fset(alice, asfRequireAuthorization));
+            env.require(Flags(alice, asfRequireAuthorization));
             env.close();
 
             // can not update tick size because bob no longer has permission
@@ -1890,7 +1894,7 @@ class Delegate_test : public beast::unit_test::Suite
             };
 
             // testSetClearFlag(asfNoFreeze);
-            testSetClearFlag(asfRequireAuth);
+            testSetClearFlag(asfRequireAuthorization);
             testSetClearFlag(asfAllowTrustLineClawback);
 
             // alice gives some granular permissions to bob
@@ -1904,8 +1908,8 @@ class Delegate_test : public beast::unit_test::Suite
             testSetClearFlag(asfDisallowIncomingNFTokenOffer);
             testSetClearFlag(asfDisallowIncomingPayChan);
             testSetClearFlag(asfDisallowIncomingTrustline);
-            testSetClearFlag(asfDisallowXRP);
-            testSetClearFlag(asfRequireDest);
+            testSetClearFlag(asfDisallowIncomingXRP);
+            testSetClearFlag(asfRequireDestinationTag);
             testSetClearFlag(asfGlobalFreeze);
 
             // bob can not set asfAccountTxnID on behalf of alice
@@ -1936,11 +1940,11 @@ class Delegate_test : public beast::unit_test::Suite
             // alice can not clear on behalf of bob
             env(fclear(alice, asfNoFreeze), delegate::As(bob), Ter(terNO_DELEGATE_PERMISSION));
 
-            // bob can not set asfDisableMaster on behalf of alice
+            // bob can not set asfDisableMasterKey on behalf of alice
             Account const bobKey{"bobKey", KeyType::Secp256k1};
             env(regkey(bob, bobKey));
             env.close();
-            env(fset(alice, asfDisableMaster),
+            env(fset(alice, asfDisableMasterKey),
                 delegate::As(bob),
                 Sig(bob),
                 Ter(terNO_DELEGATE_PERMISSION));
@@ -2683,7 +2687,7 @@ class Delegate_test : public beast::unit_test::Suite
         Account const bob{"bob"};
         env.fund(XRP(10000), gw, alice, bob);
 
-        env(fset(gw, asfRequireAuth));
+        env(fset(gw, asfRequireAuthorization));
         env.close();
         env(trust(alice, gw["USD"](50)));
         env.close();

--- a/src/test/app/EscrowToken_test.cpp
+++ b/src/test/app/EscrowToken_test.cpp
@@ -403,7 +403,7 @@ struct EscrowToken_test : public beast::unit_test::Suite
             auto const usd = gw["USD"];
             env.fund(XRP(5000), alice, bob, gw);
             env(fset(gw, asfAllowTrustLineLocking));
-            env(fset(gw, asfRequireAuth));
+            env(fset(gw, asfRequireAuthorization));
             env.close();
             env.trust(usd(10'000), alice, bob);
             env.close();
@@ -427,7 +427,7 @@ struct EscrowToken_test : public beast::unit_test::Suite
             auto const aliceUSD = alice["USD"];
             env.fund(XRP(5000), alice, bob, gw);
             env(fset(gw, asfAllowTrustLineLocking));
-            env(fset(gw, asfRequireAuth));
+            env(fset(gw, asfRequireAuthorization));
             env.close();
             env(trust(gw, aliceUSD(10'000)), Txflags(tfSetfAuth));
             env.trust(usd(10'000), alice, bob);
@@ -604,7 +604,7 @@ struct EscrowToken_test : public beast::unit_test::Suite
             auto const bobUSD = bob["USD"];
             env.fund(XRP(5000), alice, bob, gw);
             env(fset(gw, asfAllowTrustLineLocking));
-            env(fset(gw, asfRequireAuth));
+            env(fset(gw, asfRequireAuthorization));
             env.close();
             env(trust(gw, aliceUSD(10'000)), Txflags(tfSetfAuth));
             env(trust(gw, bobUSD(10'000)), Txflags(tfSetfAuth));
@@ -854,7 +854,7 @@ struct EscrowToken_test : public beast::unit_test::Suite
             auto const bobUSD = bob["USD"];
             env.fund(XRP(5000), alice, bob, gw);
             env(fset(gw, asfAllowTrustLineLocking));
-            env(fset(gw, asfRequireAuth));
+            env(fset(gw, asfRequireAuthorization));
             env.close();
             env(trust(gw, aliceUSD(10'000)), Txflags(tfSetfAuth));
             env(trust(gw, bobUSD(10'000)), Txflags(tfSetfAuth));
@@ -1827,7 +1827,7 @@ struct EscrowToken_test : public beast::unit_test::Suite
         auto const baseFee = env.current()->fees().base;
         env.fund(XRP(1'000), alice, bob, gw);
         env(fset(gw, asfAllowTrustLineLocking));
-        env(fset(gw, asfRequireAuth));
+        env(fset(gw, asfRequireAuthorization));
         env.close();
         env(trust(gw, aliceUSD(10'000)), Txflags(tfSetfAuth));
         env(trust(alice, usd(10'000)));

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -217,7 +217,7 @@ struct Escrow_test : public beast::unit_test::Suite
 
         // Check to make sure that we correctly detect if tags are really
         // required:
-        env(fset(bob, asfRequireDest));
+        env(fset(bob, asfRequireDestinationTag));
         env(escrow::create(alice, bob, XRP(1000)),
             escrow::kFinishTime(env.now() + 1s),
             Ter(tecDST_TAG_NEEDED));
@@ -253,12 +253,12 @@ struct Escrow_test : public beast::unit_test::Suite
         using namespace std::chrono;
 
         {
-            // Ignore the "asfDisallowXRP" account flag, which we should
+            // Ignore the "asfDisallowIncomingXRP" account flag, which we should
             // have been doing before.
             Env env(*this, features);
 
             env.fund(XRP(5000), "bob", "george");
-            env(fset("george", asfDisallowXRP));
+            env(fset("george", asfDisallowIncomingXRP));
             env(escrow::create("bob", "george", XRP(10)), escrow::kFinishTime(env.now() + 1s));
         }
     }
@@ -393,7 +393,7 @@ struct Escrow_test : public beast::unit_test::Suite
             Ter(temBAD_EXPIRATION));
 
         // Carol now requires the use of a destination tag
-        env(fset("carol", asfRequireDest));
+        env(fset("carol", asfRequireDestinationTag));
 
         // missing destination tag
         env(escrow::create("alice", "carol", XRP(1)),

--- a/src/test/app/LoanBroker_test.cpp
+++ b/src/test/app/LoanBroker_test.cpp
@@ -967,11 +967,11 @@ class LoanBroker_test : public beast::unit_test::Suite
             Account const dest{"dest"};
             env.fund(XRP(1'000), dest);
 
-            env(fset(dest, asfRequireDest));
+            env(fset(dest, asfRequireDestinationTag));
             env(coverWithdraw(alice, brokerKeylet.key, asset(10)),
                 kDestination(dest),
                 Ter(tecDST_TAG_NEEDED));
-            env(fclear(dest, asfRequireDest));
+            env(fclear(dest, asfRequireDestinationTag));
 
             // preclaim: tecNO_PERMISSION
             env(fset(dest, asfDepositAuth));
@@ -2269,7 +2269,7 @@ class LoanBroker_test : public beast::unit_test::Suite
 
             if (trustState == TrustState::RequireAuth)
             {
-                env(fset(issuer, asfRequireAuth));
+                env(fset(issuer, asfRequireAuthorization));
                 env.close();
 
                 setTrustLine(broker, TrustState::RequireAuth);
@@ -2316,7 +2316,7 @@ class LoanBroker_test : public beast::unit_test::Suite
             // Clearing RequireAuth shouldn't change the result
             if (trustState == TrustState::RequireAuth)
             {
-                env(fclear(issuer, asfRequireAuth));
+                env(fclear(issuer, asfRequireAuthorization));
                 env.close();
 
                 env(loanBroker::coverWithdraw(broker, brokerKeylet.key, token(100)),

--- a/src/test/app/Loan_test.cpp
+++ b/src/test/app/Loan_test.cpp
@@ -2942,7 +2942,7 @@ protected:
             env.close();
             if (args.requireAuth)
             {
-                env(fset(issuer, asfRequireAuth));
+                env(fset(issuer, asfRequireAuthorization));
                 env.close();
             }
 

--- a/src/test/app/MultiSign_test.cpp
+++ b/src/test/app/MultiSign_test.cpp
@@ -454,7 +454,7 @@ public:
         env.close();
 
         // Disable cheri's master key to mix things up.
-        env(fset(cheri, asfDisableMaster), Sig(cheri));
+        env(fset(cheri, asfDisableMasterKey), Sig(cheri));
         env.close();
 
         // Attempt a multisigned transaction that meets the quorum.
@@ -518,7 +518,7 @@ public:
         env.close();
 
         // Disable cheri's master key to mix things up.
-        env(fset(cheri, asfDisableMaster), Sig(cheri));
+        env(fset(cheri, asfDisableMasterKey), Sig(cheri));
         env.close();
 
         auto const baseFee = env.current()->fees().base;
@@ -721,7 +721,7 @@ public:
         // alice uses a regular key with the master disabled.
         Account const alie{"alie", KeyType::Secp256k1};
         env(regkey(alice, alie));
-        env(fset(alice, asfDisableMaster), Sig(alice));
+        env(fset(alice, asfDisableMasterKey), Sig(alice));
 
         // becky is master only without a regular key.
 
@@ -732,7 +732,7 @@ public:
         // daria has a regular key and disables her master key.
         Account const dari{"dari", KeyType::Ed25519};
         env(regkey(daria, dari));
-        env(fset(daria, asfDisableMaster), Sig(daria));
+        env(fset(daria, asfDisableMasterKey), Sig(daria));
         env.close();
 
         // Attach signers to alice.
@@ -862,14 +862,14 @@ public:
 
         // Master key tests.
         // M0: A lone master key cannot be disabled.
-        env(fset(alice, asfDisableMaster), Sig(alice), Ter(tecNO_ALTERNATIVE_KEY));
+        env(fset(alice, asfDisableMasterKey), Sig(alice), Ter(tecNO_ALTERNATIVE_KEY));
 
         // Add a regular key.
         Account const alie{"alie", KeyType::Ed25519};
         env(regkey(alice, alie));
 
         // M1: The master key can be disabled if there's a regular key.
-        env(fset(alice, asfDisableMaster), Sig(alice));
+        env(fset(alice, asfDisableMasterKey), Sig(alice));
 
         // R0: A lone regular key cannot be removed.
         env(regkey(alice, kDisabled), Sig(alie), Ter(tecNO_ALTERNATIVE_KEY));
@@ -885,7 +885,7 @@ public:
         env(signers(alice, jtx::kNone), Msig(bogie_), Fee(2 * baseFee), Ter(tecNO_ALTERNATIVE_KEY));
 
         // Enable the master key.
-        env(fclear(alice, asfDisableMaster), Msig(bogie_), Fee(2 * baseFee));
+        env(fclear(alice, asfDisableMasterKey), Msig(bogie_), Fee(2 * baseFee));
 
         // L1: The signer list can be removed if the master key is enabled.
         env(signers(alice, jtx::kNone), Msig(bogie_), Fee(2 * baseFee));
@@ -894,7 +894,7 @@ public:
         env(signers(alice, 1, {{bogie_, 1}}), Sig(alice));
 
         // M2: The master key can be disabled if there's a signer list.
-        env(fset(alice, asfDisableMaster), Sig(alice));
+        env(fset(alice, asfDisableMasterKey), Sig(alice));
 
         // Add a regular key.
         env(regkey(alice, alie), Msig(bogie_), Fee(2 * baseFee));
@@ -903,7 +903,7 @@ public:
         env(signers(alice, jtx::kNone), Sig(alie));
 
         // Enable the master key.
-        env(fclear(alice, asfDisableMaster), Sig(alie));
+        env(fclear(alice, asfDisableMasterKey), Sig(alie));
 
         // R2: The regular key can be removed if the master key is enabled.
         env(regkey(alice, kDisabled), Sig(alie));
@@ -966,7 +966,7 @@ public:
         // alice uses a regular key with the master disabled.
         Account const alie{"alie", KeyType::Secp256k1};
         env(regkey(alice, alie));
-        env(fset(alice, asfDisableMaster), Sig(alice));
+        env(fset(alice, asfDisableMasterKey), Sig(alice));
 
         // Attach signers to alice.
         env(signers(alice, 2, {{becky, 1}, {bogie_, 1}}), Sig(alie));
@@ -1261,7 +1261,7 @@ public:
         env.close();
 
         // Now becky disables her master key.
-        env(fset(becky, asfDisableMaster));
+        env(fset(becky, asfDisableMasterKey));
         env.close();
 
         // Since becky's master key is disabled she can no longer

--- a/src/test/app/NFTokenAuth_test.cpp
+++ b/src/test/app/NFTokenAuth_test.cpp
@@ -64,7 +64,7 @@ public:
         auto const usd{g1["USD"]};
 
         env.fund(XRP(10000), g1, a1, a2);
-        env(fset(g1, asfRequireAuth));
+        env(fset(g1, asfRequireAuthorization));
         env.close();
 
         auto const limit = usd(10000);
@@ -117,7 +117,7 @@ public:
         auto const usd{g1["USD"]};
 
         env.fund(XRP(10000), g1, a1, a2);
-        env(fset(g1, asfRequireAuth));
+        env(fset(g1, asfRequireAuthorization));
         env.close();
 
         auto const [nftID, _] = mintAndOfferNFT(env, a2, drops(1));
@@ -163,7 +163,7 @@ public:
         auto const usd{g1["USD"]};
 
         env.fund(XRP(10000), g1, a1, a2);
-        env(fset(g1, asfRequireAuth));
+        env(fset(g1, asfRequireAuthorization));
         env.close();
 
         auto const limit = usd(10000);
@@ -221,7 +221,7 @@ public:
         auto const usd{g1["USD"]};
 
         env.fund(XRP(10000), g1, a1, a2);
-        env(fset(g1, asfRequireAuth));
+        env(fset(g1, asfRequireAuthorization));
         env.close();
 
         auto const limit = usd(10000);
@@ -296,7 +296,7 @@ public:
         auto const usd{g1["USD"]};
 
         env.fund(XRP(10000), g1, a1, a2);
-        env(fset(g1, asfRequireAuth));
+        env(fset(g1, asfRequireAuthorization));
         env.close();
 
         auto const limit = usd(10000);
@@ -339,7 +339,7 @@ public:
         auto const usd{g1["USD"]};
 
         env.fund(XRP(10000), g1, a1, a2, broker);
-        env(fset(g1, asfRequireAuth));
+        env(fset(g1, asfRequireAuthorization));
         env.close();
 
         auto const limit = usd(10000);
@@ -405,7 +405,7 @@ public:
         auto const usd{g1["USD"]};
 
         env.fund(XRP(10000), g1, a1, a2, broker);
-        env(fset(g1, asfRequireAuth));
+        env(fset(g1, asfRequireAuthorization));
         env.close();
 
         auto const limit = usd(10000);
@@ -465,7 +465,7 @@ public:
         auto const usd{g1["USD"]};
 
         env.fund(XRP(10000), g1, a1, a2, broker);
-        env(fset(g1, asfRequireAuth));
+        env(fset(g1, asfRequireAuthorization));
         env.close();
 
         auto const limit = usd(10000);
@@ -539,7 +539,7 @@ public:
         auto const usd{g1["USD"]};
 
         env.fund(XRP(10000), g1, minter, a1, a2);
-        env(fset(g1, asfRequireAuth));
+        env(fset(g1, asfRequireAuthorization));
         env.close();
 
         auto const limit = usd(10000);

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -4172,7 +4172,7 @@ public:
         env.close();
 
         // GW requires authorization for holders of its IOUs
-        env(fset(gw, asfRequireAuth));
+        env(fset(gw, asfRequireAuthorization));
         env.close();
 
         // Properly set trust and have gw authorize bob and alice
@@ -4244,7 +4244,7 @@ public:
 
         env.require(offers(alice, 1));
         env.require(Balance(alice, gwUSD(kNone)));
-        env(fset(gw, asfRequireAuth));
+        env(fset(gw, asfRequireAuthorization));
         env.close();
 
         env(trust(gw, bobUSD(100)), Txflags(tfSetfAuth));
@@ -4354,7 +4354,7 @@ public:
         // Cold wallets require trust but will ripple by default
         for (auto const& cold : {coldUS, coldEU})
         {
-            env(fset(cold, asfRequireAuth));
+            env(fset(cold, asfRequireAuthorization));
             env(fset(cold, asfDefaultRipple));
         }
         env.close();
@@ -4432,7 +4432,7 @@ public:
         env.require(offers(gw, 1));
 
         // Since gw has an offer out, gw should not be able to set RequireAuth.
-        env(fset(gw, asfRequireAuth), Ter(tecOWNERS));
+        env(fset(gw, asfRequireAuthorization), Ter(tecOWNERS));
         env.close();
 
         // Cancel gw's offer so we can set RequireAuth.
@@ -4441,7 +4441,7 @@ public:
         env.require(offers(gw, 0));
 
         // gw now requires authorization for holders of its IOUs
-        env(fset(gw, asfRequireAuth));
+        env(fset(gw, asfRequireAuthorization));
         env.close();
 
         // Before DepositPreauth an account with lsfRequireAuth set could not

--- a/src/test/app/Oracle_test.cpp
+++ b/src/test/app/Oracle_test.cpp
@@ -713,7 +713,7 @@ private:
         // alice uses a regular key with the master disabled.
         Account const alie{"alie", KeyType::Secp256k1};
         env(regkey(alice, alie));
-        env(fset(alice, asfDisableMaster), Sig(alice));
+        env(fset(alice, asfDisableMasterKey), Sig(alice));
 
         // Attach signers to alice.
         env(signers(alice, 2, {{becky, 1}, {bogie, 1}, {ed, 2}}), Sig(alie));

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -634,7 +634,7 @@ struct PayChan_test : public beast::unit_test::Suite
             // since it's just advisory.
             Env env{*this, features};
             env.fund(XRP(10000), alice, bob);
-            env(fset(bob, asfDisallowXRP));
+            env(fset(bob, asfDisallowIncomingXRP));
             auto const chan = channel(alice, bob, env.seq(alice));
             env(create(alice, bob, XRP(1000), 3600s, alice.pk()));
             BEAST_EXPECT(channelExists(*env.current(), chan));
@@ -650,7 +650,7 @@ struct PayChan_test : public beast::unit_test::Suite
             env(create(alice, bob, XRP(1000), 3600s, alice.pk()));
             BEAST_EXPECT(channelExists(*env.current(), chan));
 
-            env(fset(bob, asfDisallowXRP));
+            env(fset(bob, asfDisallowIncomingXRP));
             auto const reqBal = XRP(500).value();
             env(claim(alice, chan, reqBal, reqBal));
         }
@@ -668,7 +668,7 @@ struct PayChan_test : public beast::unit_test::Suite
         auto const alice = Account("alice");
         auto const bob = Account("bob");
         env.fund(XRP(10000), alice, bob);
-        env(fset(bob, asfRequireDest));
+        env(fset(bob, asfRequireDestinationTag));
         auto const pk = alice.pk();
         auto const settleDelay = 3600s;
         auto const channelFunds = XRP(1000);

--- a/src/test/app/PayStrand_test.cpp
+++ b/src/test/app/PayStrand_test.cpp
@@ -859,7 +859,7 @@ struct PayStrand_test : public beast::unit_test::Suite
             // issuer
             Env env(*this, features);
             env.fund(XRP(10000), alice, bob, gw);
-            env(fset(gw, asfRequireAuth));
+            env(fset(gw, asfRequireAuthorization));
             env.trust(usd(1000), alice, bob);
             // Authorize alice but not bob
             env(trust(gw, alice["USD"](1000), tfSetfAuth));

--- a/src/test/app/SetAuth_test.cpp
+++ b/src/test/app/SetAuth_test.cpp
@@ -48,7 +48,7 @@ struct SetAuth_test : public beast::unit_test::Suite
         Env env(*this);
 
         env.fund(XRP(100000), "alice", "bob", gw);
-        env(fset(gw, asfRequireAuth));
+        env(fset(gw, asfRequireAuthorization));
         env.close();
         env(auth(gw, "alice", "USD"));
         BEAST_EXPECT(env.le(keylet::trustLine(Account("alice").id(), gw.id(), usd.currency)));

--- a/src/test/app/SetRegularKey_test.cpp
+++ b/src/test/app/SetRegularKey_test.cpp
@@ -42,14 +42,14 @@ public:
         env(noop(alice), Sig(alice));
 
         testcase("Disable master key");
-        env(fset(alice, asfDisableMaster), Sig(alice));
+        env(fset(alice, asfDisableMasterKey), Sig(alice));
         env(noop(alice), Sig(bob));
         env(noop(alice), Sig(alice), Ter(tefMASTER_DISABLED));
 
         testcase("Re-enable master key");
-        env(fclear(alice, asfDisableMaster), Sig(alice), Ter(tefMASTER_DISABLED));
+        env(fclear(alice, asfDisableMasterKey), Sig(alice), Ter(tefMASTER_DISABLED));
 
-        env(fclear(alice, asfDisableMaster), Sig(bob));
+        env(fclear(alice, asfDisableMasterKey), Sig(bob));
         env(noop(alice), Sig(bob));
         env(noop(alice), Sig(alice));
 
@@ -84,7 +84,7 @@ public:
         env.fund(XRP(10000), alice);
 
         env(regkey(alice, bob));
-        env(fset(alice, asfDisableMaster), Sig(alice));
+        env(fset(alice, asfDisableMasterKey), Sig(alice));
 
         env(regkey(alice, kDisabled), Sig(bob), Ter(tecNO_ALTERNATIVE_KEY));
 
@@ -159,7 +159,7 @@ public:
         env.close();
 
         // Disable alice's master key using a ticket.
-        env(fset(alice, asfDisableMaster), Sig(alice), ticket::Use(--ticketSeq));
+        env(fset(alice, asfDisableMasterKey), Sig(alice), ticket::Use(--ticketSeq));
         env.close();
 
         // alice should be able to sign using the regular key but not the
@@ -171,7 +171,7 @@ public:
         BEAST_EXPECT(env.seq(alice) == aliceSeq + 1);
 
         // Re-enable the master key using a ticket.
-        env(fclear(alice, asfDisableMaster), Sig(alie), ticket::Use(--ticketSeq));
+        env(fclear(alice, asfDisableMasterKey), Sig(alie), ticket::Use(--ticketSeq));
         env.close();
 
         // Disable the regular key using a ticket.

--- a/src/test/app/TrustSet_test.cpp
+++ b/src/test/app/TrustSet_test.cpp
@@ -114,7 +114,7 @@ public:
         env.close();
 
         // alice wants to ensure that all holders of her tokens are authorised
-        env(fset(alice, asfRequireAuth));
+        env(fset(alice, asfRequireAuthorization));
         env.close();
 
         // becky wants to hold at most 50 tokens of alice["USD"]
@@ -375,7 +375,7 @@ public:
         env.fund(XRP(10000), bob, alice);
 
         // alice wants to ensure that all holders of her tokens are authorised
-        env(fset(alice, asfRequireAuth));
+        env(fset(alice, asfRequireAuthorization));
         env.close();
 
         // create a trust line from bob to alice. bob wants to hold at most
@@ -490,7 +490,7 @@ public:
         env.fund(XRP(1000), gw, dist);
         env.close();
 
-        env(fset(gw, asfRequireAuth));
+        env(fset(gw, asfRequireAuthorization));
         env.close();
 
         env(fset(dist, asfDisallowIncomingTrustline));

--- a/src/test/app/Vault_test.cpp
+++ b/src/test/app/Vault_test.cpp
@@ -549,11 +549,11 @@ class Vault_test : public beast::unit_test::Suite
             env.fund(XRP(1000), issuer, owner, depositor, charlie, dave);
             env.close();
             env(fset(issuer, asfAllowTrustLineClawback));
-            env(fset(issuer, asfRequireAuth));
-            env(fset(dave, asfRequireDest));
+            env(fset(issuer, asfRequireAuthorization));
+            env(fset(dave, asfRequireDestinationTag));
             env.close();
             env.require(Flags(issuer, asfAllowTrustLineClawback));
-            env.require(Flags(issuer, asfRequireAuth));
+            env.require(Flags(issuer, asfRequireAuthorization));
 
             PrettyAsset const asset = setup(env);
             testSequence(prefix, env, vault, asset);
@@ -615,7 +615,7 @@ class Vault_test : public beast::unit_test::Suite
             env.close();
 
             env(fset(issuer, asfAllowTrustLineClawback));
-            env(fset(issuer, asfRequireAuth));
+            env(fset(issuer, asfRequireAuthorization));
             env.close();
 
             PrettyAsset const asset = issuer["IOU"];

--- a/src/test/app/XChain_test.cpp
+++ b/src/test/app/XChain_test.cpp
@@ -2269,7 +2269,7 @@ struct XChain_test : public beast::unit_test::Suite, public jtx::XChainBridgeObj
             }
             {
                 // B1: disabled master key
-                scEnv.tx(fset(altSigners[2].account, asfDisableMaster, 0)).close();
+                scEnv.tx(fset(altSigners[2].account, asfDisableMasterKey, 0)).close();
                 auto att = claimAttestation(
                     scAttester, jvb, mcAlice, amt, payees[2], true, claimID, dst, altSigners[2]);
                 scEnv.tx(att, Ter(tecXCHAIN_BAD_PUBLIC_KEY_ACCOUNT_PAIR)).close();
@@ -3039,7 +3039,7 @@ struct XChain_test : public beast::unit_test::Suite, public jtx::XChainBridgeObj
 
             scEnv.tx(createBridge(Account::kMaster, jvb))
                 .tx(jtx::signers(Account::kMaster, quorum, signers))
-                .tx(fset("scBob", asfRequireDest))  // set dest tag
+                .tx(fset("scBob", asfRequireDestinationTag))  // set dest tag
                 .close()
                 .tx(xchainCreateClaimId(scAlice, jvb, reward, mcAlice))
                 .close();
@@ -3088,7 +3088,7 @@ struct XChain_test : public beast::unit_test::Suite, public jtx::XChainBridgeObj
                 // and resubmit the attestations (even though the witness
                 // servers won't do it)
                 scEnv
-                    .tx(fset("scBob", 0, asfRequireDest))  // clear dest tag
+                    .tx(fset("scBob", 0, asfRequireDestinationTag))  // clear dest tag
                     .close();
 
                 test::Balance const scBobBal(scEnv, scBob);

--- a/src/test/jtx/Env_test.cpp
+++ b/src/test/jtx/Env_test.cpp
@@ -269,9 +269,11 @@ public:
         env.require(Balance("alice", usd(0)));
         env(pay(gw, "alice", usd(10)), Require(Balance("alice", usd(10))));
 
-        env.require(Nflags("alice", asfRequireDest));
-        env(fset("alice", asfRequireDest), Require(Flags("alice", asfRequireDest)));
-        env(fclear("alice", asfRequireDest), Require(Nflags("alice", asfRequireDest)));
+        env.require(Nflags("alice", asfRequireDestinationTag));
+        env(fset("alice", asfRequireDestinationTag),
+            Require(Flags("alice", asfRequireDestinationTag)));
+        env(fclear("alice", asfRequireDestinationTag),
+            Require(Nflags("alice", asfRequireDestinationTag)));
     }
 
     // Signing with secp256k1 and ed25519 keys
@@ -301,12 +303,12 @@ public:
         env(noop(alice), Sig(alice));
 
         // Regular key only
-        env(fset(alice, asfDisableMaster), Sig(alice));
+        env(fset(alice, asfDisableMasterKey), Sig(alice));
         env(noop(alice));
         env(noop(alice), Sig(bob));
         env(noop(alice), Sig(alice), Ter(tefMASTER_DISABLED));
-        env(fclear(alice, asfDisableMaster), Sig(alice), Ter(tefMASTER_DISABLED));
-        env(fclear(alice, asfDisableMaster), Sig(bob));
+        env(fclear(alice, asfDisableMasterKey), Sig(alice), Ter(tefMASTER_DISABLED));
+        env(fclear(alice, asfDisableMasterKey), Sig(bob));
         env(noop(alice), Sig(alice));
     }
 
@@ -355,20 +357,20 @@ public:
         env(noop("alice"), Sig("alice"));
         env(noop("alice"), Sig("eric"));
         env(noop("alice"), Sig("bob"), Ter(tefBAD_AUTH));
-        env(fset("alice", asfDisableMaster), Ter(tecNEED_MASTER_KEY));
-        env(fset("alice", asfDisableMaster), Sig("eric"), Ter(tecNEED_MASTER_KEY));
-        env.require(Nflags("alice", asfDisableMaster));
-        env(fset("alice", asfDisableMaster), Sig("alice"));
-        env.require(Flags("alice", asfDisableMaster));
+        env(fset("alice", asfDisableMasterKey), Ter(tecNEED_MASTER_KEY));
+        env(fset("alice", asfDisableMasterKey), Sig("eric"), Ter(tecNEED_MASTER_KEY));
+        env.require(Nflags("alice", asfDisableMasterKey));
+        env(fset("alice", asfDisableMasterKey), Sig("alice"));
+        env.require(Flags("alice", asfDisableMasterKey));
         env(regkey("alice", kDisabled), Ter(tecNO_ALTERNATIVE_KEY));
         env(noop("alice"));
         env(noop("alice"), Sig("alice"), Ter(tefMASTER_DISABLED));
         env(noop("alice"), Sig("eric"));
         env(noop("alice"), Sig("bob"), Ter(tefBAD_AUTH));
-        env(fclear("alice", asfDisableMaster), Sig("bob"), Ter(tefBAD_AUTH));
-        env(fclear("alice", asfDisableMaster), Sig("alice"), Ter(tefMASTER_DISABLED));
-        env(fclear("alice", asfDisableMaster));
-        env.require(Nflags("alice", asfDisableMaster));
+        env(fclear("alice", asfDisableMasterKey), Sig("bob"), Ter(tefBAD_AUTH));
+        env(fclear("alice", asfDisableMasterKey), Sig("alice"), Ter(tefMASTER_DISABLED));
+        env(fclear("alice", asfDisableMasterKey));
+        env.require(Nflags("alice", asfDisableMasterKey));
         env(regkey("alice", kDisabled));
         env(noop("alice"), Sig("eric"), Ter(tefBAD_AUTH));
         env(noop("alice"));

--- a/src/test/jtx/flags.h
+++ b/src/test/jtx/flags.h
@@ -26,16 +26,16 @@ private:
     {
         switch (flag)
         {
-            case asfRequireDest:
+            case asfRequireDestinationTag:
                 mask_ |= lsfRequireDestTag;
                 break;
-            case asfRequireAuth:
+            case asfRequireAuthorization:
                 mask_ |= lsfRequireAuth;
                 break;
-            case asfDisallowXRP:
+            case asfDisallowIncomingXRP:
                 mask_ |= lsfDisallowXRP;
                 break;
-            case asfDisableMaster:
+            case asfDisableMasterKey:
                 mask_ |= lsfDisableMaster;
                 break;
             // case asfAccountTxnID: // ???

--- a/src/test/rpc/AccountInfo_test.cpp
+++ b/src/test/rpc/AccountInfo_test.cpp
@@ -529,11 +529,11 @@ public:
         static constexpr std::array<std::pair<std::string_view, std::uint32_t>, 7> kAsFlags{
             {{"defaultRipple", asfDefaultRipple},
              {"depositAuth", asfDepositAuth},
-             {"disallowIncomingXRP", asfDisallowXRP},
+             {"disallowIncomingXRP", asfDisallowIncomingXRP},
              {"globalFreeze", asfGlobalFreeze},
              {"noFreeze", asfNoFreeze},
-             {"requireAuthorization", asfRequireAuth},
-             {"requireDestinationTag", asfRequireDest}}};
+             {"requireAuthorization", asfRequireAuthorization},
+             {"requireDestinationTag", asfRequireDestinationTag}}};
 
         for (auto& asf : kAsFlags)
         {

--- a/src/test/rpc/AccountLines_test.cpp
+++ b/src/test/rpc/AccountLines_test.cpp
@@ -145,7 +145,7 @@ public:
         env.fund(XRP(10000), gw2);
 
         // gw2 requires authorization.
-        env(fset(gw2, asfRequireAuth));
+        env(fset(gw2, asfRequireAuthorization));
         env.close();
         std::vector<IOU> gw2Currencies;
 
@@ -853,7 +853,7 @@ public:
         env.fund(XRP(10000), gw2);
 
         // gw2 requires authorization.
-        env(fset(gw2, asfRequireAuth));
+        env(fset(gw2, asfRequireAuthorization));
         env.close();
         std::vector<IOU> gw2Currencies;
 

--- a/src/test/rpc/ServerDefinitions_test.cpp
+++ b/src/test/rpc/ServerDefinitions_test.cpp
@@ -152,7 +152,7 @@ public:
                 BEAST_EXPECT(result[jss::result].isMember(jss::ACCOUNT_SET_FLAGS));
                 json::Value const& asFlags = result[jss::result][jss::ACCOUNT_SET_FLAGS];
 
-                BEAST_EXPECT(asFlags["asfDisallowXRP"] == 3);
+                BEAST_EXPECT(asFlags["asfDisallowIncomingXRP"] == 3);
                 BEAST_EXPECT(asFlags["asfGlobalFreeze"] == 7);
                 BEAST_EXPECT(asFlags["asfDisallowIncomingNFTokenOffer"] == 12);
                 BEAST_EXPECT(asFlags["asfDisallowIncomingTrustline"] == 15);

--- a/src/test/rpc/Simulate_test.cpp
+++ b/src/test/rpc/Simulate_test.cpp
@@ -925,7 +925,7 @@ class Simulate_test : public beast::unit_test::Suite
         static auto const kNewDomain = "123ABC";
         Account const alice{"alice"};
         env(regkey(env.master, alice));
-        env(fset(env.master, asfDisableMaster), Sig(env.master));
+        env(fset(env.master, asfDisableMasterKey), Sig(env.master));
         env.close();
 
         {

--- a/src/tests/libxrpl/helpers/TxTest.h
+++ b/src/tests/libxrpl/helpers/TxTest.h
@@ -89,7 +89,7 @@ XRP(Number const& xrp)
  * @throws std::runtime_error if the flag is not supported.
  *
  * Supported flags:
- *   asfRequireDest, asfRequireAuth, asfDisallowXRP, asfDisableMaster,
+ *   asfRequireDestinationTag, asfRequireAuthorization, asfDisallowIncomingXRP, asfDisableMasterKey,
  *   asfNoFreeze, asfGlobalFreeze, asfDefaultRipple, asfDepositAuth,
  *   asfAllowTrustLineClawback, asfDisallowIncomingCheck,
  *   asfDisallowIncomingNFTokenOffer, asfDisallowIncomingPayChan,
@@ -100,13 +100,13 @@ asfToLsf(std::uint32_t asf)
 {
     switch (asf)
     {
-        case asfRequireDest:
+        case asfRequireDestinationTag:
             return lsfRequireDestTag;
-        case asfRequireAuth:
+        case asfRequireAuthorization:
             return lsfRequireAuth;
-        case asfDisallowXRP:
+        case asfDisallowIncomingXRP:
             return lsfDisallowXRP;
-        case asfDisableMaster:
+        case asfDisableMasterKey:
             return lsfDisableMaster;
         case asfNoFreeze:
             return lsfNoFreeze;

--- a/src/tests/libxrpl/tx/AccountSet.cpp
+++ b/src/tests/libxrpl/tx/AccountSet.cpp
@@ -67,7 +67,7 @@ TEST(AccountSet, MostFlags)
     env.createAccount(alice, XRP(10000));
 
     // Give alice a regular key so she can legally set and clear
-    // her asfDisableMaster flag.
+    // her asfDisableMasterKey flag.
     Account const aliceRegularKey{"aliceRegularKey", KeyType::Secp256k1};
 
     env.createAccount(aliceRegularKey, XRP(10000));
@@ -164,11 +164,11 @@ TEST(AccountSet, MostFlags)
         }
     };
     testFlags({
-        asfRequireDest,
-        asfRequireAuth,
-        asfDisallowXRP,
+        asfRequireDestinationTag,
+        asfRequireAuthorization,
+        asfDisallowIncomingXRP,
         asfGlobalFreeze,
-        asfDisableMaster,
+        asfDisableMasterKey,
         asfDefaultRipple,
         asfDepositAuth,
     });
@@ -484,8 +484,8 @@ TEST(AccountSet, BadInputs)
     EXPECT_EQ(
         env.submit(
                transactions::AccountSetBuilder{alice}
-                   .setSetFlag(asfDisallowXRP)
-                   .setClearFlag(asfDisallowXRP),
+                   .setSetFlag(asfDisallowIncomingXRP)
+                   .setClearFlag(asfDisallowIncomingXRP),
                alice)
             .ter,
         temINVALID_FLAG);
@@ -493,8 +493,8 @@ TEST(AccountSet, BadInputs)
     EXPECT_EQ(
         env.submit(
                transactions::AccountSetBuilder{alice}
-                   .setSetFlag(asfRequireAuth)
-                   .setClearFlag(asfRequireAuth),
+                   .setSetFlag(asfRequireAuthorization)
+                   .setClearFlag(asfRequireAuthorization),
                alice)
             .ter,
         temINVALID_FLAG);
@@ -502,8 +502,8 @@ TEST(AccountSet, BadInputs)
     EXPECT_EQ(
         env.submit(
                transactions::AccountSetBuilder{alice}
-                   .setSetFlag(asfRequireDest)
-                   .setClearFlag(asfRequireDest),
+                   .setSetFlag(asfRequireDestinationTag)
+                   .setClearFlag(asfRequireDestinationTag),
                alice)
             .ter,
         temINVALID_FLAG);
@@ -512,7 +512,7 @@ TEST(AccountSet, BadInputs)
     EXPECT_EQ(
         env.submit(
                transactions::AccountSetBuilder{alice}
-                   .setSetFlag(asfDisallowXRP)
+                   .setSetFlag(asfDisallowIncomingXRP)
                    .setFlags(tfAllowXRP),
                alice)
             .ter,
@@ -521,7 +521,7 @@ TEST(AccountSet, BadInputs)
     EXPECT_EQ(
         env.submit(
                transactions::AccountSetBuilder{alice}
-                   .setSetFlag(asfRequireAuth)
+                   .setSetFlag(asfRequireAuthorization)
                    .setFlags(tfOptionalAuth),
                alice)
             .ter,
@@ -530,7 +530,7 @@ TEST(AccountSet, BadInputs)
     EXPECT_EQ(
         env.submit(
                transactions::AccountSetBuilder{alice}
-                   .setSetFlag(asfRequireDest)
+                   .setSetFlag(asfRequireDestinationTag)
                    .setFlags(tfOptionalDestTag),
                alice)
             .ter,
@@ -540,7 +540,7 @@ TEST(AccountSet, BadInputs)
     EXPECT_EQ(
         env.submit(
                transactions::AccountSetBuilder{alice}
-                   .setSetFlag(asfRequireDest)
+                   .setSetFlag(asfRequireDestinationTag)
                    .setFlags(tfAccountSetMask),
                alice)
             .ter,
@@ -548,7 +548,8 @@ TEST(AccountSet, BadInputs)
 
     // Disabling master key without an alternative key is invalid
     EXPECT_EQ(
-        env.submit(transactions::AccountSetBuilder{alice}.setSetFlag(asfDisableMaster), alice).ter,
+        env.submit(transactions::AccountSetBuilder{alice}.setSetFlag(asfDisableMasterKey), alice)
+            .ter,
         tecNO_ALTERNATIVE_KEY);
 }
 
@@ -585,7 +586,9 @@ TEST(AccountSet, RequireAuthWithDir)
 
     // Setting RequireAuth should fail because alice has owner objects
     EXPECT_EQ(
-        env.submit(transactions::AccountSetBuilder{alice}.setSetFlag(asfRequireAuth), alice).ter,
+        env.submit(
+               transactions::AccountSetBuilder{alice}.setSetFlag(asfRequireAuthorization), alice)
+            .ter,
         tecOWNERS);
 
     // Remove the signer list (quorum = 0, no entries)
@@ -596,7 +599,9 @@ TEST(AccountSet, RequireAuthWithDir)
 
     // Now setting RequireAuth should succeed
     EXPECT_EQ(
-        env.submit(transactions::AccountSetBuilder{alice}.setSetFlag(asfRequireAuth), alice).ter,
+        env.submit(
+               transactions::AccountSetBuilder{alice}.setSetFlag(asfRequireAuthorization), alice)
+            .ter,
         tesSUCCESS);
 }
 

--- a/src/xrpld/rpc/handlers/account/AccountInfo.cpp
+++ b/src/xrpld/rpc/handlers/account/AccountInfo.cpp
@@ -17,6 +17,7 @@
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/SField.h>
+#include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/Units.h>
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/protocol/jss.h>
@@ -24,13 +25,14 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/format/free_funcs.hpp>
 
-#include <array>
+#include <cctype>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 namespace xrpl {
 
@@ -121,29 +123,25 @@ doAccountInfo(RPC::JsonContext& context)
     }
     auto const accountID{id.value()};
 
-    static constexpr std::array<std::pair<std::string_view, LedgerSpecificFlags>, 9> kLsFlags{
-        {{"defaultRipple", lsfDefaultRipple},
-         {"depositAuth", lsfDepositAuth},
-         {"disableMasterKey", lsfDisableMaster},
-         {"disallowIncomingXRP", lsfDisallowXRP},
-         {"globalFreeze", lsfGlobalFreeze},
-         {"noFreeze", lsfNoFreeze},
-         {"passwordSpent", lsfPasswordSpent},
-         {"requireAuthorization", lsfRequireAuth},
-         {"requireDestinationTag", lsfRequireDestTag}}};
-
-    static constexpr std::array<std::pair<std::string_view, LedgerSpecificFlags>, 4>
-        kDisallowIncomingFlags{
-            {{"disallowIncomingNFTokenOffer", lsfDisallowIncomingNFTokenOffer},
-             {"disallowIncomingCheck", lsfDisallowIncomingCheck},
-             {"disallowIncomingPayChan", lsfDisallowIncomingPayChan},
-             {"disallowIncomingTrustline", lsfDisallowIncomingTrustline}}};
-
-    static constexpr std::pair<std::string_view, LedgerSpecificFlags> kAllowTrustLineClawbackFlag{
-        "allowTrustLineClawback", lsfAllowTrustLineClawback};
-
-    static constexpr std::pair<std::string_view, LedgerSpecificFlags> kAllowTrustLineLockingFlag{
-        "allowTrustLineLocking", lsfAllowTrustLineLocking};
+    // Build the flag table from ACCOUNTSET_FLAGS. The JSON key is the asf name with
+    // the "asf" prefix stripped and the first character lowercased. Entries where
+    // lsf == 0 (no ledger-state flag, or feature-gated) are skipped; the latter
+    // (asfAllowTrustLineLocking) is handled below with its feature check.
+    // lsfPasswordSpent has no asf counterpart, so it is prepended manually.
+#define ADD_ACCT_FLAG(name, asf, lsf)                                                 \
+    if constexpr ((lsf) != 0)                                                         \
+    {                                                                                 \
+        std::string key = std::string(#name).substr(3);                               \
+        key[0] = static_cast<char>(std::tolower(static_cast<unsigned char>(key[0]))); \
+        flags.emplace_back(std::move(key), LedgerSpecificFlags(lsf));                 \
+    }
+    static std::vector<std::pair<std::string, LedgerSpecificFlags>> const kAccountFlags = []() {
+        std::vector<std::pair<std::string, LedgerSpecificFlags>> flags;
+        flags.emplace_back("passwordSpent", lsfPasswordSpent);
+        ACCOUNTSET_FLAGS(ADD_ACCT_FLAG)
+        return flags;
+    }();
+#undef ADD_ACCT_FLAG
 
     auto const sleAccepted = ledger->read(keylet::account(accountID));
     if (sleAccepted)
@@ -163,20 +161,11 @@ doAccountInfo(RPC::JsonContext& context)
         result[jss::account_data] = jvAccepted;
 
         json::Value acctFlags{json::ValueType::Object};
-        for (auto const& lsf : kLsFlags)
-            acctFlags[lsf.first.data()] = sleAccepted->isFlag(lsf.second);
-
-        for (auto const& lsf : kDisallowIncomingFlags)
-            acctFlags[lsf.first.data()] = sleAccepted->isFlag(lsf.second);
-
-        acctFlags[kAllowTrustLineClawbackFlag.first.data()] =
-            sleAccepted->isFlag(kAllowTrustLineClawbackFlag.second);
+        for (auto const& [name, flag] : kAccountFlags)
+            acctFlags[name.c_str()] = sleAccepted->isFlag(flag);
 
         if (ledger->rules().enabled(featureTokenEscrow))
-        {
-            acctFlags[kAllowTrustLineLockingFlag.first.data()] =
-                sleAccepted->isFlag(kAllowTrustLineLockingFlag.second);
-        }
+            acctFlags["allowTrustLineLocking"] = sleAccepted->isFlag(lsfAllowTrustLineLocking);
 
         result[jss::account_flags] = std::move(acctFlags);
 


### PR DESCRIPTION
## High Level Overview of Change

This PR refactors the `ACCOUNTSET_FLAGS` macro to incorporate the flag info that is included in `account_info`.

### Context of Change

Code cleanup, preventing the ability to forget to add flags in account_info

### API Impact

There are some flag renames, which may impact downstream users, but mildly.
