### PR TITLE
Fix 6751 loglevel param type validation

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,7 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
-- `log_level`: The `severity` and `partition` fields now return `invalidParams` if the value is not a string, and `partition` also rejects the empty string. Previously, arrays and objects returned an `internal` error, and numbers, booleans, and `null` were silently coerced — for `partition` this permanently created a log partition named after the coerced value. [#7922](https://github.com/XRPLF/rippled/pull/7922)
+- `log_level`: The `severity` and `partition` fields now return `invalidParams` if the value is not a string, and `partition` also rejects the empty string. Previously, arrays and objects returned an `internal` error, and numbers, booleans, and `null` were silently coerced — for `partition` this permanently created a log partition named after the coerced value. [#7923](https://github.com/XRPLF/rippled/pull/7923)
 
 ## XRP Ledger server version 3.1.0
 

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,6 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
+- `log_level`: The `severity` and `partition` fields now return `invalidParams` if the value is not a string, and `partition` also rejects the empty string. Previously, arrays and objects returned an `internal` error, and numbers, booleans, and `null` were silently coerced — for `partition` this permanently created a log partition named after the coerced value. [#NNNN](https://github.com/XRPLF/rippled/pull/NNNN)
 
 ## XRP Ledger server version 3.1.0
 

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,7 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
-- `log_level`: The `severity` and `partition` fields now return `invalidParams` if the value is not a string, and `partition` also rejects the empty string. Previously, arrays and objects returned an `internal` error, and numbers, booleans, and `null` were silently coerced — for `partition` this permanently created a log partition named after the coerced value. [#NNNN](https://github.com/XRPLF/rippled/pull/NNNN)
+- `log_level`: The `severity` and `partition` fields now return `invalidParams` if the value is not a string, and `partition` also rejects the empty string. Previously, arrays and objects returned an `internal` error, and numbers, booleans, and `null` were silently coerced — for `partition` this permanently created a log partition named after the coerced value. [#7922](https://github.com/XRPLF/rippled/pull/7922)
 
 ## XRP Ledger server version 3.1.0
 

--- a/src/test/rpc/LogLevel_test.cpp
+++ b/src/test/rpc/LogLevel_test.cpp
@@ -1,0 +1,232 @@
+#include <test/jtx/Env.h>
+
+#include <xrpl/beast/unit_test/suite.h>
+#include <xrpl/json/json_value.h>
+#include <xrpl/protocol/jss.h>
+
+#include <boost/container/static_vector.hpp>
+
+#include <array>
+#include <string>
+#include <utility>
+
+namespace xrpl {
+
+class LogLevel_test : public beast::unit_test::Suite
+{
+    // The bad values shared by both parameters. Arrays and objects make
+    // json::Value::asString() throw; the scalars are silently stringified by
+    // it, so without a type check they reach the handler as "42", "1.500000",
+    // "true" and "". Capacity leaves room for one parameter-specific value.
+    static boost::container::static_vector<json::Value, 7>
+    badValues()
+    {
+        json::Value objValue{json::ValueType::Object};
+        objValue["nope"] = 0;
+        json::Value arrValue{json::ValueType::Array};
+        arrValue.append("warn");
+
+        return {
+            json::Value{42},    // int
+            json::Value{1.5},   // real
+            json::Value{true},  // bool
+            json::Value{},      // null
+            objValue,
+            arrValue,
+        };
+    }
+
+    // The names the bad scalars above would be stringified into if they were
+    // not rejected. "" covers both the null and the empty-string partition.
+    static constexpr std::array<char const*, 4> kJunkPartitions{
+        "42",
+        "1.500000",
+        "true",
+        "",
+    };
+
+    // A partition no other subsystem writes to, so changing its threshold has
+    // no effect on how much this suite logs.
+    static constexpr char const* kTestPartition = "LogLevelTestPartition";
+
+    static json::Value
+    levels(test::jtx::Env& env)
+    {
+        return env.client().invoke("log_level")[jss::result][jss::levels];
+    }
+
+    void
+    testGetLevels()
+    {
+        testcase("Get levels");
+        using namespace test::jtx;
+        Env env{*this};
+
+        // Omitting the severity lists the current thresholds rather than
+        // setting one.
+        auto const result = env.client().invoke("log_level")[jss::result];
+        BEAST_EXPECT(!result.isMember(jss::error));
+        BEAST_EXPECT(result[jss::status] == "success");
+        BEAST_EXPECT(result[jss::levels].isObject());
+        BEAST_EXPECT(result[jss::levels].isMember(jss::base));
+    }
+
+    void
+    testValidSeverity()
+    {
+        testcase("Valid severity");
+        using namespace test::jtx;
+        Env env{*this};
+
+        // Every alias Logs::fromString accepts, paired with the name
+        // Logs::toString reports it back as. Matching is case insensitive.
+        std::array<std::pair<char const*, char const*>, 12> const goodSeverities{{
+            {"trace", "Trace"},
+            {"debug", "Debug"},
+            {"info", "Info"},
+            {"information", "Info"},
+            {"warn", "Warning"},
+            {"warning", "Warning"},
+            {"warnings", "Warning"},
+            {"error", "Error"},
+            {"errors", "Error"},
+            {"fatal", "Fatal"},
+            {"fatals", "Fatal"},
+            {"FaTaL", "Fatal"},
+        }};
+
+        // Apply the aliases to a partition of this suite's own rather than to
+        // the base threshold: nothing writes to it, so walking down to Trace
+        // does not flood the test output the way lowering the base would.
+        std::string const name{kTestPartition};
+
+        for (auto const& [severity, reported] : goodSeverities)
+        {
+            json::Value params{json::ValueType::Object};
+            params[jss::severity] = severity;
+            params[jss::partition] = name;
+            auto const result = env.client().invoke("log_level", params)[jss::result];
+            BEAST_EXPECTS(!result.isMember(jss::error), severity);
+            BEAST_EXPECTS(result[jss::status] == "success", severity);
+            BEAST_EXPECTS(levels(env)[name] == reported, severity);
+        }
+
+        // With no partition given, the severity applies to the base threshold,
+        // which the listing reports under "base".
+        json::Value params{json::ValueType::Object};
+        params[jss::severity] = "fatals";
+        auto const result = env.client().invoke("log_level", params)[jss::result];
+        BEAST_EXPECT(!result.isMember(jss::error));
+        BEAST_EXPECT(levels(env)[jss::base] == "Fatal");
+    }
+
+    void
+    testValidPartition()
+    {
+        testcase("Valid partition");
+        using namespace test::jtx;
+        Env env{*this};
+
+        std::string const name{kTestPartition};
+
+        // A partition is created on demand, so naming one that does not exist
+        // yet is legitimate, and it shows up in the listing at the level given.
+        json::Value params{json::ValueType::Object};
+        params[jss::severity] = "fatal";
+        params[jss::partition] = name;
+        auto const result = env.client().invoke("log_level", params)[jss::result];
+        BEAST_EXPECT(!result.isMember(jss::error));
+        BEAST_EXPECT(result[jss::status] == "success");
+        BEAST_EXPECT(levels(env)[name] == "Fatal");
+
+        // "base" is matched case insensitively and sets the base threshold. It
+        // must not create a partition of that name, so a mixed-case spelling is
+        // what tells the two apart.
+        params[jss::severity] = "error";
+        params[jss::partition] = "BASE";
+        auto const baseResult = env.client().invoke("log_level", params)[jss::result];
+        BEAST_EXPECT(!baseResult.isMember(jss::error));
+        BEAST_EXPECT(baseResult[jss::status] == "success");
+
+        auto const current = levels(env);
+        BEAST_EXPECT(current[jss::base] == "Error");
+        BEAST_EXPECT(!current.isMember("BASE"));
+
+        // Setting the base threshold is not additive: Logs::threshold assigns
+        // it to every existing sink, so the partition set above is reset too.
+        BEAST_EXPECT(current[name] == "Error");
+    }
+
+    void
+    testBadSeverity()
+    {
+        testcase("Invalid severity");
+        using namespace test::jtx;
+        Env env{*this};
+
+        auto bad = badValues();
+        bad.push_back(json::Value{"err"});  // a string, but not a severity
+
+        for (auto const& badSeverity : bad)
+        {
+            json::Value params{json::ValueType::Object};
+            params[jss::severity] = badSeverity;
+            auto const result = env.client().invoke("log_level", params)[jss::result];
+            BEAST_EXPECT(result[jss::error] == "invalidParams");
+            BEAST_EXPECT(result[jss::status] == "error");
+        }
+
+        // A rejected severity must not have moved the base threshold off the
+        // level Env starts at.
+        BEAST_EXPECT(levels(env)[jss::base] == "Error");
+    }
+
+    void
+    testBadPartition()
+    {
+        testcase("Invalid partition");
+        using namespace test::jtx;
+        Env env{*this};
+
+        auto bad = badValues();
+        // Logs::get creates the partition, so an empty name is as damaging as a
+        // coerced one: it wedges a nameless sink into the listing forever.
+        bad.push_back(json::Value{""});
+
+        for (auto const& badPartition : bad)
+        {
+            json::Value params{json::ValueType::Object};
+            params[jss::severity] = "warn";
+            params[jss::partition] = badPartition;
+            auto const result = env.client().invoke("log_level", params)[jss::result];
+            BEAST_EXPECT(result[jss::error] == "invalidParams");
+            BEAST_EXPECT(result[jss::status] == "error");
+        }
+
+        // The point of the type check: none of the rejected values may have
+        // been stringified into a partition name. Other partitions can appear
+        // on their own as the server logs, so look for these names rather than
+        // comparing the whole listing.
+        auto const current = levels(env);
+        for (auto const* junk : kJunkPartitions)
+            BEAST_EXPECTS(!current.isMember(junk), std::string{"partition '"} + junk + "'");
+
+        // A rejected partition must not have moved the base threshold either.
+        BEAST_EXPECT(current[jss::base] == "Error");
+    }
+
+public:
+    void
+    run() override
+    {
+        testGetLevels();
+        testValidSeverity();
+        testValidPartition();
+        testBadSeverity();
+        testBadPartition();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(LogLevel, rpc, xrpl);
+
+}  // namespace xrpl

--- a/src/xrpld/rpc/handlers/admin/log/LogLevel.cpp
+++ b/src/xrpld/rpc/handlers/admin/log/LogLevel.cpp
@@ -35,7 +35,15 @@ doLogLevel(RPC::JsonContext& context)
         return ret;
     }
 
-    auto const severity = Logs::fromString(context.params[jss::severity].asString());
+    // Guard the conversion: json::Value::asString() throws for arrays and objects,
+    // which would surface as a generic internal error instead of invalid parameters,
+    // and silently stringifies scalars, so a number or a bool would be matched
+    // against the severity names as its printed form.
+    auto const& jvSeverity = context.params[jss::severity];
+    if (!jvSeverity.isString())
+        return rpcError(RpcInvalidParams);
+
+    auto const severity = Logs::fromString(jvSeverity.asString());
 
     if (not severity.has_value())
         return rpcError(RpcInvalidParams);
@@ -49,24 +57,26 @@ doLogLevel(RPC::JsonContext& context)
     }
 
     // log_level partition severity base?
-    if (context.params.isMember(jss::partition))
+    // Guard the conversion for the same reason, and reject the empty name: Logs::get
+    // creates a partition on demand, so any value that is not a real partition name
+    // adds a junk sink that this command then reports forever.
+    auto const& jvPartition = context.params[jss::partition];
+    if (!jvPartition.isString() || jvPartition.asString().empty())
+        return rpcError(RpcInvalidParams);
+
+    // set partition threshold
+    std::string const partition(jvPartition.asString());
+
+    if (boost::iequals(partition, "base"))
     {
-        // set partition threshold
-        std::string const partition(context.params[jss::partition].asString());
-
-        if (boost::iequals(partition, "base"))
-        {
-            context.app.getLogs().threshold(*severity);
-        }
-        else
-        {
-            context.app.getLogs().get(partition).threshold(*severity);
-        }
-
-        return json::ValueType::Object;
+        context.app.getLogs().threshold(*severity);
+    }
+    else
+    {
+        context.app.getLogs().get(partition).threshold(*severity);
     }
 
-    return rpcError(RpcInvalidParams);
+    return json::ValueType::Object;
 }
 
 }  // namespace xrpl


### PR DESCRIPTION
## High Level Overview of Change

Fixes #6751

`doLogLevel` read both of its parameters with an unguarded `asString()`. This adds
`isString()` guards to `severity` and `partition` so malformed values return
`invalidParams` instead of a generic `internal` error, and rejects the empty partition
name. Adds a `LogLevel` RPC test suite, which did not previously exist.

### Context of Change

`json::Value::asString()` throws `json::Error` for arrays and objects, and silently
stringifies every scalar (`Int` -> `"42"`, `Boolean` -> `"true"`, `Null` -> `""`). The
throw was swallowed by `callMethod`'s catch-all, so a malformed value produced a generic
`internal` error rather than `invalidParams`, and the request was recorded as a server
fault in the perf log.

The two parameters were broken to different degrees:

- **`severity`** was only half broken. A coerced scalar still failed `Logs::fromString`
  and came back as `invalidParams`, so the outcome was accidentally correct; only arrays
  and objects misbehaved.
- **`partition`** had no downstream validation at all, and `Logs::get` does an `emplace`,
  so it creates the sink on demand. A coerced value therefore permanently added a
  partition literally named `42`, `1.500000`, `true` or `""` to the map, and
  `partitionSeverities()` then reported it in every subsequent `log_level` response.

The empty partition name is rejected for the same reason the type check exists: `""` is
not a partition anyone can have meant, and accepting it wedges a nameless sink into the
listing forever.

This makes the handler stricter. A `severity` or `partition` given as a number, a bool,
or `null` was previously coerced and is now rejected. The commandline is unaffected:
`RPCParser::parseLogLevel` builds both fields from `argv` via `asString()`, so they are
always strings on that path.

Also drops the second `isMember(jss::partition)` test, which was unconditionally true
because the preceding branch already returned, along with the unreachable
`return rpcError(RpcInvalidParams);` it guarded. No behavior change.

This is the same class of defect, in the same admin handler tree, as the `blacklist`
`threshold` and `get_counts` `min_count` fixes, and follows their shape.

### API Impact

`log_level` is admin-only, so the affected surface is small. The change is filed under
Bugfixes in `API-CHANGELOG.md`, consistent with the `blacklist` and `get_counts` entries
for the same class of fix.

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

## Before / After

| request | before | after |
| --- | --- | --- |
| `{"severity": ["array"]}` | `internal` | `invalidParams` |
| `{"severity": 42}` | `invalidParams` | `invalidParams` (unchanged) |
| `{"severity": "warn", "partition": 42}` | success, creates a partition named `42` | `invalidParams` |
| `{"severity": "warn", "partition": null}` | success, creates a partition named `""` | `invalidParams` |
| `{"severity": "warn", "partition": ""}` | success, creates a partition named `""` | `invalidParams` |
| `{"severity": "warn", "partition": {}}` | `internal` | `invalidParams` |

## Test Plan

New suite `xrpl.rpc.LogLevel` (`src/test/rpc/LogLevel_test.cpp`), 5 cases / 84
assertions, modelled on `BlackList_test.cpp`. There was no handler-level test for
`log_level` before this; the existing `RPCCall_test` cases cover only the
commandline-to-JSON parse and never reach the handler.

Coverage: the levels listing; every alias `Logs::fromString` accepts and the name
`Logs::toString` reports back; the `base` / mixed-case `BASE` distinction; and the
rejected-value tables for both parameters. The invalid-partition case additionally
asserts that none of `42`, `1.500000`, `true` or `""` appear as partition names in the
listing afterwards — that assertion is what pins the sink-map pollution.

```
./xrpld --unittest=xrpl.rpc.LogLevel     # 84 tests, 0 failures
./xrpld --unittest=xrpl.rpc.RPCCall      # 2085 tests, 0 failures (CLI parser unaffected)
```

Verified the suite fails against the unpatched handler: 18 failures, including all four
sink-pollution assertions, confirming those partitions were really being created.

## Future Tasks

The `API-CHANGELOG.md` entry uses an `#NNNN` placeholder and needs a follow-up commit
pointing it at this PR number.
