### PR TITLE
fix: Validate the connect ip parameter

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,6 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
+- `connect`: The `ip` field now returns `invalidParams` if the value is not a string. Previously, arrays and objects returned an `internal` error, and numbers, booleans and `null` were coerced into a string that could never parse as an address, so the request reported an attempted connection that never happened. [#TBD](https://github.com/XRPLF/rippled/pull/TBD)
 
 ## XRP Ledger server version 3.1.0
 

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,7 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
-- `connect`: The `ip` field now returns `invalidParams` if the value is not a string. Previously, arrays and objects returned an `internal` error, and numbers, booleans and `null` were coerced into a string that could never parse as an address, so the request reported an attempted connection that never happened. [#TBD](https://github.com/XRPLF/rippled/pull/TBD)
+- `connect`: The `ip` field now returns `invalidParams` if the value is not a string. Previously, arrays and objects returned an `internal` error, and numbers, booleans and `null` were coerced into a string that could never parse as an address, so the request reported an attempted connection that never happened. [#7954](https://github.com/XRPLF/rippled/pull/7954)
 
 ## XRP Ledger server version 3.1.0
 

--- a/src/test/rpc/Connect_test.cpp
+++ b/src/test/rpc/Connect_test.cpp
@@ -1,30 +1,100 @@
 
 #include <test/jtx/Env.h>
 
+#include <xrpld/app/main/Application.h>
+#include <xrpld/core/Config.h>
+
 #include <xrpl/beast/unit_test/suite.h>
+#include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/jss.h>
+
+#include <array>
+#include <string>
 
 namespace xrpl {
 
 class Connect_test : public beast::unit_test::Suite
 {
-    void
-    testErrors()
+    // doConnect refuses every request in standalone mode before it reads a
+    // parameter, so nothing below the standalone check is reachable from a
+    // default Env. Leave standalone once the application is set up: connect is
+    // a Condition::NoCondition command, so no other part of the dispatch path
+    // reads this flag.
+    static void
+    leaveStandalone(test::jtx::Env& env)
     {
-        testcase("Errors");
+        env.app().config().setupControl(true, true, false);
+    }
+
+    void
+    testStandalone()
+    {
+        testcase("Standalone");
 
         using namespace test::jtx;
 
-        {
-            // standalone mode should fail
-            Env env{*this};
-            BEAST_EXPECT(env.app().config().standalone());
+        // standalone mode should fail
+        Env env{*this};
+        BEAST_EXPECT(env.app().config().standalone());
 
-            auto const result = env.rpc("json", "connect", "{}");
-            BEAST_EXPECT(result[jss::result][jss::status] == "error");
-            BEAST_EXPECT(result[jss::result].isMember(jss::error));
-            BEAST_EXPECT(result[jss::result][jss::error] == "notSynced");
-            BEAST_EXPECT(result[jss::result][jss::error_message] == "Not synced to the network.");
+        auto const result = env.rpc("json", "connect", "{}");
+        BEAST_EXPECT(result[jss::result][jss::status] == "error");
+        BEAST_EXPECT(result[jss::result].isMember(jss::error));
+        BEAST_EXPECT(result[jss::result][jss::error] == "notSynced");
+        BEAST_EXPECT(result[jss::result][jss::error_message] == "Not synced to the network.");
+    }
+
+    void
+    testMissingIp()
+    {
+        testcase("Missing ip");
+
+        using namespace test::jtx;
+
+        Env env{*this};
+        leaveStandalone(env);
+
+        auto const result = env.rpc("json", "connect", "{}")[jss::result];
+        BEAST_EXPECT(result[jss::status] == "error");
+        BEAST_EXPECT(result[jss::error] == "invalidParams");
+        // missingFieldMessage, unlike missingFieldError, has no StaticString
+        // overload, so jss::ip has to be converted explicitly.
+        BEAST_EXPECT(result[jss::error_message] == RPC::missingFieldMessage(std::string(jss::ip)));
+    }
+
+    void
+    testBadIp()
+    {
+        testcase("Invalid ip");
+
+        using namespace test::jtx;
+
+        Env env{*this};
+        leaveStandalone(env);
+        BEAST_EXPECT(!env.app().config().standalone());
+
+        // Before the type check the array and the object returned a generic
+        // internal error, and the scalars were stringified into "42",
+        // "1.500000", "true" and "", none of which parse as an address. The
+        // connection was silently skipped, but the reply still claimed one had
+        // been attempted.
+        std::array<char const*, 6> const badIps{
+            R"({"ip": 42})",
+            R"({"ip": 1.5})",
+            R"({"ip": true})",
+            R"({"ip": null})",
+            R"({"ip": {"host": "127.0.0.1"}})",
+            R"({"ip": ["127.0.0.1"]})",
+        };
+
+        for (auto const* badIp : badIps)
+        {
+            auto const result = env.rpc("json", "connect", badIp)[jss::result];
+            BEAST_EXPECTS(result[jss::status] == "error", badIp);
+            BEAST_EXPECTS(result[jss::error] == "invalidParams", badIp);
+            BEAST_EXPECTS(
+                result[jss::error_message] == RPC::expectedFieldMessage(jss::ip, "a string"),
+                badIp);
         }
     }
 
@@ -32,7 +102,9 @@ public:
     void
     run() override
     {
-        testErrors();
+        testStandalone();
+        testMissingIp();
+        testBadIp();
     }
 };
 

--- a/src/xrpld/rpc/handlers/admin/peer/Connect.cpp
+++ b/src/xrpld/rpc/handlers/admin/peer/Connect.cpp
@@ -31,6 +31,12 @@ doConnect(RPC::JsonContext& context)
     if (!context.params.isMember(jss::ip))
         return RPC::missingFieldError(jss::ip);
 
+    // Without this, asString() below throws for an array or an object, and
+    // silently stringifies every scalar into something that cannot parse as an
+    // address.
+    if (!context.params[jss::ip].isString())
+        return RPC::expectedFieldError(jss::ip, "a string");
+
     if (context.params.isMember(jss::port) &&
         !context.params[jss::port].isConvertibleTo(json::ValueType::Int))
     {


### PR DESCRIPTION
doConnect checked that ip was present but never that it was a string, while the sibling port field is type checked with isConvertibleTo. The unguarded asString() then failed in two different ways.

For an array or an object, asString() hits JSON_ASSERT_MESSAGE, which throws json::Error. The throw was swallowed by the dispatch catch-all, so a malformed value produced a generic internal error rather than invalidParams, and the request was recorded as a server fault in the perf log.

Every scalar was worse, because it was silently coerced instead: 42 became "42", 1.5 became "1.500000", true became "true" and null became "". None of those parse as an address, so isUnspecified() was true and the connect was skipped, yet the handler still returned "attempting connection to IP:true port: 2459". The caller was told a connection had been attempted when none ever was.

Guard the conversion with an isString() check and return invalidParams when it fails, reusing RPC::expectedFieldError so the error matches the family the port path already returns.

The commandline is unaffected. RPCParser::parseConnect always assigns jss::ip from a std::string, whether the argument is given as ip and port or as a single ip:port, so the new check can never fire there.

Connect_test only covered the standalone rejection, which returns before any parameter is read. Split it into standalone, missing ip and invalid ip cases, with a helper that leaves standalone mode so the parameter checks become reachable; connect is a Condition::NoCondition command, so no other part of dispatch reads that flag.

Fixes #6744

<!--
This PR template helps you write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR. This avoids redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to this PR.
-->
