### PR TITLE
fix: Return objectNotFound for a non-existent book_offers domain

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,6 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
+- `book_offers`: The `domain` field now returns `objectNotFound` if the specified permissioned domain does not exist in the ledger, instead of silently returning an empty `offers` array. [#6589](https://github.com/XRPLF/rippled/issues/6589)
 
 ## XRP Ledger server version 3.1.0
 

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,7 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
-- `book_offers`: The `domain` field now returns `objectNotFound` if the specified permissioned domain does not exist in the ledger, instead of silently returning an empty `offers` array. [#6589](https://github.com/XRPLF/rippled/issues/6589)
+- `book_offers`: The `domain` field now returns `objectNotFound` if the specified permissioned domain does not exist in the ledger, instead of silently returning an empty `offers` array. [#7963](https://github.com/XRPLF/rippled/issues/7963)
 
 ## XRP Ledger server version 3.1.0
 

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -1532,6 +1532,38 @@ public:
             BEAST_EXPECT(jrr[jss::error] == "domainMalformed");
             BEAST_EXPECT(jrr[jss::error_message] == "Unable to parse domain.");
         }
+
+        // Well-formed domain that does not exist in the ledger.
+        {
+            json::Value jvParams;
+            jvParams[jss::ledger_index] = "validated";
+            jvParams[jss::taker_pays][jss::currency] = "USD";
+            jvParams[jss::taker_pays][jss::issuer] = gw.human();
+            jvParams[jss::taker_gets][jss::currency] = "EUR";
+            jvParams[jss::taker_gets][jss::issuer] = gw.human();
+            jvParams[jss::domain] = std::string(64, 'A');
+            auto const jrr = env.rpc("json", "book_offers", to_string(jvParams))[jss::result];
+            BEAST_EXPECT(jrr[jss::error] == "objectNotFound");
+            BEAST_EXPECT(jrr[jss::error_message] == "Domain not found.");
+        }
+
+        // An all-zero domain is well-formed hex but can never name an object.
+        // Both ledger views are covered: a validated ledger reaches
+        // Ledger::read, which treats a zero key as UNREACHABLE, so dropping
+        // the isZero() guard in doBookOffers aborts on this case.
+        for (auto const* ledgerIndex : {"validated", "current"})
+        {
+            json::Value jvParams;
+            jvParams[jss::ledger_index] = ledgerIndex;
+            jvParams[jss::taker_pays][jss::currency] = "USD";
+            jvParams[jss::taker_pays][jss::issuer] = gw.human();
+            jvParams[jss::taker_gets][jss::currency] = "EUR";
+            jvParams[jss::taker_gets][jss::issuer] = gw.human();
+            jvParams[jss::domain] = std::string(64, '0');
+            auto const jrr = env.rpc("json", "book_offers", to_string(jvParams))[jss::result];
+            BEAST_EXPECT(jrr[jss::error] == "objectNotFound");
+            BEAST_EXPECT(jrr[jss::error_message] == "Domain not found.");
+        }
     }
 
     void
@@ -1660,6 +1692,22 @@ public:
             auto jv = wsc->invoke("book_offers", jvParams);
             auto jrr = jv[jss::result];
             checkBookOffers(jrr);
+        }
+
+        // book_offers: an unknown domain is rejected rather than silently
+        // returning an empty book
+        {
+            json::Value jvParams;
+            jvParams[jss::taker] = env.master.human();
+            jvParams[jss::taker_pays][jss::currency] = "XRP";
+            jvParams[jss::ledger_index] = "validated";
+            jvParams[jss::taker_gets][jss::currency] = "USD";
+            jvParams[jss::taker_gets][jss::issuer] = gw.human();
+            jvParams[jss::domain] = std::string(64, 'A');
+
+            auto const jrr = env.rpc("json", "book_offers", to_string(jvParams))[jss::result];
+            BEAST_EXPECT(jrr[jss::error] == "objectNotFound");
+            BEAST_EXPECT(jrr[jss::error_message] == "Domain not found.");
         }
 
         // subscribe to domain book should return domain offer

--- a/src/xrpld/rpc/handlers/orderbook/BookOffers.cpp
+++ b/src/xrpld/rpc/handlers/orderbook/BookOffers.cpp
@@ -15,6 +15,7 @@
 #include <xrpl/protocol/Asset.h>
 #include <xrpl/protocol/Book.h>
 #include <xrpl/protocol/ErrorCodes.h>
+#include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Issue.h>
 #include <xrpl/protocol/RPCErr.h>
 #include <xrpl/protocol/UintTypes.h>
@@ -231,6 +232,16 @@ doBookOffers(RPC::JsonContext& context)
         {
             return RPC::makeError(RpcDomainMalformed, "Unable to parse domain.");
         }
+
+        // A PermissionedDomain's DomainID is its ledger key, so the domain
+        // exists only if that entry is present. `read` is used rather than
+        // `exists` because the caller supplies the raw key: `exists` does not
+        // check the entry type, so the index of any unrelated object would
+        // pass. The all-zero key is well-formed hex but can never name a real
+        // object, and `Ledger::read` treats it as UNREACHABLE, so it must be
+        // rejected before reaching the view.
+        if (num.isZero() || !lpLedger->read(keylet::permissionedDomain(num)))
+            return RPC::makeError(RpcObjectNotFound, "Domain not found.");
 
         domain = num;
     }


### PR DESCRIPTION
The book_offers RPC validated the domain parameter for hex format but never checked that the PermissionedDomain existed in the ledger. The domain is folded into the order-book directory index by getBookBase(), so a typo'd or deleted domain ID hashed to a directory that was not there and the caller received an empty offers array, indistinguishable from a real domain with no offers.

Look the domain up in the ledger and return objectNotFound when it is absent, consistent with amm_info (actNotFound), ledger_entry (entryNotFound), and nft_buy_offers/nft_sell_offers, which already return objectNotFound for a missing directory.

Use read() rather than exists(): the caller supplies the raw ledger key, and Ledger::exists(Keylet) does not check the entry type, so the index of any unrelated object would otherwise pass and still yield an empty result. Reject the all-zero key up front, since Ledger::read treats a zero key as UNREACHABLE.

Fixes #6589

<!--
This PR template helps you write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR. This avoids redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to this PR.
-->
