### PR TITLE
fix: Validate the validation_create secret parameter

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,6 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
+- `validation_create`: The `secret` field now returns `invalidParams` if the value is not a string. Previously, arrays and objects returned an `internal` error, and numbers and booleans were silently coerced into a passphrase, deriving a validator key from the value's printed form. [#NNNN](https://github.com/XRPLF/rippled/pull/NNNN)
 
 ## XRP Ledger server version 3.1.0
 

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,7 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
-- `validation_create`: The `secret` field now returns `invalidParams` if the value is not a string. Previously, arrays and objects returned an `internal` error, and numbers and booleans were silently coerced into a passphrase, deriving a validator key from the value's printed form. [#NNNN](https://github.com/XRPLF/rippled/pull/NNNN)
+- `validation_create`: The `secret` field now returns `invalidParams` if the value is not a string. Previously, arrays and objects returned an `internal` error, and numbers and booleans were silently coerced into a passphrase, deriving a validator key from the value's printed form. [#7934](https://github.com/XRPLF/rippled/pull/7934)
 
 ## XRP Ledger server version 3.1.0
 

--- a/src/test/rpc/ValidationCreate_test.cpp
+++ b/src/test/rpc/ValidationCreate_test.cpp
@@ -1,0 +1,159 @@
+#include <test/jtx/Env.h>
+
+#include <xrpl/beast/unit_test/suite.h>
+#include <xrpl/json/json_value.h>
+#include <xrpl/protocol/jss.h>
+
+#include <array>
+
+namespace xrpl {
+
+class ValidationCreate_test : public beast::unit_test::Suite
+{
+    // The base58 seed the passphrase "masterpassphrase" hashes to.
+    static constexpr char const* kMasterSeed = "snoPBrXtMeMyMHUVTgbuqAfg1SUTb";
+
+    // The values a secret must not be. Arrays and objects make
+    // json::Value::asString() throw; the scalars are silently stringified by
+    // it, so without a type check they reach parseGenericSeed as "42",
+    // "1.500000", "true" and "".
+    static std::array<json::Value, 6>
+    badSecrets()
+    {
+        json::Value objValue{json::ValueType::Object};
+        objValue["nope"] = 0;
+        json::Value arrValue{json::ValueType::Array};
+        arrValue.append("masterpassphrase");
+
+        return {{
+            json::Value{42},    // int
+            json::Value{1.5},   // real
+            json::Value{true},  // bool
+            json::Value{},      // null
+            objValue,
+            arrValue,
+        }};
+    }
+
+    void
+    testNoSecret()
+    {
+        testcase("No secret");
+        using namespace test::jtx;
+        Env env{*this};
+
+        auto const first = env.client().invoke("validation_create")[jss::result];
+        BEAST_EXPECT(!first.isMember(jss::error));
+        BEAST_EXPECT(first[jss::status] == "success");
+        BEAST_EXPECT(first.isMember(jss::validation_public_key));
+        BEAST_EXPECT(first.isMember(jss::validation_private_key));
+        BEAST_EXPECT(first.isMember(jss::validation_seed));
+        BEAST_EXPECT(first.isMember(jss::validation_key));
+
+        // Omitting the secret picks a random seed, so a second call must not
+        // return the same key.
+        auto const second = env.client().invoke("validation_create")[jss::result];
+        BEAST_EXPECT(second[jss::status] == "success");
+        BEAST_EXPECT(first[jss::validation_seed] != second[jss::validation_seed]);
+    }
+
+    void
+    testValidSecret()
+    {
+        testcase("Valid secret");
+        using namespace test::jtx;
+        Env env{*this};
+
+        // The three spellings of one seed that parseGenericSeed resolves to the
+        // same value: a passphrase, its hex, and its base58 encoding.
+        std::array<char const*, 3> const masterForms{
+            "masterpassphrase",
+            "DEDCE9CE67B451D852FD4E846FCDE31C",
+            kMasterSeed,
+        };
+
+        for (auto const* secret : masterForms)
+        {
+            json::Value params{json::ValueType::Object};
+            params[jss::secret] = secret;
+            auto const result = env.client().invoke("validation_create", params)[jss::result];
+            BEAST_EXPECTS(!result.isMember(jss::error), secret);
+            BEAST_EXPECTS(result[jss::status] == "success", secret);
+            BEAST_EXPECTS(result[jss::validation_seed] == kMasterSeed, secret);
+        }
+
+        // An RFC-1751 key is accepted too, and a secret is deterministic: the
+        // same one twice derives the same validator key.
+        json::Value params{json::ValueType::Object};
+        params[jss::secret] = "BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIRE";
+        auto const first = env.client().invoke("validation_create", params)[jss::result];
+        BEAST_EXPECT(!first.isMember(jss::error));
+        BEAST_EXPECT(first[jss::status] == "success");
+
+        auto const second = env.client().invoke("validation_create", params)[jss::result];
+        BEAST_EXPECT(first[jss::validation_seed] == second[jss::validation_seed]);
+        BEAST_EXPECT(first[jss::validation_public_key] == second[jss::validation_public_key]);
+    }
+
+    void
+    testBadSecret()
+    {
+        testcase("Invalid secret");
+        using namespace test::jtx;
+        Env env{*this};
+
+        // Before the type check the objects and arrays here returned a generic
+        // internal error, and the scalars derived a real validator key from the
+        // value's printed form.
+        for (auto const& badSecret : badSecrets())
+        {
+            json::Value params{json::ValueType::Object};
+            params[jss::secret] = badSecret;
+            auto const result = env.client().invoke("validation_create", params)[jss::result];
+            BEAST_EXPECT(result[jss::error] == "invalidParams");
+            BEAST_EXPECT(result[jss::status] == "error");
+            BEAST_EXPECT(!result.isMember(jss::validation_seed));
+            BEAST_EXPECT(!result.isMember(jss::validation_private_key));
+        }
+    }
+
+    void
+    testUnparseableSecret()
+    {
+        testcase("Unparseable secret");
+        using namespace test::jtx;
+        Env env{*this};
+
+        // A string that is not a seed is still badSeed rather than
+        // invalidParams: parseGenericSeed rejects the empty string, and any
+        // token that decodes as an account address or a public or secret key.
+        std::array<char const*, 3> const notSeeds{
+            "",
+            "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",                    // an AccountID
+            "n9MXXueo837zYH36DvMc13BwHcqtfAWNJY5czWVbp7uYTj7x17TH",  // a node public key
+        };
+
+        for (auto const* secret : notSeeds)
+        {
+            json::Value params{json::ValueType::Object};
+            params[jss::secret] = secret;
+            auto const result = env.client().invoke("validation_create", params)[jss::result];
+            BEAST_EXPECTS(result[jss::error] == "badSeed", secret);
+            BEAST_EXPECTS(result[jss::status] == "error", secret);
+        }
+    }
+
+public:
+    void
+    run() override
+    {
+        testNoSecret();
+        testValidSecret();
+        testBadSecret();
+        testUnparseableSecret();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(ValidationCreate, rpc, xrpl);
+
+}  // namespace xrpl

--- a/src/xrpld/rpc/handlers/admin/keygen/ValidationCreate.cpp
+++ b/src/xrpld/rpc/handlers/admin/keygen/ValidationCreate.cpp
@@ -14,6 +14,7 @@
 
 namespace xrpl {
 
+// The caller is responsible for checking that the secret, if present, is a string.
 static std::optional<Seed>
 validationSeed(json::Value const& params)
 {
@@ -33,6 +34,13 @@ json::Value
 doValidationCreate(RPC::JsonContext& context)
 {
     json::Value obj(json::ValueType::Object);
+
+    // Guard the conversion validationSeed makes: json::Value::asString() throws for
+    // arrays and objects, which would surface as a generic internal error instead of
+    // invalid parameters, and silently stringifies scalars, so a number or a bool
+    // would be hashed into a validator key as its printed form.
+    if (context.params.isMember(jss::secret) && !context.params[jss::secret].isString())
+        return rpcError(RpcInvalidParams);
 
     auto seed = validationSeed(context.params);
 


### PR DESCRIPTION
doValidationCreate read the optional secret with an unguarded asString(), which throws for arrays and objects and silently stringifies every scalar. The throw was swallowed by callMethod's catch-all, so a malformed value produced a generic internal error rather than invalidParams, and the request was recorded as a server fault in the perf log.

The coercion case is worse than a bad error code: parseGenericSeed accepts any non-empty string as a passphrase, so {"secret": 12345} did not fail at all. It hashed "12345" and returned a real validator key derived from the printed form of a number the caller never meant as a passphrase. Booleans behaved the same way; null coerced to "" and happened to be rejected already.

Guard the conversion with an isString() check and return invalidParams when it fails. The check has to sit in the handler rather than in validationSeed, whose only failure channel is nullopt and is already mapped to badSeed, which must stay that way for a string secret that is not a seed.

This makes the handler stricter: a secret given as a number or a bool was previously coerced and is now rejected. The command is admin only, and the commandline builds the field from argv via asString(), so it is always a string there and the parser is unaffected. An absent secret still picks a random seed, and a string secret behaves exactly as before.

Add a ValidationCreate test suite, which did not exist; the two cases in ValidatorRPC go through env.rpc(), which stringifies like the commandline does and so cannot reach the handler with a non-string.

Fixes #6763

<!--
This PR template helps you write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR. This avoids redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to this PR.
-->
