### PR TITLE
refactor: Act on TODOs that are unblocked by C++23

### DIFF
--- a/src/libxrpl/protocol/ErrorCodes.cpp
+++ b/src/libxrpl/protocol/ErrorCodes.cpp
@@ -105,10 +105,9 @@ static constexpr ErrorInfo kUnorderedErrorInfos[]{
 };
 // clang-format on
 
-// Sort and validate unorderedErrorInfos at compile time.  Should be
-// converted to consteval when get to C++20.
+// Sort and validate unorderedErrorInfos at compile time.
 template <int M, int N>
-constexpr auto
+consteval auto
 sortErrorInfos(ErrorInfo const (&unordered)[N]) -> std::array<ErrorInfo, M>
 {
     std::array<ErrorInfo, M> ret = {};

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -437,16 +437,10 @@ class Invariants_test : public beast::unit_test::Suite
             XRPAmount{},
             STTx{ttACCOUNT_DELETE, [](STObject& tx) {}});
 
-        for (auto const& keyletInfo : kDirectAccountKeylets)
+        for (auto const& [keyletfunc, type, includeInTests] : kDirectAccountKeylets)
         {
-            // TODO: Use structured binding once LLVM 16 is the minimum
-            // supported version. See also:
-            // https://github.com/llvm/llvm-project/issues/48582
-            // https://github.com/llvm/llvm-project/commit/127bf44385424891eb04cff8e52d3f157fc2cb7c
-            if (!keyletInfo.includeInTests)
+            if (!includeInTests)
                 continue;
-            auto const& keyletfunc = keyletInfo.function;
-            auto const& type = keyletInfo.expectedLEName;
 
             using namespace std::string_literals;
 

--- a/src/test/jtx/TestHelpers.h
+++ b/src/test/jtx/TestHelpers.h
@@ -43,6 +43,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <ranges>
 #include <source_location>
 #include <string>
 #include <tuple>
@@ -315,19 +316,11 @@ auto const kData = JTxFieldWrapper<BlobField>(sfData);
 
 auto const kAmount = JTxFieldWrapper<StAmountField>(sfAmount);
 
-// TODO We only need this long "requires" clause as polyfill, for C++20
-// implementations which are missing <ranges> header. Replace with
-// `std::ranges::range<Input>`, and accordingly use std::ranges::begin/end
-// when we have moved to better compilers.
-template <typename Input>
+template <std::ranges::range Input>
 auto
 makeVector(Input const& input)
-    requires requires(Input& v) {
-        std::begin(v);
-        std::end(v);
-    }
 {
-    return std::vector(std::begin(input), std::end(input));
+    return std::vector(std::ranges::begin(input), std::ranges::end(input));
 }
 
 // Functions used in debugging

--- a/src/xrpld/app/misc/FeeVoteImpl.cpp
+++ b/src/xrpld/app/misc/FeeVoteImpl.cpp
@@ -260,39 +260,35 @@ FeeVoteImpl::doVoting(
     }
 
     // choose our positions
-    // TODO: Use structured binding once LLVM 16 is the minimum supported
-    // version. See also: https://github.com/llvm/llvm-project/issues/48582
-    // https://github.com/llvm/llvm-project/commit/127bf44385424891eb04cff8e52d3f157fc2cb7c
-    auto const baseFee = baseFeeVote.getVotes();
-    auto const baseReserve = baseReserveVote.getVotes();
-    auto const incReserve = incReserveVote.getVotes();
+    auto const [baseFee, baseFeeChanged] = baseFeeVote.getVotes();
+    auto const [baseReserve, baseReserveChanged] = baseReserveVote.getVotes();
+    auto const [incReserve, incReserveChanged] = incReserveVote.getVotes();
 
     auto const seq = lastClosedLedger->header().seq + 1;
 
     // add transactions to our position
-    if (baseFee.second || baseReserve.second || incReserve.second)
+    if (baseFeeChanged || baseReserveChanged || incReserveChanged)
     {
-        JLOG(journal_.warn()) << "We are voting for a fee change: " << baseFee.first << "/"
-                              << baseReserve.first << "/" << incReserve.first;
+        JLOG(journal_.warn()) << "We are voting for a fee change: " << baseFee << "/" << baseReserve
+                              << "/" << incReserve;
 
         STTx const feeTx(ttFEE, [=, &rules](auto& obj) {
             obj[sfAccount] = AccountID();
             obj[sfLedgerSequence] = seq;
             if (rules.enabled(featureXRPFees))
             {
-                obj[sfBaseFeeDrops] = baseFee.first;
-                obj[sfReserveBaseDrops] = baseReserve.first;
-                obj[sfReserveIncrementDrops] = incReserve.first;
+                obj[sfBaseFeeDrops] = baseFee;
+                obj[sfReserveBaseDrops] = baseReserve;
+                obj[sfReserveIncrementDrops] = incReserve;
             }
             else
             {
                 // Without the featureXRPFees amendment, these fields are
                 // required.
-                obj[sfBaseFee] = baseFee.first.dropsAs<std::uint64_t>(baseFeeVote.current());
-                obj[sfReserveBase] =
-                    baseReserve.first.dropsAs<std::uint32_t>(baseReserveVote.current());
+                obj[sfBaseFee] = baseFee.dropsAs<std::uint64_t>(baseFeeVote.current());
+                obj[sfReserveBase] = baseReserve.dropsAs<std::uint32_t>(baseReserveVote.current());
                 obj[sfReserveIncrement] =
-                    incReserve.first.dropsAs<std::uint32_t>(incReserveVote.current());
+                    incReserve.dropsAs<std::uint32_t>(incReserveVote.current());
                 obj[sfReferenceFeeUnits] = kFeeUnitsDeprecated;
             }
         });

--- a/src/xrpld/overlay/detail/ProtocolVersion.cpp
+++ b/src/xrpld/overlay/detail/ProtocolVersion.cpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <iterator>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -32,31 +33,17 @@ constexpr ProtocolVersion const kSupportedProtocolList[]{
     {2, 3},
 };
 
-// This ugly construct ensures that supportedProtocolList is sorted in strictly
-// ascending order and doesn't contain any duplicates.
-// FIXME: With C++20 we can use std::is_sorted with an appropriate comparator
+// There should be at least one protocol we're willing to speak.
 static_assert(
-    []() constexpr -> bool {
-        auto const len =
-            std::distance(std::begin(kSupportedProtocolList), std::end(kSupportedProtocolList));
+    !std::ranges::empty(kSupportedProtocolList),
+    "There must be at least one supported protocol.");
 
-        // There should be at least one protocol we're willing to speak.
-        if (len == 0)
-            return false;
-
-        // A list with only one entry is, by definition, sorted so we don't
-        // need to check it.
-        if (len != 1)
-        {
-            for (auto i = 0; i != len - 1; ++i)
-            {
-                if (kSupportedProtocolList[i] >= kSupportedProtocolList[i + 1])
-                    return false;
-            }
-        }
-
-        return true;
-    }(),
+// Searching for an adjacent pair where the first element is not less than the
+// second one proves the list is sorted in strictly ascending order, which in
+// turn means it holds no duplicates.
+static_assert(
+    std::ranges::adjacent_find(kSupportedProtocolList, std::ranges::greater_equal{}) ==
+        std::ranges::end(kSupportedProtocolList),
     "The list of supported protocols isn't properly sorted.");
 
 std::string

--- a/src/xrpld/rpc/handlers/server_info/ServerDefinitions.cpp
+++ b/src/xrpld/rpc/handlers/server_info/ServerDefinitions.cpp
@@ -64,7 +64,6 @@ ServerDefinitions::translate(std::string const& inp)
         return out;
     };
 
-    // TODO: use string::contains with C++23
     auto contains = [&](std::string_view s) -> bool { return inp.contains(s); };
 
     if (contains("UINT"))


### PR DESCRIPTION
## High Level Overview of Change

Resolves six `TODO` / `FIXME` comments that were each waiting on a newer language standard or compiler. All of them are unblocked today, so this acts on them and deletes the comments. No behavior changes.

| Site | What it was waiting for |
| --- | --- |
| `FeeVoteImpl.cpp` | structured bindings capturable in a lambda |
| `Invariants_test.cpp` | same |
| `ProtocolVersion.cpp` | `std::is_sorted` in a `constexpr` context |
| `ErrorCodes.cpp` | `consteval` |
| `TestHelpers.h` | a standard library shipping `<ranges>` |
| `ServerDefinitions.cpp` | `std::string::contains` |

### Context of Change

`CMakeLists.txt` has set `CMAKE_CXX_STANDARD` to 23 for a while now, and `cmake/XrplSanity.cmake` already requires clang 16 or GCC 12 at minimum. The comments were written when neither was true, and nothing has swept them up since.

Details, in the order they appear in the diff:

- **`ErrorCodes.cpp`** — `sortErrorInfos` is only ever called at compile time, to initialise `kSortedErrorInfos`. It is now `consteval` rather than `constexpr`, which makes that a guarantee instead of a convention.
- **`Invariants_test.cpp` / `FeeVoteImpl.cpp`** — both carried a TODO pointing at [llvm/llvm-project#48582](https://github.com/llvm/llvm-project/issues/48582), a bug that prevented capturing a structured binding in a lambda. It was [fixed in LLVM 16](https://github.com/llvm/llvm-project/commit/127bf44385424891eb04cff8e52d3f157fc2cb7c), which is now the minimum, so both loops use structured bindings and drop the hand-unpacked locals.
- **`ProtocolVersion.cpp`** — a 17-line `constexpr` lambda inside a `static_assert`, hand-rolling a sortedness check, described in its own comment as an "ugly construct". Replaced with `std::ranges::adjacent_find` over `std::ranges::greater_equal`: finding no adjacent pair where the first element is not less than the second proves the list is strictly ascending, which also proves it holds no duplicates. The "at least one protocol" requirement becomes its own `static_assert` so the two failures report separately.
- **`TestHelpers.h`** — `makeVector`'s `requires requires` clause existed only as a polyfill for standard libraries missing `<ranges>`. It is now constrained on `std::ranges::range` and uses `std::ranges::begin`/`end`.
- **`ServerDefinitions.cpp`** — the TODO asked for `std::string::contains`, which the code on the very next line already calls. Just a stale comment.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

The only `libxrpl` file touched is `src/libxrpl/protocol/ErrorCodes.cpp`, and the change is confined to an internal helper in an anonymous `detail` namespace within that translation unit. No public header changes.

## Test Plan

`xrpl.overlay.ProtocolVersion`, `xrpl.app.Invariants` and `xrpl.app.FeeVote` all pass (3 suites, 98 cases, 14,168 tests, 0 failures). The `ProtocolVersion` and `ErrorCodes` changes are additionally enforced at compile time — if the supported-protocol list were mis-sorted, or if `sortErrorInfos` were ever called outside a constant expression, the build would fail.
