### PR TITLE
fix: Validate the get_counts min_count parameter

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,7 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
-- `get_counts`: The `min_count` field now returns `invalidParams` if the value is not a non-negative integer. Previously, values that could not be converted returned an `internal` error, and strings, booleans, and `null` were silently coerced. [#NNNN](https://github.com/XRPLF/rippled/pull/NNNN)
+- `get_counts`: The `min_count` field now returns `invalidParams` if the value is not a non-negative integer. Previously, values that could not be converted returned an `internal` error, and strings, booleans, and `null` were silently coerced. [#7904](https://github.com/XRPLF/rippled/pull/7904)
 
 ## XRP Ledger server version 3.1.0
 

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,6 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
+- `get_counts`: The `min_count` field now returns `invalidParams` if the value is not a non-negative integer. Previously, values that could not be converted returned an `internal` error, and strings, booleans, and `null` were silently coerced. [#NNNN](https://github.com/XRPLF/rippled/pull/NNNN)
 
 ## XRP Ledger server version 3.1.0
 

--- a/src/test/rpc/GetCounts_test.cpp
+++ b/src/test/rpc/GetCounts_test.cpp
@@ -9,6 +9,8 @@
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/jss.h>
 
+#include <boost/container/static_vector.hpp>
+
 #include <thread>
 
 namespace xrpl {
@@ -18,6 +20,7 @@ class GetCounts_test : public beast::unit_test::Suite
     void
     testGetCounts()
     {
+        testcase("Get counts");
         using namespace test::jtx;
         Env env(*this);
 
@@ -91,11 +94,49 @@ class GetCounts_test : public beast::unit_test::Suite
         }
     }
 
+    void
+    testBadMinCount()
+    {
+        testcase("Invalid min_count");
+        using namespace test::jtx;
+        Env env{*this};
+
+        json::Value objMinCount{json::ValueType::Object};
+        objMinCount["nope"] = 0;
+        json::Value arrMinCount{json::ValueType::Array};
+        arrMinCount.append(0);
+
+        // Note that a whole number beyond the range of a uint, e.g.
+        // 4294967296, is rejected by the json parser itself, so it never
+        // reaches the handler and is not covered here.
+        boost::container::static_vector<json::Value, 9> const badMinCounts{
+            json::Value{-1},     // negative
+            json::Value{"abc"},  // not a number
+            json::Value{"5"},    // numeric, but a string
+            json::Value{1.5},    // not a whole number
+            json::Value{1e30},   // beyond the range of a uint
+            json::Value{true},   // bool
+            json::Value{},       // null
+            objMinCount,
+            arrMinCount,
+        };
+
+        for (auto const& badMinCount : badMinCounts)
+        {
+            json::Value params{json::ValueType::Object};
+            params[jss::min_count] = badMinCount;
+            auto const result = env.client().invoke("get_counts", params)[jss::result];
+            BEAST_EXPECT(result[jss::error] == "invalidParams");
+            BEAST_EXPECT(result[jss::status] == "error");
+        }
+    }
+
 public:
     void
     run() override
     {
         testGetCounts();
+        testBadMinCount();
     }
 };
 

--- a/src/xrpld/rpc/handlers/admin/status/GetCounts.cpp
+++ b/src/xrpld/rpc/handlers/admin/status/GetCounts.cpp
@@ -8,6 +8,8 @@
 #include <xrpl/json/json_forwards.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/nodestore/Database.h>
+#include <xrpl/protocol/ErrorCodes.h>
+#include <xrpl/protocol/RPCErr.h>
 #include <xrpl/protocol/jss.h>
 #include <xrpl/server/NetworkOPs.h>
 
@@ -116,7 +118,16 @@ doGetCounts(RPC::JsonContext& context)
     int minCount = 10;
 
     if (context.params.isMember(jss::min_count))
-        minCount = context.params[jss::min_count].asUInt();
+    {
+        // Guard the conversion: json::Value::asUInt() throws for negative,
+        // out-of-range, non-numeric or non-scalar values, which would surface as a
+        // generic internal error instead of invalid parameters.
+        auto const& jvMinCount = context.params[jss::min_count];
+        if (!jvMinCount.isUInt() && (!jvMinCount.isInt() || jvMinCount.asInt() < 0))
+            return rpcError(RpcInvalidParams);
+
+        minCount = jvMinCount.asUInt();
+    }
 
     return getCountsJson(context.app, minCount);
 }


### PR DESCRIPTION
doGetCounts read the min_count parameter with an unguarded asUInt(), which throws for negative, out-of-range, non-numeric and non-scalar values. The throw was swallowed by callMethod's catch-all, so a malformed min_count produced a generic internal error rather than invalidParams, and the request was recorded as a server fault in the perf log.

Guard the conversion with the same isUInt()/isInt() check that readLimitField already applies to the limit field, and return invalidParams when it fails.

This makes the handler stricter: a min_count given as a numeric string, null, or a bool was previously coerced and is now rejected. get_counts is admin only, so the affected surface is small. The commandline parser is unchanged; it converts its argument before the handler sees it.

Fixes #6755

<!--
This PR template helps you write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR. This avoids redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to this PR.
-->
