### PR TITLE
fix: Validate the blacklist threshold parameter

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,6 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
+- `blacklist`: The `threshold` field now returns `invalidParams` if the value is not an integer. Previously, values that could not be converted returned an `internal` error, and strings, booleans, and `null` were silently coerced. [#7914](https://github.com/XRPLF/rippled/pull/7914)
 
 ## XRP Ledger server version 3.1.0
 

--- a/src/test/rpc/BlackList_test.cpp
+++ b/src/test/rpc/BlackList_test.cpp
@@ -1,0 +1,105 @@
+#include <test/jtx/Env.h>
+
+#include <xrpl/beast/unit_test/suite.h>
+#include <xrpl/json/json_value.h>
+#include <xrpl/protocol/jss.h>
+
+#include <boost/container/static_vector.hpp>
+
+namespace xrpl {
+
+class BlackList_test : public beast::unit_test::Suite
+{
+    void
+    testBlackList()
+    {
+        testcase("Blacklist");
+        using namespace test::jtx;
+        Env env{*this};
+
+        // Omitting the threshold uses the Resource manager's warning
+        // threshold. A freshly started Env tracks no loaded consumers, so the
+        // result is an empty object rather than an error.
+        auto const result = env.client().invoke("blacklist")[jss::result];
+        BEAST_EXPECT(!result.isMember(jss::error));
+        BEAST_EXPECT(result[jss::status] == "success");
+    }
+
+    void
+    testValidThreshold()
+    {
+        testcase("Valid threshold");
+        using namespace test::jtx;
+        Env env{*this};
+
+        // The threshold is a signed load-balance cutoff, not a count or an
+        // index, so negative and zero values are meaningful: they select every
+        // tracked consumer.
+        boost::container::static_vector<json::Value, 5> const goodThresholds{
+            json::Value{json::Value::kMinInt},
+            json::Value{-1},
+            json::Value{0},
+            json::Value{5000},  // the default, Resource::kWarningThreshold
+            json::Value{json::Value::kMaxInt},
+        };
+
+        for (auto const& goodThreshold : goodThresholds)
+        {
+            json::Value params{json::ValueType::Object};
+            params[jss::threshold] = goodThreshold;
+            auto const result = env.client().invoke("blacklist", params)[jss::result];
+            BEAST_EXPECT(!result.isMember(jss::error));
+            BEAST_EXPECT(result[jss::status] == "success");
+        }
+    }
+
+    void
+    testBadThreshold()
+    {
+        testcase("Invalid threshold");
+        using namespace test::jtx;
+        Env env{*this};
+
+        json::Value objThreshold{json::ValueType::Object};
+        objThreshold["nope"] = 0;
+        json::Value arrThreshold{json::ValueType::Array};
+        arrThreshold.append(0);
+
+        // Note that a whole number beyond the range of a uint, e.g.
+        // 4294967296, is rejected by the json parser itself, so it never
+        // reaches the handler and is not covered here.
+        boost::container::static_vector<json::Value, 9> const badThresholds{
+            json::Value{"abc"},                   // not a number
+            json::Value{"5"},                     // numeric, but a string
+            json::Value{1.5},                     // not a whole number
+            json::Value{1e30},                    // beyond the range of an int
+            json::Value{true},                    // bool
+            json::Value{},                        // null
+            json::Value{json::UInt{3000000000}},  // beyond the range of an int
+            objThreshold,
+            arrThreshold,
+        };
+
+        for (auto const& badThreshold : badThresholds)
+        {
+            json::Value params{json::ValueType::Object};
+            params[jss::threshold] = badThreshold;
+            auto const result = env.client().invoke("blacklist", params)[jss::result];
+            BEAST_EXPECT(result[jss::error] == "invalidParams");
+            BEAST_EXPECT(result[jss::status] == "error");
+        }
+    }
+
+public:
+    void
+    run() override
+    {
+        testBlackList();
+        testValidThreshold();
+        testBadThreshold();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(BlackList, rpc, xrpl);
+
+}  // namespace xrpl

--- a/src/xrpld/rpc/handlers/admin/BlackList.cpp
+++ b/src/xrpld/rpc/handlers/admin/BlackList.cpp
@@ -2,6 +2,8 @@
 #include <xrpld/rpc/Context.h>
 
 #include <xrpl/json/json_value.h>
+#include <xrpl/protocol/ErrorCodes.h>
+#include <xrpl/protocol/RPCErr.h>
 #include <xrpl/protocol/jss.h>
 #include <xrpl/resource/ResourceManager.h>
 
@@ -13,7 +15,17 @@ doBlackList(RPC::JsonContext& context)
     auto& rm = context.app.getResourceManager();
     if (context.params.isMember(jss::threshold))
     {
-        return rm.getJson(context.params[jss::threshold].asInt());
+        // Guard the conversion: json::Value::asInt() throws for out-of-range,
+        // non-numeric or non-scalar values, which would surface as a generic
+        // internal error instead of invalid parameters. Only isInt() is accepted
+        // because the json reader represents every value that fits in an int as
+        // ValueType::Int; a UInt is by construction too large for the signed
+        // threshold that getJson takes.
+        auto const& jvThreshold = context.params[jss::threshold];
+        if (!jvThreshold.isInt())
+            return rpcError(RpcInvalidParams);
+
+        return rm.getJson(jvThreshold.asInt());
     }
 
     return rm.getJson();


### PR DESCRIPTION
doBlackList read the threshold parameter with an unguarded asInt(), which throws for out-of-range, non-numeric and non-scalar values. The throw was swallowed by callMethod's catch-all, so a malformed threshold produced a generic internal error rather than invalidParams, and the request was recorded as a server fault in the perf log.

Guard the conversion with an isInt() check and return invalidParams when it fails. Only isInt() is accepted because the json reader represents every value that fits in an int as ValueType::Int, so a UInt is by construction too large for the signed threshold that getJson takes.

This makes the handler stricter: a threshold given as a numeric string, a real, a bool, or null was previously coerced and is now rejected. Negative and zero thresholds remain valid, since threshold is a signed load-balance cutoff rather than a count. blacklist is admin only and has no commandline parser entry, so the affected surface is small.

Fixes #6741

<!--
This PR template helps you write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR. This avoids redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to this PR.
-->
