### PR TITLE
fix: Round vault deposit and withdraw conversions to prevent shareholder dilution

### DIFF
--- a/include/xrpl/ledger/helpers/VaultHelpers.h
+++ b/include/xrpl/ledger/helpers/VaultHelpers.h
@@ -28,14 +28,25 @@ assetsToSharesDeposit(SLE::const_ref vault, SLE::const_ref issuance, STAmount co
  * depositor when they receive a fixed amount of shares. Note, since shares are
  * MPT, they are always an integral number.
  *
+ * The result is quantized to the vault asset's precision using @p rounding.
+ * Callers charging a depositor for freshly minted shares must round Upward, so
+ * the depositor pays at least the fair value of those shares and existing
+ * shareholders cannot be diluted. The ToNearest default preserves the
+ * pre-amendment behavior.
+ *
  * @param vault The vault SLE.
  * @param issuance The MPTokenIssuance SLE for the vault's shares.
  * @param shares The amount of shares to convert.
+ * @param rounding How to round the resulting assets to the asset's precision.
  *
  * @return The number of assets, or nullopt on error.
  */
 [[nodiscard]] std::optional<STAmount>
-sharesToAssetsDeposit(SLE::const_ref vault, SLE::const_ref issuance, STAmount const& shares);
+sharesToAssetsDeposit(
+    SLE::const_ref vault,
+    SLE::const_ref issuance,
+    STAmount const& shares,
+    Number::RoundingMode rounding = Number::RoundingMode::ToNearest);
 
 /**
  * Controls whether to truncate shares instead of rounding.
@@ -79,11 +90,18 @@ assetsToSharesWithdraw(
  * depositor when they redeem a fixed amount of shares. Note, since shares are
  * MPT, they are always an integral number.
  *
+ * The result is quantized to the vault asset's precision using @p rounding.
+ * Callers paying a withdrawing shareholder must round Downward, so the
+ * shareholder receives at most the fair value of the shares they burn and the
+ * remaining shareholders cannot be diluted. The ToNearest default preserves the
+ * pre-amendment behavior.
+ *
  * @param vault The vault SLE.
  * @param issuance The MPTokenIssuance SLE for the vault's shares.
  * @param shares The amount of shares to convert.
  * @param waive Whether to waive (i.e. not subtract) the vault's unrealized
  *              loss when computing the exchange rate.
+ * @param rounding How to round the resulting assets to the asset's precision.
  *
  * @return The number of assets, or nullopt on error.
  */
@@ -92,7 +110,8 @@ sharesToAssetsWithdraw(
     SLE::const_ref vault,
     SLE::const_ref issuance,
     STAmount const& shares,
-    WaiveUnrealizedLoss waive = WaiveUnrealizedLoss::No);
+    WaiveUnrealizedLoss waive = WaiveUnrealizedLoss::No,
+    Number::RoundingMode rounding = Number::RoundingMode::ToNearest);
 
 /**
  * Returns true iff `account` holds all of the vault's outstanding shares —

--- a/include/xrpl/ledger/helpers/VaultHelpers.h
+++ b/include/xrpl/ledger/helpers/VaultHelpers.h
@@ -36,14 +36,25 @@ assetsToSharesDeposit(SLE::const_ref vault, SLE::const_ref issuance, STAmount co
  * depositor when they receive a fixed amount of shares. Note, since shares are
  * MPT, they are always an integral number.
  *
+ * The result is quantized to the vault asset's precision using @p rounding.
+ * Callers charging a depositor for freshly minted shares must round Upward, so
+ * the depositor pays at least the fair value of those shares and existing
+ * shareholders cannot be diluted. The ToNearest default preserves the
+ * pre-amendment behavior.
+ *
  * @param vault The vault SLE.
  * @param issuance The MPTokenIssuance SLE for the vault's shares.
  * @param shares The amount of shares to convert.
+ * @param rounding How to round the resulting assets to the asset's precision.
  *
  * @return The number of assets, or nullopt on error.
  */
 [[nodiscard]] std::optional<STAmount>
-sharesToAssetsDeposit(SLE::const_ref vault, SLE::const_ref issuance, STAmount const& shares);
+sharesToAssetsDeposit(
+    SLE::const_ref vault,
+    SLE::const_ref issuance,
+    STAmount const& shares,
+    Number::RoundingMode rounding = Number::RoundingMode::ToNearest);
 
 /**
  * Adjusts a requested asset change (`delta`) to match the decimal scale of the
@@ -142,11 +153,18 @@ assetsToSharesWithdraw(
  * depositor when they redeem a fixed amount of shares. Note, since shares are
  * MPT, they are always an integral number.
  *
+ * The result is quantized to the vault asset's precision using @p rounding.
+ * Callers paying a withdrawing shareholder must round Downward, so the
+ * shareholder receives at most the fair value of the shares they burn and the
+ * remaining shareholders cannot be diluted. The ToNearest default preserves the
+ * pre-amendment behavior.
+ *
  * @param vault The vault SLE.
  * @param issuance The MPTokenIssuance SLE for the vault's shares.
  * @param shares The amount of shares to convert.
  * @param waive Whether to waive (i.e. not subtract) the vault's unrealized
  *              loss when computing the exchange rate.
+ * @param rounding How to round the resulting assets to the asset's precision.
  *
  * @return The number of assets, or nullopt on error.
  */
@@ -155,7 +173,8 @@ sharesToAssetsWithdraw(
     SLE::const_ref vault,
     SLE::const_ref issuance,
     STAmount const& shares,
-    WaiveUnrealizedLoss waive = WaiveUnrealizedLoss::No);
+    WaiveUnrealizedLoss waive = WaiveUnrealizedLoss::No,
+    Number::RoundingMode rounding = Number::RoundingMode::ToNearest);
 
 /**
  * Returns true iff `account` holds all of the vault's outstanding shares —

--- a/src/libxrpl/ledger/helpers/VaultHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/VaultHelpers.cpp
@@ -41,7 +41,11 @@ assetsToSharesDeposit(SLE::const_ref vault, SLE::const_ref issuance, STAmount co
 }
 
 [[nodiscard]] std::optional<STAmount>
-sharesToAssetsDeposit(SLE::const_ref vault, SLE::const_ref issuance, STAmount const& shares)
+sharesToAssetsDeposit(
+    SLE::const_ref vault,
+    SLE::const_ref issuance,
+    STAmount const& shares,
+    Number::RoundingMode rounding)
 {
     XRPL_ASSERT(!shares.negative(), "xrpl::sharesToAssetsDeposit : non-negative shares");
     XRPL_ASSERT(
@@ -59,6 +63,10 @@ sharesToAssetsDeposit(SLE::const_ref vault, SLE::const_ref issuance, STAmount co
     }
 
     Number const shareTotal = issuance->at(sfOutstandingAmount);
+    // Quantizing to the asset's precision honors the thread-local rounding mode
+    // for both integral (XRP/MPT) and IOU assets. Charging a depositor must
+    // round Upward so they pay at least the fair value of the minted shares.
+    NumberRoundModeGuard const rg(rounding);
     assets = (assetTotal * shares) / shareTotal;
     return assets;
 }
@@ -97,7 +105,8 @@ sharesToAssetsWithdraw(
     SLE::const_ref vault,
     SLE::const_ref issuance,
     STAmount const& shares,
-    WaiveUnrealizedLoss waive)
+    WaiveUnrealizedLoss waive,
+    Number::RoundingMode rounding)
 {
     XRPL_ASSERT(!shares.negative(), "xrpl::sharesToAssetsWithdraw : non-negative shares");
     XRPL_ASSERT(
@@ -113,6 +122,12 @@ sharesToAssetsWithdraw(
     if (assetTotal == 0)
         return assets;
     Number const shareTotal = issuance->at(sfOutstandingAmount);
+    // Paying a withdrawing shareholder must round Downward so they receive at
+    // most the fair value of the shares they burn; otherwise the assets-per-
+    // share price would drop and dilute the remaining shareholders. Quantizing
+    // to the asset's precision honors the thread-local rounding mode for both
+    // integral (XRP/MPT) and IOU assets.
+    NumberRoundModeGuard const rg(rounding);
     assets = (assetTotal * shares) / shareTotal;
     return assets;
 }

--- a/src/libxrpl/ledger/helpers/VaultHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/VaultHelpers.cpp
@@ -49,7 +49,11 @@ assetsToSharesDeposit(SLE::const_ref vault, SLE::const_ref issuance, STAmount co
 }
 
 [[nodiscard]] std::optional<STAmount>
-sharesToAssetsDeposit(SLE::const_ref vault, SLE::const_ref issuance, STAmount const& shares)
+sharesToAssetsDeposit(
+    SLE::const_ref vault,
+    SLE::const_ref issuance,
+    STAmount const& shares,
+    Number::RoundingMode rounding)
 {
     XRPL_ASSERT(!shares.negative(), "xrpl::sharesToAssetsDeposit : non-negative shares");
     XRPL_ASSERT(
@@ -67,6 +71,10 @@ sharesToAssetsDeposit(SLE::const_ref vault, SLE::const_ref issuance, STAmount co
     }
 
     Number const shareTotal = issuance->at(sfOutstandingAmount);
+    // Quantizing to the asset's precision honors the thread-local rounding mode
+    // for both integral (XRP/MPT) and IOU assets. Charging a depositor must
+    // round Upward so they pay at least the fair value of the minted shares.
+    NumberRoundModeGuard const rg(rounding);
     assets = (assetTotal * shares) / shareTotal;
     return assets;
 }
@@ -179,7 +187,8 @@ sharesToAssetsWithdraw(
     SLE::const_ref vault,
     SLE::const_ref issuance,
     STAmount const& shares,
-    WaiveUnrealizedLoss waive)
+    WaiveUnrealizedLoss waive,
+    Number::RoundingMode rounding)
 {
     XRPL_ASSERT(!shares.negative(), "xrpl::sharesToAssetsWithdraw : non-negative shares");
     XRPL_ASSERT(
@@ -193,6 +202,12 @@ sharesToAssetsWithdraw(
     if (assetTotal == 0)
         return assets;
     Number const shareTotal = issuance->at(sfOutstandingAmount);
+    // Paying a withdrawing shareholder must round Downward so they receive at
+    // most the fair value of the shares they burn; otherwise the assets-per-
+    // share price would drop and dilute the remaining shareholders. Quantizing
+    // to the asset's precision honors the thread-local rounding mode for both
+    // integral (XRP/MPT) and IOU assets.
+    NumberRoundModeGuard const rg(rounding);
     assets = (assetTotal * shares) / shareTotal;
     return assets;
 }

--- a/src/libxrpl/tx/transactors/vault/VaultDeposit.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultDeposit.cpp
@@ -196,6 +196,7 @@ TER
 VaultDeposit::doApply()
 {
     bool const fix320Enabled = view().rules().enabled(fixCleanup3_2_0);
+    bool const fix330Enabled = view().rules().enabled(fixCleanup3_3_0);
     auto const vault = view().peek(keylet::vault(ctx_.tx[sfVaultID]));
     auto applyViewContext = ctx_.getApplyViewContext();
     if (!vault)
@@ -284,7 +285,15 @@ VaultDeposit::doApply()
         if (sharesCreated == beast::kZero)
             return tecPRECISION_LOSS;
 
-        auto const maybeAssets = sharesToAssetsDeposit(vault, sleIssuance, sharesCreated);
+        // Post-fixCleanup3_3_0: round the charged assets Upward so the depositor
+        // pays at least the fair value of the freshly minted shares. Round-to-
+        // nearest could undercharge, overvaluing the new shares and diluting
+        // existing shareholders.
+        auto const maybeAssets = sharesToAssetsDeposit(
+            vault,
+            sleIssuance,
+            sharesCreated,
+            fix330Enabled ? Number::RoundingMode::Upward : Number::RoundingMode::ToNearest);
         if (!maybeAssets)
         {
             return tecINTERNAL;  // LCOV_EXCL_LINE

--- a/src/libxrpl/tx/transactors/vault/VaultDeposit.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultDeposit.cpp
@@ -231,6 +231,7 @@ VaultDeposit::doApply()
 {
     bool const fix320Enabled = view().rules().enabled(fixCleanup3_2_0);
     bool const fix340Enabled = view().rules().enabled(fixCleanup3_4_0);
+    bool const fix350Enabled = view().rules().enabled(fixCleanup3_5_0);
     auto const vault = view().peek(keylet::vault(ctx_.tx[sfVaultID]));
     auto applyViewContext = ctx_.getApplyViewContext();
     if (!vault)
@@ -325,7 +326,18 @@ VaultDeposit::doApply()
         // Convert shares back to assets so the depositor is debited for the amount actually minted.
         // The truncated share count is worth <= amount; without this the difference would be
         // credited to the vault for free.
-        auto const maybeAssets = sharesToAssetsDeposit(vault, sleIssuance, sharesCreated);
+        //
+        // Post-fixCleanup3_5_0: round the charge Upward so the depositor pays at least the fair
+        // value of the freshly minted shares. Round-to-nearest could round the charge below that
+        // value, handing the depositor shares worth more than they paid and diluting the existing
+        // shareholders. For an IOU the fixCleanup3_4_0 clamp below re-floors this to the
+        // sfAssetsTotal grid; the Upward mode is load-bearing for integral (XRP/MPT) assets, which
+        // clampToAssetsTotalScale returns unchanged.
+        auto const maybeAssets = sharesToAssetsDeposit(
+            vault,
+            sleIssuance,
+            sharesCreated,
+            fix350Enabled ? Number::RoundingMode::Upward : Number::RoundingMode::ToNearest);
         if (!maybeAssets)
         {
             return tecINTERNAL;  // LCOV_EXCL_LINE

--- a/src/libxrpl/tx/transactors/vault/VaultWithdraw.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultWithdraw.cpp
@@ -1,6 +1,7 @@
 #include <xrpl/tx/transactors/vault/VaultWithdraw.h>
 
 #include <xrpl/basics/Log.h>
+#include <xrpl/basics/Number.h>
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/beast/utility/Zero.h>
 #include <xrpl/beast/utility/instrumentation.h>
@@ -124,8 +125,14 @@ VaultWithdraw::preclaim(PreclaimContext const& ctx)
         auto const waiveUnrealizedLoss = shouldWaiveWithdrawal(ctx.view, account, sleIssuance);
         try
         {
-            auto const maybeAssets =
-                sharesToAssetsWithdraw(vault, sleIssuance, amount, waiveUnrealizedLoss);
+            // Match the Downward payout rounding used in doApply so the limit
+            // check estimates the same asset amount the withdrawal will pay.
+            auto const maybeAssets = sharesToAssetsWithdraw(
+                vault,
+                sleIssuance,
+                amount,
+                waiveUnrealizedLoss,
+                fix330Enabled ? Number::RoundingMode::Downward : Number::RoundingMode::ToNearest);
             if (!maybeAssets)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
 
@@ -193,6 +200,7 @@ VaultWithdraw::preclaim(PreclaimContext const& ctx)
 TER
 VaultWithdraw::doApply()
 {
+    bool const fix330Enabled = view().rules().enabled(fixCleanup3_3_0);
     auto const vault = view().peek(keylet::vault(ctx_.tx[sfVaultID]));
     auto applyViewContext = ctx_.getApplyViewContext();
     if (!vault)
@@ -224,6 +232,13 @@ VaultWithdraw::doApply()
     // We waive the unrealized-loss subtraction in this case to avoid user withdrawing all of their
     // shares but keeping future value in the vault.
     auto const waiveUnrealizedLoss = shouldWaiveWithdrawal(view(), accountID_, sleIssuance);
+
+    // Post-fixCleanup3_3_0: round the assets paid to the withdrawing shareholder
+    // Downward, so they receive at most the fair value of the shares they burn.
+    // Round-to-nearest could overpay, dropping the assets-per-share price and
+    // diluting the remaining shareholders.
+    auto const withdrawRounding =
+        fix330Enabled ? Number::RoundingMode::Downward : Number::RoundingMode::ToNearest;
     try
     {
         if (amount.asset() == vaultAsset)
@@ -239,8 +254,8 @@ VaultWithdraw::doApply()
 
             if (sharesRedeemed == beast::kZero)
                 return tecPRECISION_LOSS;
-            auto const maybeAssets =
-                sharesToAssetsWithdraw(vault, sleIssuance, sharesRedeemed, waiveUnrealizedLoss);
+            auto const maybeAssets = sharesToAssetsWithdraw(
+                vault, sleIssuance, sharesRedeemed, waiveUnrealizedLoss, withdrawRounding);
             if (!maybeAssets)
                 return tecINTERNAL;  // LCOV_EXCL_LINE
             assetsWithdrawn = *maybeAssets;
@@ -249,8 +264,8 @@ VaultWithdraw::doApply()
         {
             // Fixed shares, variable assets.
             sharesRedeemed = amount;
-            auto const maybeAssets =
-                sharesToAssetsWithdraw(vault, sleIssuance, sharesRedeemed, waiveUnrealizedLoss);
+            auto const maybeAssets = sharesToAssetsWithdraw(
+                vault, sleIssuance, sharesRedeemed, waiveUnrealizedLoss, withdrawRounding);
             if (!maybeAssets)
                 return tecINTERNAL;  // LCOV_EXCL_LINE
             assetsWithdrawn = *maybeAssets;
@@ -277,9 +292,8 @@ VaultWithdraw::doApply()
     // (checkWithdrawFreeze), so IgnoreFreeze avoids a redundant check that
     // would incorrectly return zero for vault pseudo-accounts whose shares
     // are frozen via a transitively frozen underlying asset.
-    auto const freezeHandling = view().rules().enabled(fixCleanup3_3_0)
-        ? FreezeHandling::IgnoreFreeze
-        : FreezeHandling::ZeroIfFrozen;
+    auto const freezeHandling =
+        fix330Enabled ? FreezeHandling::IgnoreFreeze : FreezeHandling::ZeroIfFrozen;
     if (accountHolds(view(), accountID_, share, freezeHandling, AuthHandling::IgnoreAuth, j_) <
         sharesRedeemed)
     {

--- a/src/libxrpl/tx/transactors/vault/VaultWithdraw.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultWithdraw.cpp
@@ -82,6 +82,7 @@ VaultWithdraw::preclaim(PreclaimContext const& ctx)
     auto const fix320Enabled = ctx.view.rules().enabled(fixCleanup3_2_0);
     auto const fix330Enabled = ctx.view.rules().enabled(fixCleanup3_3_0);
     auto const fix340Enabled = ctx.view.rules().enabled(fixCleanup3_4_0);
+    auto const fix350Enabled = ctx.view.rules().enabled(fixCleanup3_5_0);
 
     auto const vault = ctx.view.read(keylet::vault(ctx.tx[sfVaultID]));
     if (!vault)
@@ -165,8 +166,14 @@ VaultWithdraw::preclaim(PreclaimContext const& ctx)
         auto const waiveUnrealizedLoss = shouldWaiveWithdrawal(ctx.view, account, sleIssuance);
         try
         {
-            auto const maybeAssets =
-                sharesToAssetsWithdraw(vault, sleIssuance, amount, waiveUnrealizedLoss);
+            // Match the Downward payout rounding used in doApply so the limit
+            // check estimates the same asset amount the withdrawal will pay.
+            auto const maybeAssets = sharesToAssetsWithdraw(
+                vault,
+                sleIssuance,
+                amount,
+                waiveUnrealizedLoss,
+                fix350Enabled ? Number::RoundingMode::Downward : Number::RoundingMode::ToNearest);
             if (!maybeAssets)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
 
@@ -278,6 +285,7 @@ TER
 VaultWithdraw::doApply()
 {
     bool const fix340Enabled = view().rules().enabled(fixCleanup3_4_0);
+    bool const fix350Enabled = view().rules().enabled(fixCleanup3_5_0);
     auto const vault = view().peek(keylet::vault(ctx_.tx[sfVaultID]));
     auto applyViewContext = ctx_.getApplyViewContext();
     if (!vault)
@@ -311,6 +319,16 @@ VaultWithdraw::doApply()
     // We waive the unrealized-loss subtraction in this case to avoid user withdrawing all of their
     // shares but keeping future value in the vault.
     auto const waiveUnrealizedLoss = shouldWaiveWithdrawal(view(), accountID_, sleIssuance);
+
+    // Post-fixCleanup3_5_0: round the assets paid to the withdrawing shareholder Downward, so they
+    // receive at most the fair value of the shares they burn. Round-to-nearest could round the
+    // payout above that value, dropping the assets-per-share price and diluting the shareholders
+    // who remain. For an IOU the fixCleanup3_4_0 clamp below re-floors the payout to the
+    // sfAssetsTotal grid; the Downward mode is load-bearing for integral (XRP/MPT) assets, which
+    // clampToAssetsTotalScale returns unchanged.
+    auto const withdrawRounding =
+        fix350Enabled ? Number::RoundingMode::Downward : Number::RoundingMode::ToNearest;
+
     // Number arithmetic can throw overflow_error when Scale and totals are large. Caught below.
     try
     {
@@ -342,8 +360,8 @@ VaultWithdraw::doApply()
                 return tecPRECISION_LOSS;
             // Convert shares back to assets so the payout matches the shares actually burned, not
             // the requested amount. The extra would otherwise be paid from the vault for free.
-            auto const maybeAssets =
-                sharesToAssetsWithdraw(vault, sleIssuance, sharesRedeemed, waiveUnrealizedLoss);
+            auto const maybeAssets = sharesToAssetsWithdraw(
+                vault, sleIssuance, sharesRedeemed, waiveUnrealizedLoss, withdrawRounding);
             if (!maybeAssets)
                 return tecINTERNAL;  // LCOV_EXCL_LINE
             assetsWithdrawn = *maybeAssets;
@@ -353,8 +371,8 @@ VaultWithdraw::doApply()
             // Fixed shares, variable assets. No round-trip: the share count is exactly what the
             // caller specified; only the payout amount is derived.
             sharesRedeemed = amount;
-            auto const maybeAssets =
-                sharesToAssetsWithdraw(vault, sleIssuance, sharesRedeemed, waiveUnrealizedLoss);
+            auto const maybeAssets = sharesToAssetsWithdraw(
+                vault, sleIssuance, sharesRedeemed, waiveUnrealizedLoss, withdrawRounding);
             if (!maybeAssets)
                 return tecINTERNAL;  // LCOV_EXCL_LINE
             assetsWithdrawn = *maybeAssets;

--- a/src/test/app/Vault_test.cpp
+++ b/src/test/app/Vault_test.cpp
@@ -41,6 +41,7 @@
 #include <xrpl/ledger/Sandbox.h>
 #include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/MPTokenHelpers.h>
+#include <xrpl/ledger/helpers/VaultHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Asset.h>
 #include <xrpl/protocol/Feature.h>
@@ -6343,6 +6344,220 @@ class Vault_test : public beast::unit_test::Suite
         BEAST_EXPECT(vaultAfter->at(sfLossUnrealized) == lossBefore);
     }
 
+    // Common Prefix formal-verification finding: VaultDeposit charged the
+    // depositor via round-to-nearest (sharesToAssetsDeposit). When the vault
+    // holds an integral asset (MPT/XRP) at a non-unit exchange rate, the
+    // charge for freshly minted shares could be rounded *down* below their
+    // fair value. The depositor then receives shares worth more than the
+    // assets they pay in, diluting the existing shareholders.
+    //
+    // Post-fixCleanup3_3_0 the charge rounds Upward (in the pool's favor), so
+    // a depositor always pays at least the fair value of the shares they
+    // receive and the assets-per-share price never decreases for existing
+    // holders.
+    //
+    // This exercises sharesToAssetsDeposit directly: the ToNearest overload is
+    // the pre-amendment behavior, the Upward overload is the fix. For an
+    // integral asset the difference is a full unit, so the undercharge is
+    // unambiguous.
+    void
+    testDepositRoundingFavorsPool()
+    {
+        using namespace test::jtx;
+        testcase("Vault deposit: share-to-asset rounding favors the pool");
+
+        AccountID const issuer = Account("issuer").id();
+        MPTID const assetMPT = makeMptID(1, issuer);
+        MPTID const shareMPT = makeMptID(2, issuer);
+        Asset const vaultAsset{MPTIssue{assetMPT}};
+
+        // Build the minimal vault + share-issuance state the conversion reads.
+        auto const makeState = [&](std::int64_t assetsTotal, std::uint64_t sharesTotal) {
+            auto vault = std::make_shared<SLE>(keylet::vault(uint256{1}));
+            vault->setFieldIssue(sfAsset, STIssue{sfAsset, vaultAsset});
+            vault->at(sfShareMPTID) = shareMPT;
+            vault->at(sfScale) = std::uint8_t(0);
+            vault->at(sfAssetsTotal) = Number(assetsTotal);
+
+            auto issuance = std::make_shared<SLE>(keylet::mptokenIssuance(shareMPT));
+            issuance->at(sfOutstandingAmount) = sharesTotal;
+            return std::make_pair(vault, issuance);
+        };
+
+        // Charge for `minted` shares against a vault holding `assetsTotal`
+        // integral assets backed by `sharesTotal` shares.
+        auto const charge = [&](std::int64_t assetsTotal,
+                                std::uint64_t sharesTotal,
+                                std::uint64_t minted,
+                                Number::RoundingMode mode) -> std::uint64_t {
+            auto const [vault, issuance] = makeState(assetsTotal, sharesTotal);
+            STAmount const shares{MPTIssue{shareMPT}, Number(minted)};
+            auto const assets = sharesToAssetsDeposit(vault, issuance, shares, mode);
+            BEAST_EXPECT(assets.has_value());
+            return assets ? assets->mantissa() : 0;
+        };
+
+        // rate 100/3: charging 1 share is worth 33.33 assets.
+        //   ToNearest -> 33 (undercharges: 33 * 3 = 99 < 100 -> dilution)
+        //   Upward    -> 34 (favors pool: 34 * 3 = 102 >= 100)
+        {
+            std::uint64_t const nearest = charge(100, 3, 1, Number::RoundingMode::ToNearest);
+            std::uint64_t const up = charge(100, 3, 1, Number::RoundingMode::Upward);
+            BEAST_EXPECT(nearest == 33);
+            BEAST_EXPECT(up == 34);
+            // Pre-fix undercharges (dilutes); post-fix never does.
+            BEAST_EXPECT(nearest * 3 < 100 * 1);
+            BEAST_EXPECT(up * 3 >= 100 * 1);
+        }
+
+        // rate 100/3, 2 shares -> 66.67. ToNearest already rounds up here, so
+        // both agree and neither dilutes: the fix only ever raises the charge.
+        {
+            std::uint64_t const nearest = charge(100, 3, 2, Number::RoundingMode::ToNearest);
+            std::uint64_t const up = charge(100, 3, 2, Number::RoundingMode::Upward);
+            BEAST_EXPECT(nearest == 67);
+            BEAST_EXPECT(up == 67);
+            BEAST_EXPECT(up * 3 >= 100 * 2);
+        }
+
+        // Exact rate: no rounding, the fix is a no-op.
+        {
+            std::uint64_t const nearest = charge(100, 4, 2, Number::RoundingMode::ToNearest);
+            std::uint64_t const up = charge(100, 4, 2, Number::RoundingMode::Upward);
+            BEAST_EXPECT(nearest == 50);
+            BEAST_EXPECT(up == 50);
+        }
+
+        // A large, awkward rate: Upward is always the ceiling of the exact
+        // fair value, so the pool is never shortchanged.
+        {
+            std::int64_t const assetsTotal = 1'000'003;
+            std::uint64_t const sharesTotal = 999'983;  // coprime-ish
+            std::uint64_t const minted = 7;
+            std::uint64_t const up =
+                charge(assetsTotal, sharesTotal, minted, Number::RoundingMode::Upward);
+            std::uint64_t const nearest =
+                charge(assetsTotal, sharesTotal, minted, Number::RoundingMode::ToNearest);
+            // up == ceil(assetsTotal * minted / sharesTotal)
+            std::uint64_t const num = assetsTotal * minted;
+            std::uint64_t const expectedUp = (num + sharesTotal - 1) / sharesTotal;
+            BEAST_EXPECT(up == expectedUp);
+            BEAST_EXPECT(up * sharesTotal >= num);      // no dilution
+            BEAST_EXPECT(nearest * sharesTotal < num);  // pre-fix dilutes
+        }
+    }
+
+    // Common Prefix formal-verification finding (mirror of the deposit case):
+    // VaultWithdraw paid the withdrawing shareholder via round-to-nearest
+    // (sharesToAssetsWithdraw). When the vault holds an integral asset (MPT/XRP)
+    // at a non-unit exchange rate, the payout for burned shares could be rounded
+    // *up* above their fair value. The shareholder then receives assets worth
+    // more than the shares they burn, diluting the remaining shareholders.
+    //
+    // Post-fixCleanup3_3_0 the payout rounds Downward (in the pool's favor), so
+    // a withdrawer always receives at most the fair value of the shares they
+    // burn and the assets-per-share price never decreases for the holders who
+    // remain.
+    //
+    // This exercises sharesToAssetsWithdraw directly: the ToNearest overload is
+    // the pre-amendment behavior, the Downward overload is the fix. For an
+    // integral asset the difference is a full unit, so the overpayment is
+    // unambiguous.
+    void
+    testWithdrawRoundingFavorsPool()
+    {
+        using namespace test::jtx;
+        testcase("Vault withdraw: share-to-asset rounding favors the pool");
+
+        AccountID const issuer = Account("issuer").id();
+        MPTID const assetMPT = makeMptID(1, issuer);
+        MPTID const shareMPT = makeMptID(2, issuer);
+        Asset const vaultAsset{MPTIssue{assetMPT}};
+
+        // Build the minimal vault + share-issuance state the conversion reads.
+        // No unrealized loss, so the waive flag is irrelevant here.
+        auto const makeState = [&](std::int64_t assetsTotal, std::uint64_t sharesTotal) {
+            auto vault = std::make_shared<SLE>(keylet::vault(uint256{1}));
+            vault->setFieldIssue(sfAsset, STIssue{sfAsset, vaultAsset});
+            vault->at(sfShareMPTID) = shareMPT;
+            vault->at(sfScale) = std::uint8_t(0);
+            vault->at(sfAssetsTotal) = Number(assetsTotal);
+            vault->at(sfLossUnrealized) = Number(0);
+
+            auto issuance = std::make_shared<SLE>(keylet::mptokenIssuance(shareMPT));
+            issuance->at(sfOutstandingAmount) = sharesTotal;
+            return std::make_pair(vault, issuance);
+        };
+
+        // Pay out for burning `burned` shares against a vault holding
+        // `assetsTotal` integral assets backed by `sharesTotal` shares.
+        auto const payout = [&](std::int64_t assetsTotal,
+                                std::uint64_t sharesTotal,
+                                std::uint64_t burned,
+                                Number::RoundingMode mode) -> std::uint64_t {
+            auto const [vault, issuance] = makeState(assetsTotal, sharesTotal);
+            STAmount const shares{MPTIssue{shareMPT}, Number(burned)};
+            auto const assets =
+                sharesToAssetsWithdraw(vault, issuance, shares, WaiveUnrealizedLoss::No, mode);
+            BEAST_EXPECT(assets.has_value());
+            return assets ? assets->mantissa() : 0;
+        };
+
+        // rate 100/3: burning 1 share is worth 33.33 assets.
+        //   ToNearest -> 33 (fair: 33 * 3 = 99 <= 100, no dilution here)
+        //   Downward  -> 33 (favors pool: 33 * 3 = 99 <= 100)
+        {
+            std::uint64_t const nearest = payout(100, 3, 1, Number::RoundingMode::ToNearest);
+            std::uint64_t const down = payout(100, 3, 1, Number::RoundingMode::Downward);
+            BEAST_EXPECT(nearest == 33);
+            BEAST_EXPECT(down == 33);
+            BEAST_EXPECT(down * 3 <= 100 * 1);  // pool never shortchanged
+        }
+
+        // rate 100/3, 2 shares -> 66.67. ToNearest rounds *up* to 67 and
+        // overpays (67 * 3 = 201 > 200 -> dilution); Downward floors to 66.
+        {
+            std::uint64_t const nearest = payout(100, 3, 2, Number::RoundingMode::ToNearest);
+            std::uint64_t const down = payout(100, 3, 2, Number::RoundingMode::Downward);
+            BEAST_EXPECT(nearest == 67);
+            BEAST_EXPECT(down == 66);
+            // Pre-fix overpays (dilutes remaining holders); post-fix never does.
+            BEAST_EXPECT(nearest * 3 > 100 * 2);
+            BEAST_EXPECT(down * 3 <= 100 * 2);
+        }
+
+        // Exact rate: no rounding, the fix is a no-op.
+        {
+            std::uint64_t const nearest = payout(100, 4, 2, Number::RoundingMode::ToNearest);
+            std::uint64_t const down = payout(100, 4, 2, Number::RoundingMode::Downward);
+            BEAST_EXPECT(nearest == 50);
+            BEAST_EXPECT(down == 50);
+        }
+
+        // A large, awkward rate whose fair value has a fractional part above
+        // 0.5, so ToNearest rounds *up* and overpays. Downward is always the
+        // floor of the exact fair value, so the remaining shareholders are
+        // never shortchanged.
+        //   fair = 1'000'003 * 3 / 7 = 3'000'009 / 7 = 428'572.71...
+        //   ToNearest -> 428'573 (428'573 * 7 = 3'000'011 > 3'000'009 -> dilution)
+        //   Downward  -> 428'572 (428'572 * 7 = 3'000'004 <= 3'000'009)
+        {
+            std::int64_t const assetsTotal = 1'000'003;
+            std::uint64_t const sharesTotal = 7;  // coprime-ish
+            std::uint64_t const burned = 3;
+            std::uint64_t const down =
+                payout(assetsTotal, sharesTotal, burned, Number::RoundingMode::Downward);
+            std::uint64_t const nearest =
+                payout(assetsTotal, sharesTotal, burned, Number::RoundingMode::ToNearest);
+            // down == floor(assetsTotal * burned / sharesTotal)
+            std::uint64_t const num = assetsTotal * burned;
+            std::uint64_t const expectedDown = num / sharesTotal;
+            BEAST_EXPECT(down == expectedDown);
+            BEAST_EXPECT(down * sharesTotal <= num);    // no dilution
+            BEAST_EXPECT(nearest * sharesTotal > num);  // pre-fix dilutes
+        }
+    }
+
     // Post-fix end-to-end resolution: after the sole-shareholder partial
     // exit, the loan is repaid in full. With unrealized loss cleared and
     // all assets back as cash, the depositor can burn all remaining
@@ -8330,6 +8545,9 @@ public:
         testWithdrawSoleShareholderCleanVaultUnaffected(all_);
         testWithdrawSoleShareholderPartialFixedSharesUsesFullPrice();
         testWithdrawSoleShareholderLoanRepaymentExit();
+
+        testDepositRoundingFavorsPool();
+        testWithdrawRoundingFavorsPool();
 
         testVaultDepositFreezeIOU();
         testVaultDepositFreezeMPT();

--- a/src/test/app/vault/VaultBugs_test.cpp
+++ b/src/test/app/vault/VaultBugs_test.cpp
@@ -929,10 +929,13 @@ private:
             env.close();
         };
 
+        // fixCleanup3_5_0 must be disabled alongside fixCleanup3_4_0 to reproduce the bug: its
+        // Downward payout rounding floors the last-share withdrawal onto a representable amount,
+        // which keeps the invariant satisfied even without the fixCleanup3_4_0 clamp.
         testcase(
             "bug: VaultWithdraw permanently locks a large IOU vault "
             "(pre-fixCleanup3_4_0)");
-        runScenario(all_ - fixCleanup3_4_0, tecINVARIANT_FAILED);
+        runScenario(all_ - fixCleanup3_4_0 - fixCleanup3_5_0, tecINVARIANT_FAILED);
         testcase(
             "bug: VaultWithdraw no longer locks a large IOU vault "
             "(post-fixCleanup3_4_0)");

--- a/src/test/app/vault/VaultHelpers_test.cpp
+++ b/src/test/app/vault/VaultHelpers_test.cpp
@@ -20,10 +20,12 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <expected>
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 
 namespace xrpl {
 
@@ -462,6 +464,225 @@ private:
         runCases(xrp, xrpCases);
     }
 
+    // Builds the minimal vault + share-issuance pair that the share<->asset
+    // conversions read: they only touch sfAsset, sfAssetsTotal, sfShareMPTID,
+    // sfScale and sfLossUnrealized on the vault, plus sfOutstandingAmount on
+    // the issuance. No ledger view and no Rules are involved.
+    static std::pair<std::shared_ptr<SLE>, std::shared_ptr<SLE>>
+    makeVaultAndIssuance(
+        Asset const& asset,
+        MPTID const& shareMPT,
+        Number const& assetsTotal,
+        std::uint64_t sharesTotal)
+    {
+        auto vault = std::make_shared<SLE>(keylet::vault(uint256(1)));
+        vault->setFieldIssue(sfAsset, STIssue{sfAsset, asset});
+        vault->at(sfShareMPTID) = shareMPT;
+        vault->at(sfScale) = std::uint8_t(0);
+        vault->at(sfAssetsTotal) = assetsTotal;
+        vault->at(sfLossUnrealized) = Number(0);
+        associateAsset(*vault, asset);
+
+        auto issuance = std::make_shared<SLE>(keylet::mptokenIssuance(shareMPT));
+        issuance->at(sfOutstandingAmount) = sharesTotal;
+        return {vault, issuance};
+    }
+
+    // Common Prefix formal-verification finding: VaultDeposit charges the
+    // depositor via sharesToAssetsDeposit, which quantized the exchange under
+    // round-to-nearest. When the vault holds an integral asset (MPT/XRP) at a
+    // non-unit exchange rate, the charge for freshly minted shares can be
+    // rounded *down* below their fair value. The depositor then receives
+    // shares worth more than the assets they pay in, diluting the existing
+    // shareholders.
+    //
+    // Post-fixCleanup3_5_0 the charge rounds Upward (in the pool's favor), so
+    // a depositor always pays at least the fair value of the shares they
+    // receive and the assets-per-share price never decreases for existing
+    // holders.
+    //
+    // Note this is only load-bearing for integral assets. For an IOU the
+    // fixCleanup3_4_0 clamp in VaultDeposit::doApply re-floors the charge onto
+    // the posterior sfAssetsTotal grid, whereas clampToAssetsTotalScale
+    // returns integral magnitudes unchanged (see testIntegralAssets above).
+    //
+    // This exercises sharesToAssetsDeposit directly: the ToNearest overload is
+    // the pre-amendment behavior, the Upward overload is the fix. For an
+    // integral asset the difference is a full unit, so the undercharge is
+    // unambiguous.
+    void
+    testDepositRoundingFavorsPool(MPTIssue const& assetMPT, MPTID const& shareMPT)
+    {
+        testcase("Deposit: share-to-asset rounding favors the pool");
+
+        Asset const vaultAsset{assetMPT};
+
+        // Charge for `minted` shares against a vault holding `assetsTotal`
+        // integral assets backed by `sharesTotal` shares.
+        auto const charge = [&](std::int64_t assetsTotal,
+                                std::uint64_t sharesTotal,
+                                std::uint64_t minted,
+                                Number::RoundingMode mode) -> std::uint64_t {
+            auto const [vault, issuance] =
+                makeVaultAndIssuance(vaultAsset, shareMPT, Number(assetsTotal), sharesTotal);
+            STAmount const shares{MPTIssue{shareMPT}, Number(minted)};
+            auto const assets = sharesToAssetsDeposit(vault, issuance, shares, mode);
+            BEAST_EXPECT(assets.has_value());
+            return assets ? assets->mantissa() : 0;
+        };
+
+        // rate 100/3: charging 1 share is worth 33.33 assets.
+        //   ToNearest -> 33 (undercharges: 33 * 3 = 99 < 100 -> dilution)
+        //   Upward    -> 34 (favors pool: 34 * 3 = 102 >= 100)
+        {
+            std::uint64_t const nearest = charge(100, 3, 1, Number::RoundingMode::ToNearest);
+            std::uint64_t const up = charge(100, 3, 1, Number::RoundingMode::Upward);
+            BEAST_EXPECT(nearest == 33);
+            BEAST_EXPECT(up == 34);
+            // Pre-fix undercharges (dilutes); post-fix never does.
+            BEAST_EXPECT(nearest * 3 < 100 * 1);
+            BEAST_EXPECT(up * 3 >= 100 * 1);
+        }
+
+        // rate 100/3, 2 shares -> 66.67. ToNearest already rounds up here, so
+        // both agree and neither dilutes: the fix only ever raises the charge.
+        {
+            std::uint64_t const nearest = charge(100, 3, 2, Number::RoundingMode::ToNearest);
+            std::uint64_t const up = charge(100, 3, 2, Number::RoundingMode::Upward);
+            BEAST_EXPECT(nearest == 67);
+            BEAST_EXPECT(up == 67);
+            BEAST_EXPECT(up * 3 >= 100 * 2);
+        }
+
+        // Exact rate: no rounding, the fix is a no-op.
+        {
+            std::uint64_t const nearest = charge(100, 4, 2, Number::RoundingMode::ToNearest);
+            std::uint64_t const up = charge(100, 4, 2, Number::RoundingMode::Upward);
+            BEAST_EXPECT(nearest == 50);
+            BEAST_EXPECT(up == 50);
+        }
+
+        // A large, awkward rate: Upward is always the ceiling of the exact
+        // fair value, so the pool is never shortchanged.
+        //   fair = 1'000'003 * 7 / 999'983 = 7'000'021 / 999'983 = 7.00014...
+        //   ToNearest -> 7 (7 * 999'983 = 6'999'881 < 7'000'021 -> dilution)
+        //   Upward    -> 8 (8 * 999'983 = 7'999'864 >= 7'000'021)
+        {
+            std::int64_t const assetsTotal = 1'000'003;
+            std::uint64_t const sharesTotal = 999'983;  // coprime-ish
+            std::uint64_t const minted = 7;
+            std::uint64_t const up =
+                charge(assetsTotal, sharesTotal, minted, Number::RoundingMode::Upward);
+            std::uint64_t const nearest =
+                charge(assetsTotal, sharesTotal, minted, Number::RoundingMode::ToNearest);
+            // up == ceil(assetsTotal * minted / sharesTotal)
+            std::uint64_t const num = assetsTotal * minted;
+            std::uint64_t const expectedUp = (num + sharesTotal - 1) / sharesTotal;
+            BEAST_EXPECT(up == expectedUp);
+            BEAST_EXPECT(up * sharesTotal >= num);      // no dilution
+            BEAST_EXPECT(nearest * sharesTotal < num);  // pre-fix dilutes
+        }
+    }
+
+    // Common Prefix formal-verification finding (mirror of the deposit case):
+    // VaultWithdraw pays the withdrawing shareholder via
+    // sharesToAssetsWithdraw, which quantized the exchange under
+    // round-to-nearest. When the vault holds an integral asset (MPT/XRP) at a
+    // non-unit exchange rate, the payout for burned shares can be rounded *up*
+    // above their fair value. The shareholder then receives assets worth more
+    // than the shares they burn, diluting the remaining shareholders.
+    //
+    // Post-fixCleanup3_5_0 the payout rounds Downward (in the pool's favor), so
+    // a withdrawer always receives at most the fair value of the shares they
+    // burn and the assets-per-share price never decreases for the holders who
+    // remain.
+    //
+    // As with the deposit case this is only load-bearing for integral assets:
+    // for an IOU the fixCleanup3_4_0 clamp in VaultWithdraw::doApply already
+    // floors the payout onto the posterior sfAssetsTotal grid.
+    //
+    // This exercises sharesToAssetsWithdraw directly: the ToNearest overload is
+    // the pre-amendment behavior, the Downward overload is the fix. For an
+    // integral asset the difference is a full unit, so the overpayment is
+    // unambiguous.
+    void
+    testWithdrawRoundingFavorsPool(MPTIssue const& assetMPT, MPTID const& shareMPT)
+    {
+        testcase("Withdraw: share-to-asset rounding favors the pool");
+
+        Asset const vaultAsset{assetMPT};
+
+        // Pay out for burning `burned` shares against a vault holding
+        // `assetsTotal` integral assets backed by `sharesTotal` shares. The
+        // vault carries no unrealized loss, so the waive flag is irrelevant.
+        auto const payout = [&](std::int64_t assetsTotal,
+                                std::uint64_t sharesTotal,
+                                std::uint64_t burned,
+                                Number::RoundingMode mode) -> std::uint64_t {
+            auto const [vault, issuance] =
+                makeVaultAndIssuance(vaultAsset, shareMPT, Number(assetsTotal), sharesTotal);
+            STAmount const shares{MPTIssue{shareMPT}, Number(burned)};
+            auto const assets =
+                sharesToAssetsWithdraw(vault, issuance, shares, WaiveUnrealizedLoss::No, mode);
+            BEAST_EXPECT(assets.has_value());
+            return assets ? assets->mantissa() : 0;
+        };
+
+        // rate 100/3: burning 1 share is worth 33.33 assets.
+        //   ToNearest -> 33 (fair: 33 * 3 = 99 <= 100, no dilution here)
+        //   Downward  -> 33 (favors pool: 33 * 3 = 99 <= 100)
+        {
+            std::uint64_t const nearest = payout(100, 3, 1, Number::RoundingMode::ToNearest);
+            std::uint64_t const down = payout(100, 3, 1, Number::RoundingMode::Downward);
+            BEAST_EXPECT(nearest == 33);
+            BEAST_EXPECT(down == 33);
+            BEAST_EXPECT(down * 3 <= 100 * 1);  // pool never shortchanged
+        }
+
+        // rate 100/3, 2 shares -> 66.67. ToNearest rounds *up* to 67 and
+        // overpays (67 * 3 = 201 > 200 -> dilution); Downward floors to 66.
+        {
+            std::uint64_t const nearest = payout(100, 3, 2, Number::RoundingMode::ToNearest);
+            std::uint64_t const down = payout(100, 3, 2, Number::RoundingMode::Downward);
+            BEAST_EXPECT(nearest == 67);
+            BEAST_EXPECT(down == 66);
+            // Pre-fix overpays (dilutes remaining holders); post-fix never does.
+            BEAST_EXPECT(nearest * 3 > 100 * 2);
+            BEAST_EXPECT(down * 3 <= 100 * 2);
+        }
+
+        // Exact rate: no rounding, the fix is a no-op.
+        {
+            std::uint64_t const nearest = payout(100, 4, 2, Number::RoundingMode::ToNearest);
+            std::uint64_t const down = payout(100, 4, 2, Number::RoundingMode::Downward);
+            BEAST_EXPECT(nearest == 50);
+            BEAST_EXPECT(down == 50);
+        }
+
+        // A large, awkward rate whose fair value has a fractional part above
+        // 0.5, so ToNearest rounds *up* and overpays. Downward is always the
+        // floor of the exact fair value, so the remaining shareholders are
+        // never shortchanged.
+        //   fair = 1'000'003 * 3 / 7 = 3'000'009 / 7 = 428'572.71...
+        //   ToNearest -> 428'573 (428'573 * 7 = 3'000'011 > 3'000'009 -> dilution)
+        //   Downward  -> 428'572 (428'572 * 7 = 3'000'004 <= 3'000'009)
+        {
+            std::int64_t const assetsTotal = 1'000'003;
+            std::uint64_t const sharesTotal = 7;  // coprime-ish
+            std::uint64_t const burned = 3;
+            std::uint64_t const down =
+                payout(assetsTotal, sharesTotal, burned, Number::RoundingMode::Downward);
+            std::uint64_t const nearest =
+                payout(assetsTotal, sharesTotal, burned, Number::RoundingMode::ToNearest);
+            // down == floor(assetsTotal * burned / sharesTotal)
+            std::uint64_t const num = assetsTotal * burned;
+            std::uint64_t const expectedDown = num / sharesTotal;
+            BEAST_EXPECT(down == expectedDown);
+            BEAST_EXPECT(down * sharesTotal <= num);    // no dilution
+            BEAST_EXPECT(nearest * sharesTotal > num);  // pre-fix dilutes
+        }
+    }
+
 public:
     void
     run() override
@@ -476,6 +697,10 @@ public:
         testIouDebits(iou);
         testIouCredits(iou);
         testIntegralAssets(mpt, xrp);
+
+        MPTID const shareMPT = makeMptID(2, issuer.id());
+        testDepositRoundingFavorsPool(mpt, shareMPT);
+        testWithdrawRoundingFavorsPool(mpt, shareMPT);
     }
 };
 


### PR DESCRIPTION
## High Level Overview of Change

Under the `fixCleanup3_3_0` amendment, the vault's share↔asset conversions are rounded **in the pool's favor** so that a single depositor or withdrawer can no longer dilute the other shareholders through round-to-nearest:

- **Deposit** — `sharesToAssetsDeposit()` rounds the assets *charged* for freshly minted shares **Upward**, so the depositor pays at least the fair value of those shares.
- **Withdraw** — `sharesToAssetsWithdraw()` rounds the assets *paid* for burned shares **Downward**, so the withdrawer receives at most the fair value of those shares.

Both helpers take a rounding-mode parameter defaulting to `ToNearest` (pre-amendment behavior); the paired transactors pass the pool-favoring mode only when the amendment is enabled.

### Context of Change

Both defects predate this PR and are symmetric. The conversions computed `assetsTotal · shares / shareTotal` and quantized to the asset's precision with the default `ToNearest` rounding:

- On **deposit**, an inexact rate could round the charge **down**, so the depositor paid less than the fair value of the shares received — the shortfall accrues to NAV and dilutes existing holders.
- On **withdraw**, an inexact rate could round the payout **up**, so the withdrawer took more assets than their burned shares were worth — dropping the assets-per-share price for the remaining holders.

Both are corrected only behind `fixCleanup3_3_0`, so pre-amendment ledgers replay identically. Part of the ongoing vault/lending rounding cleanup (cf. `fixCleanup3_2_0`, `fixCleanup3_1_3`).

Scope notes:
- `assetsToSharesDeposit` already truncates (down) and `assetsToSharesWithdraw` needs no change — flooring the withdraw *payout* alone guarantees `assetsWithdrawn ≤ fairValue(sharesBurned)` regardless of how the shares were derived, so the "equal balance" invariant is preserved by construction (`assetsWithdrawn` drives both the vault decrement and the destination credit).
- **Clawback** callers of `sharesToAssetsWithdraw` are intentionally left on `ToNearest` (different economic direction).
- `VaultWithdraw::preclaim` passes the same `Downward` mode so the withdrawal-limit check estimates the same amount the apply will pay.

**Bug discovery — Common Prefix formal verification.** These fixes address findings from [Common Prefix](https://www.commonprefix.com/)'s public formal verification of the XRPL single-asset vault / lending protocol. Their [`testVaultDepositOvervaluedShares`](https://github.com/commonprefix/rippled-formal-verification/blob/lending-protocol-fv/src/test/formal_verification/tx/vault/LeanVaultDeposit_test.cpp#L466) snippet states the deposit finding directly:

> // Finding (C++ bug): a deposit charges round-to-nearest, so a deposit into a vault
> // can be undercharged, overvaluing the new shares and diluting existing holders.

The withdraw payout corrected here is the exact symmetric case: round-to-nearest can *overpay* a withdrawer, diluting the holders who remain.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change — `sharesToAssetsDeposit()` and `sharesToAssetsWithdraw()` in `include/xrpl/ledger/helpers/VaultHelpers.h` each gain a defaulted `Number::RoundingMode` parameter (source-compatible; the default preserves prior behavior).
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

Transaction-processing behavior changes only when `fixCleanup3_3_0` is enabled, so no peer-protocol/version impact.

## Before / After

Inexact rate, pool `100` assets / `3` shares:

| Op | Shares | Fair value | Before (`ToNearest`) | After (amendment on) | Effect of fix |
|---|---|---|---|---|---|
| Deposit charge | mint 1 | `33.33…` | `33` (`33·3=99 < 100` → dilution) | **`34`** Upward (`102 ≥ 100`) | charge favors pool |
| Withdraw payout | burn 2 | `66.67…` | `67` (`67·3=201 > 200` → dilution) | **`66`** Downward (`198 ≤ 200`) | payout favors pool |

Exact rates, and cases where `ToNearest` already rounds the safe way, are unchanged — the fix only ever moves the amount toward the pool.

## Test Plan

Direct unit tests of both conversion helpers (`src/test/app/Vault_test.cpp`) build minimal `ltVAULT` + `ltMPTOKEN_ISSUANCE` SLEs and call the helper with `ToNearest` vs the pool-favoring mode:

- `testDepositRoundingFavorsPool` — asserts the undercharge/dilution case (`33` vs `34`) and the invariant `charged · shareTotal ≥ assetsTotal · shares`, plus no-op cases.
- `testWithdrawRoundingFavorsPool` — asserts the overpay/dilution case (`67` vs `66`) and the invariant `paid · shareTotal ≤ assetsTotal · shares`, plus exact-rate and large awkward-rate cases.

Both target **MPT** assets deliberately: for IOU the fair value fits within STAmount's 16-digit quantization so the rounding difference is sub-ULP and unobservable; on integral (MPT/XRP) assets a wrong rounding is a full unit.

Local regression run (Debug): `xrpl.app.Vault` (409 cases / 11,358 tests), `xrpl.tx.Loan` (1,055 / 115,934 — the unrealized-loss withdraw path), and `xrpl.app.Invariants` (85 / 13,978) all pass with 0 failures.
