### PR TITLE
fix: Correct sign-check wording in lending protocol messages

### DIFF
--- a/src/libxrpl/tx/invariants/VaultInvariant.cpp
+++ b/src/libxrpl/tx/invariants/VaultInvariant.cpp
@@ -465,7 +465,7 @@ ValidVault::finalize(
 
     if (afterVault.assetsAvailable < kZero)
     {
-        JLOG(j.fatal()) << "Invariant failed: assets available must be positive";
+        JLOG(j.fatal()) << "Invariant failed: assets available must not be negative";
         result = false;
     }
 
@@ -485,13 +485,13 @@ ValidVault::finalize(
 
     if (afterVault.assetsTotal < kZero)
     {
-        JLOG(j.fatal()) << "Invariant failed: assets outstanding must be positive";
+        JLOG(j.fatal()) << "Invariant failed: assets outstanding must not be negative";
         result = false;
     }
 
     if (afterVault.assetsMaximum < kZero)
     {
-        JLOG(j.fatal()) << "Invariant failed: assets maximum must be positive";
+        JLOG(j.fatal()) << "Invariant failed: assets maximum must not be negative";
         result = false;
     }
 

--- a/src/libxrpl/tx/transactors/lending/LoanPay.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanPay.cpp
@@ -813,7 +813,7 @@ LoanPay::doApply()
     XRPL_ASSERT_PARTS(
         vaultBalanceAfter >= beast::kZero && brokerBalanceAfter >= beast::kZero,
         "xrpl::LoanPay::doApply",
-        "positive vault and broker balances");
+        "non-negative vault and broker balances");
     XRPL_ASSERT_PARTS(
         vaultBalanceAfter >= vaultBalanceBefore,
         "xrpl::LoanPay::doApply",

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -3260,9 +3260,9 @@ class Invariants_test : public beast::unit_test::Suite
              "set must not change assets available",
              "set must not change shares outstanding",
              "set must not change vault balance",
-             "assets available must be positive",
+             "assets available must not be negative",
              "assets available must not be greater than assets outstanding",
-             "assets outstanding must be positive"},
+             "assets outstanding must not be negative"},
             [&](Account const& a1, Account const& a2, ApplyContext& ac) {
                 auto const keylet = keylet::vault(a1.id(), ac.view().seq());
                 auto sleVault = ac.view().peek(keylet);
@@ -3389,7 +3389,7 @@ class Invariants_test : public beast::unit_test::Suite
             TxAccount::A2);
 
         doInvariantCheck(
-            {"assets maximum must be positive"},
+            {"assets maximum must not be negative"},
             [&](Account const& a1, Account const& a2, ApplyContext& ac) {
                 auto const keylet = keylet::vault(a1.id(), ac.view().seq());
                 return kAdjust(ac.view(), keylet, kArgs(a2.id(), 0, [&](Adjustments& sample) {
@@ -3577,7 +3577,7 @@ class Invariants_test : public beast::unit_test::Suite
 
         doInvariantCheck(
             {
-                "assets maximum must be positive",
+                "assets maximum must not be negative",
                 "create operation must not have updated a vault",
             },
             [&](Account const& a1, Account const& a2, ApplyContext& ac) {


### PR DESCRIPTION
## High Level Overview of Change

Correct misleading sign-check wording in lending-protocol diagnostic messages. Several
vault invariant log messages and one `LoanPay` assert stated that a value "must be
positive" while the corresponding check only rejects negative values (zero is a valid
state). They now say "must not be negative" / "non-negative" to match the actual check.

This is diagnostic text only — there is no behavioural or consensus change.

### Context of Change

Following review discussion on #7863: the vault/loan invariants use `< 0` (or `>= 0`)
comparisons, i.e. they enforce non-negativity, but several messages read "must be
positive", which implies `> 0`. Zero is legitimate (e.g. an empty vault has
`assetsAvailable == 0`, `assetsTotal == 0`; `assetsMaximum == 0` means "no maximum";
a vault with no impaired loans has `lossUnrealized == 0`), so the wording was misleading
when diagnosing invariant failures.

Reworded to match the checks:
- `VaultInvariant.cpp` — "assets available / assets outstanding / assets maximum must be
  positive" → "... must not be negative" (each guards `< 0`).
- `LoanPay.cpp` — assert description "positive vault and broker balances" → "non-negative
  vault and broker balances" (guards `>= 0`).

A full sweep of the lending-protocol files confirmed these are the only mismatches;
`LoanInvariant` / `LoanBrokerInvariant` already use "is negative" / "is zero or negative"
correctly, and the remaining "positive" mentions are code comments or genuinely
strict-positive checks (`<= 0`).

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

## Test Plan

Updated the affected expectations in `Invariants_test.cpp` and confirmed the invariant
suite passes with the new wording. Both test sets are green (`xrpld --unittest` and
`ctest --preset conan-debug`). No logic changed, so no new tests were added.
