### PR TITLE
refactor: Remove operator!= overloads that C++20 synthesizes

### DIFF
--- a/include/xrpl/basics/Buffer.h
+++ b/include/xrpl/basics/Buffer.h
@@ -226,10 +226,4 @@ operator==(Buffer const& lhs, Buffer const& rhs) noexcept
     return std::memcmp(lhs.data(), rhs.data(), lhs.size()) == 0;
 }
 
-inline bool
-operator!=(Buffer const& lhs, Buffer const& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
-
 }  // namespace xrpl

--- a/include/xrpl/basics/IntrusivePointer.h
+++ b/include/xrpl/basics/IntrusivePointer.h
@@ -97,9 +97,6 @@ public:
     operator=(SharedIntrusive const& rhs);
 
     bool
-    operator!=(std::nullptr_t) const;
-
-    bool
     operator==(std::nullptr_t) const;
 
     template <class TT>

--- a/include/xrpl/basics/IntrusivePointer.ipp
+++ b/include/xrpl/basics/IntrusivePointer.ipp
@@ -113,13 +113,6 @@ SharedIntrusive<T>::operator=(SharedIntrusive<TT>&& rhs)
 
 template <class T>
 bool
-SharedIntrusive<T>::operator!=(std::nullptr_t) const
-{
-    return this->get() != nullptr;
-}
-
-template <class T>
-bool
 SharedIntrusive<T>::operator==(std::nullptr_t) const
 {
     return this->get() == nullptr;

--- a/include/xrpl/basics/Number.h
+++ b/include/xrpl/basics/Number.h
@@ -450,12 +450,6 @@ public:
     }
 
     friend constexpr bool
-    operator!=(Number const& x, Number const& y) noexcept
-    {
-        return !(x == y);
-    }
-
-    friend constexpr bool
     operator<(Number const& l, Number const& r) noexcept
     {
         bool const lneg = l.negative_;

--- a/include/xrpl/basics/SHAMapHash.h
+++ b/include/xrpl/basics/SHAMapHash.h
@@ -85,12 +85,6 @@ public:
     }
 };
 
-inline bool
-operator!=(SHAMapHash const& x, SHAMapHash const& y)
-{
-    return !(x == y);
-}
-
 template <>
 inline std::size_t
 extract(SHAMapHash const& key)

--- a/include/xrpl/basics/Slice.h
+++ b/include/xrpl/basics/Slice.h
@@ -209,12 +209,6 @@ operator==(Slice const& lhs, Slice const& rhs) noexcept
 }
 
 inline bool
-operator!=(Slice const& lhs, Slice const& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
-
-inline bool
 operator<(Slice const& lhs, Slice const& rhs) noexcept
 {
     return std::lexicographical_compare(

--- a/include/xrpl/basics/partitioned_unordered_map.h
+++ b/include/xrpl/basics/partitioned_unordered_map.h
@@ -116,12 +116,6 @@ public:
         {
             return lhs.map == rhs.map && lhs.ait == rhs.ait && lhs.mit == rhs.mit;
         }
-
-        friend bool
-        operator!=(Iterator const& lhs, Iterator const& rhs)
-        {
-            return !(lhs == rhs);
-        }
     };
 
     struct ConstIterator
@@ -188,12 +182,6 @@ public:
         operator==(ConstIterator const& lhs, ConstIterator const& rhs)
         {
             return lhs.map == rhs.map && lhs.ait == rhs.ait && lhs.mit == rhs.mit;
-        }
-
-        friend bool
-        operator!=(ConstIterator const& lhs, ConstIterator const& rhs)
-        {
-            return !(lhs == rhs);
         }
     };
 

--- a/include/xrpl/beast/container/detail/aged_ordered_container.h
+++ b/include/xrpl/beast/container/detail/aged_ordered_container.h
@@ -1045,25 +1045,6 @@ public:
         class OtherDuration,
         class OtherAllocator>
     bool
-    operator!=(AgedOrderedContainer<
-               OtherIsMulti,
-               OtherIsMap,
-               Key,
-               OtherT,
-               OtherDuration,
-               Compare,
-               OtherAllocator> const& other) const
-    {
-        return !(this->operator==(other));
-    }
-
-    template <
-        bool OtherIsMulti,
-        bool OtherIsMap,
-        class OtherT,
-        class OtherDuration,
-        class OtherAllocator>
-    bool
     operator<(AgedOrderedContainer<
               OtherIsMulti,
               OtherIsMap,

--- a/include/xrpl/beast/container/detail/aged_unordered_container.h
+++ b/include/xrpl/beast/container/detail/aged_unordered_container.h
@@ -1340,28 +1340,6 @@ public:
                OtherAllocator> const& other) const
         requires MaybeMulti;
 
-    template <
-        bool OtherIsMulti,
-        bool OtherIsMap,
-        class OtherKey,
-        class OtherT,
-        class OtherDuration,
-        class OtherHash,
-        class OtherAllocator>
-    bool
-    operator!=(AgedUnorderedContainer<
-               OtherIsMulti,
-               OtherIsMap,
-               OtherKey,
-               OtherT,
-               OtherDuration,
-               OtherHash,
-               KeyEqual,
-               OtherAllocator> const& other) const
-    {
-        return !(this->operator==(other));
-    }
-
 private:
     bool
     wouldExceed(size_type additional) const

--- a/include/xrpl/beast/core/List.h
+++ b/include/xrpl/beast/core/List.h
@@ -82,13 +82,6 @@ public:
         return node_ == other.node_;
     }
 
-    template <typename M>
-    bool
-    operator!=(ListIterator<M> const& other) const noexcept
-    {
-        return !((*this) == other);
-    }
-
     reference
     operator*() const noexcept
     {

--- a/include/xrpl/beast/net/IPEndpoint.h
+++ b/include/xrpl/beast/net/IPEndpoint.h
@@ -110,12 +110,6 @@ public:
     operator==(Endpoint const& lhs, Endpoint const& rhs);
     friend bool
     operator<(Endpoint const& lhs, Endpoint const& rhs);
-
-    friend bool
-    operator!=(Endpoint const& lhs, Endpoint const& rhs)
-    {
-        return !(lhs == rhs);
-    }
     friend bool
     operator>(Endpoint const& lhs, Endpoint const& rhs)
     {

--- a/include/xrpl/beast/rfc2616.h
+++ b/include/xrpl/beast/rfc2616.h
@@ -229,12 +229,6 @@ public:
         return other.it_ == it_ && other.end_ == end_ && other.value_.size() == value_.size();
     }
 
-    bool
-    operator!=(ListIterator const& other) const
-    {
-        return !(*this == other);
-    }
-
     reference
     operator*() const
     {

--- a/include/xrpl/conditions/Condition.h
+++ b/include/xrpl/conditions/Condition.h
@@ -92,10 +92,4 @@ operator==(Condition const& lhs, Condition const& rhs)
         lhs.fingerprint == rhs.fingerprint;
 }
 
-inline bool
-operator!=(Condition const& lhs, Condition const& rhs)
-{
-    return !(lhs == rhs);
-}
-
 }  // namespace xrpl::cryptoconditions

--- a/include/xrpl/conditions/Fulfillment.h
+++ b/include/xrpl/conditions/Fulfillment.h
@@ -93,12 +93,6 @@ operator==(Fulfillment const& lhs, Fulfillment const& rhs)
         lhs.fingerprint() == rhs.fingerprint();
 }
 
-inline bool
-operator!=(Fulfillment const& lhs, Fulfillment const& rhs)
-{
-    return !(lhs == rhs);
-}
-
 /**
  * Determine whether the given fulfillment and condition match
  */

--- a/include/xrpl/json/json_value.h
+++ b/include/xrpl/json/json_value.h
@@ -73,33 +73,15 @@ operator==(StaticString x, StaticString y)
 }
 
 inline bool
-operator!=(StaticString x, StaticString y)
-{
-    return !(x == y);
-}
-
-inline bool
 operator==(std::string const& x, StaticString y)
 {
     return strcmp(x.c_str(), y.cStr()) == 0;
 }
 
 inline bool
-operator!=(std::string const& x, StaticString y)
-{
-    return !(x == y);
-}
-
-inline bool
 operator==(StaticString x, std::string const& y)
 {
     return y == x;
-}
-
-inline bool
-operator!=(StaticString x, std::string const& y)
-{
-    return !(y == x);
 }
 
 /**
@@ -489,12 +471,6 @@ toJson(xrpl::Number const& number)
 bool
 operator==(Value const&, Value const&);
 
-inline bool
-operator!=(Value const& x, Value const& y)
-{
-    return !(x == y);
-}
-
 bool
 operator<(Value const&, Value const&);
 
@@ -560,12 +536,6 @@ public:
     operator==(SelfType const& other) const
     {
         return isEqual(other);
-    }
-
-    bool
-    operator!=(SelfType const& other) const
-    {
-        return !isEqual(other);
     }
 
     /**

--- a/include/xrpl/ledger/BookDirs.h
+++ b/include/xrpl/ledger/BookDirs.h
@@ -49,12 +49,6 @@ public:
     bool
     operator==(const_iterator const& other) const;
 
-    bool
-    operator!=(const_iterator const& other) const
-    {
-        return !(*this == other);
-    }
-
     reference
     operator*() const;
 

--- a/include/xrpl/ledger/CanonicalTXSet.h
+++ b/include/xrpl/ledger/CanonicalTXSet.h
@@ -59,12 +59,6 @@ private:
             return lhs.txId_ == rhs.txId_;
         }
 
-        friend bool
-        operator!=(Key const& lhs, Key const& rhs)
-        {
-            return !(lhs == rhs);
-        }
-
         [[nodiscard]] uint256 const&
         getAccount() const
         {

--- a/include/xrpl/ledger/Dir.h
+++ b/include/xrpl/ledger/Dir.h
@@ -59,12 +59,6 @@ public:
     bool
     operator==(ConstIterator const& other) const;
 
-    bool
-    operator!=(ConstIterator const& other) const
-    {
-        return !(*this == other);
-    }
-
     reference
     operator*() const;
 

--- a/include/xrpl/ledger/detail/ReadViewFwdRange.h
+++ b/include/xrpl/ledger/detail/ReadViewFwdRange.h
@@ -85,9 +85,6 @@ public:
         bool
         operator==(Iterator const& other) const;
 
-        bool
-        operator!=(Iterator const& other) const;
-
         // Can throw
         reference
         operator*() const;

--- a/include/xrpl/ledger/detail/ReadViewFwdRange.ipp
+++ b/include/xrpl/ledger/detail/ReadViewFwdRange.ipp
@@ -65,13 +65,6 @@ ReadViewFwdRange<ValueType>::Iterator::operator==(Iterator const& other) const
 }
 
 template <class ValueType>
-bool
-ReadViewFwdRange<ValueType>::Iterator::operator!=(Iterator const& other) const
-{
-    return !(*this == other);
-}
-
-template <class ValueType>
 auto
 ReadViewFwdRange<ValueType>::Iterator::operator*() const -> reference
 {

--- a/include/xrpl/protocol/Quality.h
+++ b/include/xrpl/protocol/Quality.h
@@ -75,13 +75,6 @@ operator==(TAmounts<In, Out> const& lhs, TAmounts<In, Out> const& rhs) noexcept
     return lhs.in == rhs.in && lhs.out == rhs.out;
 }
 
-template <class In, class Out>
-bool
-operator!=(TAmounts<In, Out> const& lhs, TAmounts<In, Out> const& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
-
 //------------------------------------------------------------------------------
 
 // XRPL specific constant used for parsing qualities and other things
@@ -269,12 +262,6 @@ public:
     operator==(Quality const& lhs, Quality const& rhs) noexcept
     {
         return lhs.value_ == rhs.value_;
-    }
-
-    friend bool
-    operator!=(Quality const& lhs, Quality const& rhs) noexcept
-    {
-        return !(lhs == rhs);
     }
 
     friend std::ostream&

--- a/include/xrpl/protocol/Rules.h
+++ b/include/xrpl/protocol/Rules.h
@@ -98,9 +98,6 @@ public:
      */
     bool
     operator==(Rules const&) const;
-
-    bool
-    operator!=(Rules const& other) const;
 };
 
 std::optional<Rules> const&

--- a/include/xrpl/protocol/STAmount.h
+++ b/include/xrpl/protocol/STAmount.h
@@ -643,12 +643,6 @@ bool
 operator<(STAmount const& lhs, STAmount const& rhs);
 
 inline bool
-operator!=(STAmount const& lhs, STAmount const& rhs)
-{
-    return !(lhs == rhs);
-}
-
-inline bool
 operator>(STAmount const& lhs, STAmount const& rhs)
 {
     return rhs < lhs;

--- a/include/xrpl/protocol/STArray.h
+++ b/include/xrpl/protocol/STArray.h
@@ -133,9 +133,6 @@ public:
     bool
     operator==(STArray const& s) const;
 
-    bool
-    operator!=(STArray const& s) const;
-
     iterator
     erase(iterator pos);
 
@@ -281,12 +278,6 @@ inline bool
 STArray::operator==(STArray const& s) const
 {
     return v_ == s.v_;
-}
-
-inline bool
-STArray::operator!=(STArray const& s) const
-{
-    return v_ != s.v_;
 }
 
 inline STArray::iterator

--- a/include/xrpl/protocol/STBase.h
+++ b/include/xrpl/protocol/STBase.h
@@ -140,8 +140,6 @@ public:
 
     bool
     operator==(STBase const& t) const;
-    bool
-    operator!=(STBase const& t) const;
 
     template <class D>
     D&

--- a/include/xrpl/protocol/STCurrency.h
+++ b/include/xrpl/protocol/STCurrency.h
@@ -94,12 +94,6 @@ operator==(STCurrency const& lhs, STCurrency const& rhs)
 }
 
 inline bool
-operator!=(STCurrency const& lhs, STCurrency const& rhs)
-{
-    return !operator==(lhs, rhs);
-}
-
-inline bool
 operator<(STCurrency const& lhs, STCurrency const& rhs)
 {
     return lhs.currency() < rhs.currency();

--- a/include/xrpl/protocol/STObject.h
+++ b/include/xrpl/protocol/STObject.h
@@ -432,8 +432,6 @@ public:
 
     bool
     operator==(STObject const& o) const;
-    bool
-    operator!=(STObject const& o) const;
 
     class FieldErr;
 
@@ -665,36 +663,6 @@ public:
         if (lhs.engaged() != rhs.engaged())
             return false;
         return !lhs.engaged() || *lhs == *rhs;
-    }
-
-    friend bool
-    operator!=(OptionalProxy const& lhs, std::nullopt_t) noexcept
-    {
-        return !(lhs == std::nullopt);
-    }
-
-    friend bool
-    operator!=(std::nullopt_t, OptionalProxy const& rhs) noexcept
-    {
-        return !(rhs == std::nullopt);
-    }
-
-    friend bool
-    operator!=(OptionalProxy const& lhs, optional_type const& rhs) noexcept
-    {
-        return !(lhs == rhs);
-    }
-
-    friend bool
-    operator!=(optional_type const& lhs, OptionalProxy const& rhs) noexcept
-    {
-        return !(lhs == rhs);
-    }
-
-    friend bool
-    operator!=(OptionalProxy const& lhs, OptionalProxy const& rhs) noexcept
-    {
-        return !(lhs == rhs);
     }
 
     // Emulate std::optional::value_or
@@ -1200,12 +1168,6 @@ STObject::setFieldH160(SField const& field, BaseUInt<160, Tag> const& v)
     {
         Throw<std::runtime_error>("Wrong field type");
     }
-}
-
-inline bool
-STObject::operator!=(STObject const& o) const
-{
-    return !(*this == o);
 }
 
 template <typename T, typename V>

--- a/include/xrpl/protocol/STPathSet.h
+++ b/include/xrpl/protocol/STPathSet.h
@@ -115,9 +115,6 @@ public:
     bool
     operator==(STPathElement const& t) const;
 
-    bool
-    operator!=(STPathElement const& t) const;
-
 private:
     static std::size_t
     getHash(STPathElement const& element);
@@ -430,12 +427,6 @@ STPathElement::operator==(STPathElement const& t) const
 {
     return (type_ & TypeAccount) == (t.type_ & TypeAccount) && hashValue_ == t.hashValue_ &&
         accountID_ == t.accountID_ && assetID_ == t.assetID_ && issuerID_ == t.issuerID_;
-}
-
-inline bool
-STPathElement::operator!=(STPathElement const& t) const
-{
-    return !operator==(t);
 }
 
 // ------------ STPath ------------

--- a/include/xrpl/protocol/SeqProxy.h
+++ b/include/xrpl/protocol/SeqProxy.h
@@ -124,12 +124,6 @@ public:
     }
 
     friend constexpr bool
-    operator!=(SeqProxy lhs, SeqProxy rhs)
-    {
-        return !(lhs == rhs);
-    }
-
-    friend constexpr bool
     operator<(SeqProxy lhs, SeqProxy rhs)
     {
         if (lhs.type_ != rhs.type_)

--- a/include/xrpl/protocol/Serializer.h
+++ b/include/xrpl/protocol/Serializer.h
@@ -265,19 +265,9 @@ public:
         return v == data_;
     }
     bool
-    operator!=(Blob const& v) const
-    {
-        return v != data_;
-    }
-    bool
     operator==(Serializer const& v) const
     {
         return v.data_ == data_;
-    }
-    bool
-    operator!=(Serializer const& v) const
-    {
-        return v.data_ != data_;
     }
 
     static int

--- a/include/xrpl/protocol/Units.h
+++ b/include/xrpl/protocol/Units.h
@@ -258,13 +258,6 @@ public:
         return value_ == other;
     }
 
-    template <Compatible<ValueUnit> Other>
-    constexpr bool
-    operator!=(ValueUnit<unit_type, Other> const& other) const
-    {
-        return !operator==(other);
-    }
-
     constexpr bool
     operator<(ValueUnit const& other) const
     {

--- a/include/xrpl/protocol/detail/STVar.h
+++ b/include/xrpl/protocol/detail/STVar.h
@@ -152,10 +152,4 @@ operator==(STVar const& lhs, STVar const& rhs)
     return lhs.get().isEquivalent(rhs.get());
 }
 
-inline bool
-operator!=(STVar const& lhs, STVar const& rhs)
-{
-    return !(lhs == rhs);
-}
-
 }  // namespace xrpl::detail

--- a/include/xrpl/server/Manifest.h
+++ b/include/xrpl/server/Manifest.h
@@ -306,12 +306,6 @@ operator==(Manifest const& lhs, Manifest const& rhs)
         lhs.serialized == rhs.serialized;
 }
 
-inline bool
-operator!=(Manifest const& lhs, Manifest const& rhs)
-{
-    return !(lhs == rhs);
-}
-
 struct ValidatorToken
 {
     std::string manifest;

--- a/include/xrpl/shamap/SHAMap.h
+++ b/include/xrpl/shamap/SHAMap.h
@@ -789,12 +789,6 @@ operator==(SHAMap::ConstIterator const& x, SHAMap::ConstIterator const& y)
     return x.item_ == y.item_;
 }
 
-inline bool
-operator!=(SHAMap::ConstIterator const& x, SHAMap::ConstIterator const& y)
-{
-    return !(x == y);
-}
-
 inline SHAMap::ConstIterator
 SHAMap::begin() const
 {

--- a/include/xrpl/shamap/SHAMapNodeID.h
+++ b/include/xrpl/shamap/SHAMapNodeID.h
@@ -3,6 +3,7 @@
 #include <xrpl/basics/CountedObject.h>
 #include <xrpl/basics/base_uint.h>
 
+#include <compare>
 #include <cstddef>
 #include <optional>
 #include <ostream>
@@ -65,44 +66,25 @@ public:
     static SHAMapNodeID
     createID(int depth, uint256 const& key);
 
-    // FIXME-C++20: use spaceship and operator synthesis
     /**
      * Comparison operators
+     *
+     * <, >, <= and >= are synthesized from the spaceship. It is written out
+     * rather than defaulted because the ordering is by depth first, and the
+     * members are not declared in that order.
      */
-    bool
-    operator<(SHAMapNodeID const& n) const
+    std::strong_ordering
+    operator<=>(SHAMapNodeID const& n) const
     {
-        return std::tie(depth_, id_) < std::tie(n.depth_, n.id_);
+        return std::tie(depth_, id_) <=> std::tie(n.depth_, n.id_);
     }
 
-    bool
-    operator>(SHAMapNodeID const& n) const
-    {
-        return n < *this;
-    }
-
-    bool
-    operator<=(SHAMapNodeID const& n) const
-    {
-        return !(n < *this);
-    }
-
-    bool
-    operator>=(SHAMapNodeID const& n) const
-    {
-        return !(*this < n);
-    }
-
+    // Not defaulted: that would also compare the CountedObject base, which is
+    // not equality comparable.
     bool
     operator==(SHAMapNodeID const& n) const
     {
         return (depth_ == n.depth_) && (id_ == n.id_);
-    }
-
-    bool
-    operator!=(SHAMapNodeID const& n) const
-    {
-        return !(*this == n);
     }
 };
 

--- a/include/xrpl/shamap/SHAMapNodeID.h
+++ b/include/xrpl/shamap/SHAMapNodeID.h
@@ -79,8 +79,14 @@ public:
         return std::tie(depth_, id_) <=> std::tie(n.depth_, n.id_);
     }
 
-    // Not defaulted: that would also compare the CountedObject base, which is
-    // not equality comparable.
+    /**
+     * Equality, which the spaceship above does not provide.
+     *
+     * Only a *defaulted* operator<=> implicitly declares a defaulted
+     * operator==; the one above is user-provided, so == has to be written.
+     * It cannot be defaulted either, because a defaulted == would also compare
+     * the CountedObject base, which is not equality comparable.
+     */
     bool
     operator==(SHAMapNodeID const& n) const
     {

--- a/include/xrpl/tx/paths/detail/Steps.h
+++ b/include/xrpl/tx/paths/detail/Steps.h
@@ -275,13 +275,6 @@ public:
     }
 
     /**
-     * Return true if lhs != rhs.
-     *
-     * @param lhs Step to compare.
-     * @param rhs Step to compare.
-     * @return true if lhs != rhs.
-     */
-    /**
      * Streaming operator for a Step.
      */
     friend std::ostream&

--- a/include/xrpl/tx/paths/detail/Steps.h
+++ b/include/xrpl/tx/paths/detail/Steps.h
@@ -281,12 +281,6 @@ public:
      * @param rhs Step to compare.
      * @return true if lhs != rhs.
      */
-    friend bool
-    operator!=(Step const& lhs, Step const& rhs)
-    {
-        return !(lhs == rhs);
-    }
-
     /**
      * Streaming operator for a Step.
      */

--- a/src/libxrpl/protocol/Rules.cpp
+++ b/src/libxrpl/protocol/Rules.cpp
@@ -194,12 +194,6 @@ Rules::operator==(Rules const& other) const
 }
 
 bool
-Rules::operator!=(Rules const& other) const
-{
-    return !(*this == other);
-}
-
-bool
 isFeatureEnabled(uint256 const& feature, bool resultIfNoRules)
 {
     auto const& rules = getCurrentTransactionRules();

--- a/src/libxrpl/protocol/STBase.cpp
+++ b/src/libxrpl/protocol/STBase.cpp
@@ -38,12 +38,6 @@ STBase::operator==(STBase const& t) const
     return (getSType() == t.getSType()) && isEquivalent(t);
 }
 
-bool
-STBase::operator!=(STBase const& t) const
-{
-    return (getSType() != t.getSType()) || !isEquivalent(t);
-}
-
 STBase*
 STBase::copy(std::size_t n, void* buf) const
 {

--- a/src/test/jtx/amount.h
+++ b/src/test/jtx/amount.h
@@ -162,12 +162,6 @@ operator==(PrettyAmount const& lhs, PrettyAmount const& rhs)
     return lhs.value() == rhs.value();
 }
 
-inline bool
-operator!=(PrettyAmount const& lhs, PrettyAmount const& rhs)
-{
-    return !operator==(lhs, rhs);
-}
-
 std::ostream&
 operator<<(std::ostream& os, PrettyAmount const& amount);
 


### PR DESCRIPTION
## High Level Overview of Change

Removes 40 `operator!=` overloads across 37 files that do nothing but negate the neighbouring `operator==`. Since C++20 the compiler synthesizes these. Also collapses `SHAMapNodeID`'s four relational operators into one `operator<=>`, resolving a `FIXME-C++20` there.

Net effect is 355 lines deleted for 10 added, with no behavior change.

### Context of Change

Since C++20, when the compiler sees `a != b` and finds no viable `operator!=`, it rewrites the expression as `!(a == b)`. It will also consider reversed operands, so a single `operator==` covers `a != b`, `b != a`, `a == b` and `b == a`. That makes a hand-written `operator!=` whose entire body is `return !(lhs == rhs);` dead weight — it has to be kept in sync with `operator==` by hand, and it is one more thing to write for every new comparable type.

**Every removal in this PR is verified by the compiler.** If the rewrite were not viable for some type — an inaccessible `operator==`, a mismatched signature, an ambiguity introduced by the reversed candidate — the call sites would fail to compile rather than silently change meaning. That is the main reason I'd argue this is low-risk despite the file count.

Most of the removals were literally `return !(lhs == rhs);`. Four were spelled differently but are the same predicate:

| Site | Body | Its `operator==` |
| --- | --- | --- |
| `STBase::operator!=` | `getSType() != t.getSType() \|\| !isEquivalent(t)` | `getSType() == t.getSType() && isEquivalent(t)` |
| `STArray::operator!=` | `v_ != s.v_` | `v_ == s.v_` |
| `Serializer::operator!=` | `v.data_ != data_` | `v.data_ == data_` |
| `SharedIntrusive::operator!=(nullptr_t)` | `get() != nullptr` | `get() == nullptr` |

`STBase` is a De Morgan expansion; the other three negate exactly the member comparison their `operator==` affirms.

#### `SHAMapNodeID`

This one is a rewrite rather than a deletion. It carried:

```cpp
// FIXME-C++20: use spaceship and operator synthesis
```

and five comparison operators. `<`, `>`, `<=` and `>=` collapse into a single `operator<=>`, from which the compiler synthesizes the other four. Two details worth flagging, both commented in the code:

- **`operator<=>` is written out, not defaulted.** The existing ordering is `std::tie(depth_, id_)` — depth first — but the members are declared `id_` then `depth_`. A defaulted spaceship compares in *declaration* order, which would silently reverse the sort key. Rather than reorder the members (and change the layout) I kept the explicit `std::tie` comparison, so the ordering is provably identical to before.
- **`operator==` stays explicit.** Defaulting it makes it implicitly deleted, because `SHAMapNodeID` derives from `CountedObject<SHAMapNodeID>`, which is not equality comparable, and a defaulted `==` compares base classes too. I hit this as a compile error in `SHAMapSync.cpp` on the first attempt.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

This removes declarations from many public `include/xrpl` headers, so it is a `libxrpl` change even though it is source-compatible for ordinary use.

Worth stating explicitly for downstream consumers: `a != b` keeps working everywhere, because that is the expression the compiler rewrites. What would break is code that names the operator directly — `operator!=(a, b)` as a function call, taking its address, or passing it as a template argument. I found no such usage in this repository, and it would be unusual downstream, but it is the one pattern that is not covered by the rewrite.

## Test Plan

Given the breadth, I ran everything rather than a targeted subset:

- Full legacy suite: 228 suites, 4,495 cases, **1,223,369 tests, 0 failures**
- Full gtest binary: **894 tests, 0 failures**
- Clean build with clang 22 (Debug), zero errors and no new warnings

Plus the compile-time argument above: because these operators are removed rather than reimplemented, any type where the C++20 rewrite does not apply becomes a build failure, not a behavior change. The comparison-heavy suites (`STObject`, `STAmount`, `SeqProxy`, `Quality`, `Directory`, `aged_associative_container`) pass specifically.
