### PR TITLE
fix: Add VaultInvariant check that lossUnrealized is non-negative

### DIFF
--- a/src/libxrpl/tx/invariants/VaultInvariant.cpp
+++ b/src/libxrpl/tx/invariants/VaultInvariant.cpp
@@ -483,6 +483,12 @@ ValidVault::finalize(
         result = false;
     }
 
+    if (view.rules().enabled(fixCleanup3_4_0) && afterVault.lossUnrealized < kZero)
+    {
+        JLOG(j.fatal()) << "Invariant failed: loss unrealized must not be negative";
+        result = false;
+    }
+
     if (afterVault.assetsTotal < kZero)
     {
         JLOG(j.fatal()) << "Invariant failed: assets outstanding must be positive";

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -3374,6 +3374,41 @@ class Invariants_test : public beast::unit_test::Suite
             precloseXrp,
             TxAccount::A2);
 
+        // A negative loss unrealized must trip the invariant. ttLOAN_MANAGE is
+        // allowed to change loss unrealized, so it isolates this check from the
+        // "must not change loss unrealized" invariant. Gated behind
+        // fixCleanup3_4_0 (see below).
+        doInvariantCheck(
+            {"loss unrealized must not be negative"},
+            [&](Account const& a1, Account const& a2, ApplyContext& ac) {
+                auto const keylet = keylet::vault(a1.id(), ac.view().seq());
+                return kAdjust(ac.view(), keylet, kArgs(a2.id(), 0, [&](Adjustments& sample) {
+                                   sample.lossUnrealized = -1;
+                               }));
+            },
+            XRPAmount{},
+            STTx{ttLOAN_MANAGE, [](STObject& tx) {}},
+            {tecINVARIANT_FAILED, tecINVARIANT_FAILED},
+            precloseXrp,
+            TxAccount::A2);
+
+        // Without fixCleanup3_4_0 the same state must NOT trip the invariant,
+        // preserving pre-amendment behavior (no fork risk).
+        doInvariantCheck(
+            makeEnv(defaultAmendments() - fixCleanup3_4_0),
+            {},
+            [&](Account const& a1, Account const& a2, ApplyContext& ac) {
+                auto const keylet = keylet::vault(a1.id(), ac.view().seq());
+                return kAdjust(ac.view(), keylet, kArgs(a2.id(), 0, [&](Adjustments& sample) {
+                                   sample.lossUnrealized = -1;
+                               }));
+            },
+            XRPAmount{},
+            STTx{ttLOAN_MANAGE, [](STObject& tx) {}},
+            {tesSUCCESS, tesSUCCESS},
+            precloseXrp,
+            TxAccount::A2);
+
         doInvariantCheck(
             {"set assets outstanding must not exceed assets maximum"},
             [&](Account const& a1, Account const& a2, ApplyContext& ac) {


### PR DESCRIPTION
## High Level Overview of Change

`ValidVault::finalize` (the VaultInvariant) validated the *upper* bound on the vault's
`sfLossUnrealized` field but never the *lower* bound. This adds a defense-in-depth check
that `lossUnrealized` must be non-negative, plus a unit test.

Ref: FN-32.

### Context of Change

The invariant already checks `lossUnrealized <= assetsTotal - assetsAvailable`,
`assetsTotal >= 0`, and `assetsAvailable >= 0`, but not `lossUnrealized >= 0`.

A negative `lossUnrealized` would pass all existing checks. Downstream, the withdraw
math in `VaultHelpers` computes `assetTotal -= lossUnrealized`; with a negative loss this
*inflates* the effective asset total above `assetsTotal`, which would let withdrawers
extract more assets than the vault tracks.

Today the only writers of `sfLossUnrealized` (the `LoanManage` impair / unimpair / default
paths) already guard against underflow, so `lossUnrealized` cannot currently go negative —
there is no mainnet exposure. This change is purely defense-in-depth: if a future lending
bug drove the field negative, the invariant would now catch it instead of allowing a
silent over-withdrawal.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

## Test Plan

Added a unit test in `Invariants_test.cpp` that sets `lossUnrealized` negative on a vault
and confirms the invariant fails with "loss unrealized must be positive". Verified the test
fails without the fix and passes with it; both test sets are green (`xrpld --unittest` and
`ctest --preset conan-debug`).
