### PR TITLE
refactor: Drop unnecessary associateAsset calls from loan delete paths

### DIFF
--- a/src/libxrpl/tx/transactors/lending/LoanBrokerDelete.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanBrokerDelete.cpp
@@ -12,7 +12,6 @@
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STAmount.h>
 #include <xrpl/protocol/STLedgerEntry.h>
-#include <xrpl/protocol/STTakesAsset.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
@@ -197,8 +196,6 @@ LoanBrokerDelete::doApply()
     }
 
     view().erase(broker);
-
-    associateAsset(*broker, vaultAsset);
 
     return tesSUCCESS;
 }

--- a/src/libxrpl/tx/transactors/lending/LoanDelete.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanDelete.cpp
@@ -10,7 +10,6 @@
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STAmount.h>  // IWYU pragma: keep
 #include <xrpl/protocol/STLedgerEntry.h>
-#include <xrpl/protocol/STTakesAsset.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
@@ -93,7 +92,6 @@ LoanDelete::doApply()
     auto const vaultSle = view.peek(keylet::vault(brokerSle->at(sfVaultID)));
     if (!vaultSle)
         return tefBAD_LEDGER;  // LCOV_EXCL_LINE
-    auto const vaultAsset = vaultSle->at(sfAsset);
 
     // Remove LoanID from Directory of the LoanBroker pseudo-account.
     if (!view.dirRemove(
@@ -129,11 +127,6 @@ LoanDelete::doApply()
     }
     // Decrement the borrower's owner count
     decreaseOwnerCountForObject(view, borrowerSle, loanSle, 1, j_);
-
-    // These associations shouldn't do anything, but do them just to be safe
-    associateAsset(*loanSle, vaultAsset);
-    associateAsset(*brokerSle, vaultAsset);
-    associateAsset(*vaultSle, vaultAsset);
 
     return tesSUCCESS;
 }

--- a/src/libxrpl/tx/transactors/lending/LoanDelete.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanDelete.cpp
@@ -10,6 +10,7 @@
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STAmount.h>  // IWYU pragma: keep
 #include <xrpl/protocol/STLedgerEntry.h>
+#include <xrpl/protocol/STTakesAsset.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
@@ -92,6 +93,7 @@ LoanDelete::doApply()
     auto const vaultSle = view.peek(keylet::vault(brokerSle->at(sfVaultID)));
     if (!vaultSle)
         return tefBAD_LEDGER;  // LCOV_EXCL_LINE
+    auto const vaultAsset = vaultSle->at(sfAsset);
 
     // Remove LoanID from Directory of the LoanBroker pseudo-account.
     if (!view.dirRemove(
@@ -127,6 +129,8 @@ LoanDelete::doApply()
     }
     // Decrement the borrower's owner count
     decreaseOwnerCountForObject(view, borrowerSle, loanSle, 1, j_);
+
+    associateAsset(*vaultSle, vaultAsset);
 
     return tesSUCCESS;
 }


### PR DESCRIPTION
## High Level Overview of Change

Remove no-op `associateAsset` calls from `LoanDelete` and `LoanBrokerDelete`. They ran after `view.erase` (or without `view.update`), so they could not affect the ledger.

### Context of Change

`associateAsset` binds a runtime Asset to `STNumber` fields on new or modified SLEs before serialization. It is not part of the LoanDelete / LoanBrokerDelete protocol state changes. The LoanDelete comment already said these calls should not do anything; on erased objects they were dead. Dropping them avoids the false impression that an erased SLE is still a live ledger object.

### API Impact

- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)

## Test Plan

- Existing LoanBroker / LoanLifecycle / LoanValidation coverage of delete paths
