### PR TITLE
refactor: Replace boost::lexical_cast with existing alternatives

### DIFF
--- a/include/xrpl/beast/unit_test/reporter.h
+++ b/include/xrpl/beast/unit_test/reporter.h
@@ -8,7 +8,6 @@
 #include <xrpl/beast/unit_test/runner.h>
 #include <xrpl/beast/unit_test/suite_info.h>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/optional.hpp>
 
 #include <algorithm>
@@ -188,7 +187,7 @@ Reporter<Unused>::fmtdur(clock_type::duration const& d)
     using namespace std::chrono;
     auto const ms = duration_cast<milliseconds>(d);
     if (ms < seconds{1})
-        return boost::lexical_cast<std::string>(ms.count()) + "ms";
+        return std::to_string(ms.count()) + "ms";
     std::stringstream ss;
     ss << std::fixed << std::setprecision(1) << (ms.count() / 1000.) << "s";
     return ss.str();

--- a/include/xrpl/beast/unit_test/suite.h
+++ b/include/xrpl/beast/unit_test/suite.h
@@ -7,7 +7,6 @@
 #include <xrpl/beast/unit_test/runner.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
 
 #include <exception>
@@ -30,7 +29,7 @@ makeReason(String const& reason, char const* file, int line)
     namespace fs = boost::filesystem;
     s.append(fs::path{file}.filename().string());
     s.append("(");
-    s.append(boost::lexical_cast<std::string>(line));
+    s.append(std::to_string(line));
     s.append(")");
     return s;
 }

--- a/src/test/unit_test/multi_runner.cpp
+++ b/src/test/unit_test/multi_runner.cpp
@@ -7,7 +7,6 @@
 #include <boost/interprocess/creation_tags.hpp>
 #include <boost/interprocess/detail/os_file_functions.hpp>
 #include <boost/interprocess/shared_memory_object.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -36,7 +35,7 @@ fmtdur(typename clock_type::duration const& d)
     using namespace std::chrono;
     auto const ms = duration_cast<milliseconds>(d);
     if (ms < seconds{1})
-        return boost::lexical_cast<std::string>(ms.count()) + "ms";
+        return std::to_string(ms.count()) + "ms";
     std::stringstream ss;
     ss << std::fixed << std::setprecision(1) << (ms.count() / 1000.) << "s";
     return ss.str();

--- a/src/xrpld/rpc/handlers/account/AccountChannels.cpp
+++ b/src/xrpld/rpc/handlers/account/AccountChannels.cpp
@@ -140,7 +140,7 @@ doAccountChannels(rpc::JsonContext& context)
             return rpcError(RpcInvalidParams);
 
         auto const hint = toUInt64(value);
-        if (!hint)
+        if (!hint.has_value())
             return rpcError(RpcInvalidParams);
         startHint = *hint;
 

--- a/src/xrpld/rpc/handlers/account/AccountChannels.cpp
+++ b/src/xrpld/rpc/handlers/account/AccountChannels.cpp
@@ -3,6 +3,7 @@
 #include <xrpld/rpc/detail/RPCLedgerHelpers.h>
 #include <xrpld/rpc/detail/Tuning.h>
 
+#include <xrpl/basics/StringUtilities.h>
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/basics/strHex.h>
 #include <xrpl/beast/utility/Zero.h>
@@ -21,9 +22,6 @@
 #include <xrpl/protocol/jss.h>
 #include <xrpl/protocol/tokens.h>
 #include <xrpl/resource/Fees.h>
-
-#include <boost/lexical_cast.hpp>
-#include <boost/lexical_cast/bad_lexical_cast.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -129,7 +127,7 @@ doAccountChannels(rpc::JsonContext& context)
             return rpc::expectedFieldError(jss::marker, "string");
 
         // Marker is composed of a comma separated index and start hint. The
-        // former will be read as hex, and the latter using boost lexical cast.
+        // former will be read as hex, and the latter as a decimal integer.
         std::stringstream marker(params[jss::marker].asString());
         std::string value;
         if (!std::getline(marker, value, ','))
@@ -141,14 +139,10 @@ doAccountChannels(rpc::JsonContext& context)
         if (!std::getline(marker, value, ','))
             return rpcError(RpcInvalidParams);
 
-        try
-        {
-            startHint = boost::lexical_cast<std::uint64_t>(value);
-        }
-        catch (boost::bad_lexical_cast&)
-        {
+        auto const hint = toUInt64(value);
+        if (!hint)
             return rpcError(RpcInvalidParams);
-        }
+        startHint = *hint;
 
         // We then must check if the object pointed to by the marker is actually
         // owned by the account in the request.

--- a/src/xrpld/rpc/handlers/account/AccountLines.cpp
+++ b/src/xrpld/rpc/handlers/account/AccountLines.cpp
@@ -4,6 +4,7 @@
 #include <xrpld/rpc/detail/TrustLine.h>
 #include <xrpld/rpc/detail/Tuning.h>
 
+#include <xrpl/basics/StringUtilities.h>
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/beast/utility/Zero.h>
 #include <xrpl/beast/utility/instrumentation.h>
@@ -21,9 +22,6 @@
 #include <xrpl/protocol/UintTypes.h>
 #include <xrpl/protocol/jss.h>
 #include <xrpl/resource/Fees.h>
-
-#include <boost/lexical_cast.hpp>
-#include <boost/lexical_cast/bad_lexical_cast.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -153,7 +151,7 @@ doAccountLines(rpc::JsonContext& context)
             return rpc::expectedFieldError(jss::marker, "string");
 
         // Marker is composed of a comma separated index and start hint. The
-        // former will be read as hex, and the latter using boost lexical cast.
+        // former will be read as hex, and the latter as a decimal integer.
         std::stringstream marker(params[jss::marker].asString());
         std::string value;
         if (!std::getline(marker, value, ','))
@@ -165,14 +163,10 @@ doAccountLines(rpc::JsonContext& context)
         if (!std::getline(marker, value, ','))
             return rpcError(RpcInvalidParams);
 
-        try
-        {
-            startHint = boost::lexical_cast<std::uint64_t>(value);
-        }
-        catch (boost::bad_lexical_cast&)
-        {
+        auto const hint = toUInt64(value);
+        if (!hint)
             return rpcError(RpcInvalidParams);
-        }
+        startHint = *hint;
 
         // We then must check if the object pointed to by the marker is actually
         // owned by the account in the request.

--- a/src/xrpld/rpc/handlers/account/AccountLines.cpp
+++ b/src/xrpld/rpc/handlers/account/AccountLines.cpp
@@ -164,7 +164,7 @@ doAccountLines(rpc::JsonContext& context)
             return rpcError(RpcInvalidParams);
 
         auto const hint = toUInt64(value);
-        if (!hint)
+        if (!hint.has_value())
             return rpcError(RpcInvalidParams);
         startHint = *hint;
 

--- a/src/xrpld/rpc/handlers/account/AccountOffers.cpp
+++ b/src/xrpld/rpc/handlers/account/AccountOffers.cpp
@@ -108,7 +108,7 @@ doAccountOffers(rpc::JsonContext& context)
             return rpc::invalidFieldError(jss::marker);
 
         auto const hint = toUInt64(value);
-        if (!hint)
+        if (!hint.has_value())
             return rpc::invalidFieldError(jss::marker);
         startHint = *hint;
 

--- a/src/xrpld/rpc/handlers/account/AccountOffers.cpp
+++ b/src/xrpld/rpc/handlers/account/AccountOffers.cpp
@@ -3,6 +3,7 @@
 #include <xrpld/rpc/detail/RPCLedgerHelpers.h>
 #include <xrpld/rpc/detail/Tuning.h>
 
+#include <xrpl/basics/StringUtilities.h>
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/beast/utility/Zero.h>
 #include <xrpl/beast/utility/instrumentation.h>
@@ -19,9 +20,6 @@
 #include <xrpl/protocol/STAmount.h>
 #include <xrpl/protocol/jss.h>
 #include <xrpl/resource/Fees.h>
-
-#include <boost/lexical_cast.hpp>
-#include <boost/lexical_cast/bad_lexical_cast.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -97,7 +95,7 @@ doAccountOffers(rpc::JsonContext& context)
             return rpc::expectedFieldError(jss::marker, "string");
 
         // Marker is composed of a comma separated index and start hint. The
-        // former will be read as hex, and the latter using boost lexical cast.
+        // former will be read as hex, and the latter as a decimal integer.
         std::stringstream marker(params[jss::marker].asString());
         std::string value;
         if (!std::getline(marker, value, ','))
@@ -109,14 +107,10 @@ doAccountOffers(rpc::JsonContext& context)
         if (!std::getline(marker, value, ','))
             return rpc::invalidFieldError(jss::marker);
 
-        try
-        {
-            startHint = boost::lexical_cast<std::uint64_t>(value);
-        }
-        catch (boost::bad_lexical_cast&)
-        {
+        auto const hint = toUInt64(value);
+        if (!hint)
             return rpc::invalidFieldError(jss::marker);
-        }
+        startHint = *hint;
 
         // We then must check if the object pointed to by the marker is actually
         // owned by the account in the request.


### PR DESCRIPTION
## High Level Overview of Change

Removes `boost::lexical_cast` from six translation units, replacing each use with something the codebase already has:

- Number-to-string conversions become `std::to_string`.
- The three account RPC handlers that parse a pagination marker use the existing `xrpl::toUInt64` helper.

### Context of Change

`boost::lexical_cast` is doing two different jobs here, and neither needs Boost.

**Number to string.** `beast/unit_test/suite.h`, `beast/unit_test/reporter.h` and `test/unit_test/multi_runner.cpp` each used `boost::lexical_cast<std::string>` on an `int` or a `chrono` count. `std::to_string` is exactly equivalent for these types. The two beast headers are pulled into every legacy test translation unit, so dropping `<boost/lexical_cast.hpp>` from them removes the header from a very wide fan-out.

**String to number.** `account_lines`, `account_channels` and `account_offers` each parsed the start hint out of the pagination marker like this:

```cpp
try
{
    startHint = boost::lexical_cast<std::uint64_t>(value);
}
catch (boost::bad_lexical_cast&)
{
    return rpcError(RpcInvalidParams);
}
```

`xrpl::toUInt64` in `StringUtilities.h` already does this without exceptions, and is what the rest of the codebase reaches for. The three copies of the try/catch collapse to:

```cpp
auto const hint = toUInt64(value);
if (!hint)
    return rpcError(RpcInvalidParams);
startHint = *hint;
```

The stale comment above each block ("the latter using boost lexical cast") is updated to say what it actually does.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

`libxrpl` box is ticked because two public headers change: `include/xrpl/beast/unit_test/suite.h` and `include/xrpl/beast/unit_test/reporter.h`. Both changes are implementation-only — no declarations move — but each stops including `<boost/lexical_cast.hpp>`, so a dependent that was picking that header up transitively would now need to include it itself.

## Before / After

One deliberate, user-visible behavior change, which I want a reviewer's eyes on.

`toUInt64` is built on `std::from_chars` (it tolerates a leading `+`, and requires the whole string to be consumed), whereas `boost::lexical_cast`'s stream extraction also skipped leading whitespace. So marker parsing is now slightly stricter:

| Marker hint | Before | After |
| --- | --- | --- |
| `123` | accepted | accepted |
| `+123` | accepted | accepted |
| `" 123"` | accepted | `invalidParams` |
| `123abc` | `invalidParams` | `invalidParams` |
| `""` | `invalidParams` | `invalidParams` |

In practice this should reach no one. The marker is an opaque token the server itself generates, as `to_string(key) + ',' + std::to_string(hint)`, so nothing xrpld hands out contains whitespace in that field. It would only affect a client hand-crafting a marker with padding.

Flagging two things for the reviewer to decide:

1. Whether this warrants an `API-CHANGELOG.md` entry. I left it out on the grounds that the marker is opaque and no server-generated value changes meaning, but I'm happy to add one.
2. If you'd rather have strictly zero behavior change, I can trim the value before the call, or split the three RPC handlers off into their own PR and land only the `std::to_string` half here.

## Test Plan

`xrpl.rpc.AccountLines`, `xrpl.rpc.AccountObjects`, `xrpl.rpc.AccountOffers` and `xrpl.app.PayChan` all pass, covering the marker round-trip in each of the three handlers. Full unit test suite is green (228 suites, 1,223,369 tests, 0 failures).
