### PR TITLE
docs: Rearrange & simplify build/nix/environment docs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,33 +4,15 @@
 
 ## Minimum Requirements
 
-See [System Requirements](https://xrpl.org/system-requirements.html).
+For the hardware needed to run a node, see
+[System Requirements](https://xrpl.org/system-requirements.html).
 
-Building xrpld generally requires Git, Python, Conan, CMake, and a C++
-compiler.
-
-- [Python](https://www.python.org/downloads/)
-- [Conan](https://conan.io/downloads.html)
-- [CMake](https://cmake.org/download/)
-
-You can verify that the required tools are installed and runnable with:
-
-```bash
-./bin/check-tools.sh
-```
-
-`xrpld` is written in the C++23 dialect. The [tested compiler versions][cpp23-support] are:
-
-| Compiler    | Version         |
-| ----------- | --------------- |
-| GCC         | 15.2            |
-| Clang       | 22              |
-| Apple Clang | 21              |
-| MSVC        | 19.44[^windows] |
+Building xrpld requires Git, Python, Conan, CMake, and a C++23 compiler. The
+required tool versions, the compiler versions tested in CI, and how to install
+them on each platform are documented in the
+[environment setup guide](./docs/build/environment.md).
 
 ## Operating Systems
-
-Please see the [environment setup guide](./docs/build/environment.md) for detailed instructions for all platforms.
 
 ### Linux
 
@@ -47,9 +29,8 @@ CI testing is done in macOS 26 (Tahoe), but the build defaults `CMAKE_OSX_DEPLOY
 
 ### Windows
 
-Windows is used by some engineers for development only.
-
-[^windows]: Windows is not recommended for production use.
+Windows is used by some engineers for development only, and is not recommended
+for production use.
 
 ## Steps
 
@@ -74,12 +55,8 @@ releases](https://github.com/XRPLF/rippled/releases).
 
 ### Set Up Conan
 
-After you have a [C++ development environment](./docs/build/environment.md) ready with Git, Python,
-Conan, CMake, and a C++ compiler, you may need to set up your Conan profile.
-
-These instructions assume a basic familiarity with Conan and CMake. If you are
-unfamiliar with Conan, then please read [this crash course](./docs/build/conan.md) or the official
-[Getting Started][conan-getting-started] walkthrough.
+Once your [development environment](./docs/build/environment.md) is ready, you
+may need to set up your Conan profile.
 
 #### Profiles
 
@@ -273,6 +250,10 @@ Prerequisites for the coverage report:
 - `llvm-cov` for Clang (installed with the compiler by default)
 - `Debug` build type
 
+In the [Nix development shell](./docs/build/nix.md#building-xrpld-in-the-nix-shell),
+use one of the `gcc` shells: they ship a matching `gcov`, while the `clang`
+shells do not include `llvm-cov`.
+
 A coverage report is created when the following steps are completed, in order:
 
 1. `xrpld` binary built with instrumentation data, enabled by the `coverage`
@@ -389,6 +370,10 @@ After any updates or changes to dependencies, you may need to do the following:
 4. [Regenerate lockfile](./docs/build/advanced_conan.md#conan-lockfile).
 5. Re-run [conan install](#build-and-test).
 
+If you are using the Nix development shell, prebuilt Conan binaries may be
+incompatible with it — see
+[Building xrpld in the Nix shell](./docs/build/nix.md#building-xrpld-in-the-nix-shell).
+
 #### ERROR: Package not resolved
 
 If you're seeing an error like `ERROR: Package 'snappy/1.1.10' not resolved: Unable to find 'snappy/1.1.10#968fef506ff261592ec30c574d4a7809%1756234314.246' in remotes.`,
@@ -412,7 +397,6 @@ For example, if you want to build Debug:
 1. For conan install, pass `--settings build_type=Debug`
 2. For cmake, pass `-DCMAKE_BUILD_TYPE=Debug`
 
-[cpp23-support]: https://en.cppreference.com/w/cpp/compiler_support/23
 [conan-getting-started]: https://docs.conan.io/en/latest/getting_started.html
 [unity-build]: https://en.wikipedia.org/wiki/Unity_build
 [gcovr]: https://gcovr.com/en/stable/getting-started.html

--- a/BUILD.md
+++ b/BUILD.md
@@ -7,9 +7,7 @@
 For the hardware needed to run a node, see
 [System Requirements](https://xrpl.org/system-requirements.html).
 
-Building xrpld requires Git, Python, Conan, CMake, and a C++23 compiler. The
-required tool versions, the compiler versions tested in CI, and how to install
-them on each platform are documented in the
+For the software needed to build xrpld, see the
 [environment setup guide](./docs/build/environment.md).
 
 ## Operating Systems

--- a/BUILD.md
+++ b/BUILD.md
@@ -246,13 +246,13 @@ which is only enabled when the `coverage` option is set, e.g. with
 Prerequisites for the coverage report:
 
 - [gcovr tool][gcovr] (can be installed e.g. with [pip][python-pip])
-- `gcov` for GCC (installed with the compiler by default) or
-- `llvm-cov` for Clang (installed with the compiler by default)
+- `gcov` for GCC or `llvm-cov` for Clang, usually installed with the compiler
 - `Debug` build type
 
-In the [Nix development shell](./docs/build/nix.md#building-xrpld-in-the-nix-shell),
-use one of the `gcc` shells: they ship a matching `gcov`, while the `clang`
-shells do not include `llvm-cov`.
+> [!NOTE]
+> Clang coverage is not available in the [Nix development shell](./docs/build/nix.md#building-xrpld-in-the-nix-shell):
+> its `clang` shells do not ship `llvm-cov`. Use a `gcc` shell instead (`.#gcc`,
+> or `.#gcc-plain` on Linux), which provides a `gcov` matching its compiler.
 
 A coverage report is created when the following steps are completed, in order:
 

--- a/docs/build/environment.md
+++ b/docs/build/environment.md
@@ -41,7 +41,7 @@ Besides a compiler, building `xrpld` requires:
 | [Git](https://git-scm.com/downloads)        | any recent      |
 | [Python](https://www.python.org/downloads/) | 3.11            |
 | [Conan](https://conan.io/downloads.html)    | 2.17            |
-| [CMake](https://cmake.org/download/)        | 3.22            |
+| [CMake](https://cmake.org/download/)        | 3.16            |
 
 On Linux and macOS, the [Nix development shell](./nix.md) provides all of them
 (see below). On Windows they have to be installed manually.

--- a/docs/build/environment.md
+++ b/docs/build/environment.md
@@ -7,20 +7,41 @@ This document explains how to set one up.
 ## Tested compiler versions
 
 `xrpld` is built in the **C++23** dialect by default.
-Make sure your toolchain is recent enough — the compiler versions currently tested in CI are:
+Make sure your toolchain is recent enough — the [compiler versions][cpp23-support]
+currently tested in CI are:
 
-| Compiler    | Version |
-| ----------- | ------- |
-| GCC         | 15.2    |
-| Clang       | 22      |
-| Apple Clang | 17      |
-| MSVC        | 19.44   |
+| Compiler    | Version            |
+| ----------- | ------------------ |
+| GCC         | 15.2               |
+| Clang       | 22                 |
+| Apple Clang | 21                 |
+| MSVC        | Visual Studio 2026 |
 
 LLVM tools (`clang-tidy` and `clang-format`) are also pinned to version 22.
 
 Older compilers may fail to build the latest `develop` code: the codebase now
 relies on C++23 features and has been adjusted for `clang-tidy`.
 If the latest code doesn't build for you, update your build toolchain first.
+
+## Required tools
+
+Besides a compiler, building `xrpld` requires:
+
+| Tool                                        | Minimum version |
+| ------------------------------------------- | --------------- |
+| [Git](https://git-scm.com/downloads)        | any recent      |
+| [Python](https://www.python.org/downloads/) | 3.11            |
+| [Conan](https://conan.io/downloads.html)    | 2.17            |
+| [CMake](https://cmake.org/download/)        | 3.22            |
+
+On Linux and macOS, the [Nix development shell](./nix.md) provides all of them
+(see below). On Windows they have to be installed manually.
+
+Once they are in place, verify that everything is installed and runnable with:
+
+```bash
+./bin/check-tools.sh
+```
 
 ## Linux and macOS
 
@@ -39,20 +60,15 @@ Clang. If you instead opt to use your system-wide Apple Clang (via
 below).
 
 See [Using the Nix development shell](./nix.md) for installation and usage
-details, including how to select a different compiler.
-
-> [!NOTE]
-> Using Nix is not mandatory. Any custom environment (Homebrew packages or
-> anything else) will continue to work, but then it is up to you to keep it in
-> sync with the environment used in CI. Nix unifies the development environment
-> for everyone and synchronizes updates, which is why we recommend it.
+details, including how to select a different compiler and why we recommend Nix
+over a hand-maintained environment.
 
 ### macOS: managing the Apple Clang version
 
 If you use your system-wide Apple Clang on macOS (via `nix develop .#apple-clang`),
 the compiler version is whatever your installed Xcode (or Command Line Tools)
 provides. The following command should return a version greater than or equal to
-the [minimum required](#tested-compiler-versions):
+the [tested one](#tested-compiler-versions):
 
 ```bash
 clang --version
@@ -89,23 +105,23 @@ building xrpld. You may want to install and pin a specific version of Xcode:
 Nix is not available on Windows, so the required tools have to be installed
 manually:
 
-- [Visual Studio 2022](https://visualstudio.microsoft.com/) with the
+- [Visual Studio 2026](https://visualstudio.microsoft.com/) with the
   **"Desktop development with C++"** workload — this provides MSVC and the
-  "x64 Native Tools Command Prompt".
+  "x64 Native Tools Command Prompt". CI configures CMake with the
+  `Visual Studio 18 2026` generator.
 - [Git for Windows](https://git-scm.com/download/win)
-- [Python 3.11](https://www.python.org/downloads/), or higher
-- [Conan 2.17](https://conan.io/downloads.html), or higher
-- [CMake 3.22](https://cmake.org/download/), or higher
-
-> [!NOTE]
-> Windows is used for development only and is not recommended for production.
+- Python, Conan, and CMake, at the versions listed in
+  [Required tools](#required-tools).
 
 ## Clang-tidy
 
 `clang-tidy` is required to run static analysis checks locally (see
 [CONTRIBUTING.md](../../CONTRIBUTING.md)). It is not required to build the
-project. This project currently uses `clang-tidy` version 22.
+project. The version this project uses is listed in
+[Tested compiler versions](#tested-compiler-versions).
 
-On Linux and macOS, the [Nix development shell](./nix.md) provides `clang-tidy`
-22 out of the box — run it via `run-clang-tidy`. No separate installation is
-needed.
+On Linux and macOS, the [Nix development shell](./nix.md) provides that exact
+version out of the box — run it via `run-clang-tidy`. No separate installation
+is needed.
+
+[cpp23-support]: https://en.cppreference.com/w/cpp/compiler_support/23

--- a/docs/build/environment.md
+++ b/docs/build/environment.md
@@ -6,9 +6,9 @@ This document explains how to set one up.
 
 ## Tested compiler versions
 
-`xrpld` is built in the **C++23** dialect by default.
-Make sure your toolchain is recent enough — the [compiler versions][cpp23-support]
-currently tested in CI are:
+`xrpld` is built in the **C++23** dialect by default, so your toolchain has to
+support it — see [compiler support for C++23][cpp23-support].
+The versions currently tested in CI are:
 
 | Compiler    | Version            |
 | ----------- | ------------------ |

--- a/docs/build/environment.md
+++ b/docs/build/environment.md
@@ -19,9 +19,18 @@ currently tested in CI are:
 
 LLVM tools (`clang-tidy` and `clang-format`) are also pinned to version 22.
 
+### Older compilers
+
 Older compilers may fail to build the latest `develop` code: the codebase now
 relies on C++23 features and has been adjusted for `clang-tidy`.
 If the latest code doesn't build for you, update your build toolchain first.
+
+If updating isn't an option for you, we do accept pull requests that fix builds
+on older compilers, as long as the change is small and doesn't make the code
+harder to read. What we can't promise is that older compilers will keep working:
+only the versions in the table above are tested in CI, and we won't hold back
+the use of C++23 features or add invasive workarounds to keep an untested
+compiler building. Treat support for anything outside the table as best-effort.
 
 ## Required tools
 

--- a/docs/build/nix.md
+++ b/docs/build/nix.md
@@ -126,11 +126,7 @@ Once inside the Nix development shell, follow the standard [build instructions](
 
 Two things differ from a system environment:
 
-**Prebuilt Conan packages.** There is no guarantee that binaries from the Conan cache will work when using Nix. If you encounter any errors, use `--build '*'` to force Conan to compile everything from source:
-
-```bash
-conan install .. --output-folder . --build '*' --settings build_type=Release
-```
+**Prebuilt Conan packages.** There is no guarantee that binaries from the Conan cache will work when using Nix. If you encounter any errors, add `--build '*'` to the `conan install` command in [Build and Test](../../BUILD.md#build-and-test) to force Conan to compile everything from source. Keep the rest of the command as it is there, so it rebuilds the `build_type` you are actually configuring.
 
 **Coverage builds.** `-Dcoverage=ON` works in the `gcc` shell (and `gcc-plain` on Linux):
 each ships a `gcov` matching its compiler, since Nix's cc-wrapper does not expose one.

--- a/docs/build/nix.md
+++ b/docs/build/nix.md
@@ -120,11 +120,19 @@ nix develop -c "$SHELL"
 >
 > If it doesn't, either adjust your shell configuration so it doesn't override `$PATH`, or use [direnv](#automatic-activation-with-direnv) (below), which loads the environment _after_ your shell config and so takes precedence regardless of the shell you use.
 
-## Building xrpld with Nix
+## Building xrpld in the Nix shell
 
 Once inside the Nix development shell, follow the standard [build instructions](../../BUILD.md#steps). The Nix shell provides all necessary tools (CMake, Ninja, Conan, etc.).
 
-Coverage builds (`-Dcoverage=ON`) work in the `gcc` shell (and `gcc-plain` on Linux):
+Two things differ from a system environment:
+
+**Prebuilt Conan packages.** There is no guarantee that binaries from the Conan cache will work when using Nix. If you encounter any errors, use `--build '*'` to force Conan to compile everything from source:
+
+```bash
+conan install .. --output-folder . --build '*' --settings build_type=Release
+```
+
+**Coverage builds.** `-Dcoverage=ON` works in the `gcc` shell (and `gcc-plain` on Linux):
 each ships a `gcov` matching its compiler, since Nix's cc-wrapper does not expose one.
 The `clang` shells do not include `llvm-cov`, so use a `gcc` shell for coverage.
 
@@ -141,14 +149,6 @@ The repository already ships an `.envrc` at its root that activates the Nix flak
 
 > [!NOTE]
 > direnv only caches the `.direnv` directory (already listed in `.gitignore`); no other repository files are affected.
-
-## Conan and Prebuilt Packages
-
-Please note that there is no guarantee that binaries from conan cache will work when using nix. If you encounter any errors, please use `--build '*'` to force conan to compile everything from source:
-
-```bash
-conan install .. --output-folder . --build '*' --settings build_type=Release
-```
 
 ## Updating `flake.lock` file
 


### PR DESCRIPTION
<!--
This PR template helps you write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR. This avoids redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Deduplicated the build docs so each fact lives in one place, and fixed the drifted compiler versions.
Also added a section how we treat PRs for old compilers.

### Fixed stale versions

- `Apple Clang`: was `17` in `environment.md`, `21` in `BUILD.md` — CI uses 21 (runner `macos-26-apple-clang-21`).
- `MSVC`: both files said `19.44` (Visual Studio 2022) — CI moved to Visual Studio 2026 in #7550 (`Visual Studio 18 2026` generator, runner `dev-box-windows-2026`). `environment.md` also told Windows devs to install VS 2022.

### `docs/build/environment.md` — now the single source of truth for tooling

- Holds the only copy of the tested compiler versions table.
- New `Required tools` section with minimum versions (Python 3.11, Conan 2.17, CMake 3.22) and `./bin/check-tools.sh`; these were previously buried in the Windows-only section despite being platform-independent.
- `Clang-tidy` section no longer repeats the version literal, it points at the table. Anchor kept — `CONTRIBUTING.md` links to it.

### `BUILD.md` — now purely "how to build"

- Removed the duplicate compiler table and the two extra restatements of the "you need Git/Python/Conan/CMake/a compiler" prerequisite (already in the top banner).
- Removed the duplicated Conan crash-course paragraph in `Set Up Conan` (same links as the banner above it).
- Turned the orphaned `[^windows]` footnote into plain text under `Operating Systems`, and dropped the matching duplicate note from `environment.md`.

### `docs/build/nix.md` — Nix-specific build caveats collected

- Merged the coverage/`gcov` note and the "Conan and Prebuilt Packages" note into one `Building xrpld in the Nix shell` section (they were separated by unrelated sections).
- Cross-linked from `BUILD.md`'s `Coverage report` and `Troubleshooting → Conan` so the caveats are findable from where the problem shows up.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to this PR.
-->
