### PR TITLE
fix: Data race and no-subscriber update failure in reportFeeChange()

### DIFF
--- a/src/test/rpc/Subscribe_test.cpp
+++ b/src/test/rpc/Subscribe_test.cpp
@@ -43,6 +43,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -51,6 +52,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -1957,6 +1959,95 @@ public:
     }
 
     void
+    testReportFeeChangeRace()
+    {
+        // Prove that reportFeeChange() has a data race on lastFeeSummary_.
+        // Multiple threads can simultaneously pass the f != lastFeeSummary_
+        // guard and queue redundant PubFee jobs even when the fee has not
+        // changed. If the guard were thread-safe, exactly one serverStatus
+        // message would arrive. More than one proves the race.
+        testcase("reportFeeChange race condition on lastFeeSummary_");
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env{*this, singleThreadIo(envconfig())};
+        auto wsc = makeWSClient(env.app().config());
+
+        // Subscribe to server stream
+        {
+            json::Value stream;
+            stream[jss::streams] = json::ValueType::Array;
+            stream[jss::streams].append("server");
+            auto jv = wsc->invoke("subscribe", stream);
+            BEAST_EXPECT(jv[jss::status] == "success");
+        }
+
+        // Stop LoadManager to prevent it interfering with fee state
+        env.app().getLoadManager().stop();
+
+        // Raise fee once so lastFeeSummary_ is initialised with a known state
+        {
+            auto& feeTrack = env.app().getFeeTrack();
+            feeTrack.raiseLocalFee();
+            env.app().getOPs().reportFeeChange();
+            // Drain the one legitimate message
+            BEAST_EXPECT(
+                wsc->findMsg(5s, [&](auto const& jv) { return jv[jss::type] == "serverStatus"; }));
+        }
+
+        // Raise the fee once more before spawning threads so the fee
+        // summary IS genuinely different from lastFeeSummary_. Threads
+        // only call reportFeeChange() — no raiseLocalFee() per-thread,
+        // which would create genuine (non-racy) fee summary changes and
+        // make count==1 unreliable as a race detector.
+        {
+            auto& feeTrack2 = env.app().getFeeTrack();
+            feeTrack2.raiseLocalFee();
+        }
+        // Now call reportFeeChange() from many threads simultaneously.
+        // A thread-safe guard would produce exactly 1 message (first
+        // thread wins, rest see updated lastFeeSummary_ and bail).
+        // The race produces > 1 message because multiple threads read
+        // the old lastFeeSummary_ before any job executes to update it.
+        constexpr int kThreads = 16;
+        std::vector<std::thread> threads;
+        threads.reserve(kThreads);
+        std::atomic<int> ready{0};
+        for (int i = 0; i < kThreads; ++i)
+        {
+            threads.emplace_back([&]() {
+                ready.fetch_add(1, std::memory_order_relaxed);
+                while (ready.load(std::memory_order_relaxed) < kThreads)
+                    ;
+                env.app().getOPs().reportFeeChange();
+            });
+        }
+        for (auto& t : threads)
+            t.join();
+        // Wait for the first serverStatus message, then drain any remaining.
+        int count = 0;
+        if (wsc->findMsg(5s, [&](auto const& jv) { return jv[jss::type] == "serverStatus"; }))
+            ++count;
+        while (auto jvo = wsc->getMsg(50ms))
+        {
+            if ((*jvo)[jss::type] == "serverStatus")
+                ++count;
+        }
+        // If thread-safe: exactly 1 message (one fee change).
+        // If race condition present: > 1 message (multiple threads
+        // queued PubFee jobs before lastFeeSummary_ was updated).
+        // This test FAILS on unfixed code, proving the race.
+        BEAST_EXPECT(count == 1);
+
+        // Unsubscribe
+        {
+            json::Value stream;
+            stream[jss::streams] = json::ValueType::Array;
+            stream[jss::streams].append("server");
+            wsc->invoke("unsubscribe", stream);
+        }
+    }
+
+    void
     run() override
     {
         using namespace test::jtx;
@@ -1964,6 +2055,7 @@ public:
         FeatureBitset const xrpFees{featureXRPFees};
 
         testServer();
+        testReportFeeChangeRace();
         testLedger();
         testTransactionsAPIv1();
         testTransactionsAPIv2();

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -3404,9 +3404,15 @@ NetworkOPsImp::reportFeeChange()
         registry_.get().getTxQ().getMetrics(*registry_.get().getOpenLedger().current()),
         registry_.get().getFeeTrack()};
 
-    // only schedule the job if something has changed
+    // Guard lastFeeSummary_ under streamLock_ to prevent concurrent
+    // threads from simultaneously passing the check and queuing
+    // duplicate JtClientFeeChange jobs (data race fix).
+    // Also fixes the no-subscriber case where lastFeeSummary_ was
+    // never updated by pubServer(), causing endless job queuing.
+    std::scoped_lock const sl(streamLock_);
     if (f != lastFeeSummary_)
     {
+        lastFeeSummary_ = f;
         jobQueue_.addJob(JtClientFeeChange, "PubFee", [this]() { pubServer(); });
     }
 }


### PR DESCRIPTION
<html><body>
<!--StartFragment--><html><head></head><body>Fixes #8008<h2>Background</h2>
<p>David Schwartz (@JoelKatz) observed elevated <code>clientFeeChange</code> job rates on his hub node running 3.3.0 and applied a partial fix in his <code>3.3.0-DJS</code> build. He noted: <em>"if anyone else is seeing large numbers of clientFeeChange jobs, then we might need to investigate why I needed that change"</em>.</p>
<p>Seeing the same behaviour on a production validator and a test node, I investigated further. This PR documents the root cause analysis and proposes a fix that addresses both the symptom David observed and a second underlying cause his fix did not cover.</p>
<h2>Summary</h2>
<p><code>NetworkOPsImp::reportFeeChange()</code> in 3.3.0 contains two related bugs that compound to produce a sustained flood of redundant <code>JtClientFeeChange</code> ("PubFee") jobs:</p>
<ol>
<li>
<p><strong>Data race:</strong> <code>lastFeeSummary_</code> is read without holding any lock in <code>reportFeeChange()</code>, but is written under <code>streamLock_</code> in <code>pubServer()</code>. Under concurrent calls, multiple threads simultaneously pass the <code>f != lastFeeSummary_</code> deduplication guard and queue redundant jobs.</p>
</li>
<li>
<p><strong>No-subscriber update failure:</strong> <code>lastFeeSummary_</code> is only written inside <code>pubServer()</code> under <code>if (!streamMaps_[SServer].empty())</code>. On nodes with no WebSocket subscribers on the server stream — the typical production configuration for validators — <code>pubServer()</code> never updates <code>lastFeeSummary_</code>. This means every genuine fee change queues a job, <code>pubServer()</code> runs, finds no subscribers, skips the update, and the cycle repeats on the next fee change indefinitely.</p>
</li>
</ol>
<p>Both bugs are addressed by a single two-line change.</p>
<h2>Affected version</h2>
<p>3.3.0 (<code>00a178fb92ca49521b937ae1a99d863765ea8a90</code>)</p>
<h2>Root cause</h2>
<h3>Bug 1: Data race on <code>lastFeeSummary_</code></h3>
<pre><code class="language-cpp">// reportFeeChange() — no lock held
void
NetworkOPsImp::reportFeeChange()
{
    ServerFeeSummary const f{...};
    if (f != lastFeeSummary_)   // READ, no lock
    {
        jobQueue_.addJob(JtClientFeeChange, "PubFee", [this]() { pubServer(); });
    }
}

// pubServer() — written under streamLock_
std::scoped_lock const sl(streamLock_);
if (!streamMaps_[SServer].empty())
{
    // ...
    lastFeeSummary_ = f;   // WRITE, under streamLock_
}
</code></pre>
<p><code>lastFeeSummary_</code> is a plain member (line 1003) with no associated mutex. Between a <code>PubFee</code> job being queued and executing, any concurrent caller reads the stale value, passes the guard, and queues another redundant job.</p>
<h3>Bug 2: No-subscriber update failure</h3>
<p><code>pubServer()</code> only updates <code>lastFeeSummary_</code> when <code>streamMaps_[SServer]</code> is non-empty. On nodes with no server stream subscribers:</p>
<ol>
<li>Fee changes → <code>reportFeeChange()</code> reads stale <code>lastFeeSummary_</code>, passes guard, queues job</li>
<li><code>pubServer()</code> runs, finds no subscribers, <strong>skips the <code>lastFeeSummary_</code> update</strong></li>
<li>Next fee change → stale value still present, guard passes again, another job queued</li>
<li>Repeat indefinitely</li>
</ol>
<p>This is why the issue manifests predominantly on validators and non-public nodes — they typically have no WebSocket clients subscribed to the server stream.</p>
<h2>Evidence</h2>
<h3>1. Sustained production observation — stock 3.3.0</h3>
<p>Two nodes (a production validator and a fresh test node) running stock 3.3.0 sampled simultaneously every 10 seconds over 5 minutes. Values are near-identical and spike simultaneously — confirming the churn is network-driven, not node-specific:</p>
<pre><code># validator (reputation-test)    # test node (chris-xahau1)
04:45:00 — per_second: 19        04:45:00 — per_second: 19
04:45:50 — per_second: 28        04:45:50 — per_second: 28
04:46:40 — per_second: 44        04:46:40 — per_second: 47  ← simultaneous spike
04:49:52 — per_second: 24        04:49:51 — per_second: 17
</code></pre>
<p>Rate sustained at 15–47/sec throughout, never recovering to zero.</p>
<h3>2. JobQueue debug log — burst pattern</h3>
<p>7 <code>PubFee</code> jobs queued within 27ms — consistent with multiple threads simultaneously passing the unguarded check:</p>
<pre><code>2026-Aug-10 07:59:08.612 JobQueue:DBG addRefCountedJob : Adding job : PubFee : 4
2026-Aug-10 07:59:08.616 JobQueue:DBG addRefCountedJob : Adding job : PubFee : 4
2026-Aug-10 07:59:08.622 JobQueue:DBG addRefCountedJob : Adding job : PubFee : 4
2026-Aug-10 07:59:08.625 JobQueue:DBG addRefCountedJob : Adding job : PubFee : 4
2026-Aug-10 07:59:08.629 JobQueue:DBG addRefCountedJob : Adding job : PubFee : 4
2026-Aug-10 07:59:08.636 JobQueue:DBG addRefCountedJob : Adding job : PubFee : 4
2026-Aug-10 07:59:08.639 JobQueue:DBG addRefCountedJob : Adding job : PubFee : 4
</code></pre>
<h3>3. Reproducible unit test</h3>
<p>A new test case in <code>src/test/rpc/Subscribe_test.cpp</code> reliably reproduces the race:</p>
<ul>
<li>Subscribe to the server stream</li>
<li>Raise the fee once and drain the legitimate <code>serverStatus</code> message</li>
<li>Spawn 16 threads, barrier them, have each raise the fee and call <code>reportFeeChange()</code> simultaneously</li>
<li>Expect exactly 1 <code>serverStatus</code> message (one fee change event)</li>
</ul>
<p><strong>Result on stock 3.3.0 — test fails:</strong></p>
<pre><code>xrpl.rpc.Subscribe reportFeeChange race condition on lastFeeSummary_
#3 failed: Subscribe_test.cpp(2034)
failed: xrpl.rpc.Subscribe had 1 failures.
</code></pre>
<p>More than 1 message received — multiple threads passed the guard before <code>lastFeeSummary_</code> was updated.</p>
<h3>4. 24-hour monitoring with fix applied</h3>
<p>The same node (chris-xahau1) run as a proposing validator with the fix applied was monitored for 24 hours. <code>clientFeeChange</code> was absent from <code>server_info</code> during normal operation and appeared only during genuine network transaction spikes, correlating directly with TxQ metric changes:</p>

Time (UTC) | Ledger | Trigger | TxQ event
-- | -- | -- | --
10:50:23 | 106220016 | 2/sec | 869 tx ledger, expected=830
14:54:30 | 106223779 | 2/sec | New account burst, TxQ depth change
15:26:41 | 106224275 | 1/sec | TxQ metric oscillation
19:08:02 | 106227686 | 1/sec | 775 tx ledger
19:23:16 | 106227920 | 7/sec | 552 + 755 tx consecutive ledgers
21:11:36 | 106229593 | 1/sec | TxQ metric change
23:49:46 | 106232030 | 5/sec | 682 tx ledger, expected=700


<p>Every trigger correlates with a genuine <code>ServerFeeSummary</code> change. The rate is proportionate to the intensity of the event (1/sec for small changes, 5-7/sec for larger consecutive spikes). Under normal network load the job type is absent entirely from <code>server_info</code>.</p>
<p>The unfixed production validator (reputation-test) maintained 15–44/sec continuously throughout the same period.</p>
<h3>5. Correctness confirmed</h3>
<p>Legitimate fee change notifications are correctly delivered and not suppressed by the fix. The <code>clientFeeChange</code> job fires when and only when the fee summary genuinely changes.</p>
<h2>Proposed fix</h2>
<pre><code class="language-diff">--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -3404,9 +3404,15 @@ NetworkOPsImp::reportFeeChange()
         registry_.get().getTxQ().getMetrics(*registry_.get().getOpenLedger().current()),
         registry_.get().getFeeTrack()};
-    // only schedule the job if something has changed
+    // Guard lastFeeSummary_ under streamLock_ to prevent concurrent
+    // threads from simultaneously passing the check and queuing
+    // duplicate JtClientFeeChange jobs (data race fix).
+    // Also fixes the no-subscriber case where lastFeeSummary_ was
+    // never updated by pubServer(), causing endless job queuing.
+    std::scoped_lock const sl(streamLock_);
     if (f != lastFeeSummary_)
     {
+        lastFeeSummary_ = f;
         jobQueue_.addJob(JtClientFeeChange, "PubFee", [this]() { pubServer(); });
     }
 }
</code></pre>
<p>This fix:</p>
<ol>
<li>Acquires <code>streamLock_</code> before reading <code>lastFeeSummary_</code>, serialising concurrent callers and eliminating the race</li>
<li>Updates <code>lastFeeSummary_</code> immediately when queuing the job, before <code>pubServer()</code> executes, ensuring subsequent callers see the updated value regardless of whether subscribers exist</li>
</ol>
<h2>Relationship to existing partial fix</h2>
<p>David Schwartz's <code>3.3.0-DJS</code> build includes a fix using a <code>static ServerFeeSummary q</code> with <code>streamLock_</code> inside the existing guard. That approach effectively addresses Bug 1 (the race condition). The fix proposed here additionally addresses Bug 2 (the no-subscriber update failure) by updating <code>lastFeeSummary_</code> at the point of queuing rather than relying on <code>pubServer()</code> to do so.</p>
<h2>Impact</h2>
<ul>
<li>Redundant <code>pubServer()</code> executions on every fee change event, proportional to thread concurrency</li>
<li>Unnecessary WebSocket message fan-out to server stream subscribers on every redundant job</li>
<li>Sustained job queue overhead of 15–47 jobs/sec on production validators with no WebSocket clients</li>
</ul>
<h2>Related</h2>
<p>@nbougalis identified a separate underlying issue with fee escalation in `LoadManager::run()` that needs to be addressed.</p></body></html><!--EndFragment-->
</body>
</html>