### PR TITLE
fix: Explicit mtSQUELCH classification in Message::compress switch (#6740)

### DIFF
--- a/src/test/overlay/compression_test.cpp
+++ b/src/test/overlay/compression_test.cpp
@@ -396,6 +396,37 @@ public:
     }
 
     void
+    testMtSquelchUncompressed()
+    {
+        testcase("mtSQUELCH is uncompressed");
+
+        //construct >70 so should be eligible for compression
+        auto squelch = std::make_shared<protocol::TMSquelch>();
+        squelch->set_squelch(true);
+        // Use a large validatorPubKey to push the message over the 70-byte
+        // threshold that triggers compression
+        std::string largePubKey(256, 'A');
+        squelch->set_validatorpubkey(largePubKey);
+        squelch->set_squelchduration(600);
+
+        Message m(*squelch, protocol::mtSQUELCH);
+
+        auto const& compressed = m.getBuffer(Compressed::On);
+        auto const& uncompressed = m.getBuffer(Compressed::Off);
+
+        BEAST_EXPECT(compressed.size() == uncompressed.size());
+        BEAST_EXPECT(compressed == uncompressed);
+
+        log << "  Uncompressed size: " << uncompressed.size() << " bytes\n";
+        log << "  'Compressed' size: " << compressed.size() << " bytes\n";
+        log << "  Buffers are identical: "
+            << (compressed == uncompressed
+                    ? "YES (mtSQUELCH is non-compressible)"
+                    : "NO — REGRESSION")
+            << std::endl;
+    }
+
+    void
     testHandshake()
     {
         testcase("Handshake");
@@ -455,6 +486,7 @@ public:
     {
         testProtocol();
         testHandshake();
+        testMtSquelchUncompressed();
     }
 };
 

--- a/src/xrpld/overlay/detail/Message.cpp
+++ b/src/xrpld/overlay/detail/Message.cpp
@@ -73,7 +73,6 @@ Message::compress()
         if (messageBytes <= 70)
             return false;
 
-        // NOLINTNEXTLINE(bugprone-switch-missing-default-case)
         switch (type)
         {
             case protocol::mtMANIFESTS:
@@ -97,6 +96,11 @@ Message::compress()
             case protocol::mtPROOF_PATH_RESPONSE:
             case protocol::mtREPLAY_DELTA_REQ:
             case protocol::mtHAVE_TRANSACTIONS:
+            case protocol::mtSQUELCH:
+                break;
+            default:
+                XRPL_ASSERT(
+                    false, "xrpl::Message::compress : unknown message type");
                 break;
         }
         return false;


### PR DESCRIPTION
## High Level Overview of Change

Fix for #6740: `Message::compress()` in `src/xrpld/overlay/detail/Message.cpp` enumerates message types in a switch statement to decide compressibility, but `mtSQUELCH` was absent from both the compressible and non-compressible groups. Silent fall-through happened to produce the correct behavior (uncompressed), but any future `MessageType` enum value would silently inherit the same fall-through — a maintenance hazard flagged by the `NOLINTNEXTLINE(bugprone-switch-missing-default-case)` suppression.

This PR:

- Adds `case protocol::mtSQUELCH: break;` to the non-compressible group.
- Adds a `default:` case with `XRPL_ASSERT(false, ...)` so future omissions surface loudly in debug/test builds instead of silently falling through.
- Removes the now-redundant `NOLINTNEXTLINE` suppression.
- Adds a regression test in `src/test/overlay/compression_test.cpp` (`testMtSquelchUncompressed`) that constructs a `TMSquelch` payload padded above the 70-byte compression gate and asserts `getBuffer(Compressed::On)` and `getBuffer(Compressed::Off)` return byte-identical buffers — locking in the non-compressible classification.

### Context of Change

INFORMATIONAL — no security impact, no observable behavior change. Code hygiene / maintenance fix.

Continues work from closed PR #6805, which had the code change but no test, kept the `NOLINTNEXTLINE`, and was closed due to unsigned commits.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change
- [ ] `libxrpl` change
- [ ] Peer protocol change

Internal `xrpld/overlay` change only — no public or wire-protocol impact.

## Test plan

Run the compression suite:

\`\`\`
./xrpld --unittest=xrpl.overlay.compression --unittest-log
\`\`\`

- [x] Full suite passes with the fix in place (16 cases, 0 failures).
- [x] New \`testMtSquelchUncompressed\` case runs and asserts the compressed/uncompressed buffers are byte-identical for a padded \`TMSquelch\` payload.