### PR TITLE
docs: Document [peers_in_max] and [peers_out_max] in the example config

### DIFF
--- a/cfg/xrpld-example.cfg
+++ b/cfg/xrpld-example.cfg
@@ -459,6 +459,31 @@
 #   implementation-defined lower limits imposed on this value for security
 #   purposes.
 #
+#   If this section is present, [peers_in_max] and [peers_out_max] below are
+#   ignored.
+#
+#
+#
+# [peers_in_max]
+#
+#   The largest number of incoming peer connections to accept. Must be between
+#   0 and 1000. A value of 0 accepts no incoming connections.
+#
+#   This section and [peers_out_max] must be configured together: setting only
+#   one of the two is an error and the server will not start. Both are ignored
+#   if [peers_max] is present.
+#
+#
+#
+# [peers_out_max]
+#
+#   The largest number of outgoing peer connections to make. Must be between
+#   10 and 1000.
+#
+#   This section and [peers_in_max] must be configured together: setting only
+#   one of the two is an error and the server will not start. Both are ignored
+#   if [peers_max] is present.
+#
 #
 #
 # [node_seed]


### PR DESCRIPTION
## High Level Overview of Change

Documents `[peers_in_max]` and `[peers_out_max]` in `cfg/xrpld-example.cfg`. Comment
only — no behaviour change.

### Context of Change

Both settings were added in #3616, which didn't touch a config file, so they have
never appeared in the example config. Today the only way to learn they exist — or
what they accept — is to read `Config.cpp`.

The behaviour most likely to cost someone time is that they must be set as a
**pair**. Configuring only one throws at startup:

> Both sections [peers_in_max] and [peers_out_max] must be configured

which is easy to hit when trying to bound inbound connections alone. The valid
ranges also differ between the two (`peers_in_max` 0–1000, `peers_out_max` 10–1000),
and both are ignored when `[peers_max]` is present.

This documents the pair, the ranges, the both-or-neither requirement, and the
precedence, following the style of the surrounding stanzas. Verified against
`src/xrpld/core/detail/Config.cpp` on `develop`.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

None — this changes only comments in the example config.
