### PR TITLE
chore: Split multiple-in-one into individual tests

### DIFF
--- a/src/tests/libxrpl/basics/IntrusiveShared.cpp
+++ b/src/tests/libxrpl/basics/IntrusiveShared.cpp
@@ -190,175 +190,182 @@ std::function<void(TrackedState, std::optional<TrackedState>)> TIBase::tracingCa
 
 }  // namespace
 
-TEST(IntrusiveSharedTest, basics)
+TEST(IntrusiveSharedTest, ref_counts_on_a_bare_object)
 {
-    {
-        TIBase::ResetStatesGuard const rsg{true};
+    TIBase::ResetStatesGuard const rsg{true};
 
-        TIBase const b;
-        EXPECT_EQ(b.useCount(), 1);
-        b.addWeakRef();
-        EXPECT_EQ(b.useCount(), 1);
-        auto s = b.releaseStrongRef();
-        EXPECT_EQ(s, ReleaseStrongRefAction::PartialDestroy);
-        EXPECT_EQ(b.useCount(), 0);
-        TIBase const* pb = &b;
-        partialDestructorFinished(&pb);
-        EXPECT_FALSE(pb);
-        auto w = b.releaseWeakRef();
-        EXPECT_EQ(w, ReleaseWeakRefAction::Destroy);
-    }
+    TIBase const b;
+    EXPECT_EQ(b.useCount(), 1);
+    b.addWeakRef();
+    EXPECT_EQ(b.useCount(), 1);
+    auto s = b.releaseStrongRef();
+    EXPECT_EQ(s, ReleaseStrongRefAction::PartialDestroy);
+    EXPECT_EQ(b.useCount(), 0);
+    TIBase const* pb = &b;
+    partialDestructorFinished(&pb);
+    EXPECT_FALSE(pb);
+    auto w = b.releaseWeakRef();
+    EXPECT_EQ(w, ReleaseWeakRefAction::Destroy);
+}
 
+TEST(IntrusiveSharedTest, strong_and_weak_containers_track_liveness)
+{
     std::vector<SharedIntrusive<TIBase>> strong;
     std::vector<WeakIntrusive<TIBase>> weak;
-    {
-        TIBase::ResetStatesGuard const rsg{true};
+    TIBase::ResetStatesGuard const rsg{true};
 
-        using enum TrackedState;
-        auto b = makeSharedIntrusive<TIBase>();
-        auto id = b->id;
-        EXPECT_EQ(TIBase::getState(id), Alive);
+    using enum TrackedState;
+    auto b = makeSharedIntrusive<TIBase>();
+    auto id = b->id;
+    EXPECT_EQ(TIBase::getState(id), Alive);
+    EXPECT_EQ(b->useCount(), 1);
+    strong.reserve(10);
+    for (auto i = 0uz; i < 10; ++i)
+        strong.push_back(b);
+    b.reset();
+    EXPECT_EQ(TIBase::getState(id), Alive);
+    strong.resize(strong.size() - 1);
+    EXPECT_EQ(TIBase::getState(id), Alive);
+    strong.clear();
+    EXPECT_EQ(TIBase::getState(id), Deleted);
+
+    b = makeSharedIntrusive<TIBase>();
+    id = b->id;
+    EXPECT_EQ(TIBase::getState(id), Alive);
+    EXPECT_EQ(b->useCount(), 1);
+    weak.reserve(10);
+    for (auto i = 0uz; i < 10; ++i)
+    {
+        weak.emplace_back(b);
         EXPECT_EQ(b->useCount(), 1);
-        for (auto i = 0uz; i < 10; ++i)
-            strong.push_back(b);
-        b.reset();
-        EXPECT_EQ(TIBase::getState(id), Alive);
-        strong.resize(strong.size() - 1);
-        EXPECT_EQ(TIBase::getState(id), Alive);
-        strong.clear();
-        EXPECT_EQ(TIBase::getState(id), Deleted);
-
-        b = makeSharedIntrusive<TIBase>();
-        id = b->id;
-        EXPECT_EQ(TIBase::getState(id), Alive);
-        EXPECT_EQ(b->useCount(), 1);
-        for (auto i = 0uz; i < 10; ++i)
+    }
+    EXPECT_EQ(TIBase::getState(id), Alive);
+    weak.resize(weak.size() - 1);
+    EXPECT_EQ(TIBase::getState(id), Alive);
+    b.reset();
+    EXPECT_EQ(TIBase::getState(id), PartiallyDeleted);
+    while (!weak.empty())
+    {
+        if (weak.resize(weak.size() - 1); !weak.empty())
         {
-            weak.emplace_back(b);
-            EXPECT_EQ(b->useCount(), 1);
+            EXPECT_EQ(TIBase::getState(id), PartiallyDeleted);
         }
-        EXPECT_EQ(TIBase::getState(id), Alive);
-        weak.resize(weak.size() - 1);
-        EXPECT_EQ(TIBase::getState(id), Alive);
-        b.reset();
-        EXPECT_EQ(TIBase::getState(id), PartiallyDeleted);
-        while (!weak.empty())
-        {
-            if (weak.resize(weak.size() - 1); !weak.empty())
-            {
-                EXPECT_EQ(TIBase::getState(id), PartiallyDeleted);
-            }
-        }
-        EXPECT_EQ(TIBase::getState(id), Deleted);
     }
-    {
-        TIBase::ResetStatesGuard const rsg{true};
+    EXPECT_EQ(TIBase::getState(id), Deleted);
+}
 
-        using enum TrackedState;
-        auto b = makeSharedIntrusive<TIBase>();
-        auto id = b->id;
-        EXPECT_EQ(TIBase::getState(id), Alive);
-        WeakIntrusive<TIBase> w{b};
-        EXPECT_EQ(TIBase::getState(id), Alive);
-        auto s = w.lock();
-        EXPECT_TRUE(s && s->useCount() == 2);
-        b.reset();
-        EXPECT_TRUE(TIBase::getState(id) == Alive);
-        EXPECT_TRUE(s && s->useCount() == 1);
-        s.reset();
-        EXPECT_EQ(TIBase::getState(id), PartiallyDeleted);
-        EXPECT_TRUE(w.expired());
-        s = w.lock();
-        // Cannot convert a weak pointer to a strong pointer if object is
-        // already partially deleted
-        EXPECT_FALSE(s);
-        w.reset();
-        EXPECT_EQ(TIBase::getState(id), Deleted);
-    }
-    {
-        TIBase::ResetStatesGuard const rsg{true};
+TEST(IntrusiveSharedTest, a_weak_pointer_cannot_revive_a_partially_deleted_object)
+{
+    TIBase::ResetStatesGuard const rsg{true};
 
-        using enum TrackedState;
-        using SharedWeak = SharedWeakUnion<TIBase>;
-        SharedWeak b = makeSharedIntrusive<TIBase>();
-        EXPECT_TRUE(b.isStrong() && b.useCount() == 1);
-        auto id = b.get()->id;
-        EXPECT_EQ(TIBase::getState(id), Alive);
-        SharedWeak w = b;
-        EXPECT_TRUE(TIBase::getState(id) == Alive);
-        EXPECT_TRUE(w.isStrong() && b.useCount() == 2);
-        w.convertToWeak();
-        EXPECT_TRUE(w.isWeak() && b.useCount() == 1);
-        SharedWeak s = w;
-        EXPECT_TRUE(s.isWeak() && b.useCount() == 1);
-        s.convertToStrong();
-        EXPECT_TRUE(s.isStrong() && b.useCount() == 2);
-        b.reset();
-        EXPECT_EQ(TIBase::getState(id), Alive);
-        EXPECT_EQ(s.useCount(), 1);
-        EXPECT_FALSE(w.expired());
-        s.reset();
-        EXPECT_EQ(TIBase::getState(id), PartiallyDeleted);
-        EXPECT_TRUE(w.expired());
-        w.convertToStrong();
-        // Cannot convert a weak pointer to a strong pointer if object is
-        // already partially deleted
-        EXPECT_TRUE(w.isWeak());
-        w.reset();
-        EXPECT_EQ(TIBase::getState(id), Deleted);
-    }
-    {
-        // Testing SharedWeakUnion assignment operator
+    using enum TrackedState;
+    auto b = makeSharedIntrusive<TIBase>();
+    auto id = b->id;
+    EXPECT_EQ(TIBase::getState(id), Alive);
+    WeakIntrusive<TIBase> w{b};
+    EXPECT_EQ(TIBase::getState(id), Alive);
+    auto s = w.lock();
+    EXPECT_TRUE(s && s->useCount() == 2);
+    b.reset();
+    EXPECT_TRUE(TIBase::getState(id) == Alive);
+    EXPECT_TRUE(s && s->useCount() == 1);
+    s.reset();
+    EXPECT_EQ(TIBase::getState(id), PartiallyDeleted);
+    EXPECT_TRUE(w.expired());
+    s = w.lock();
+    // Cannot convert a weak pointer to a strong pointer if object is
+    // already partially deleted
+    EXPECT_FALSE(s);
+    w.reset();
+    EXPECT_EQ(TIBase::getState(id), Deleted);
+}
 
-        TIBase::ResetStatesGuard const rsg{true};
+TEST(IntrusiveSharedTest, shared_weak_union_converts_between_strong_and_weak)
+{
+    TIBase::ResetStatesGuard const rsg{true};
 
-        auto strong1 = makeSharedIntrusive<TIBase>();
-        auto strong2 = makeSharedIntrusive<TIBase>();
+    using enum TrackedState;
+    using SharedWeak = SharedWeakUnion<TIBase>;
+    SharedWeak b = makeSharedIntrusive<TIBase>();
+    EXPECT_TRUE(b.isStrong() && b.useCount() == 1);
+    auto id = b.get()->id;
+    EXPECT_EQ(TIBase::getState(id), Alive);
+    SharedWeak w = b;
+    EXPECT_TRUE(TIBase::getState(id) == Alive);
+    EXPECT_TRUE(w.isStrong() && b.useCount() == 2);
+    w.convertToWeak();
+    EXPECT_TRUE(w.isWeak() && b.useCount() == 1);
+    SharedWeak s = w;
+    EXPECT_TRUE(s.isWeak() && b.useCount() == 1);
+    s.convertToStrong();
+    EXPECT_TRUE(s.isStrong() && b.useCount() == 2);
+    b.reset();
+    EXPECT_EQ(TIBase::getState(id), Alive);
+    EXPECT_EQ(s.useCount(), 1);
+    EXPECT_FALSE(w.expired());
+    s.reset();
+    EXPECT_EQ(TIBase::getState(id), PartiallyDeleted);
+    EXPECT_TRUE(w.expired());
+    w.convertToStrong();
+    // Cannot convert a weak pointer to a strong pointer if object is
+    // already partially deleted
+    EXPECT_TRUE(w.isWeak());
+    w.reset();
+    EXPECT_EQ(TIBase::getState(id), Deleted);
+}
 
-        auto id1 = strong1->id;
-        auto id2 = strong2->id;
+TEST(IntrusiveSharedTest, shared_weak_union_assignment)
+{
+    // Testing SharedWeakUnion assignment operator
 
-        EXPECT_NE(id1, id2);
+    TIBase::ResetStatesGuard const rsg{true};
 
-        SharedWeakUnion<TIBase> union1 = strong1;
-        SharedWeakUnion<TIBase> union2 = strong2;
+    auto strong1 = makeSharedIntrusive<TIBase>();
+    auto strong2 = makeSharedIntrusive<TIBase>();
 
-        EXPECT_TRUE(union1.isStrong());
-        EXPECT_TRUE(union2.isStrong());
-        EXPECT_EQ(union1.get(), strong1.get());
-        EXPECT_EQ(union2.get(), strong2.get());
+    auto id1 = strong1->id;
+    auto id2 = strong2->id;
 
-        // 1) Normal assignment: explicitly calls SharedWeakUnion assignment
-        union1 = union2;
-        EXPECT_TRUE(union1.isStrong());
-        EXPECT_TRUE(union2.isStrong());
-        EXPECT_EQ(union1.get(), union2.get());
-        EXPECT_EQ(TIBase::getState(id1), TrackedState::Alive);
-        EXPECT_EQ(TIBase::getState(id2), TrackedState::Alive);
+    EXPECT_NE(id1, id2);
 
-        // 2) Test self-assignment
-        EXPECT_TRUE(union1.isStrong());
-        EXPECT_EQ(TIBase::getState(id1), TrackedState::Alive);
-        int const initialRefCount = strong1->useCount();
+    SharedWeakUnion<TIBase> union1 = strong1;
+    SharedWeakUnion<TIBase> union2 = strong2;
+
+    EXPECT_TRUE(union1.isStrong());
+    EXPECT_TRUE(union2.isStrong());
+    EXPECT_EQ(union1.get(), strong1.get());
+    EXPECT_EQ(union2.get(), strong2.get());
+
+    // 1) Normal assignment: explicitly calls SharedWeakUnion assignment
+    union1 = union2;
+    EXPECT_TRUE(union1.isStrong());
+    EXPECT_TRUE(union2.isStrong());
+    EXPECT_EQ(union1.get(), union2.get());
+    EXPECT_EQ(TIBase::getState(id1), TrackedState::Alive);
+    EXPECT_EQ(TIBase::getState(id2), TrackedState::Alive);
+
+    // 2) Test self-assignment
+    EXPECT_TRUE(union1.isStrong());
+    EXPECT_EQ(TIBase::getState(id1), TrackedState::Alive);
+    int const initialRefCount = strong1->useCount();
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-assign-overloaded"
-        union1 = union1;  // Self-assignment
+    union1 = union1;  // Self-assignment
 #pragma clang diagnostic pop
-        EXPECT_TRUE(union1.isStrong());
-        EXPECT_EQ(TIBase::getState(id1), TrackedState::Alive);
-        EXPECT_EQ(strong1->useCount(), initialRefCount);
+    EXPECT_TRUE(union1.isStrong());
+    EXPECT_EQ(TIBase::getState(id1), TrackedState::Alive);
+    EXPECT_EQ(strong1->useCount(), initialRefCount);
 
-        // 3) Test assignment from null union pointer
-        union1 = SharedWeakUnion<TIBase>();
-        EXPECT_EQ(union1.get(), nullptr);
+    // 3) Test assignment from null union pointer
+    union1 = SharedWeakUnion<TIBase>();
+    EXPECT_EQ(union1.get(), nullptr);
 
-        // 4) Test assignment to expired union pointer
-        strong2.reset();
-        union2.reset();
-        union1 = union2;
-        EXPECT_EQ(union1.get(), nullptr);
-        EXPECT_EQ(TIBase::getState(id2), TrackedState::Deleted);
-    }
+    // 4) Test assignment to expired union pointer
+    strong2.reset();
+    union2.reset();
+    union1 = union2;
+    EXPECT_EQ(union1.get(), nullptr);
+    EXPECT_EQ(TIBase::getState(id2), TrackedState::Deleted);
 }
 
 TEST(IntrusiveSharedTest, partial_delete)

--- a/src/tests/libxrpl/basics/StringUtilities.cpp
+++ b/src/tests/libxrpl/basics/StringUtilities.cpp
@@ -5,7 +5,11 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <cstdint>
+#include <optional>
 #include <string>
+#include <string_view>
 
 namespace xrpl {
 
@@ -46,242 +50,245 @@ TEST_F(StringUtilitiesTest, un_hex)
     testUnHexFailure("XRP");
 }
 
-TEST_F(StringUtilitiesTest, parse_url)
+// Everything a URL is expected to parse into. The components a case does not
+// mention default to "absent", so each row lists only what it is about.
+struct ParseUrlCase
 {
-    // Expected passes.
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme://"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_TRUE(pUrl.domain.empty());
-        EXPECT_FALSE(pUrl.port);
-        // RFC 3986:
-        // > In general, a URI that uses the generic syntax for authority
-        //   with an empty path should be normalized to a path of "/".
-        // Do we want to normalize paths?
-        EXPECT_TRUE(pUrl.path.empty());
-    }
+    std::string_view name;
+    std::string_view url;
+    std::string_view scheme;
+    std::string_view username = {};          // NOLINT(readability-redundant-member-init)
+    std::string_view password = {};          // NOLINT(readability-redundant-member-init)
+    std::string_view domain = {};            // NOLINT(readability-redundant-member-init)
+    std::optional<std::uint16_t> port = {};  // NOLINT(readability-redundant-member-init)
+    std::string_view path = {};              // NOLINT(readability-redundant-member-init)
+};
 
+constexpr auto kParseUrlCases = std::to_array<ParseUrlCase>({
+    // RFC 3986:
+    // > In general, a URI that uses the generic syntax for authority
+    //   with an empty path should be normalized to a path of "/".
+    // Do we want to normalize paths? Today an absent path stays absent.
     {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme:///"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_TRUE(pUrl.domain.empty());
-        EXPECT_FALSE(pUrl.port);
-        EXPECT_EQ(pUrl.path, "/");
-    }
+        .name = "scheme_only",
+        .url = "scheme://",
+        .scheme = "scheme",
+    },
+    {
+        .name = "empty_authority_with_root_path",
+        .url = "scheme:///",
+        .scheme = "scheme",
+        .path = "/",
+    },
+    {
+        .name = "lowercase_scheme",
+        .url = "lower://domain",
+        .scheme = "lower",
+        .domain = "domain",
+    },
+    {
+        .name = "uppercase_scheme_is_lowercased",
+        .url = "UPPER://domain:234/",
+        .scheme = "upper",
+        .domain = "domain",
+        .port = 234,
+        .path = "/",
+    },
+    {
+        .name = "mixed_case_scheme_is_lowercased",
+        .url = "Mixed://domain/path",
+        .scheme = "mixed",
+        .domain = "domain",
+        .path = "/path",
+    },
+    {
+        .name = "bracketed_ipv6_keeps_its_port",
+        .url = "scheme://[::1]:123/path",
+        .scheme = "scheme",
+        .domain = "::1",
+        .port = 123,
+        .path = "/path",
+    },
+    {
+        .name = "username_and_password_with_port",
+        .url = "scheme://user:pass@domain:123/abc:321",
+        .scheme = "scheme",
+        .username = "user",
+        .password = "pass",
+        .domain = "domain",
+        .port = 123,
+        .path = "/abc:321",
+    },
+    {
+        .name = "username_only_with_port",
+        .url = "scheme://user@domain:123/abc:321",
+        .scheme = "scheme",
+        .username = "user",
+        .domain = "domain",
+        .port = 123,
+        .path = "/abc:321",
+    },
+    {
+        .name = "password_only_with_port",
+        .url = "scheme://:pass@domain:123/abc:321",
+        .scheme = "scheme",
+        .password = "pass",
+        .domain = "domain",
+        .port = 123,
+        .path = "/abc:321",
+    },
+    {
+        .name = "no_credentials_with_port",
+        .url = "scheme://domain:123/abc:321",
+        .scheme = "scheme",
+        .domain = "domain",
+        .port = 123,
+        .path = "/abc:321",
+    },
+    {
+        .name = "username_and_password_without_port",
+        .url = "scheme://user:pass@domain/abc:321",
+        .scheme = "scheme",
+        .username = "user",
+        .password = "pass",
+        .domain = "domain",
+        .path = "/abc:321",
+    },
+    {
+        .name = "username_only_without_port",
+        .url = "scheme://user@domain/abc:321",
+        .scheme = "scheme",
+        .username = "user",
+        .domain = "domain",
+        .path = "/abc:321",
+    },
+    {
+        .name = "password_only_without_port",
+        .url = "scheme://:pass@domain/abc:321",
+        .scheme = "scheme",
+        .password = "pass",
+        .domain = "domain",
+        .path = "/abc:321",
+    },
+    {
+        .name = "no_credentials_without_port",
+        .url = "scheme://domain/abc:321",
+        .scheme = "scheme",
+        .domain = "domain",
+        .path = "/abc:321",
+    },
+    {
+        .name = "empty_authority_with_file_path",
+        .url = "scheme:///path/to/file",
+        .scheme = "scheme",
+        .path = "/path/to/file",
+    },
+    // The '@' separating credentials from the domain is the first one, so a
+    // later '@' belongs to the path.
+    {
+        .name = "at_sign_in_path_with_credentials",
+        .url = "scheme://user:pass@domain/path/with/an@sign",
+        .scheme = "scheme",
+        .username = "user",
+        .password = "pass",
+        .domain = "domain",
+        .path = "/path/with/an@sign",
+    },
+    {
+        .name = "at_sign_in_path_without_credentials",
+        .url = "scheme://domain/path/with/an@sign",
+        .scheme = "scheme",
+        .domain = "domain",
+        .path = "/path/with/an@sign",
+    },
+    // A port with no domain in front of it is not recognised as a port at all;
+    // the whole ":999" becomes the domain.
+    {
+        .name = "port_without_domain_is_taken_as_domain",
+        .url = "scheme://:999/",
+        .scheme = "scheme",
+        .domain = ":999",
+        .path = "/",
+    },
+    // An unbracketed IPv6 address is parsed as an address, not as host:port, so
+    // the trailing ":1234" is folded into the address itself.
+    {
+        .name = "unbracketed_ipv6_absorbs_the_trailing_port",
+        .url = "http://::1:1234/validators",
+        .scheme = "http",
+        .domain = "::0.1.18.52",
+        .path = "/validators",
+    },
+});
 
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "lower://domain"));
-        EXPECT_EQ(pUrl.scheme, "lower");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_EQ(pUrl.domain, "domain");
-        EXPECT_FALSE(pUrl.port);
-        EXPECT_TRUE(pUrl.path.empty());
-    }
+class ParseUrlTest : public ::testing::TestWithParam<ParseUrlCase>
+{
+};
 
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "UPPER://domain:234/"));
-        EXPECT_EQ(pUrl.scheme, "upper");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_EQ(pUrl.domain, "domain");
-        EXPECT_EQ(*pUrl.port, 234);  // NOLINT(bugprone-unchecked-optional-access)
-        EXPECT_EQ(pUrl.path, "/");
-    }
+TEST_P(ParseUrlTest, splits_url_into_components)
+{
+    auto const& testCase = GetParam();
 
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "Mixed://domain/path"));
-        EXPECT_EQ(pUrl.scheme, "mixed");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_EQ(pUrl.domain, "domain");
-        EXPECT_FALSE(pUrl.port);
-        EXPECT_EQ(pUrl.path, "/path");
-    }
+    ParsedUrl parsed;
+    ASSERT_TRUE(parseUrl(parsed, std::string{testCase.url}));
 
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme://[::1]:123/path"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_EQ(pUrl.domain, "::1");
-        EXPECT_EQ(*pUrl.port, 123);  // NOLINT(bugprone-unchecked-optional-access)
-        EXPECT_EQ(pUrl.path, "/path");
-    }
+    EXPECT_EQ(parsed.scheme, testCase.scheme);
+    EXPECT_EQ(parsed.username, testCase.username);
+    EXPECT_EQ(parsed.password, testCase.password);
+    EXPECT_EQ(parsed.domain, testCase.domain);
+    EXPECT_EQ(parsed.port, testCase.port);
+    EXPECT_EQ(parsed.path, testCase.path);
+}
 
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme://user:pass@domain:123/abc:321"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_EQ(pUrl.username, "user");
-        EXPECT_EQ(pUrl.password, "pass");
-        EXPECT_EQ(pUrl.domain, "domain");
-        EXPECT_EQ(*pUrl.port, 123);  // NOLINT(bugprone-unchecked-optional-access)
-        EXPECT_EQ(pUrl.path, "/abc:321");
-    }
+INSTANTIATE_TEST_SUITE_P(
+    StringUtilities,
+    ParseUrlTest,
+    ::testing::ValuesIn(kParseUrlCases),
+    [](::testing::TestParamInfo<ParseUrlCase> const& info) {
+        return std::string{info.param.name};
+    });
 
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme://user@domain:123/abc:321"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_EQ(pUrl.username, "user");
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_EQ(pUrl.domain, "domain");
-        EXPECT_EQ(*pUrl.port, 123);  // NOLINT(bugprone-unchecked-optional-access)
-        EXPECT_EQ(pUrl.path, "/abc:321");
-    }
+struct ParseUrlFailureCase
+{
+    std::string_view name;
+    std::string_view url;
+};
 
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme://:pass@domain:123/abc:321"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_EQ(pUrl.password, "pass");
-        EXPECT_EQ(pUrl.domain, "domain");
-        EXPECT_EQ(*pUrl.port, 123);  // NOLINT(bugprone-unchecked-optional-access)
-        EXPECT_EQ(pUrl.path, "/abc:321");
-    }
+constexpr auto kParseUrlFailureCases = std::to_array<ParseUrlFailureCase>({
+    {.name = "empty", .url = ""},
+    {.name = "no_scheme_separator", .url = "nonsense"},
+    {.name = "empty_scheme", .url = "://"},
+    {.name = "empty_scheme_with_path", .url = ":///"},
+    {.name = "port_one_above_the_16_bit_range", .url = "scheme://user:pass@domain:65536/abc:321"},
+    {.name = "port_far_above_the_16_bit_range", .url = "UPPER://domain:23498765/"},
+    {.name = "port_zero", .url = "UPPER://domain:0/"},
+    {.name = "port_with_a_plus_sign", .url = "UPPER://domain:+7/"},
+    {.name = "negative_port", .url = "UPPER://domain:-7234/"},
+    {.name = "port_of_punctuation", .url = "UPPER://domain:@#$56!/"},
+});
 
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme://domain:123/abc:321"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_EQ(pUrl.domain, "domain");
-        EXPECT_EQ(*pUrl.port, 123);  // NOLINT(bugprone-unchecked-optional-access)
-        EXPECT_EQ(pUrl.path, "/abc:321");
-    }
+class ParseUrlFailureTest : public ::testing::TestWithParam<ParseUrlFailureCase>
+{
+};
 
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme://user:pass@domain/abc:321"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_EQ(pUrl.username, "user");
-        EXPECT_EQ(pUrl.password, "pass");
-        EXPECT_EQ(pUrl.domain, "domain");
-        EXPECT_FALSE(pUrl.port);
-        EXPECT_EQ(pUrl.path, "/abc:321");
-    }
+TEST_P(ParseUrlFailureTest, rejects_url)
+{
+    ParsedUrl parsed;
+    EXPECT_FALSE(parseUrl(parsed, std::string{GetParam().url}));
+}
 
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme://user@domain/abc:321"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_EQ(pUrl.username, "user");
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_EQ(pUrl.domain, "domain");
-        EXPECT_FALSE(pUrl.port);
-        EXPECT_EQ(pUrl.path, "/abc:321");
-    }
+INSTANTIATE_TEST_SUITE_P(
+    StringUtilities,
+    ParseUrlFailureTest,
+    ::testing::ValuesIn(kParseUrlFailureCases),
+    [](::testing::TestParamInfo<ParseUrlFailureCase> const& info) {
+        return std::string{info.param.name};
+    });
 
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme://:pass@domain/abc:321"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_EQ(pUrl.password, "pass");
-        EXPECT_EQ(pUrl.domain, "domain");
-        EXPECT_FALSE(pUrl.port);
-        EXPECT_EQ(pUrl.path, "/abc:321");
-    }
-
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme://domain/abc:321"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_EQ(pUrl.domain, "domain");
-        EXPECT_FALSE(pUrl.port);
-        EXPECT_EQ(pUrl.path, "/abc:321");
-    }
-
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme:///path/to/file"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_TRUE(pUrl.domain.empty());
-        EXPECT_FALSE(pUrl.port);
-        EXPECT_EQ(pUrl.path, "/path/to/file");
-    }
-
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme://user:pass@domain/path/with/an@sign"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_EQ(pUrl.username, "user");
-        EXPECT_EQ(pUrl.password, "pass");
-        EXPECT_EQ(pUrl.domain, "domain");
-        EXPECT_FALSE(pUrl.port);
-        EXPECT_EQ(pUrl.path, "/path/with/an@sign");
-    }
-
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme://domain/path/with/an@sign"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_EQ(pUrl.domain, "domain");
-        EXPECT_FALSE(pUrl.port);
-        EXPECT_EQ(pUrl.path, "/path/with/an@sign");
-    }
-
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "scheme://:999/"));
-        EXPECT_EQ(pUrl.scheme, "scheme");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_EQ(pUrl.domain, ":999");
-        EXPECT_FALSE(pUrl.port);
-        EXPECT_EQ(pUrl.path, "/");
-    }
-
-    {
-        ParsedUrl pUrl;
-        EXPECT_TRUE(parseUrl(pUrl, "http://::1:1234/validators"));
-        EXPECT_EQ(pUrl.scheme, "http");
-        EXPECT_TRUE(pUrl.username.empty());
-        EXPECT_TRUE(pUrl.password.empty());
-        EXPECT_EQ(pUrl.domain, "::0.1.18.52");
-        EXPECT_FALSE(pUrl.port);
-        EXPECT_EQ(pUrl.path, "/validators");
-    }
-
-    // Expected fails.
-    {
-        ParsedUrl pUrl;
-        EXPECT_FALSE(parseUrl(pUrl, ""));
-        EXPECT_FALSE(parseUrl(pUrl, "nonsense"));
-        EXPECT_FALSE(parseUrl(pUrl, "://"));
-        EXPECT_FALSE(parseUrl(pUrl, ":///"));
-        EXPECT_FALSE(parseUrl(pUrl, "scheme://user:pass@domain:65536/abc:321"));
-        EXPECT_FALSE(parseUrl(pUrl, "UPPER://domain:23498765/"));
-        EXPECT_FALSE(parseUrl(pUrl, "UPPER://domain:0/"));
-        EXPECT_FALSE(parseUrl(pUrl, "UPPER://domain:+7/"));
-        EXPECT_FALSE(parseUrl(pUrl, "UPPER://domain:-7234/"));
-        EXPECT_FALSE(parseUrl(pUrl, "UPPER://domain:@#$56!/"));
-    }
-
-    {
-        std::string const strUrl("s://" + std::string(8192, ':'));
-        ParsedUrl pUrl;
-        EXPECT_FALSE(parseUrl(pUrl, strUrl));
-    }
+TEST_F(StringUtilitiesTest, parse_url_rejects_an_overlong_authority)
+{
+    ParsedUrl parsed;
+    EXPECT_FALSE(parseUrl(parsed, "s://" + std::string(8192, ':')));
 }
 
 TEST_F(StringUtilitiesTest, to_string)
@@ -290,7 +297,7 @@ TEST_F(StringUtilitiesTest, to_string)
     EXPECT_EQ(result, "hello");
 }
 
-TEST_F(StringUtilitiesTest, trimWhitespace)
+TEST_F(StringUtilitiesTest, trim_whitespace)
 {
     EXPECT_EQ(trimWhitespace(""), "");
     EXPECT_EQ(trimWhitespace("   "), "");
@@ -303,7 +310,7 @@ TEST_F(StringUtilitiesTest, trimWhitespace)
     EXPECT_EQ(trimWhitespace("  a b\tc  "), "a b\tc");
 }
 
-TEST_F(StringUtilitiesTest, toLower)
+TEST_F(StringUtilitiesTest, to_lower)
 {
     EXPECT_EQ(toLower(""), "");
     EXPECT_EQ(toLower("ABC"), "abc");
@@ -318,7 +325,7 @@ TEST_F(StringUtilitiesTest, toLower)
 // Both helpers are documented as depending only on their input. Guard that by
 // checking the bytes just outside ASCII, which a locale-aware isspace/tolower
 // could classify differently.
-TEST_F(StringUtilitiesTest, trimAndLowerIgnoreLocale)
+TEST_F(StringUtilitiesTest, trim_and_lower_ignore_locale)
 {
     // 0xA0 is NO-BREAK SPACE in Latin-1 and is whitespace to some locales.
     std::string const nbsp("\xA0", 1);

--- a/src/tests/libxrpl/basics/TaggedCache.cpp
+++ b/src/tests/libxrpl/basics/TaggedCache.cpp
@@ -10,237 +10,259 @@
 #include <gtest/gtest.h>
 #include <helpers/TestSink.h>
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <utility>
 
 namespace xrpl {
 
-/*
-I guess you can put some items in, make sure they're still there. Let some
-time pass, make sure they're gone. Keep a strong pointer to one of them, make
-sure you can still find it even after time passes. Create two objects with
-the same key, canonicalize them both and make sure you get the same object.
-Put an object in but keep a strong pointer to it, advance the clock a lot,
-then canonicalize a new object with the same key, make sure you get the
-original object.
-*/
-
-TEST(TaggedCacheTest, tagged_cache)
+struct TaggedCacheTest : public ::testing::Test
 {
-    using namespace std::chrono_literals;
-    beast::Journal const journal{TestSink::instance()};
-
-    TestStopwatch clock;
-    clock.set(0);
-
     using Key = LedgerIndex;
     using Value = std::string;
     using Cache = TaggedCache<Key, Value>;
 
-    Cache c("test", 1, 1s, clock, journal);
+    // A single `++clock` plus a sweep is enough to age any entry out.
+    static constexpr std::chrono::seconds kExpiration{1};
+    static constexpr int kTargetSize = 1;
 
-    // Insert an item, retrieve it, and age it so it gets purged.
-    {
-        EXPECT_EQ(c.getCacheSize(), 0);
-        EXPECT_EQ(c.getTrackSize(), 0);
-        EXPECT_FALSE(c.insert(1, "one"));
-        EXPECT_EQ(c.getCacheSize(), 1);
-        EXPECT_EQ(c.getTrackSize(), 1);
+    beast::Journal const journal{TestSink::instance()};
+    TestStopwatch clock;  ///< ManualClock starts at zero
+    Cache cache{"test", kTargetSize, kExpiration, clock, journal};
+};
 
-        {
-            std::string s;
-            EXPECT_TRUE(c.retrieve(1, s));
-            EXPECT_EQ(s, "one");
-        }
+TEST_F(TaggedCacheTest, insert_then_retrieve)
+{
+    EXPECT_EQ(cache.getCacheSize(), 0);
+    EXPECT_EQ(cache.getTrackSize(), 0);
 
-        ++clock;
-        c.sweep();
-        EXPECT_EQ(c.getCacheSize(), 0);
-        EXPECT_EQ(c.getTrackSize(), 0);
-    }
+    EXPECT_FALSE(cache.insert(1, "one"));
+    EXPECT_EQ(cache.getCacheSize(), 1);
+    EXPECT_EQ(cache.getTrackSize(), 1);
 
-    // Insert an item, maintain a strong pointer, age it, and
-    // verify that the entry still exists.
-    {
-        EXPECT_FALSE(c.insert(2, "two"));
-        EXPECT_EQ(c.getCacheSize(), 1);
-        EXPECT_EQ(c.getTrackSize(), 1);
+    std::string retrieved;
+    EXPECT_TRUE(cache.retrieve(1, retrieved));
+    EXPECT_EQ(retrieved, "one");
+}
 
-        {
-            auto p = c.fetch(2);
-            EXPECT_NE(p, nullptr);
-            ++clock;
-            c.sweep();
-            EXPECT_EQ(c.getCacheSize(), 0);
-            EXPECT_EQ(c.getTrackSize(), 1);
-        }
+TEST_F(TaggedCacheTest, sweep_purges_an_aged_entry)
+{
+    EXPECT_FALSE(cache.insert(1, "one"));
 
-        // Make sure its gone now that our reference is gone
-        ++clock;
-        c.sweep();
-        EXPECT_EQ(c.getCacheSize(), 0);
-        EXPECT_EQ(c.getTrackSize(), 0);
-    }
+    ++clock;
+    cache.sweep();
 
-    // Insert the same key/value pair and make sure we get the same result
-    {
-        EXPECT_FALSE(c.insert(3, "three"));
+    EXPECT_EQ(cache.getCacheSize(), 0);
+    EXPECT_EQ(cache.getTrackSize(), 0);
+}
 
-        {
-            auto const p1 = c.fetch(3);
-            auto p2 = std::make_shared<Value>("three");
-            c.canonicalizeReplaceClient(3, p2);
-            EXPECT_EQ(p1.get(), p2.get());
-        }
-        ++clock;
-        c.sweep();
-        EXPECT_EQ(c.getCacheSize(), 0);
-        EXPECT_EQ(c.getTrackSize(), 0);
-    }
-
-    // Put an object in but keep a strong pointer to it, advance the clock a
-    // lot, then canonicalize a new object with the same key, make sure you
-    // get the original object.
-    {
-        // Put an object in
-        EXPECT_FALSE(c.insert(4, "four"));
-        EXPECT_EQ(c.getCacheSize(), 1);
-        EXPECT_EQ(c.getTrackSize(), 1);
-
-        {
-            // Keep a strong pointer to it
-            auto const p1 = c.fetch(4);
-            EXPECT_NE(p1, nullptr);
-            EXPECT_EQ(c.getCacheSize(), 1);
-            EXPECT_EQ(c.getTrackSize(), 1);
-            // Advance the clock a lot
-            ++clock;
-            c.sweep();
-            EXPECT_EQ(c.getCacheSize(), 0);
-            EXPECT_EQ(c.getTrackSize(), 1);
-            // Canonicalize a new object with the same key
-            auto p2 = std::make_shared<std::string>("four");
-            EXPECT_TRUE(c.canonicalizeReplaceClient(4, p2));
-            EXPECT_EQ(c.getCacheSize(), 1);
-            EXPECT_EQ(c.getTrackSize(), 1);
-            // Make sure we get the original object
-            EXPECT_EQ(p1.get(), p2.get());
-        }
-
-        ++clock;
-        c.sweep();
-        EXPECT_EQ(c.getCacheSize(), 0);
-        EXPECT_EQ(c.getTrackSize(), 0);
-    }
+TEST_F(TaggedCacheTest, sweep_keeps_tracking_an_entry_a_caller_still_holds)
+{
+    EXPECT_FALSE(cache.insert(2, "two"));
+    EXPECT_EQ(cache.getCacheSize(), 1);
+    EXPECT_EQ(cache.getTrackSize(), 1);
 
     {
-        EXPECT_FALSE(c.insert(5, "five"));
-        EXPECT_EQ(c.getCacheSize(), 1);
-        EXPECT_EQ(c.size(), 1);
-
-        {
-            auto const p1 = c.fetch(5);
-            EXPECT_NE(p1, nullptr);
-            EXPECT_EQ(c.getCacheSize(), 1);
-            EXPECT_EQ(c.size(), 1);
-
-            // Advance the clock a lot
-            ++clock;
-            c.sweep();
-            EXPECT_EQ(c.getCacheSize(), 0);
-            EXPECT_EQ(c.size(), 1);
-
-            auto p2 = std::make_shared<std::string>("five_2");
-            EXPECT_TRUE(c.canonicalizeReplaceCache(5, p2));
-            EXPECT_EQ(c.getCacheSize(), 1);
-            EXPECT_EQ(c.size(), 1);
-            // Make sure the caller's original pointer is unchanged
-            EXPECT_NE(p1.get(), p2.get());
-            EXPECT_EQ(*p2, "five_2");
-
-            auto const p3 = c.fetch(5);
-            EXPECT_NE(p3, nullptr);
-            EXPECT_EQ(p3.get(), p2.get());
-            EXPECT_NE(p3.get(), p1.get());
-        }
+        // Scope is load-bearing: the entry survives the sweep only while this
+        // pointer is alive.
+        auto held = cache.fetch(2);
+        EXPECT_NE(held, nullptr);
 
         ++clock;
-        c.sweep();
-        EXPECT_EQ(c.getCacheSize(), 0);
-        EXPECT_EQ(c.size(), 0);
+        cache.sweep();
+        EXPECT_EQ(cache.getCacheSize(), 0);
+        EXPECT_EQ(cache.getTrackSize(), 1);
     }
+
+    ++clock;
+    cache.sweep();
+    EXPECT_EQ(cache.getCacheSize(), 0);
+    EXPECT_EQ(cache.getTrackSize(), 0);
+}
+
+TEST_F(TaggedCacheTest, canonicalize_replace_client_hands_back_the_cached_object)
+{
+    EXPECT_FALSE(cache.insert(3, "three"));
 
     {
-        struct MyRefCountObject : IntrusiveRefCounts
-        {
-            std::string data;
+        // Scope is load-bearing: both pointers must die before the sweep below.
+        auto const cached = cache.fetch(3);
+        auto candidate = std::make_shared<Value>("three");
+        cache.canonicalizeReplaceClient(3, candidate);
 
-            // Needed to support weak intrusive pointers
-            virtual void
-            partialDestructor()
-            {
-            }
+        EXPECT_EQ(cached.get(), candidate.get());
+    }
 
-            MyRefCountObject() = default;
-            explicit MyRefCountObject(std::string data) : data(std::move(data))
-            {
-            }
+    // Canonicalizing left no lingering reference, so the entry still ages out.
+    ++clock;
+    cache.sweep();
+    EXPECT_EQ(cache.getCacheSize(), 0);
+    EXPECT_EQ(cache.getTrackSize(), 0);
+}
 
-            bool
-            operator==(std::string const& other) const
-            {
-                return data == other;
-            }
-        };
+TEST_F(TaggedCacheTest, canonicalize_replace_client_revives_a_swept_entry)
+{
+    EXPECT_FALSE(cache.insert(4, "four"));
+    EXPECT_EQ(cache.getCacheSize(), 1);
+    EXPECT_EQ(cache.getTrackSize(), 1);
 
-        using IntrPtrCache = TaggedCache<
-            Key,
-            MyRefCountObject,
-            /*IsKeyCache*/ false,
-            intr_ptr::SharedWeakUnionPtr<MyRefCountObject>,
-            intr_ptr::SharedPtr<MyRefCountObject>>;
-
-        IntrPtrCache intrPtrCache("IntrPtrTest", 1, 1s, clock, journal);
-
-        intrPtrCache.canonicalizeReplaceCache(1, intr_ptr::makeShared<MyRefCountObject>("one"));
-        EXPECT_EQ(intrPtrCache.getCacheSize(), 1);
-        EXPECT_EQ(intrPtrCache.size(), 1);
-
-        {
-            {
-                intrPtrCache.canonicalizeReplaceCache(
-                    1, intr_ptr::makeShared<MyRefCountObject>("one_replaced"));
-
-                auto p = intrPtrCache.fetch(1);
-                EXPECT_EQ(*p, "one_replaced");
-
-                // Advance the clock a lot
-                ++clock;
-                intrPtrCache.sweep();
-                EXPECT_EQ(intrPtrCache.getCacheSize(), 0);
-                EXPECT_EQ(intrPtrCache.size(), 1);
-
-                intrPtrCache.canonicalizeReplaceCache(
-                    1, intr_ptr::makeShared<MyRefCountObject>("one_replaced_2"));
-
-                auto p2 = intrPtrCache.fetch(1);
-                EXPECT_EQ(*p2, "one_replaced_2");
-
-                intrPtrCache.del(1, true);
-            }
-
-            intrPtrCache.canonicalizeReplaceCache(
-                1, intr_ptr::makeShared<MyRefCountObject>("one_replaced_3"));
-            auto p3 = intrPtrCache.fetch(1);
-            EXPECT_EQ(*p3, "one_replaced_3");
-        }
+    {
+        // Scope is load-bearing: the final sweep must see nothing held.
+        auto const held = cache.fetch(4);
+        EXPECT_NE(held, nullptr);
+        // Fetching does not disturb the counts.
+        EXPECT_EQ(cache.getCacheSize(), 1);
+        EXPECT_EQ(cache.getTrackSize(), 1);
 
         ++clock;
-        intrPtrCache.sweep();
-        EXPECT_EQ(intrPtrCache.getCacheSize(), 0);
-        EXPECT_EQ(intrPtrCache.size(), 0);
+        cache.sweep();
+        EXPECT_EQ(cache.getCacheSize(), 0);
+        EXPECT_EQ(cache.getTrackSize(), 1);
+
+        auto candidate = std::make_shared<Value>("four");
+        EXPECT_TRUE(cache.canonicalizeReplaceClient(4, candidate));
+        EXPECT_EQ(cache.getCacheSize(), 1);
+        EXPECT_EQ(cache.getTrackSize(), 1);
+
+        EXPECT_EQ(held.get(), candidate.get());
     }
+
+    ++clock;
+    cache.sweep();
+    EXPECT_EQ(cache.getCacheSize(), 0);
+    EXPECT_EQ(cache.getTrackSize(), 0);
+}
+
+TEST_F(TaggedCacheTest, canonicalize_replace_cache_installs_the_new_object)
+{
+    EXPECT_FALSE(cache.insert(5, "five"));
+    EXPECT_EQ(cache.getCacheSize(), 1);
+    EXPECT_EQ(cache.size(), 1);
+
+    {
+        // Scope is load-bearing: the final sweep must see nothing held.
+        auto const held = cache.fetch(5);
+        EXPECT_NE(held, nullptr);
+        // Fetching does not disturb the counts.
+        EXPECT_EQ(cache.getCacheSize(), 1);
+        EXPECT_EQ(cache.size(), 1);
+
+        ++clock;
+        cache.sweep();
+        EXPECT_EQ(cache.getCacheSize(), 0);
+        EXPECT_EQ(cache.size(), 1);
+
+        auto replacement = std::make_shared<Value>("five_2");
+        EXPECT_TRUE(cache.canonicalizeReplaceCache(5, replacement));
+        EXPECT_EQ(cache.getCacheSize(), 1);
+        EXPECT_EQ(cache.size(), 1);
+
+        // Unlike ReplaceClient, the caller's object wins and the old one is
+        // left untouched in the caller's hands.
+        EXPECT_NE(held.get(), replacement.get());
+        EXPECT_EQ(*replacement, "five_2");
+
+        auto const refetched = cache.fetch(5);
+        EXPECT_NE(refetched, nullptr);
+        EXPECT_EQ(refetched.get(), replacement.get());
+        EXPECT_NE(refetched.get(), held.get());
+    }
+
+    ++clock;
+    cache.sweep();
+    EXPECT_EQ(cache.getCacheSize(), 0);
+    EXPECT_EQ(cache.size(), 0);
+}
+
+namespace {
+
+struct TestRefCountObject : IntrusiveRefCounts
+{
+    std::string data;
+
+    // Needed to support weak intrusive pointers
+    virtual void
+    partialDestructor()
+    {
+    }
+
+    TestRefCountObject() = default;
+    explicit TestRefCountObject(std::string data) : data(std::move(data))
+    {
+    }
+
+    bool
+    operator==(std::string const& other) const
+    {
+        return data == other;
+    }
+};
+
+}  // namespace
+
+struct IntrusiveTaggedCacheTest : public TaggedCacheTest
+{
+    using IntrPtrCache = TaggedCache<
+        Key,
+        TestRefCountObject,
+        /*IsKeyCache*/ false,
+        intr_ptr::SharedWeakUnionPtr<TestRefCountObject>,
+        intr_ptr::SharedPtr<TestRefCountObject>>;
+
+    IntrPtrCache intrPtrCache{"IntrPtrTest", kTargetSize, kExpiration, clock, journal};
+};
+
+TEST_F(IntrusiveTaggedCacheTest, canonicalize_replace_cache_replaces_the_entry)
+{
+    intrPtrCache.canonicalizeReplaceCache(1, intr_ptr::makeShared<TestRefCountObject>("one"));
+    EXPECT_EQ(intrPtrCache.getCacheSize(), 1);
+    EXPECT_EQ(intrPtrCache.size(), 1);
+
+    intrPtrCache.canonicalizeReplaceCache(
+        1, intr_ptr::makeShared<TestRefCountObject>("one_replaced"));
+    EXPECT_EQ(*intrPtrCache.fetch(1), "one_replaced");
+}
+
+TEST_F(IntrusiveTaggedCacheTest, canonicalize_replace_cache_replaces_a_swept_entry)
+{
+    intrPtrCache.canonicalizeReplaceCache(1, intr_ptr::makeShared<TestRefCountObject>("one"));
+
+    // Load-bearing: without this the sweep drops the entry and size() is 0.
+    auto const held = intrPtrCache.fetch(1);
+
+    ++clock;
+    intrPtrCache.sweep();
+    EXPECT_EQ(intrPtrCache.getCacheSize(), 0);
+    EXPECT_EQ(intrPtrCache.size(), 1);
+
+    intrPtrCache.canonicalizeReplaceCache(
+        1, intr_ptr::makeShared<TestRefCountObject>("one_replaced_2"));
+    EXPECT_EQ(*intrPtrCache.fetch(1), "one_replaced_2");
+}
+
+TEST_F(IntrusiveTaggedCacheTest, an_entry_can_be_reinserted_after_del)
+{
+    intrPtrCache.canonicalizeReplaceCache(1, intr_ptr::makeShared<TestRefCountObject>("one"));
+    intrPtrCache.del(1, true);
+
+    intrPtrCache.canonicalizeReplaceCache(
+        1, intr_ptr::makeShared<TestRefCountObject>("one_replaced_3"));
+    EXPECT_EQ(*intrPtrCache.fetch(1), "one_replaced_3");
+}
+
+TEST_F(IntrusiveTaggedCacheTest, sweep_empties_the_cache_once_nothing_is_held)
+{
+    intrPtrCache.canonicalizeReplaceCache(1, intr_ptr::makeShared<TestRefCountObject>("one"));
+
+    ++clock;
+    intrPtrCache.sweep();
+    EXPECT_EQ(intrPtrCache.getCacheSize(), 0);
+
+    ++clock;
+    intrPtrCache.sweep();
+    EXPECT_EQ(intrPtrCache.getCacheSize(), 0);
+    EXPECT_EQ(intrPtrCache.size(), 0);
 }
 
 }  // namespace xrpl

--- a/src/tests/libxrpl/basics/Units.cpp
+++ b/src/tests/libxrpl/basics/Units.cpp
@@ -144,179 +144,321 @@ TEST(UnitsTest, json)
     }
 }
 
-TEST(UnitsTest, functions)
+// The ValueUnit operators are templated and mostly unused elsewhere, so each is
+// exercised explicitly. FeeLevel64 is the unsigned-integral instantiation;
+// FeeLevelDouble below repeats the set for the floating-point one, where the
+// modulo and unary-minus cases differ.
+struct FeeLevel64Test : public ::testing::Test
 {
-    // Explicitly test every defined function for the ValueUnit class
-    // since some of them are templated, but not used anywhere else.
     using FeeLevel32 = FeeLevel<std::uint32_t>;
 
+    static FeeLevel64
+    make(auto x)
     {
-        auto make = [&](auto x) -> FeeLevel64 { return x; };
-        auto explicitmake = [&](auto x) -> FeeLevel64 { return FeeLevel64{x}; };
-
-        [[maybe_unused]]
-        FeeLevel64 const defaulted{};
-        FeeLevel64 test{0};
-        EXPECT_EQ(test.fee(), 0);
-
-        test = explicitmake(beast::kZero);
-        EXPECT_EQ(test.fee(), 0);
-
-        test = beast::kZero;
-        EXPECT_EQ(test.fee(), 0);
-
-        test = explicitmake(100u);
-        EXPECT_EQ(test.fee(), 100);
-
-        FeeLevel64 const targetSame{200u};
-        FeeLevel32 const targetOther{300u};
-        test = make(targetSame);
-        EXPECT_EQ(test.fee(), 200);
-        EXPECT_EQ(test, targetSame);
-        EXPECT_TRUE(test < FeeLevel64{1000});
-        EXPECT_TRUE(test > FeeLevel64{100});
-        test = make(targetOther);
-        EXPECT_EQ(test.fee(), 300);
-        EXPECT_EQ(test, targetOther);
-
-        test = std::uint64_t(200);
-        EXPECT_EQ(test.fee(), 200);
-        test = std::uint32_t(300);
-        EXPECT_EQ(test.fee(), 300);
-
-        test = targetSame;
-        EXPECT_EQ(test.fee(), 200);
-        test = targetOther.fee();
-        EXPECT_EQ(test.fee(), 300);
-        EXPECT_EQ(test, targetOther);
-
-        test = targetSame * 2;
-        EXPECT_EQ(test.fee(), 400);
-        test = 3 * targetSame;
-        EXPECT_EQ(test.fee(), 600);
-        test = targetSame / 10;
-        EXPECT_EQ(test.fee(), 20);
-
-        test += targetSame;
-        EXPECT_EQ(test.fee(), 220);
-
-        test -= targetSame;
-        EXPECT_EQ(test.fee(), 20);
-
-        test++;
-        EXPECT_EQ(test.fee(), 21);
-        ++test;
-        EXPECT_EQ(test.fee(), 22);
-        test--;
-        EXPECT_EQ(test.fee(), 21);
-        --test;
-        EXPECT_EQ(test.fee(), 20);
-
-        test *= 5;
-        EXPECT_EQ(test.fee(), 100);
-        test /= 2;
-        EXPECT_EQ(test.fee(), 50);
-        test %= 13;
-        EXPECT_EQ(test.fee(), 11);
-
-        /*
-        // illegal with unsigned
-        test = -test;
-        EXPECT_EQ(test.fee(), -11);
-        EXPECT_EQ(test.signum(), -1);
-        EXPECT_EQ(to_string(test), "-11");
-        */
-
-        EXPECT_TRUE(test);
-        test = 0;
-        EXPECT_FALSE(test);
-        EXPECT_EQ(test.signum(), 0);
-        test = targetSame;
-        EXPECT_EQ(test.signum(), 1);
-        EXPECT_EQ(to_string(test), "200");
+        return x;
     }
+
+    static FeeLevel64
+    explicitMake(auto x)
     {
-        auto make = [&](auto x) -> FeeLevelDouble { return x; };
-        auto explicitmake = [&](auto x) -> FeeLevelDouble { return FeeLevelDouble{x}; };
-
-        [[maybe_unused]]
-        FeeLevelDouble const defaulted{};
-        FeeLevelDouble test{0};
-        EXPECT_EQ(test.fee(), 0);
-
-        test = explicitmake(beast::kZero);
-        EXPECT_EQ(test.fee(), 0);
-
-        test = beast::kZero;
-        EXPECT_EQ(test.fee(), 0);
-
-        test = explicitmake(100.0);
-        EXPECT_EQ(test.fee(), 100);
-
-        FeeLevelDouble const targetSame{200.0};
-        FeeLevel64 const targetOther{300};
-        test = make(targetSame);
-        EXPECT_EQ(test.fee(), 200);
-        EXPECT_EQ(test, targetSame);
-        EXPECT_TRUE(test < FeeLevelDouble{1000.0});
-        EXPECT_TRUE(test > FeeLevelDouble{100.0});
-        test = targetOther.fee();
-        EXPECT_EQ(test.fee(), 300);
-        EXPECT_EQ(test, targetOther);
-
-        test = 200.0;
-        EXPECT_EQ(test.fee(), 200);
-        test = std::uint64_t(300);
-        EXPECT_EQ(test.fee(), 300);
-
-        test = targetSame;
-        EXPECT_EQ(test.fee(), 200);
-
-        test = targetSame * 2;
-        EXPECT_EQ(test.fee(), 400);
-        test = 3 * targetSame;
-        EXPECT_EQ(test.fee(), 600);
-        test = targetSame / 10;
-        EXPECT_EQ(test.fee(), 20);
-
-        test += targetSame;
-        EXPECT_EQ(test.fee(), 220);
-
-        test -= targetSame;
-        EXPECT_EQ(test.fee(), 20);
-
-        test++;
-        EXPECT_EQ(test.fee(), 21);
-        ++test;
-        EXPECT_EQ(test.fee(), 22);
-        test--;
-        EXPECT_EQ(test.fee(), 21);
-        --test;
-        EXPECT_EQ(test.fee(), 20);
-
-        test *= 5;
-        EXPECT_EQ(test.fee(), 100);
-        test /= 2;
-        EXPECT_EQ(test.fee(), 50);
-        /* illegal with floating
-        test %= 13;
-        EXPECT_EQ(test.fee(), 11);
-        */
-
-        // legal with signed
-        test = -test;
-        EXPECT_EQ(test.fee(), -50);
-        EXPECT_EQ(test.signum(), -1);
-        EXPECT_EQ(to_string(test), "-50.000000");
-
-        EXPECT_TRUE(test);
-        test = 0;
-        EXPECT_FALSE(test);
-        EXPECT_EQ(test.signum(), 0);
-        test = targetSame;
-        EXPECT_EQ(test.signum(), 1);
-        EXPECT_EQ(to_string(test), "200.000000");
+        return FeeLevel64{x};
     }
+
+    FeeLevel64 const targetSame{200u};
+    FeeLevel32 const targetOther{300u};
+};
+
+TEST_F(FeeLevel64Test, construction)
+{
+    [[maybe_unused]]
+    FeeLevel64 const defaulted{};
+
+    FeeLevel64 const test{0};
+    EXPECT_EQ(test.fee(), 0);
+}
+
+TEST_F(FeeLevel64Test, construction_from_zero)
+{
+    FeeLevel64 test{0};
+
+    test = explicitMake(beast::kZero);
+    EXPECT_EQ(test.fee(), 0);
+
+    test = beast::kZero;
+    EXPECT_EQ(test.fee(), 0);
+}
+
+TEST_F(FeeLevel64Test, construction_from_an_unsigned_literal)
+{
+    FeeLevel64 const test = explicitMake(100u);
+    EXPECT_EQ(test.fee(), 100);
+}
+
+TEST_F(FeeLevel64Test, conversion_from_the_same_unit)
+{
+    FeeLevel64 const test = make(targetSame);
+
+    EXPECT_EQ(test.fee(), 200);
+    EXPECT_EQ(test, targetSame);
+    EXPECT_TRUE(test < FeeLevel64{1000});
+    EXPECT_TRUE(test > FeeLevel64{100});
+}
+
+TEST_F(FeeLevel64Test, conversion_from_a_narrower_unit)
+{
+    FeeLevel64 const test = make(targetOther);
+
+    EXPECT_EQ(test.fee(), 300);
+    EXPECT_EQ(test, targetOther);
+}
+
+TEST_F(FeeLevel64Test, assignment_from_raw_integers)
+{
+    FeeLevel64 test{0};
+
+    test = std::uint64_t(200);
+    EXPECT_EQ(test.fee(), 200);
+
+    test = std::uint32_t(300);
+    EXPECT_EQ(test.fee(), 300);
+}
+
+TEST_F(FeeLevel64Test, assignment_from_units)
+{
+    FeeLevel64 test{0};
+
+    test = targetSame;
+    EXPECT_EQ(test.fee(), 200);
+
+    test = targetOther.fee();
+    EXPECT_EQ(test.fee(), 300);
+    EXPECT_EQ(test, targetOther);
+}
+
+TEST_F(FeeLevel64Test, multiplication_and_division)
+{
+    FeeLevel64 test{0};
+
+    test = targetSame * 2;
+    EXPECT_EQ(test.fee(), 400);
+
+    test = 3 * targetSame;
+    EXPECT_EQ(test.fee(), 600);
+
+    test = targetSame / 10;
+    EXPECT_EQ(test.fee(), 20);
+}
+
+TEST_F(FeeLevel64Test, compound_addition_and_subtraction)
+{
+    FeeLevel64 test{20u};
+
+    test += targetSame;
+    EXPECT_EQ(test.fee(), 220);
+
+    test -= targetSame;
+    EXPECT_EQ(test.fee(), 20);
+}
+
+TEST_F(FeeLevel64Test, increment_and_decrement)
+{
+    FeeLevel64 test{20u};
+
+    test++;
+    EXPECT_EQ(test.fee(), 21);
+    ++test;
+    EXPECT_EQ(test.fee(), 22);
+    test--;
+    EXPECT_EQ(test.fee(), 21);
+    --test;
+    EXPECT_EQ(test.fee(), 20);
+}
+
+TEST_F(FeeLevel64Test, compound_multiplication_division_and_modulo)
+{
+    FeeLevel64 test{20u};
+
+    test *= 5;
+    EXPECT_EQ(test.fee(), 100);
+
+    test /= 2;
+    EXPECT_EQ(test.fee(), 50);
+
+    // Modulo is only available on the integral instantiation.
+    test %= 13;
+    EXPECT_EQ(test.fee(), 11);
+}
+
+TEST_F(FeeLevel64Test, truthiness_signum_and_to_string)
+{
+    FeeLevel64 test{11u};
+    EXPECT_TRUE(test);
+
+    test = 0;
+    EXPECT_FALSE(test);
+    EXPECT_EQ(test.signum(), 0);
+
+    test = targetSame;
+    EXPECT_EQ(test.signum(), 1);
+    EXPECT_EQ(to_string(test), "200");
+}
+
+struct FeeLevelDoubleTest : public ::testing::Test
+{
+    static FeeLevelDouble
+    make(auto x)
+    {
+        return x;
+    }
+
+    static FeeLevelDouble
+    explicitMake(auto x)
+    {
+        return FeeLevelDouble{x};
+    }
+
+    FeeLevelDouble const targetSame{200.0};
+    FeeLevel64 const targetOther{300};
+};
+
+TEST_F(FeeLevelDoubleTest, construction)
+{
+    [[maybe_unused]]
+    FeeLevelDouble const defaulted{};
+
+    FeeLevelDouble const test{0};
+    EXPECT_EQ(test.fee(), 0);
+}
+
+TEST_F(FeeLevelDoubleTest, construction_from_zero)
+{
+    FeeLevelDouble test{0};
+
+    test = explicitMake(beast::kZero);
+    EXPECT_EQ(test.fee(), 0);
+
+    test = beast::kZero;
+    EXPECT_EQ(test.fee(), 0);
+}
+
+TEST_F(FeeLevelDoubleTest, construction_from_a_floating_literal)
+{
+    FeeLevelDouble const test = explicitMake(100.0);
+    EXPECT_EQ(test.fee(), 100);
+}
+
+TEST_F(FeeLevelDoubleTest, conversion_from_the_same_unit)
+{
+    FeeLevelDouble const test = make(targetSame);
+
+    EXPECT_EQ(test.fee(), 200);
+    EXPECT_EQ(test, targetSame);
+    EXPECT_TRUE(test < FeeLevelDouble{1000.0});
+    EXPECT_TRUE(test > FeeLevelDouble{100.0});
+}
+
+TEST_F(FeeLevelDoubleTest, assignment_from_an_integral_unit)
+{
+    FeeLevelDouble test{0};
+
+    test = targetOther.fee();
+    EXPECT_EQ(test.fee(), 300);
+    EXPECT_EQ(test, targetOther);
+}
+
+TEST_F(FeeLevelDoubleTest, assignment_from_raw_numbers)
+{
+    FeeLevelDouble test{0};
+
+    test = 200.0;
+    EXPECT_EQ(test.fee(), 200);
+
+    test = std::uint64_t(300);
+    EXPECT_EQ(test.fee(), 300);
+}
+
+TEST_F(FeeLevelDoubleTest, assignment_from_units)
+{
+    FeeLevelDouble test{0};
+
+    test = targetSame;
+    EXPECT_EQ(test.fee(), 200);
+}
+
+TEST_F(FeeLevelDoubleTest, multiplication_and_division)
+{
+    FeeLevelDouble test{0};
+
+    test = targetSame * 2;
+    EXPECT_EQ(test.fee(), 400);
+
+    test = 3 * targetSame;
+    EXPECT_EQ(test.fee(), 600);
+
+    test = targetSame / 10;
+    EXPECT_EQ(test.fee(), 20);
+}
+
+TEST_F(FeeLevelDoubleTest, compound_addition_and_subtraction)
+{
+    FeeLevelDouble test{20.0};
+
+    test += targetSame;
+    EXPECT_EQ(test.fee(), 220);
+
+    test -= targetSame;
+    EXPECT_EQ(test.fee(), 20);
+}
+
+TEST_F(FeeLevelDoubleTest, increment_and_decrement)
+{
+    FeeLevelDouble test{20.0};
+
+    test++;
+    EXPECT_EQ(test.fee(), 21);
+    ++test;
+    EXPECT_EQ(test.fee(), 22);
+    test--;
+    EXPECT_EQ(test.fee(), 21);
+    --test;
+    EXPECT_EQ(test.fee(), 20);
+}
+
+TEST_F(FeeLevelDoubleTest, compound_multiplication_and_division)
+{
+    // No %=: modulo is not defined for the floating-point instantiation.
+    FeeLevelDouble test{20.0};
+
+    test *= 5;
+    EXPECT_EQ(test.fee(), 100);
+
+    test /= 2;
+    EXPECT_EQ(test.fee(), 50);
+}
+
+TEST_F(FeeLevelDoubleTest, negation)
+{
+    // Only legal on the signed instantiation.
+    FeeLevelDouble test{50.0};
+
+    test = -test;
+    EXPECT_EQ(test.fee(), -50);
+    EXPECT_EQ(test.signum(), -1);
+    EXPECT_EQ(to_string(test), "-50.000000");
+}
+
+TEST_F(FeeLevelDoubleTest, truthiness_signum_and_to_string)
+{
+    FeeLevelDouble test{-50.0};
+    EXPECT_TRUE(test);
+
+    test = 0;
+    EXPECT_FALSE(test);
+    EXPECT_EQ(test.signum(), 0);
+
+    test = targetSame;
+    EXPECT_EQ(test.signum(), 1);
+    EXPECT_EQ(to_string(test), "200.000000");
 }
 
 TEST(UnitsTest, initial_xrp)

--- a/src/tests/libxrpl/basics/XRPAmount.cpp
+++ b/src/tests/libxrpl/basics/XRPAmount.cpp
@@ -192,104 +192,126 @@ TEST(XRPAmountTest, functions)
     EXPECT_EQ(to_string(test), "200");
 }
 
-TEST(XRPAmountTest, mul_ratio)
+class XRPAmountMulRatioTest : public ::testing::Test
 {
-    constexpr auto kMaxUInt32 = std::numeric_limits<std::uint32_t>::max();
-    constexpr auto kMaxXrp = std::numeric_limits<XRPAmount::value_type>::max();
-    constexpr auto kMinXrp = std::numeric_limits<XRPAmount::value_type>::min();
+protected:
+    static constexpr auto kMaxUInt32 = std::numeric_limits<std::uint32_t>::max();
+    static constexpr auto kMaxXrp = std::numeric_limits<XRPAmount::value_type>::max();
+    static constexpr auto kMinXrp = std::numeric_limits<XRPAmount::value_type>::min();
+};
 
-    {
-        // multiply by a number that would overflow then divide by the same
-        // number, and check we didn't lose any value
-        XRPAmount big(kMaxXrp);
-        EXPECT_EQ(big, mulRatio(big, kMaxUInt32, kMaxUInt32, true));
-        // rounding mode shouldn't matter as the result is exact
-        EXPECT_EQ(big, mulRatio(big, kMaxUInt32, kMaxUInt32, false));
+TEST_F(XRPAmountMulRatioTest, scaling_the_maximum_by_one_is_lossless)
+{
+    // The intermediate product overflows; mulRatio must not lose value anyway.
+    XRPAmount const big(kMaxXrp);
 
-        // multiply and divide by values that would overflow if done
-        // naively, and check that it gives the correct answer
-        big -= 0xf;  // Subtract a little so it's divisible by 4
-        EXPECT_EQ(mulRatio(big, 3, 4, false).value(), (big.value() / 4) * 3);
-        EXPECT_EQ(mulRatio(big, 3, 4, true).value(), (big.value() / 4) * 3);
-        EXPECT_EQ(big.value() % 4, 0);
-        EXPECT_GT(big.value(), kMaxXrp / 3);
-        EXPECT_LE(big.value() / 4, kMaxXrp / 3);
-    }
+    EXPECT_EQ(big, mulRatio(big, kMaxUInt32, kMaxUInt32, true));
+    // Rounding mode shouldn't matter as the result is exact.
+    EXPECT_EQ(big, mulRatio(big, kMaxUInt32, kMaxUInt32, false));
+}
 
-    {
-        // Similar test as above, but for negative values
-        XRPAmount big(kMinXrp);  // NOLINT TODO
-        EXPECT_EQ(big, mulRatio(big, kMaxUInt32, kMaxUInt32, true));
-        // rounding mode shouldn't matter as the result is exact
-        EXPECT_EQ(big, mulRatio(big, kMaxUInt32, kMaxUInt32, false));
+TEST_F(XRPAmountMulRatioTest, three_quarters_of_the_maximum_avoids_overflow)
+{
+    XRPAmount big(kMaxXrp);
+    big -= 0xf;  // Subtract a little so it's divisible by 4
 
-        // multiply and divide by values that would overflow if done
-        // naively, and check that it gives the correct answer
-        EXPECT_EQ(mulRatio(big, 3, 4, false).value(), (big.value() / 4) * 3);
-        EXPECT_EQ(mulRatio(big, 3, 4, true).value(), (big.value() / 4) * 3);
-        EXPECT_EQ(big.value() % 4, 0);
-        EXPECT_LT(big.value(), kMinXrp / 3);
-        EXPECT_GE(big.value() / 4, kMinXrp / 3);
-    }
+    EXPECT_EQ(mulRatio(big, 3, 4, false).value(), (big.value() / 4) * 3);
+    EXPECT_EQ(mulRatio(big, 3, 4, true).value(), (big.value() / 4) * 3);
 
-    {
-        // small amounts
-        XRPAmount const tiny(1);
-        // Round up should give the smallest allowable number
-        EXPECT_EQ(tiny, mulRatio(tiny, 1, kMaxUInt32, true));
-        // rounding down should be zero
-        EXPECT_EQ(beast::kZero, mulRatio(tiny, 1, kMaxUInt32, false));
-        EXPECT_EQ(beast::kZero, mulRatio(tiny, kMaxUInt32 - 1, kMaxUInt32, false));
+    // The premises the two checks above rest on: exact division by 4, and an
+    // input large enough that a naive multiply by 3 really would overflow.
+    EXPECT_EQ(big.value() % 4, 0);
+    EXPECT_GT(big.value(), kMaxXrp / 3);
+    EXPECT_LE(big.value() / 4, kMaxXrp / 3);
+}
 
-        // tiny negative numbers
-        XRPAmount const tinyNeg(-1);
-        // Round up should give zero
-        EXPECT_EQ(beast::kZero, mulRatio(tinyNeg, 1, kMaxUInt32, true));
-        EXPECT_EQ(beast::kZero, mulRatio(tinyNeg, kMaxUInt32 - 1, kMaxUInt32, true));
-        // rounding down should be tiny
-        EXPECT_EQ(tinyNeg, mulRatio(tinyNeg, kMaxUInt32 - 1, kMaxUInt32, false));
-    }
+TEST_F(XRPAmountMulRatioTest, scaling_the_minimum_by_one_is_lossless)
+{
+    XRPAmount const big(kMinXrp);  // NOLINT TODO
 
-    {  // rounding
-        {
-            XRPAmount const one(1);
-            auto const rup = mulRatio(one, kMaxUInt32 - 1, kMaxUInt32, true);
-            auto const rdown = mulRatio(one, kMaxUInt32 - 1, kMaxUInt32, false);
-            EXPECT_EQ(rup.drops() - rdown.drops(), 1);
-        }
+    EXPECT_EQ(big, mulRatio(big, kMaxUInt32, kMaxUInt32, true));
+    // Rounding mode shouldn't matter as the result is exact.
+    EXPECT_EQ(big, mulRatio(big, kMaxUInt32, kMaxUInt32, false));
+}
 
-        {
-            XRPAmount const big(kMaxXrp);
-            auto const rup = mulRatio(big, kMaxUInt32 - 1, kMaxUInt32, true);
-            auto const rdown = mulRatio(big, kMaxUInt32 - 1, kMaxUInt32, false);
-            EXPECT_EQ(rup.drops() - rdown.drops(), 1);
-        }
+TEST_F(XRPAmountMulRatioTest, three_quarters_of_the_minimum_avoids_overflow)
+{
+    XRPAmount const big(kMinXrp);  // NOLINT TODO
 
-        {
-            XRPAmount const negOne(-1);
-            auto const rup = mulRatio(negOne, kMaxUInt32 - 1, kMaxUInt32, true);
-            auto const rdown = mulRatio(negOne, kMaxUInt32 - 1, kMaxUInt32, false);
-            EXPECT_EQ(rup.drops() - rdown.drops(), 1);
-        }
-    }
+    EXPECT_EQ(mulRatio(big, 3, 4, false).value(), (big.value() / 4) * 3);
+    EXPECT_EQ(mulRatio(big, 3, 4, true).value(), (big.value() / 4) * 3);
 
-    {
-        // division by zero
-        XRPAmount const one(1);
-        EXPECT_ANY_THROW({ mulRatio(one, 1, 0, true); });
-    }
+    EXPECT_EQ(big.value() % 4, 0);
+    EXPECT_LT(big.value(), kMinXrp / 3);
+    EXPECT_GE(big.value() / 4, kMinXrp / 3);
+}
 
-    {
-        // overflow
-        XRPAmount const big(kMaxXrp);
-        EXPECT_ANY_THROW({ mulRatio(big, 2, 1, true); });
-    }
+TEST_F(XRPAmountMulRatioTest, a_single_drop_rounds_up_to_a_drop_and_down_to_zero)
+{
+    XRPAmount const tiny(1);
 
-    {
-        // underflow
-        XRPAmount const bigNegative(kMinXrp + 10);
-        EXPECT_EQ(mulRatio(bigNegative, 2, 1, true), kMinXrp);
-    }
+    EXPECT_EQ(tiny, mulRatio(tiny, 1, kMaxUInt32, true));
+    EXPECT_EQ(beast::kZero, mulRatio(tiny, 1, kMaxUInt32, false));
+    EXPECT_EQ(beast::kZero, mulRatio(tiny, kMaxUInt32 - 1, kMaxUInt32, false));
+}
+
+TEST_F(XRPAmountMulRatioTest, a_single_negative_drop_rounds_up_to_zero_and_down_to_a_drop)
+{
+    XRPAmount const tinyNeg(-1);
+
+    // "Up" is towards zero for a negative amount.
+    EXPECT_EQ(beast::kZero, mulRatio(tinyNeg, 1, kMaxUInt32, true));
+    EXPECT_EQ(beast::kZero, mulRatio(tinyNeg, kMaxUInt32 - 1, kMaxUInt32, true));
+    EXPECT_EQ(tinyNeg, mulRatio(tinyNeg, kMaxUInt32 - 1, kMaxUInt32, false));
+}
+
+TEST_F(XRPAmountMulRatioTest, rounding_up_and_down_a_drop_differ_by_one_drop)
+{
+    XRPAmount const one(1);
+
+    auto const roundedUp = mulRatio(one, kMaxUInt32 - 1, kMaxUInt32, true);
+    auto const roundedDown = mulRatio(one, kMaxUInt32 - 1, kMaxUInt32, false);
+    EXPECT_EQ(roundedUp.drops() - roundedDown.drops(), 1);
+}
+
+TEST_F(XRPAmountMulRatioTest, rounding_up_and_down_the_maximum_differ_by_one_drop)
+{
+    XRPAmount const big(kMaxXrp);
+
+    auto const roundedUp = mulRatio(big, kMaxUInt32 - 1, kMaxUInt32, true);
+    auto const roundedDown = mulRatio(big, kMaxUInt32 - 1, kMaxUInt32, false);
+    EXPECT_EQ(roundedUp.drops() - roundedDown.drops(), 1);
+}
+
+TEST_F(XRPAmountMulRatioTest, rounding_up_and_down_a_negative_drop_differ_by_one_drop)
+{
+    XRPAmount const negOne(-1);
+
+    auto const roundedUp = mulRatio(negOne, kMaxUInt32 - 1, kMaxUInt32, true);
+    auto const roundedDown = mulRatio(negOne, kMaxUInt32 - 1, kMaxUInt32, false);
+    EXPECT_EQ(roundedUp.drops() - roundedDown.drops(), 1);
+}
+
+TEST_F(XRPAmountMulRatioTest, dividing_by_zero_throws)
+{
+    XRPAmount const one(1);
+
+    EXPECT_ANY_THROW({ mulRatio(one, 1, 0, true); });
+}
+
+TEST_F(XRPAmountMulRatioTest, overflowing_the_maximum_throws)
+{
+    XRPAmount const big(kMaxXrp);
+
+    EXPECT_ANY_THROW({ mulRatio(big, 2, 1, true); });
+}
+
+TEST_F(XRPAmountMulRatioTest, underflow_saturates_at_the_minimum)
+{
+    // Unlike overflow, underflow clamps rather than throwing.
+    XRPAmount const bigNegative(kMinXrp + 10);
+
+    EXPECT_EQ(mulRatio(bigNegative, 2, 1, true), kMinXrp);
 }
 
 }  // namespace xrpl

--- a/src/tests/libxrpl/basics/base58.cpp
+++ b/src/tests/libxrpl/basics/base58.cpp
@@ -159,14 +159,20 @@ randomBigInt(std::uint8_t minSize = 1, std::uint8_t maxSize = 5)
 }
 }  // namespace multiprecision_utils
 
-TEST(Base58Test, multiprecision)
+struct Base58MultiprecisionTest : public ::testing::Test
+{
+    static constexpr std::size_t kIters = 100000;
+
+    // Copied, as the original test did, so each case advances its own engine.
+    std::mt19937 eng{randEngine()};
+    std::uniform_int_distribution<std::uint64_t> dist;
+    std::uniform_int_distribution<std::uint64_t> dist1{1};
+};
+
+TEST_F(Base58MultiprecisionTest, div_rem_matches_boost)
 {
     using namespace boost::multiprecision;
 
-    constexpr std::size_t kIters = 100000;
-    auto eng = randEngine();
-    std::uniform_int_distribution<std::uint64_t> dist;
-    std::uniform_int_distribution<std::uint64_t> dist1(1);
     for (auto i = 0uz; i < kIters; ++i)
     {
         std::uint64_t const d = dist(eng);
@@ -185,6 +191,12 @@ TEST(Base58Test, multiprecision)
         EXPECT_EQ(refMod.convert_to<std::uint64_t>(), mod);
         EXPECT_EQ(foundDiv, refDiv);
     }
+}
+
+TEST_F(Base58MultiprecisionTest, add_matches_boost)
+{
+    using namespace boost::multiprecision;
+
     for (auto i = 0uz; i < kIters; ++i)
     {
         std::uint64_t const d = dist(eng);
@@ -204,6 +216,12 @@ TEST(Base58Test, multiprecision)
         auto const foundAdd = multiprecision_utils::toBoostMP(bigInt);
         EXPECT_EQ(refAdd, foundAdd);
     }
+}
+
+TEST_F(Base58MultiprecisionTest, add_reports_overflow)
+{
+    using namespace boost::multiprecision;
+
     for (auto i = 0uz; i < kIters; ++i)
     {
         std::uint64_t const d = dist1(eng);
@@ -221,6 +239,12 @@ TEST(Base58Test, multiprecision)
         auto const foundAdd = multiprecision_utils::toBoostMP(bigInt);
         EXPECT_NE(refAdd, foundAdd);
     }
+}
+
+TEST_F(Base58MultiprecisionTest, mul_matches_boost)
+{
+    using namespace boost::multiprecision;
+
     for (auto i = 0uz; i < kIters; ++i)
     {
         std::uint64_t const d = dist(eng);
@@ -239,6 +263,12 @@ TEST(Base58Test, multiprecision)
         auto const foundMul = multiprecision_utils::toBoostMP(bigInt);
         EXPECT_EQ(refMul, foundMul);
     }
+}
+
+TEST_F(Base58MultiprecisionTest, mul_reports_input_too_large)
+{
+    using namespace boost::multiprecision;
+
     for (auto i = 0uz; i < kIters; ++i)
     {
         std::uint64_t const d = dist1(eng);
@@ -257,9 +287,13 @@ TEST(Base58Test, multiprecision)
     }
 }
 
-TEST(Base58Test, fast_matches_ref)
+// b58_fast must agree with the reference implementation for both raw and
+// token-framed data, in each direction.
+struct Base58FastMatchesRefTest : public ::testing::Test
 {
-    auto testRawEncode = [&](std::span<std::uint8_t> const& b256Data) {
+    static void
+    testRawEncode(std::span<std::uint8_t> const& b256Data)
+    {
         std::array<std::uint8_t, 64> b58ResultBuf[2];
         std::array<std::span<std::uint8_t>, 2> b58Result;
 
@@ -330,10 +364,11 @@ TEST(Base58Test, fast_matches_ref)
                 printAsInt(b256Result[0], b256Result[1]);
             }
         }
-    };
+    }
 
-    auto testTokenEncode = [&](xrpl::TokenType const tokType,
-                               std::span<std::uint8_t> const& b256Data) {
+    static void
+    testTokenEncode(xrpl::TokenType const tokType, std::span<std::uint8_t> const& b256Data)
+    {
         std::array<std::uint8_t, 64> b58ResultBuf[2];
         std::array<std::span<std::uint8_t>, 2> b58Result;
 
@@ -403,15 +438,19 @@ TEST(Base58Test, fast_matches_ref)
                 printAsInt(b256Result[0], b256Result[1]);
             }
         }
-    };
+    }
 
-    auto testIt = [&](xrpl::TokenType const tokType, std::span<std::uint8_t> const& b256Data) {
+    static void
+    testIt(xrpl::TokenType const tokType, std::span<std::uint8_t> const& b256Data)
+    {
         testRawEncode(b256Data);
         testTokenEncode(tokType, b256Data);
-    };
+    }
+};
 
-    // test every token type with data where every byte is the same and the
-    // bytes range from 0-255
+TEST_F(Base58FastMatchesRefTest, every_token_type_over_every_byte_value)
+{
+    // Data where every byte is the same, for byte values 0-255.
     for (int i = 0; i < kNumTokenTypeIndexes; ++i)
     {
         std::array<std::uint8_t, 128> b256DataBuf{};
@@ -422,9 +461,12 @@ TEST(Base58Test, fast_matches_ref)
             testIt(tokType, std::span(b256DataBuf.data(), tokSize));
         }
     }
+}
 
-    // test with random data
+TEST_F(Base58FastMatchesRefTest, random_data)
+{
     constexpr std::size_t kIters = 100000;
+
     for (auto i = 0uz; i < kIters; ++i)
     {
         std::array<std::uint8_t, 128> b256DataBuf{};

--- a/src/tests/libxrpl/basics/base_uint.cpp
+++ b/src/tests/libxrpl/basics/base_uint.cpp
@@ -56,6 +56,12 @@ struct BaseUintTest : public ::testing::Test
     using BaseUInt96 = BaseUInt<96>;
     static_assert(std::is_copy_constructible_v<BaseUInt96>);
     static_assert(std::is_copy_assignable_v<BaseUInt96>);
+    static_assert(!std::is_constructible_v<BaseUInt96, std::complex<double>>);
+    static_assert(!std::is_assignable_v<BaseUInt96&, std::complex<double>>);
+
+    Blob const raw{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    BaseUInt96 const ascending{BaseUInt96::fromRaw(raw)};
+    BaseUInt96 const zero{beast::kZero};
 
     static void
     testComparisons()
@@ -128,7 +134,7 @@ struct BaseUintTest : public ::testing::Test
 
 using BaseUintDeathTest = BaseUintTest;
 
-TEST_F(BaseUintDeathTest, fromRaw_size_mismatch)
+TEST_F(BaseUintDeathTest, from_raw_size_mismatch)
 {
     // ENABLE_VOIDSTAR is a debug build, but does not crash on failed asserts. Rather than twist
     // these tests into knots to make them work, just skip them.
@@ -193,21 +199,14 @@ TEST_F(BaseUintDeathTest, fromRaw_size_mismatch)
 #endif
 }
 
-TEST_F(BaseUintTest, base_uint)
+TEST_F(BaseUintTest, comparisons)
 {
-    static_assert(!std::is_constructible_v<BaseUInt96, std::complex<double>>);
-    static_assert(!std::is_assignable_v<BaseUInt96&, std::complex<double>>);
-
     testComparisons();
+}
 
-    // used to verify set insertion (hashing required)
-    std::unordered_set<BaseUInt96, HardenedHash<>> uset;
-
-    Blob const raw{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+TEST_F(BaseUintTest, from_raw)
+{
     EXPECT_EQ(BaseUInt96::kBytes, raw.size());
-
-    BaseUInt96 ascending = BaseUInt96::fromRaw(raw);
-    uset.insert(ascending);
     EXPECT_EQ(raw.size(), ascending.size());
     EXPECT_EQ(to_string(ascending), "0102030405060708090A0B0C");
     EXPECT_EQ(toShortString(ascending), "01020304...");
@@ -216,21 +215,28 @@ TEST_F(BaseUintTest, base_uint)
     EXPECT_FALSE(!ascending);
     EXPECT_FALSE(ascending.isZero());
     EXPECT_TRUE(ascending.isNonZero());
+
     unsigned char expectedByte = 0;
     for (auto& byte : ascending)
         EXPECT_EQ(byte, ++expectedByte);
+}
 
-    // Test hash_append by "hashing" with a no-op hasher (hasher)
-    // and then extracting the bytes that were written during hashing
-    // back into another base_uint (rehashed) for comparison with the original
+TEST_F(BaseUintTest, hash_append_writes_the_raw_bytes)
+{
+    // "Hash" with a no-op hasher and read the bytes it was handed back into
+    // another base_uint, which must then equal the original.
     Nonhash<96> hasher{};
     hash_append(hasher, ascending);
+
     BaseUInt96 const rehashed =
         BaseUInt96::fromRaw(std::vector<std::uint8_t>(hasher.data.begin(), hasher.data.end()));
     EXPECT_EQ(rehashed, ascending);
+}
 
+TEST_F(BaseUintTest, complement)
+{
     BaseUInt96 complement{~ascending};
-    uset.insert(complement);
+
     EXPECT_EQ(to_string(complement), "FEFDFCFBFAF9F8F7F6F5F4F3");
     EXPECT_EQ(toShortString(complement), "FEFDFCFB...");
     EXPECT_EQ(*complement.data(), 0xfe);
@@ -239,7 +245,7 @@ TEST_F(BaseUintTest, base_uint)
     EXPECT_FALSE(complement.isZero());
     EXPECT_TRUE(complement.isNonZero());
 
-    expectedByte = 0xff;
+    unsigned char expectedByte = 0xff;
     for (auto& byte : complement)
         EXPECT_EQ(byte, --expectedByte);
 
@@ -248,9 +254,10 @@ TEST_F(BaseUintTest, base_uint)
 
     complement = ascending;
     EXPECT_EQ(complement, ascending);
+}
 
-    BaseUInt96 zero{beast::kZero};
-    uset.insert(zero);
+TEST_F(BaseUintTest, zero)
+{
     EXPECT_EQ(to_string(zero), "000000000000000000000000");
     EXPECT_EQ(toShortString(zero), "00000000...");
     EXPECT_EQ(*zero.data(), 0);
@@ -260,147 +267,196 @@ TEST_F(BaseUintTest, base_uint)
     EXPECT_TRUE(!zero);
     EXPECT_TRUE(zero.isZero());
     EXPECT_FALSE(zero.isNonZero());
+
     for (auto& byte : zero)
         EXPECT_EQ(byte, 0);
+}
 
-    {
-        // There are several ways to create a zero. beast::kZero is tested above. Test some
-        // others.
-        BaseUInt96 const defaultZero;
-        EXPECT_EQ(defaultZero, zero) << to_string(defaultZero);
+TEST_F(BaseUintTest, the_several_ways_of_spelling_zero_agree)
+{
+    BaseUInt96 const defaultZero;
+    EXPECT_EQ(defaultZero, zero) << to_string(defaultZero);
 
-        BaseUInt96 const bracedZero{};
-        EXPECT_EQ(bracedZero, zero) << to_string(bracedZero);
+    BaseUInt96 const bracedZero{};
+    EXPECT_EQ(bracedZero, zero) << to_string(bracedZero);
 
-        BaseUInt96 const zeroFromUInt{0u};
-        EXPECT_EQ(zeroFromUInt, zero) << to_string(zeroFromUInt);
-    }
+    BaseUInt96 const zeroFromUInt{0u};
+    EXPECT_EQ(zeroFromUInt, zero) << to_string(zeroFromUInt);
+}
 
+TEST_F(BaseUintTest, increment_and_decrement)
+{
     BaseUInt96 counter{zero};
+
     counter++;
     EXPECT_EQ(counter, BaseUInt96(1));
+
     counter--;
     EXPECT_EQ(counter, beast::kZero);
     EXPECT_EQ(counter, zero);
+
+    // Decrementing past zero wraps to all-ones.
     counter--;
     EXPECT_EQ(to_string(counter), "FFFFFFFFFFFFFFFFFFFFFFFF");
     EXPECT_EQ(toShortString(counter), "FFFFFFFF...");
+
     counter = beast::kZero;
     EXPECT_EQ(counter, zero);
+}
+
+TEST_F(BaseUintTest, exclusive_or)
+{
+    BaseUInt96 zeroPlusOne{zero};
+    zeroPlusOne++;
+    BaseUInt96 zeroMinusOne{zero};
+    zeroMinusOne--;
+
+    BaseUInt96 const xored{zeroMinusOne ^ zeroPlusOne};
+    EXPECT_EQ(to_string(xored), "FFFFFFFFFFFFFFFFFFFFFFFE") << to_string(xored);
+    EXPECT_EQ(toShortString(xored), "FFFFFFFF...") << toShortString(xored);
+}
+
+TEST_F(BaseUintTest, distinct_values_hash_into_a_set)
+{
+    // Requires hashing to work; four distinct values must stay four entries.
+    std::unordered_set<BaseUInt96, HardenedHash<>> uset;
 
     BaseUInt96 zeroPlusOne{zero};
     zeroPlusOne++;
     BaseUInt96 zeroMinusOne{zero};
     zeroMinusOne--;
-    BaseUInt96 const xored{zeroMinusOne ^ zeroPlusOne};
-    uset.insert(xored);
-    EXPECT_EQ(to_string(xored), "FFFFFFFFFFFFFFFFFFFFFFFE") << to_string(xored);
-    EXPECT_EQ(toShortString(xored), "FFFFFFFF...") << toShortString(xored);
+
+    uset.insert(ascending);
+    uset.insert(BaseUInt96{~ascending});
+    uset.insert(zero);
+    uset.insert(BaseUInt96{zeroMinusOne ^ zeroPlusOne});
 
     EXPECT_EQ(uset.size(), 4);
+}
 
+TEST_F(BaseUintTest, parse_hex_round_trip)
+{
     BaseUInt96 parsed;
+
     EXPECT_TRUE(parsed.parseHex(to_string(ascending)));
     EXPECT_EQ(parsed, ascending);
-    parsed = zero;
+}
 
-    // fails with extra char
+TEST_F(BaseUintTest, parse_hex_rejects_an_extra_leading_character)
+{
+    BaseUInt96 parsed{zero};
+
     EXPECT_FALSE(parsed.parseHex("A" + to_string(ascending)));
-    parsed = zero;
+}
 
-    // fails with extra char at end
+TEST_F(BaseUintTest, parse_hex_rejects_an_extra_trailing_character)
+{
+    BaseUInt96 parsed{zero};
+
     EXPECT_FALSE(parsed.parseHex(to_string(ascending) + "A"));
+}
 
-    // fails with a non-hex character at some point in the string:
-    parsed = zero;
+TEST_F(BaseUintTest, parse_hex_rejects_a_non_hex_character_at_any_position)
+{
+    BaseUInt96 parsed{zero};
 
     for (std::size_t i = 0; i != 24; ++i)
     {
-        std::string xored = to_string(zero);
-        xored[i] = ('G' + (i % 10));
-        EXPECT_FALSE(parsed.parseHex(xored));
+        std::string corrupted = to_string(zero);
+        corrupted[i] = ('G' + (i % 10));
+        EXPECT_FALSE(parsed.parseHex(corrupted));
     }
+}
 
-    // Walking 1s:
+TEST_F(BaseUintTest, parse_hex_walking_ones)
+{
+    BaseUInt96 parsed;
+
     for (std::size_t i = 0; i != 24; ++i)
     {
-        std::string s1 = "000000000000000000000000";
-        s1[i] = '1';
+        std::string text = "000000000000000000000000";
+        text[i] = '1';
 
-        EXPECT_TRUE(parsed.parseHex(s1));
-        EXPECT_EQ(to_string(parsed), s1);
+        EXPECT_TRUE(parsed.parseHex(text));
+        EXPECT_EQ(to_string(parsed), text);
     }
+}
 
-    // Walking 0s:
+TEST_F(BaseUintTest, parse_hex_walking_zeroes)
+{
+    BaseUInt96 parsed;
+
     for (std::size_t i = 0; i != 24; ++i)
     {
-        std::string s1 = "111111111111111111111111";
-        s1[i] = '0';
+        std::string text = "111111111111111111111111";
+        text[i] = '0';
 
-        EXPECT_TRUE(parsed.parseHex(s1));
-        EXPECT_EQ(to_string(parsed), s1);
+        EXPECT_TRUE(parsed.parseHex(text));
+        EXPECT_EQ(to_string(parsed), text);
     }
+}
 
-    // Constexpr constructors
+TEST_F(BaseUintTest, constexpr_construction)
+{
+    static_assert(BaseUInt96{}.signum() == 0);
+    static_assert(BaseUInt96("0").signum() == 0);
+    static_assert(BaseUInt96("000000000000000000000000").signum() == 0);
+    static_assert(BaseUInt96("000000000000000000000001").signum() == 1);
+    static_assert(BaseUInt96("800000000000000000000000").signum() == 1);
+}
+
+TEST_F(BaseUintTest, constexpr_constructor_throws_on_a_bad_length)
+{
+    // The vector keeps this out of a constant expression, so the constructor
+    // throws instead of failing to compile.
+    auto tooShort = [] {
+        std::vector<char> const str(23, '7');
+        std::string_view const sView(str.data(), str.size());
+        [[maybe_unused]] BaseUInt96 const t96(sView);
+    };
+
+    EXPECT_THAT(
+        tooShort, ::testing::ThrowsMessage<std::invalid_argument>("invalid length for hex string"));
+}
+
+TEST_F(BaseUintTest, constexpr_constructor_throws_on_a_bad_character)
+{
+    auto badCharacter = [] {
+        std::vector<char> str(23, '7');
+        str.push_back('G');
+        std::string_view const sView(str.data(), str.size());
+        [[maybe_unused]] BaseUInt96 const t96(sView);
+    };
+
+    EXPECT_THAT(badCharacter, ::testing::ThrowsMessage<std::range_error>("invalid hex character"));
+}
+
+TEST_F(BaseUintTest, constexpr_construction_agrees_with_parse_hex)
+{
+    struct StrBaseUInt
     {
-        static_assert(BaseUInt96{}.signum() == 0);
-        static_assert(BaseUInt96("0").signum() == 0);
-        static_assert(BaseUInt96("000000000000000000000000").signum() == 0);
-        static_assert(BaseUInt96("000000000000000000000001").signum() == 1);
-        static_assert(BaseUInt96("800000000000000000000000").signum() == 1);
+        char const* const str;
+        BaseUInt96 tst;
 
-        // Using the constexpr constructor in a non-constexpr context
-        // with an error in the parsing throws an exception.
+        constexpr StrBaseUInt(char const* s) : str(s), tst(s)
         {
-            // Invalid length for string. The vector keeps this out of a constant
-            // expression, so the constructor throws instead of failing to compile.
-            auto tooShort = [] {
-                std::vector<char> const str(23, '7');
-                std::string_view const sView(str.data(), str.size());
-                [[maybe_unused]] BaseUInt96 const t96(sView);
-            };
-            EXPECT_THAT(
-                tooShort,
-                ::testing::ThrowsMessage<std::invalid_argument>("invalid length for hex string"));
         }
-        {
-            // Invalid character in string.
-            auto badCharacter = [] {
-                std::vector<char> str(23, '7');
-                str.push_back('G');
-                std::string_view const sView(str.data(), str.size());
-                [[maybe_unused]] BaseUInt96 const t96(sView);
-            };
-            EXPECT_THAT(
-                badCharacter, ::testing::ThrowsMessage<std::range_error>("invalid hex character"));
-        }
+    };
 
-        // Verify that constexpr base_uints interpret a string the same
-        // way parseHex() does.
-        struct StrBaseUInt
-        {
-            char const* const str;
-            BaseUInt96 tst;
+    constexpr auto kTestCases = std::to_array<StrBaseUInt>({
+        "000000000000000000000000",
+        "000000000000000000000001",
+        "fedcba9876543210ABCDEF91",
+        "19FEDCBA0123456789abcdef",
+        "800000000000000000000000",
+        "fFfFfFfFfFfFfFfFfFfFfFfF",
+    });
 
-            constexpr StrBaseUInt(char const* s) : str(s), tst(s)
-            {
-            }
-        };
-        constexpr auto kTestCases = std::to_array<StrBaseUInt>({
-            "000000000000000000000000",
-            "000000000000000000000001",
-            "fedcba9876543210ABCDEF91",
-            "19FEDCBA0123456789abcdef",
-            "800000000000000000000000",
-            "fFfFfFfFfFfFfFfFfFfFfFfF",
-        });
-
-        for (StrBaseUInt const& expectedByte : kTestCases)
-        {
-            BaseUInt96 t96;
-            EXPECT_TRUE(t96.parseHex(expectedByte.str));
-            EXPECT_EQ(t96, expectedByte.tst);
-        }
+    for (StrBaseUInt const& testCase : kTestCases)
+    {
+        BaseUInt96 t96;
+        EXPECT_TRUE(t96.parseHex(testCase.str));
+        EXPECT_EQ(t96, testCase.tst);
     }
 }
 

--- a/src/tests/libxrpl/consensus/LedgerTrie.cpp
+++ b/src/tests/libxrpl/consensus/LedgerTrie.cpp
@@ -9,261 +9,288 @@
 
 namespace xrpl::test {
 
-TEST(LedgerTrieTest, insert)
+TEST(LedgerTrieTest, insert_single_entry_by_itself)
 {
     using namespace csf;
-    // Single entry by itself
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abc"]);
-        EXPECT_TRUE(t.checkInvariants());
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 1);
 
-        t.insert(h["abc"]);
-        EXPECT_TRUE(t.checkInvariants());
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 2);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
-    }
-    // Suffix of existing (extending tree)
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abc"]);
-        EXPECT_TRUE(t.checkInvariants());
-        // extend with no siblings
-        t.insert(h["abcd"]);
-        EXPECT_TRUE(t.checkInvariants());
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abc"]);
+    EXPECT_TRUE(t.checkInvariants());
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 1);
 
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
-        EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abcd"]) == 1);
-
-        // extend with existing sibling
-        t.insert(h["abce"]);
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 3);
-        EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abcd"]) == 1);
-        EXPECT_TRUE(t.tipSupport(h["abce"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abce"]) == 1);
-    }
-    // uncommitted of existing node
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abcd"]);
-        EXPECT_TRUE(t.checkInvariants());
-        // uncommitted with no siblings
-        t.insert(h["abcdf"]);
-        EXPECT_TRUE(t.checkInvariants());
-
-        EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abcd"]) == 2);
-        EXPECT_TRUE(t.tipSupport(h["abcdf"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abcdf"]) == 1);
-
-        // uncommitted with existing child
-        t.insert(h["abc"]);
-        EXPECT_TRUE(t.checkInvariants());
-
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 3);
-        EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abcd"]) == 2);
-        EXPECT_TRUE(t.tipSupport(h["abcdf"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abcdf"]) == 1);
-    }
-    // Suffix + uncommitted of existing node
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abcd"]);
-        EXPECT_TRUE(t.checkInvariants());
-        t.insert(h["abce"]);
-        EXPECT_TRUE(t.checkInvariants());
-
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
-        EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abcd"]) == 1);
-        EXPECT_TRUE(t.tipSupport(h["abce"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abce"]) == 1);
-    }
-    // Suffix + uncommitted with existing child
-    {
-        //  abcd : abcde, abcf
-
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abcd"]);
-        EXPECT_TRUE(t.checkInvariants());
-        t.insert(h["abcde"]);
-        EXPECT_TRUE(t.checkInvariants());
-        t.insert(h["abcf"]);
-        EXPECT_TRUE(t.checkInvariants());
-
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 3);
-        EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abcd"]) == 2);
-        EXPECT_TRUE(t.tipSupport(h["abcf"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abcf"]) == 1);
-        EXPECT_TRUE(t.tipSupport(h["abcde"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abcde"]) == 1);
-    }
-
-    // Multiple counts
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["ab"], 4);
-        EXPECT_TRUE(t.tipSupport(h["ab"]) == 4);
-        EXPECT_TRUE(t.branchSupport(h["ab"]) == 4);
-        EXPECT_TRUE(t.tipSupport(h["a"]) == 0);
-        EXPECT_TRUE(t.branchSupport(h["a"]) == 4);
-
-        t.insert(h["abc"], 2);
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 2);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
-        EXPECT_TRUE(t.tipSupport(h["ab"]) == 4);
-        EXPECT_TRUE(t.branchSupport(h["ab"]) == 6);
-        EXPECT_TRUE(t.tipSupport(h["a"]) == 0);
-        EXPECT_TRUE(t.branchSupport(h["a"]) == 6);
-    }
+    t.insert(h["abc"]);
+    EXPECT_TRUE(t.checkInvariants());
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 2);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
 }
 
-TEST(LedgerTrieTest, remove)
+TEST(LedgerTrieTest, insert_suffix_of_existing_extending_tree)
 {
     using namespace csf;
-    // Not in trie
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abc"]);
 
-        EXPECT_TRUE(!t.remove(h["ab"]));
-        EXPECT_TRUE(t.checkInvariants());
-        EXPECT_TRUE(!t.remove(h["a"]));
-        EXPECT_TRUE(t.checkInvariants());
-    }
-    // In trie but with 0 tip support
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abcd"]);
-        t.insert(h["abce"]);
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abc"]);
+    EXPECT_TRUE(t.checkInvariants());
+    // extend with no siblings
+    t.insert(h["abcd"]);
+    EXPECT_TRUE(t.checkInvariants());
 
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
-        EXPECT_TRUE(!t.remove(h["abc"]));
-        EXPECT_TRUE(t.checkInvariants());
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
-    }
-    // In trie with > 1 tip support
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abc"], 2);
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
+    EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abcd"]) == 1);
 
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 2);
-        EXPECT_TRUE(t.remove(h["abc"]));
-        EXPECT_TRUE(t.checkInvariants());
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
+    // extend with existing sibling
+    t.insert(h["abce"]);
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 3);
+    EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abcd"]) == 1);
+    EXPECT_TRUE(t.tipSupport(h["abce"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abce"]) == 1);
+}
 
-        t.insert(h["abc"], 1);
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 2);
-        EXPECT_TRUE(t.remove(h["abc"], 2));
-        EXPECT_TRUE(t.checkInvariants());
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
+TEST(LedgerTrieTest, insert_uncommitted_of_existing_node)
+{
+    using namespace csf;
 
-        t.insert(h["abc"], 3);
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 3);
-        EXPECT_TRUE(t.remove(h["abc"], 300));
-        EXPECT_TRUE(t.checkInvariants());
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
-    }
-    // In trie with = 1 tip support, no children
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["ab"]);
-        t.insert(h["abc"]);
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abcd"]);
+    EXPECT_TRUE(t.checkInvariants());
+    // uncommitted with no siblings
+    t.insert(h["abcdf"]);
+    EXPECT_TRUE(t.checkInvariants());
 
-        EXPECT_TRUE(t.tipSupport(h["ab"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["ab"]) == 2);
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 1);
+    EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abcd"]) == 2);
+    EXPECT_TRUE(t.tipSupport(h["abcdf"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abcdf"]) == 1);
 
-        EXPECT_TRUE(t.remove(h["abc"]));
-        EXPECT_TRUE(t.checkInvariants());
-        EXPECT_TRUE(t.tipSupport(h["ab"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["ab"]) == 1);
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 0);
-    }
-    // In trie with = 1 tip support, 1 child
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["ab"]);
-        t.insert(h["abc"]);
-        t.insert(h["abcd"]);
+    // uncommitted with existing child
+    t.insert(h["abc"]);
+    EXPECT_TRUE(t.checkInvariants());
 
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
-        EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abcd"]) == 1);
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 3);
+    EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abcd"]) == 2);
+    EXPECT_TRUE(t.tipSupport(h["abcdf"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abcdf"]) == 1);
+}
 
-        EXPECT_TRUE(t.remove(h["abc"]));
-        EXPECT_TRUE(t.checkInvariants());
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 1);
-        EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abcd"]) == 1);
-    }
-    // In trie with = 1 tip support, > 1 children
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["ab"]);
-        t.insert(h["abc"]);
-        t.insert(h["abcd"]);
-        t.insert(h["abce"]);
+TEST(LedgerTrieTest, insert_suffix_uncommitted_of_existing_node)
+{
+    using namespace csf;
 
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 3);
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abcd"]);
+    EXPECT_TRUE(t.checkInvariants());
+    t.insert(h["abce"]);
+    EXPECT_TRUE(t.checkInvariants());
 
-        EXPECT_TRUE(t.remove(h["abc"]));
-        EXPECT_TRUE(t.checkInvariants());
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
-        EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
-    }
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
+    EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abcd"]) == 1);
+    EXPECT_TRUE(t.tipSupport(h["abce"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abce"]) == 1);
+}
 
-    // In trie with = 1 tip support, parent compaction
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["ab"]);
-        t.insert(h["abc"]);
-        t.insert(h["abd"]);
-        EXPECT_TRUE(t.checkInvariants());
-        t.remove(h["ab"]);
-        EXPECT_TRUE(t.checkInvariants());
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
-        EXPECT_TRUE(t.tipSupport(h["abd"]) == 1);
-        EXPECT_TRUE(t.tipSupport(h["ab"]) == 0);
-        EXPECT_TRUE(t.branchSupport(h["ab"]) == 2);
+TEST(LedgerTrieTest, insert_suffix_uncommitted_with_existing_child)
+{
+    using namespace csf;
 
-        t.remove(h["abd"]);
-        EXPECT_TRUE(t.checkInvariants());
+    //  abcd : abcde, abcf
 
-        EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
-        EXPECT_TRUE(t.branchSupport(h["ab"]) == 1);
-    }
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abcd"]);
+    EXPECT_TRUE(t.checkInvariants());
+    t.insert(h["abcde"]);
+    EXPECT_TRUE(t.checkInvariants());
+    t.insert(h["abcf"]);
+    EXPECT_TRUE(t.checkInvariants());
+
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 3);
+    EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abcd"]) == 2);
+    EXPECT_TRUE(t.tipSupport(h["abcf"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abcf"]) == 1);
+    EXPECT_TRUE(t.tipSupport(h["abcde"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abcde"]) == 1);
+}
+
+TEST(LedgerTrieTest, insert_multiple_counts)
+{
+    using namespace csf;
+
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["ab"], 4);
+    EXPECT_TRUE(t.tipSupport(h["ab"]) == 4);
+    EXPECT_TRUE(t.branchSupport(h["ab"]) == 4);
+    EXPECT_TRUE(t.tipSupport(h["a"]) == 0);
+    EXPECT_TRUE(t.branchSupport(h["a"]) == 4);
+
+    t.insert(h["abc"], 2);
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 2);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
+    EXPECT_TRUE(t.tipSupport(h["ab"]) == 4);
+    EXPECT_TRUE(t.branchSupport(h["ab"]) == 6);
+    EXPECT_TRUE(t.tipSupport(h["a"]) == 0);
+    EXPECT_TRUE(t.branchSupport(h["a"]) == 6);
+}
+
+TEST(LedgerTrieTest, remove_not_in_trie)
+{
+    using namespace csf;
+
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abc"]);
+
+    EXPECT_TRUE(!t.remove(h["ab"]));
+    EXPECT_TRUE(t.checkInvariants());
+    EXPECT_TRUE(!t.remove(h["a"]));
+    EXPECT_TRUE(t.checkInvariants());
+}
+
+TEST(LedgerTrieTest, remove_in_trie_but_with_0_tip_support)
+{
+    using namespace csf;
+
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abcd"]);
+    t.insert(h["abce"]);
+
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
+    EXPECT_TRUE(!t.remove(h["abc"]));
+    EXPECT_TRUE(t.checkInvariants());
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
+}
+
+TEST(LedgerTrieTest, remove_in_trie_with_1_tip_support)
+{
+    using namespace csf;
+
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abc"], 2);
+
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 2);
+    EXPECT_TRUE(t.remove(h["abc"]));
+    EXPECT_TRUE(t.checkInvariants());
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
+
+    t.insert(h["abc"], 1);
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 2);
+    EXPECT_TRUE(t.remove(h["abc"], 2));
+    EXPECT_TRUE(t.checkInvariants());
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
+
+    t.insert(h["abc"], 3);
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 3);
+    EXPECT_TRUE(t.remove(h["abc"], 300));
+    EXPECT_TRUE(t.checkInvariants());
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
+}
+
+TEST(LedgerTrieTest, remove_in_trie_with_1_tip_support_no_children)
+{
+    using namespace csf;
+
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["ab"]);
+    t.insert(h["abc"]);
+
+    EXPECT_TRUE(t.tipSupport(h["ab"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["ab"]) == 2);
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 1);
+
+    EXPECT_TRUE(t.remove(h["abc"]));
+    EXPECT_TRUE(t.checkInvariants());
+    EXPECT_TRUE(t.tipSupport(h["ab"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["ab"]) == 1);
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 0);
+}
+
+TEST(LedgerTrieTest, remove_in_trie_with_1_tip_support_1_child)
+{
+    using namespace csf;
+
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["ab"]);
+    t.insert(h["abc"]);
+    t.insert(h["abcd"]);
+
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
+    EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abcd"]) == 1);
+
+    EXPECT_TRUE(t.remove(h["abc"]));
+    EXPECT_TRUE(t.checkInvariants());
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 1);
+    EXPECT_TRUE(t.tipSupport(h["abcd"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abcd"]) == 1);
+}
+
+TEST(LedgerTrieTest, remove_in_trie_with_1_tip_support_1_children)
+{
+    using namespace csf;
+
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["ab"]);
+    t.insert(h["abc"]);
+    t.insert(h["abcd"]);
+    t.insert(h["abce"]);
+
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 3);
+
+    EXPECT_TRUE(t.remove(h["abc"]));
+    EXPECT_TRUE(t.checkInvariants());
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 0);
+    EXPECT_TRUE(t.branchSupport(h["abc"]) == 2);
+}
+
+TEST(LedgerTrieTest, remove_in_trie_with_1_tip_support_parent_compaction)
+{
+    using namespace csf;
+
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["ab"]);
+    t.insert(h["abc"]);
+    t.insert(h["abd"]);
+    EXPECT_TRUE(t.checkInvariants());
+    t.remove(h["ab"]);
+    EXPECT_TRUE(t.checkInvariants());
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
+    EXPECT_TRUE(t.tipSupport(h["abd"]) == 1);
+    EXPECT_TRUE(t.tipSupport(h["ab"]) == 0);
+    EXPECT_TRUE(t.branchSupport(h["ab"]) == 2);
+
+    t.remove(h["abd"]);
+    EXPECT_TRUE(t.checkInvariants());
+
+    EXPECT_TRUE(t.tipSupport(h["abc"]) == 1);
+    EXPECT_TRUE(t.branchSupport(h["ab"]) == 1);
 }
 
 TEST(LedgerTrieTest, empty)
@@ -331,285 +358,323 @@ TEST(LedgerTrieTest, support)
     EXPECT_TRUE(t.branchSupport(h["abe"]) == 1);
 }
 
-TEST(LedgerTrieTest, get_preferred)
+TEST(LedgerTrieTest, preferred_empty)
 {
     using namespace csf;
     using Seq = Ledger::Seq;
-    // Empty
-    {
-        LedgerTrie<Ledger> const t;
-        EXPECT_TRUE(t.getPreferred(Seq{0}) == std::nullopt);
-        EXPECT_TRUE(t.getPreferred(Seq{2}) == std::nullopt);
-    }
-    // Genesis support is NOT empty
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        Ledger const genesis = h[""];
-        t.insert(genesis);
 
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{0})->id == genesis.id());
-        EXPECT_TRUE(t.remove(genesis));
-        EXPECT_TRUE(t.getPreferred(Seq{0}) == std::nullopt);
-        EXPECT_TRUE(!t.remove(genesis));
-    }
-    // Single node no children
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abc"]);
+    LedgerTrie<Ledger> const t;
+    EXPECT_TRUE(t.getPreferred(Seq{0}) == std::nullopt);
+    EXPECT_TRUE(t.getPreferred(Seq{2}) == std::nullopt);
+}
 
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
-    }
-    // Single node smaller child support
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abc"]);
-        t.insert(h["abcd"]);
+TEST(LedgerTrieTest, preferred_genesis_support_is_not_empty)
+{
+    using namespace csf;
+    using Seq = Ledger::Seq;
 
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    Ledger const genesis = h[""];
+    t.insert(genesis);
 
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abc"].id());
-    }
-    // Single node larger child
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abc"]);
-        t.insert(h["abcd"], 2);
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{0})->id == genesis.id());
+    EXPECT_TRUE(t.remove(genesis));
+    EXPECT_TRUE(t.getPreferred(Seq{0}) == std::nullopt);
+    EXPECT_TRUE(!t.remove(genesis));
+}
 
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abcd"].id());
+TEST(LedgerTrieTest, preferred_single_node_no_children)
+{
+    using namespace csf;
+    using Seq = Ledger::Seq;
 
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abcd"].id());
-    }
-    // Single node smaller children support
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abc"]);
-        t.insert(h["abcd"]);
-        t.insert(h["abce"]);
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abc"]);
 
-        // NOLINTBEGIN(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abc"].id());
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
+}
 
-        t.insert(h["abc"]);
+TEST(LedgerTrieTest, preferred_single_node_smaller_child_support)
+{
+    using namespace csf;
+    using Seq = Ledger::Seq;
 
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abc"].id());
-        // NOLINTEND(bugprone-unchecked-optional-access)
-    }
-    // Single node larger children
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abc"]);
-        t.insert(h["abcd"], 2);
-        t.insert(h["abce"]);
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abc"]);
+    t.insert(h["abcd"]);
 
-        // NOLINTBEGIN(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abc"].id());
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
 
-        t.insert(h["abcd"]);
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abc"].id());
+}
 
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abcd"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abcd"].id());
-        // NOLINTEND(bugprone-unchecked-optional-access)
-    }
-    // Tie-breaker by id
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abcd"], 2);
-        t.insert(h["abce"], 2);
+TEST(LedgerTrieTest, preferred_single_node_larger_child)
+{
+    using namespace csf;
+    using Seq = Ledger::Seq;
 
-        EXPECT_TRUE(h["abce"].id() > h["abcd"].id());
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abc"]);
+    t.insert(h["abcd"], 2);
 
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abce"].id());
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abcd"].id());
 
-        t.insert(h["abcd"]);
-        EXPECT_TRUE(h["abce"].id() > h["abcd"].id());
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abcd"].id());
+}
 
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abcd"].id());
-    }
+TEST(LedgerTrieTest, preferred_single_node_smaller_children_support)
+{
+    using namespace csf;
+    using Seq = Ledger::Seq;
 
-    // Tie-breaker not needed
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abc"]);
-        t.insert(h["abcd"]);
-        t.insert(h["abce"], 2);
-        // abce only has a margin of 1, but it owns the tie-breaker
-        EXPECT_TRUE(h["abce"].id() > h["abcd"].id());
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abc"]);
+    t.insert(h["abcd"]);
+    t.insert(h["abce"]);
 
-        // NOLINTBEGIN(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abce"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abce"].id());
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abc"].id());
 
-        // Switch support from abce to abcd, tie-breaker now needed
-        t.remove(h["abce"]);
-        t.insert(h["abcd"]);
+    t.insert(h["abc"]);
 
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abc"].id());
-        // NOLINTEND(bugprone-unchecked-optional-access)
-    }
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abc"].id());
+    // NOLINTEND(bugprone-unchecked-optional-access)
+}
 
-    // Single node larger grand child
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abc"]);
-        t.insert(h["abcd"], 2);
-        t.insert(h["abcde"], 4);
+TEST(LedgerTrieTest, preferred_single_node_larger_children)
+{
+    using namespace csf;
+    using Seq = Ledger::Seq;
 
-        // NOLINTBEGIN(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abcde"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abcde"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{5})->id == h["abcde"].id());
-        // NOLINTEND(bugprone-unchecked-optional-access)
-    }
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abc"]);
+    t.insert(h["abcd"], 2);
+    t.insert(h["abce"]);
 
-    // Too much uncommitted support from competing branches
-    {
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["abc"]);
-        t.insert(h["abcde"], 2);
-        t.insert(h["abcfg"], 2);
-        // 'de' and 'fg' are tied without 'abc' vote
-        // NOLINTBEGIN(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abc"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{5})->id == h["abc"].id());
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abc"].id());
 
-        t.remove(h["abc"]);
-        t.insert(h["abcd"]);
+    t.insert(h["abcd"]);
 
-        // 'de' branch has 3 votes to 2, so earlier sequences see it as preferred
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abcde"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abcde"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abcd"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abcd"].id());
+    // NOLINTEND(bugprone-unchecked-optional-access)
+}
 
-        // However, if you validated a ledger with Seq 5, potentially on
-        // a different branch, you do not yet know if they chose abcd
-        // or abcf because of you, so abc remains preferred
-        EXPECT_TRUE(t.getPreferred(Seq{5})->id == h["abc"].id());
-        // NOLINTEND(bugprone-unchecked-optional-access)
-    }
+TEST(LedgerTrieTest, preferred_tie_breaker_by_id)
+{
+    using namespace csf;
+    using Seq = Ledger::Seq;
 
-    // Changing largestSeq perspective changes preferred branch
-    {
-        /**
-         * Build the tree below with initial tip support annotated
-         *       A
-         *      / \
-         *   B(1)  C(1)
-         *  /  |   |
-         * H   D   F(1)
-         *     |
-         *     E(2)
-         *     |
-         *     G
-         */
-        LedgerTrie<Ledger> t;
-        LedgerHistoryHelper h;
-        t.insert(h["ab"]);
-        t.insert(h["ac"]);
-        t.insert(h["acf"]);
-        t.insert(h["abde"], 2);
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abcd"], 2);
+    t.insert(h["abce"], 2);
 
-        // B has more branch support
-        // NOLINTBEGIN(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{1})->id == h["ab"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{2})->id == h["ab"].id());
+    EXPECT_TRUE(h["abce"].id() > h["abcd"].id());
 
-        // But if you last validated D,F or E, you do not yet know
-        // if someone used that validation to commit to B or C
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["a"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["a"].id());
-        // NOLINTEND(bugprone-unchecked-optional-access)
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abce"].id());
 
-        /**
-         * One of E advancing to G doesn't change anything
-         *       A
-         *      / \
-         *   B(1)  C(1)
-         *  /  |   |
-         * H   D   F(1)
-         *     |
-         *     E(1)
-         *     |
-         *     G(1)
-         */
-        t.remove(h["abde"]);
-        t.insert(h["abdeg"]);
+    t.insert(h["abcd"]);
+    EXPECT_TRUE(h["abce"].id() > h["abcd"].id());
 
-        // NOLINTBEGIN(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{1})->id == h["ab"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{2})->id == h["ab"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["a"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["a"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{5})->id == h["a"].id());
-        // NOLINTEND(bugprone-unchecked-optional-access)
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abcd"].id());
+}
 
-        /**
-         * C advancing to H does advance the seq 3 preferred ledger
-         *       A
-         *      / \
-         *   B(1)  C
-         *  /  |   |
-         * H(1)D   F(1)
-         *     |
-         *     E(1)
-         *     |
-         *     G(1)
-         */
-        t.remove(h["ac"]);
-        t.insert(h["abh"]);
+TEST(LedgerTrieTest, preferred_tie_breaker_not_needed)
+{
+    using namespace csf;
+    using Seq = Ledger::Seq;
 
-        // NOLINTBEGIN(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{1})->id == h["ab"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{2})->id == h["ab"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["ab"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["a"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{5})->id == h["a"].id());
-        // NOLINTEND(bugprone-unchecked-optional-access)
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abc"]);
+    t.insert(h["abcd"]);
+    t.insert(h["abce"], 2);
+    // abce only has a margin of 1, but it owns the tie-breaker
+    EXPECT_TRUE(h["abce"].id() > h["abcd"].id());
 
-        /**
-         * F advancing to E also moves the preferred ledger forward
-         *       A
-         *      / \
-         *   B(1)  C
-         *  /  |   |
-         * H(1)D   F
-         *     |
-         *     E(2)
-         *     |
-         *     G(1)
-         */
-        t.remove(h["acf"]);
-        t.insert(h["abde"]);
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abce"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abce"].id());
 
-        // NOLINTBEGIN(bugprone-unchecked-optional-access)
-        EXPECT_TRUE(t.getPreferred(Seq{1})->id == h["abde"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{2})->id == h["abde"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abde"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["ab"].id());
-        EXPECT_TRUE(t.getPreferred(Seq{5})->id == h["ab"].id());
-        // NOLINTEND(bugprone-unchecked-optional-access)
-    }
+    // Switch support from abce to abcd, tie-breaker now needed
+    t.remove(h["abce"]);
+    t.insert(h["abcd"]);
+
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abc"].id());
+    // NOLINTEND(bugprone-unchecked-optional-access)
+}
+
+TEST(LedgerTrieTest, preferred_single_node_larger_grand_child)
+{
+    using namespace csf;
+    using Seq = Ledger::Seq;
+
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abc"]);
+    t.insert(h["abcd"], 2);
+    t.insert(h["abcde"], 4);
+
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abcde"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abcde"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{5})->id == h["abcde"].id());
+    // NOLINTEND(bugprone-unchecked-optional-access)
+}
+
+TEST(LedgerTrieTest, preferred_too_much_uncommitted_support_from_competing_branches)
+{
+    using namespace csf;
+    using Seq = Ledger::Seq;
+
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["abc"]);
+    t.insert(h["abcde"], 2);
+    t.insert(h["abcfg"], 2);
+    // 'de' and 'fg' are tied without 'abc' vote
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abc"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abc"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{5})->id == h["abc"].id());
+
+    t.remove(h["abc"]);
+    t.insert(h["abcd"]);
+
+    // 'de' branch has 3 votes to 2, so earlier sequences see it as preferred
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abcde"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["abcde"].id());
+
+    // However, if you validated a ledger with Seq 5, potentially on
+    // a different branch, you do not yet know if they chose abcd
+    // or abcf because of you, so abc remains preferred
+    EXPECT_TRUE(t.getPreferred(Seq{5})->id == h["abc"].id());
+    // NOLINTEND(bugprone-unchecked-optional-access)
+}
+
+TEST(LedgerTrieTest, preferred_changing_largestseq_perspective_changes_preferred_branch)
+{
+    using namespace csf;
+    using Seq = Ledger::Seq;
+
+    /**
+     * Build the tree below with initial tip support annotated
+     *       A
+     *      / \
+     *   B(1)  C(1)
+     *  /  |   |
+     * H   D   F(1)
+     *     |
+     *     E(2)
+     *     |
+     *     G
+     */
+    LedgerTrie<Ledger> t;
+    LedgerHistoryHelper h;
+    t.insert(h["ab"]);
+    t.insert(h["ac"]);
+    t.insert(h["acf"]);
+    t.insert(h["abde"], 2);
+
+    // B has more branch support
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{1})->id == h["ab"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{2})->id == h["ab"].id());
+
+    // But if you last validated D,F or E, you do not yet know
+    // if someone used that validation to commit to B or C
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["a"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["a"].id());
+    // NOLINTEND(bugprone-unchecked-optional-access)
+
+    /**
+     * One of E advancing to G doesn't change anything
+     *       A
+     *      / \
+     *   B(1)  C(1)
+     *  /  |   |
+     * H   D   F(1)
+     *     |
+     *     E(1)
+     *     |
+     *     G(1)
+     */
+    t.remove(h["abde"]);
+    t.insert(h["abdeg"]);
+
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{1})->id == h["ab"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{2})->id == h["ab"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["a"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["a"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{5})->id == h["a"].id());
+    // NOLINTEND(bugprone-unchecked-optional-access)
+
+    /**
+     * C advancing to H does advance the seq 3 preferred ledger
+     *       A
+     *      / \
+     *   B(1)  C
+     *  /  |   |
+     * H(1)D   F(1)
+     *     |
+     *     E(1)
+     *     |
+     *     G(1)
+     */
+    t.remove(h["ac"]);
+    t.insert(h["abh"]);
+
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{1})->id == h["ab"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{2})->id == h["ab"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["ab"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["a"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{5})->id == h["a"].id());
+    // NOLINTEND(bugprone-unchecked-optional-access)
+
+    /**
+     * F advancing to E also moves the preferred ledger forward
+     *       A
+     *      / \
+     *   B(1)  C
+     *  /  |   |
+     * H(1)D   F
+     *     |
+     *     E(2)
+     *     |
+     *     G(1)
+     */
+    t.remove(h["acf"]);
+    t.insert(h["abde"]);
+
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(t.getPreferred(Seq{1})->id == h["abde"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{2})->id == h["abde"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{3})->id == h["abde"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{4})->id == h["ab"].id());
+    EXPECT_TRUE(t.getPreferred(Seq{5})->id == h["ab"].id());
+    // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST(LedgerTrieTest, root_related)

--- a/src/tests/libxrpl/consensus/Validations.cpp
+++ b/src/tests/libxrpl/consensus/Validations.cpp
@@ -245,11 +245,8 @@ Ledger const kGenesisLedger{Ledger::MakeGenesis{}};
 
 }  // namespace
 
-TEST(ValidationsTest, add_validation)
+struct AddValidationTest : public ::testing::Test
 {
-    using namespace std::chrono_literals;
-
-    SCOPED_TRACE("Add validation");
     LedgerHistoryHelper h;
     Ledger const ledgerA = h["a"];
     Ledger ledgerAB = h["ab"];
@@ -257,119 +254,131 @@ TEST(ValidationsTest, add_validation)
     Ledger ledgerABC = h["abc"];
     Ledger const ledgerABCD = h["abcd"];
     Ledger const ledgerABCDE = h["abcde"];
+};
 
+TEST_F(AddValidationTest, sequencing_key_rotation_and_out_of_order_arrival)
+{
+    using namespace std::chrono_literals;
+
+    TestHarness harness(h.oracle);
+    Node n = harness.makeNode();
+
+    auto const v = n.validate(ledgerA);
+
+    // Add a current validation
+    EXPECT_TRUE(ValStatus::Current == harness.add(v));
+
+    // Re-adding violates the increasing seq requirement for full
+    // validations
+    EXPECT_TRUE(ValStatus::BadSeq == harness.add(v));
+
+    harness.clock().advance(1s);
+
+    EXPECT_TRUE(ValStatus::Current == harness.add(n.validate(ledgerAB)));
+
+    // Test the node changing signing key
+
+    // Confirm old ledger on hand, but not new ledger
+    EXPECT_TRUE(harness.vals().numTrustedForLedger(ledgerAB.id()) == 1);
+    EXPECT_TRUE(harness.vals().numTrustedForLedger(ledgerABC.id()) == 0);
+
+    // Rotate signing keys
+    n.advanceKey();
+
+    harness.clock().advance(1s);
+
+    // Cannot re-do the same full validation sequence
+    EXPECT_TRUE(ValStatus::Conflicting == harness.add(n.validate(ledgerAB)));
+    // Cannot send the same partial validation sequence
+    EXPECT_TRUE(ValStatus::Conflicting == harness.add(n.partial(ledgerAB)));
+
+    // Now trusts the newest ledger too
+    harness.clock().advance(1s);
+    EXPECT_TRUE(ValStatus::Current == harness.add(n.validate(ledgerABC)));
+    EXPECT_TRUE(harness.vals().numTrustedForLedger(ledgerAB.id()) == 1);
+    EXPECT_TRUE(harness.vals().numTrustedForLedger(ledgerABC.id()) == 1);
+
+    // Processing validations out of order should ignore the older
+    // validation
+    harness.clock().advance(2s);
+    auto const valABCDE = n.validate(ledgerABCDE);
+
+    harness.clock().advance(4s);
+    auto const valABCD = n.validate(ledgerABCD);
+
+    EXPECT_TRUE(ValStatus::Current == harness.add(valABCD));
+
+    EXPECT_TRUE(ValStatus::Stale == harness.add(valABCDE));
+}
+
+TEST_F(AddValidationTest, validations_arriving_out_of_order_with_shifted_times)
+{
+    using namespace std::chrono_literals;
+
+    // Process validations out of order with shifted times
+
+    TestHarness harness(h.oracle);
+    Node const n = harness.makeNode();
+
+    // Establish a new current validation
+    EXPECT_TRUE(ValStatus::Current == harness.add(n.validate(ledgerA)));
+
+    // Process a validation that has "later" seq but early sign time
+    EXPECT_TRUE(ValStatus::Stale == harness.add(n.validate(ledgerAB, -1s, -1s)));
+
+    // Process a validation that has a later seq and later sign
+    // time
+    EXPECT_TRUE(ValStatus::Current == harness.add(n.validate(ledgerABC, 1s, 1s)));
+}
+
+TEST_F(AddValidationTest, validations_that_are_stale_on_arrival)
+{
+    using namespace std::chrono_literals;
+
+    // Test stale on arrival validations
+    TestHarness harness(h.oracle);
+    Node const n = harness.makeNode();
+
+    EXPECT_TRUE(
+        ValStatus::Stale ==
+        harness.add(n.validate(ledgerA, -harness.parms().validationCurrentEarly, 0s)));
+
+    EXPECT_TRUE(
+        ValStatus::Stale ==
+        harness.add(n.validate(ledgerA, harness.parms().validationCurrentWall, 0s)));
+
+    EXPECT_TRUE(
+        ValStatus::Stale ==
+        harness.add(n.validate(ledgerA, 0s, harness.parms().validationCurrentLocal)));
+}
+
+TEST_F(AddValidationTest, older_sequence_numbers_are_rejected_until_the_set_expires)
+{
+    using namespace std::chrono_literals;
+
+    // Test that full or partials cannot be sent for older sequence
+    // numbers, unless time-out has happened
+    for (bool doFull : {true, false})
     {
         TestHarness harness(h.oracle);
         Node n = harness.makeNode();
 
-        auto const v = n.validate(ledgerA);
+        auto process = [&](Ledger& lgr) {
+            if (doFull)
+                return harness.add(n.validate(lgr));
+            return harness.add(n.partial(lgr));
+        };
 
-        // Add a current validation
-        EXPECT_TRUE(ValStatus::Current == harness.add(v));
-
-        // Re-adding violates the increasing seq requirement for full
-        // validations
-        EXPECT_TRUE(ValStatus::BadSeq == harness.add(v));
-
+        EXPECT_TRUE(ValStatus::Current == process(ledgerABC));
         harness.clock().advance(1s);
+        EXPECT_TRUE(ledgerAB.seq() < ledgerABC.seq());
+        EXPECT_TRUE(ValStatus::BadSeq == process(ledgerAB));
 
-        EXPECT_TRUE(ValStatus::Current == harness.add(n.validate(ledgerAB)));
-
-        // Test the node changing signing key
-
-        // Confirm old ledger on hand, but not new ledger
-        EXPECT_TRUE(harness.vals().numTrustedForLedger(ledgerAB.id()) == 1);
-        EXPECT_TRUE(harness.vals().numTrustedForLedger(ledgerABC.id()) == 0);
-
-        // Rotate signing keys
-        n.advanceKey();
-
-        harness.clock().advance(1s);
-
-        // Cannot re-do the same full validation sequence
-        EXPECT_TRUE(ValStatus::Conflicting == harness.add(n.validate(ledgerAB)));
-        // Cannot send the same partial validation sequence
-        EXPECT_TRUE(ValStatus::Conflicting == harness.add(n.partial(ledgerAB)));
-
-        // Now trusts the newest ledger too
-        harness.clock().advance(1s);
-        EXPECT_TRUE(ValStatus::Current == harness.add(n.validate(ledgerABC)));
-        EXPECT_TRUE(harness.vals().numTrustedForLedger(ledgerAB.id()) == 1);
-        EXPECT_TRUE(harness.vals().numTrustedForLedger(ledgerABC.id()) == 1);
-
-        // Processing validations out of order should ignore the older
-        // validation
-        harness.clock().advance(2s);
-        auto const valABCDE = n.validate(ledgerABCDE);
-
-        harness.clock().advance(4s);
-        auto const valABCD = n.validate(ledgerABCD);
-
-        EXPECT_TRUE(ValStatus::Current == harness.add(valABCD));
-
-        EXPECT_TRUE(ValStatus::Stale == harness.add(valABCDE));
-    }
-
-    {
-        // Process validations out of order with shifted times
-
-        TestHarness harness(h.oracle);
-        Node const n = harness.makeNode();
-
-        // Establish a new current validation
-        EXPECT_TRUE(ValStatus::Current == harness.add(n.validate(ledgerA)));
-
-        // Process a validation that has "later" seq but early sign time
-        EXPECT_TRUE(ValStatus::Stale == harness.add(n.validate(ledgerAB, -1s, -1s)));
-
-        // Process a validation that has a later seq and later sign
-        // time
-        EXPECT_TRUE(ValStatus::Current == harness.add(n.validate(ledgerABC, 1s, 1s)));
-    }
-
-    {
-        // Test stale on arrival validations
-        TestHarness harness(h.oracle);
-        Node const n = harness.makeNode();
-
-        EXPECT_TRUE(
-            ValStatus::Stale ==
-            harness.add(n.validate(ledgerA, -harness.parms().validationCurrentEarly, 0s)));
-
-        EXPECT_TRUE(
-            ValStatus::Stale ==
-            harness.add(n.validate(ledgerA, harness.parms().validationCurrentWall, 0s)));
-
-        EXPECT_TRUE(
-            ValStatus::Stale ==
-            harness.add(n.validate(ledgerA, 0s, harness.parms().validationCurrentLocal)));
-    }
-
-    {
-        // Test that full or partials cannot be sent for older sequence
-        // numbers, unless time-out has happened
-        for (bool doFull : {true, false})
-        {
-            TestHarness harness(h.oracle);
-            Node n = harness.makeNode();
-
-            auto process = [&](Ledger& lgr) {
-                if (doFull)
-                    return harness.add(n.validate(lgr));
-                return harness.add(n.partial(lgr));
-            };
-
-            EXPECT_TRUE(ValStatus::Current == process(ledgerABC));
-            harness.clock().advance(1s);
-            EXPECT_TRUE(ledgerAB.seq() < ledgerABC.seq());
-            EXPECT_TRUE(ValStatus::BadSeq == process(ledgerAB));
-
-            // If we advance far enough for AB to expire, we can fully
-            // validate or partially validate that sequence number again
-            EXPECT_TRUE(ValStatus::Conflicting == process(ledgerAZ));
-            harness.clock().advance(harness.parms().validationSetExpires + 1ms);
-            EXPECT_TRUE(ValStatus::Current == process(ledgerAZ));
-        }
+        // If we advance far enough for AB to expire, we can fully
+        // validate or partially validate that sequence number again
+        EXPECT_TRUE(ValStatus::Conflicting == process(ledgerAZ));
+        harness.clock().advance(harness.parms().validationSetExpires + 1ms);
+        EXPECT_TRUE(ValStatus::Current == process(ledgerAZ));
     }
 }
 

--- a/src/tests/libxrpl/json/Value.cpp
+++ b/src/tests/libxrpl/json/Value.cpp
@@ -29,7 +29,7 @@ TEST(json_value, limits)
     static_assert(Value::kMaxUInt == UInt(-1));
 }
 
-TEST(json_value, construct_and_compare_Json_StaticString)
+TEST(json_value, construct_and_compare_json_static_string)
 {
     static constexpr char kSample[]{"Contents of a json::StaticString"};
 
@@ -52,11 +52,8 @@ TEST(json_value, construct_and_compare_Json_StaticString)
     EXPECT_NE(kTest3, str);
 }
 
-TEST(json_value, different_types)
+TEST(json_value, type_null)
 {
-    // Exercise ValueType constructor
-    static constexpr json::StaticString kStaticStr{"staticStr"};
-
     auto testCopy = [](json::ValueType typ) {
         json::Value val{typ};
         json::Value const cpy{val};
@@ -64,146 +61,219 @@ TEST(json_value, different_types)
         EXPECT_EQ(cpy.type(), typ);
         return val;
     };
+
+    json::Value const nullV{testCopy(json::ValueType::Null)};
+    EXPECT_TRUE(nullV.isNull());
+    EXPECT_FALSE(nullV.isBool());
+    EXPECT_FALSE(nullV.isInt());
+    EXPECT_FALSE(nullV.isUInt());
+    EXPECT_FALSE(nullV.isIntegral());
+    EXPECT_FALSE(nullV.isDouble());
+    EXPECT_FALSE(nullV.isNumeric());
+    EXPECT_FALSE(nullV.isString());
+    EXPECT_FALSE(nullV.isArray());
+    EXPECT_TRUE(nullV.isArrayOrNull());
+    EXPECT_FALSE(nullV.isObject());
+    EXPECT_TRUE(nullV.isObjectOrNull());
+}
+
+TEST(json_value, type_int)
+{
+    auto testCopy = [](json::ValueType typ) {
+        json::Value val{typ};
+        json::Value const cpy{val};
+        EXPECT_EQ(val.type(), typ);
+        EXPECT_EQ(cpy.type(), typ);
+        return val;
+    };
+
+    json::Value const intV{testCopy(json::ValueType::Int)};
+    EXPECT_FALSE(intV.isNull());
+    EXPECT_FALSE(intV.isBool());
+    EXPECT_TRUE(intV.isInt());
+    EXPECT_FALSE(intV.isUInt());
+    EXPECT_TRUE(intV.isIntegral());
+    EXPECT_FALSE(intV.isDouble());
+    EXPECT_TRUE(intV.isNumeric());
+    EXPECT_FALSE(intV.isString());
+    EXPECT_FALSE(intV.isArray());
+    EXPECT_FALSE(intV.isArrayOrNull());
+    EXPECT_FALSE(intV.isObject());
+    EXPECT_FALSE(intV.isObjectOrNull());
+}
+
+TEST(json_value, type_uint)
+{
+    auto testCopy = [](json::ValueType typ) {
+        json::Value val{typ};
+        json::Value const cpy{val};
+        EXPECT_EQ(val.type(), typ);
+        EXPECT_EQ(cpy.type(), typ);
+        return val;
+    };
+
+    json::Value const uintV{testCopy(json::ValueType::UInt)};
+    EXPECT_FALSE(uintV.isNull());
+    EXPECT_FALSE(uintV.isBool());
+    EXPECT_FALSE(uintV.isInt());
+    EXPECT_TRUE(uintV.isUInt());
+    EXPECT_TRUE(uintV.isIntegral());
+    EXPECT_FALSE(uintV.isDouble());
+    EXPECT_TRUE(uintV.isNumeric());
+    EXPECT_FALSE(uintV.isString());
+    EXPECT_FALSE(uintV.isArray());
+    EXPECT_FALSE(uintV.isArrayOrNull());
+    EXPECT_FALSE(uintV.isObject());
+    EXPECT_FALSE(uintV.isObjectOrNull());
+}
+
+TEST(json_value, type_real)
+{
+    auto testCopy = [](json::ValueType typ) {
+        json::Value val{typ};
+        json::Value const cpy{val};
+        EXPECT_EQ(val.type(), typ);
+        EXPECT_EQ(cpy.type(), typ);
+        return val;
+    };
+
+    json::Value const realV{testCopy(json::ValueType::Real)};
+    EXPECT_FALSE(realV.isNull());
+    EXPECT_FALSE(realV.isBool());
+    EXPECT_FALSE(realV.isInt());
+    EXPECT_FALSE(realV.isUInt());
+    EXPECT_FALSE(realV.isIntegral());
+    EXPECT_TRUE(realV.isDouble());
+    EXPECT_TRUE(realV.isNumeric());
+    EXPECT_FALSE(realV.isString());
+    EXPECT_FALSE(realV.isArray());
+    EXPECT_FALSE(realV.isArrayOrNull());
+    EXPECT_FALSE(realV.isObject());
+    EXPECT_FALSE(realV.isObjectOrNull());
+}
+
+TEST(json_value, type_string)
+{
+    auto testCopy = [](json::ValueType typ) {
+        json::Value val{typ};
+        json::Value const cpy{val};
+        EXPECT_EQ(val.type(), typ);
+        EXPECT_EQ(cpy.type(), typ);
+        return val;
+    };
+
+    json::Value const stringV{testCopy(json::ValueType::String)};
+    EXPECT_FALSE(stringV.isNull());
+    EXPECT_FALSE(stringV.isBool());
+    EXPECT_FALSE(stringV.isInt());
+    EXPECT_FALSE(stringV.isUInt());
+    EXPECT_FALSE(stringV.isIntegral());
+    EXPECT_FALSE(stringV.isDouble());
+    EXPECT_FALSE(stringV.isNumeric());
+    EXPECT_TRUE(stringV.isString());
+    EXPECT_FALSE(stringV.isArray());
+    EXPECT_FALSE(stringV.isArrayOrNull());
+    EXPECT_FALSE(stringV.isObject());
+    EXPECT_FALSE(stringV.isObjectOrNull());
+}
+
+TEST(json_value, type_static_string)
+{
+    static constexpr json::StaticString kStaticStr{"staticStr"};
+
+    json::Value const staticStrV{kStaticStr};
     {
-        json::Value const nullV{testCopy(json::ValueType::Null)};
-        EXPECT_TRUE(nullV.isNull());
-        EXPECT_FALSE(nullV.isBool());
-        EXPECT_FALSE(nullV.isInt());
-        EXPECT_FALSE(nullV.isUInt());
-        EXPECT_FALSE(nullV.isIntegral());
-        EXPECT_FALSE(nullV.isDouble());
-        EXPECT_FALSE(nullV.isNumeric());
-        EXPECT_FALSE(nullV.isString());
-        EXPECT_FALSE(nullV.isArray());
-        EXPECT_TRUE(nullV.isArrayOrNull());
-        EXPECT_FALSE(nullV.isObject());
-        EXPECT_TRUE(nullV.isObjectOrNull());
+        json::Value const cpy{staticStrV};
+        EXPECT_EQ(staticStrV.type(), json::ValueType::String);
+        EXPECT_EQ(cpy.type(), json::ValueType::String);
     }
-    {
-        json::Value const intV{testCopy(json::ValueType::Int)};
-        EXPECT_FALSE(intV.isNull());
-        EXPECT_FALSE(intV.isBool());
-        EXPECT_TRUE(intV.isInt());
-        EXPECT_FALSE(intV.isUInt());
-        EXPECT_TRUE(intV.isIntegral());
-        EXPECT_FALSE(intV.isDouble());
-        EXPECT_TRUE(intV.isNumeric());
-        EXPECT_FALSE(intV.isString());
-        EXPECT_FALSE(intV.isArray());
-        EXPECT_FALSE(intV.isArrayOrNull());
-        EXPECT_FALSE(intV.isObject());
-        EXPECT_FALSE(intV.isObjectOrNull());
-    }
-    {
-        json::Value const uintV{testCopy(json::ValueType::UInt)};
-        EXPECT_FALSE(uintV.isNull());
-        EXPECT_FALSE(uintV.isBool());
-        EXPECT_FALSE(uintV.isInt());
-        EXPECT_TRUE(uintV.isUInt());
-        EXPECT_TRUE(uintV.isIntegral());
-        EXPECT_FALSE(uintV.isDouble());
-        EXPECT_TRUE(uintV.isNumeric());
-        EXPECT_FALSE(uintV.isString());
-        EXPECT_FALSE(uintV.isArray());
-        EXPECT_FALSE(uintV.isArrayOrNull());
-        EXPECT_FALSE(uintV.isObject());
-        EXPECT_FALSE(uintV.isObjectOrNull());
-    }
-    {
-        json::Value const realV{testCopy(json::ValueType::Real)};
-        EXPECT_FALSE(realV.isNull());
-        EXPECT_FALSE(realV.isBool());
-        EXPECT_FALSE(realV.isInt());
-        EXPECT_FALSE(realV.isUInt());
-        EXPECT_FALSE(realV.isIntegral());
-        EXPECT_TRUE(realV.isDouble());
-        EXPECT_TRUE(realV.isNumeric());
-        EXPECT_FALSE(realV.isString());
-        EXPECT_FALSE(realV.isArray());
-        EXPECT_FALSE(realV.isArrayOrNull());
-        EXPECT_FALSE(realV.isObject());
-        EXPECT_FALSE(realV.isObjectOrNull());
-    }
-    {
-        json::Value const stringV{testCopy(json::ValueType::String)};
-        EXPECT_FALSE(stringV.isNull());
-        EXPECT_FALSE(stringV.isBool());
-        EXPECT_FALSE(stringV.isInt());
-        EXPECT_FALSE(stringV.isUInt());
-        EXPECT_FALSE(stringV.isIntegral());
-        EXPECT_FALSE(stringV.isDouble());
-        EXPECT_FALSE(stringV.isNumeric());
-        EXPECT_TRUE(stringV.isString());
-        EXPECT_FALSE(stringV.isArray());
-        EXPECT_FALSE(stringV.isArrayOrNull());
-        EXPECT_FALSE(stringV.isObject());
-        EXPECT_FALSE(stringV.isObjectOrNull());
-    }
-    {
-        json::Value const staticStrV{kStaticStr};
-        {
-            json::Value const cpy{staticStrV};
-            EXPECT_EQ(staticStrV.type(), json::ValueType::String);
-            EXPECT_EQ(cpy.type(), json::ValueType::String);
-        }
-        EXPECT_FALSE(staticStrV.isNull());
-        EXPECT_FALSE(staticStrV.isBool());
-        EXPECT_FALSE(staticStrV.isInt());
-        EXPECT_FALSE(staticStrV.isUInt());
-        EXPECT_FALSE(staticStrV.isIntegral());
-        EXPECT_FALSE(staticStrV.isDouble());
-        EXPECT_FALSE(staticStrV.isNumeric());
-        EXPECT_TRUE(staticStrV.isString());
-        EXPECT_FALSE(staticStrV.isArray());
-        EXPECT_FALSE(staticStrV.isArrayOrNull());
-        EXPECT_FALSE(staticStrV.isObject());
-        EXPECT_FALSE(staticStrV.isObjectOrNull());
-    }
-    {
-        json::Value const boolV{testCopy(json::ValueType::Boolean)};
-        EXPECT_FALSE(boolV.isNull());
-        EXPECT_TRUE(boolV.isBool());
-        EXPECT_FALSE(boolV.isInt());
-        EXPECT_FALSE(boolV.isUInt());
-        EXPECT_TRUE(boolV.isIntegral());
-        EXPECT_FALSE(boolV.isDouble());
-        EXPECT_TRUE(boolV.isNumeric());
-        EXPECT_FALSE(boolV.isString());
-        EXPECT_FALSE(boolV.isArray());
-        EXPECT_FALSE(boolV.isArrayOrNull());
-        EXPECT_FALSE(boolV.isObject());
-        EXPECT_FALSE(boolV.isObjectOrNull());
-    }
-    {
-        json::Value const arrayV{testCopy(json::ValueType::Array)};
-        EXPECT_FALSE(arrayV.isNull());
-        EXPECT_FALSE(arrayV.isBool());
-        EXPECT_FALSE(arrayV.isInt());
-        EXPECT_FALSE(arrayV.isUInt());
-        EXPECT_FALSE(arrayV.isIntegral());
-        EXPECT_FALSE(arrayV.isDouble());
-        EXPECT_FALSE(arrayV.isNumeric());
-        EXPECT_FALSE(arrayV.isString());
-        EXPECT_TRUE(arrayV.isArray());
-        EXPECT_TRUE(arrayV.isArrayOrNull());
-        EXPECT_FALSE(arrayV.isObject());
-        EXPECT_FALSE(arrayV.isObjectOrNull());
-    }
-    {
-        json::Value const objectV{testCopy(json::ValueType::Object)};
-        EXPECT_FALSE(objectV.isNull());
-        EXPECT_FALSE(objectV.isBool());
-        EXPECT_FALSE(objectV.isInt());
-        EXPECT_FALSE(objectV.isUInt());
-        EXPECT_FALSE(objectV.isIntegral());
-        EXPECT_FALSE(objectV.isDouble());
-        EXPECT_FALSE(objectV.isNumeric());
-        EXPECT_FALSE(objectV.isString());
-        EXPECT_FALSE(objectV.isArray());
-        EXPECT_FALSE(objectV.isArrayOrNull());
-        EXPECT_TRUE(objectV.isObject());
-        EXPECT_TRUE(objectV.isObjectOrNull());
-    }
+    EXPECT_FALSE(staticStrV.isNull());
+    EXPECT_FALSE(staticStrV.isBool());
+    EXPECT_FALSE(staticStrV.isInt());
+    EXPECT_FALSE(staticStrV.isUInt());
+    EXPECT_FALSE(staticStrV.isIntegral());
+    EXPECT_FALSE(staticStrV.isDouble());
+    EXPECT_FALSE(staticStrV.isNumeric());
+    EXPECT_TRUE(staticStrV.isString());
+    EXPECT_FALSE(staticStrV.isArray());
+    EXPECT_FALSE(staticStrV.isArrayOrNull());
+    EXPECT_FALSE(staticStrV.isObject());
+    EXPECT_FALSE(staticStrV.isObjectOrNull());
+}
+
+TEST(json_value, type_bool)
+{
+    auto testCopy = [](json::ValueType typ) {
+        json::Value val{typ};
+        json::Value const cpy{val};
+        EXPECT_EQ(val.type(), typ);
+        EXPECT_EQ(cpy.type(), typ);
+        return val;
+    };
+
+    json::Value const boolV{testCopy(json::ValueType::Boolean)};
+    EXPECT_FALSE(boolV.isNull());
+    EXPECT_TRUE(boolV.isBool());
+    EXPECT_FALSE(boolV.isInt());
+    EXPECT_FALSE(boolV.isUInt());
+    EXPECT_TRUE(boolV.isIntegral());
+    EXPECT_FALSE(boolV.isDouble());
+    EXPECT_TRUE(boolV.isNumeric());
+    EXPECT_FALSE(boolV.isString());
+    EXPECT_FALSE(boolV.isArray());
+    EXPECT_FALSE(boolV.isArrayOrNull());
+    EXPECT_FALSE(boolV.isObject());
+    EXPECT_FALSE(boolV.isObjectOrNull());
+}
+
+TEST(json_value, type_array)
+{
+    auto testCopy = [](json::ValueType typ) {
+        json::Value val{typ};
+        json::Value const cpy{val};
+        EXPECT_EQ(val.type(), typ);
+        EXPECT_EQ(cpy.type(), typ);
+        return val;
+    };
+
+    json::Value const arrayV{testCopy(json::ValueType::Array)};
+    EXPECT_FALSE(arrayV.isNull());
+    EXPECT_FALSE(arrayV.isBool());
+    EXPECT_FALSE(arrayV.isInt());
+    EXPECT_FALSE(arrayV.isUInt());
+    EXPECT_FALSE(arrayV.isIntegral());
+    EXPECT_FALSE(arrayV.isDouble());
+    EXPECT_FALSE(arrayV.isNumeric());
+    EXPECT_FALSE(arrayV.isString());
+    EXPECT_TRUE(arrayV.isArray());
+    EXPECT_TRUE(arrayV.isArrayOrNull());
+    EXPECT_FALSE(arrayV.isObject());
+    EXPECT_FALSE(arrayV.isObjectOrNull());
+}
+
+TEST(json_value, type_object)
+{
+    auto testCopy = [](json::ValueType typ) {
+        json::Value val{typ};
+        json::Value const cpy{val};
+        EXPECT_EQ(val.type(), typ);
+        EXPECT_EQ(cpy.type(), typ);
+        return val;
+    };
+
+    json::Value const objectV{testCopy(json::ValueType::Object)};
+    EXPECT_FALSE(objectV.isNull());
+    EXPECT_FALSE(objectV.isBool());
+    EXPECT_FALSE(objectV.isInt());
+    EXPECT_FALSE(objectV.isUInt());
+    EXPECT_FALSE(objectV.isIntegral());
+    EXPECT_FALSE(objectV.isDouble());
+    EXPECT_FALSE(objectV.isNumeric());
+    EXPECT_FALSE(objectV.isString());
+    EXPECT_FALSE(objectV.isArray());
+    EXPECT_FALSE(objectV.isArrayOrNull());
+    EXPECT_TRUE(objectV.isObject());
+    EXPECT_TRUE(objectV.isObjectOrNull());
 }
 
 TEST(json_value, compare_strings)
@@ -644,7 +714,7 @@ TEST(json_value, parse_double_malformed)
         EXPECT_FALSE(parseValue(bad).has_value()) << bad;
 }
 
-TEST(json_value, edge_cases)
+TEST(json_value, parses_integers_at_the_edges_of_the_32_bit_range)
 {
     std::uint32_t const maxUInt = std::numeric_limits<std::uint32_t>::max();
     std::int32_t const maxInt = std::numeric_limits<std::int32_t>::max();
@@ -654,141 +724,153 @@ TEST(json_value, edge_cases)
     std::int32_t const aLargeInt = maxInt - 1978;
     std::int32_t const aSmallInt = minInt + 1978;
 
-    {
-        std::string json = "{\"max_uint\":" + std::to_string(maxUInt);
-        json += ",\"max_int\":" + std::to_string(maxInt);
-        json += ",\"min_int\":" + std::to_string(minInt);
-        json += ",\"a_uint\":" + std::to_string(aUInt);
-        json += ",\"a_large_int\":" + std::to_string(aLargeInt);
-        json += ",\"a_small_int\":" + std::to_string(aSmallInt);
-        json += "}";
+    std::string json = "{\"max_uint\":" + std::to_string(maxUInt);
+    json += ",\"max_int\":" + std::to_string(maxInt);
+    json += ",\"min_int\":" + std::to_string(minInt);
+    json += ",\"a_uint\":" + std::to_string(aUInt);
+    json += ",\"a_large_int\":" + std::to_string(aLargeInt);
+    json += ",\"a_small_int\":" + std::to_string(aSmallInt);
+    json += "}";
 
-        json::Value j1;
-        json::Reader r1;
+    json::Value j1;
+    json::Reader r1;
 
-        EXPECT_TRUE(r1.parse(json, j1));
-        EXPECT_EQ(j1["max_uint"].asUInt(), maxUInt);
-        EXPECT_EQ(j1["max_uint"].asAbsUInt(), maxUInt);
-        EXPECT_EQ(j1["max_int"].asInt(), maxInt);
-        EXPECT_EQ(j1["max_int"].asAbsUInt(), maxInt);
-        EXPECT_EQ(j1["min_int"].asInt(), minInt);
-        EXPECT_EQ(j1["min_int"].asAbsUInt(), static_cast<std::int64_t>(minInt) * -1);
-        EXPECT_EQ(j1["a_uint"].asUInt(), aUInt);
-        EXPECT_EQ(j1["a_uint"].asAbsUInt(), aUInt);
-        EXPECT_GT(j1["a_uint"], aLargeInt);
-        EXPECT_GT(j1["a_uint"], aSmallInt);
-        EXPECT_EQ(j1["a_large_int"].asInt(), aLargeInt);
-        EXPECT_EQ(j1["a_large_int"].asAbsUInt(), aLargeInt);
-        EXPECT_EQ(j1["a_large_int"].asUInt(), aLargeInt);
-        EXPECT_LT(j1["a_large_int"], aUInt);
-        EXPECT_EQ(j1["a_small_int"].asInt(), aSmallInt);
-        EXPECT_EQ(j1["a_small_int"].asAbsUInt(), static_cast<std::int64_t>(aSmallInt) * -1);
-        EXPECT_LT(j1["a_small_int"], aUInt);
-    }
+    EXPECT_TRUE(r1.parse(json, j1));
+    EXPECT_EQ(j1["max_uint"].asUInt(), maxUInt);
+    EXPECT_EQ(j1["max_uint"].asAbsUInt(), maxUInt);
+    EXPECT_EQ(j1["max_int"].asInt(), maxInt);
+    EXPECT_EQ(j1["max_int"].asAbsUInt(), maxInt);
+    EXPECT_EQ(j1["min_int"].asInt(), minInt);
+    EXPECT_EQ(j1["min_int"].asAbsUInt(), static_cast<std::int64_t>(minInt) * -1);
+    EXPECT_EQ(j1["a_uint"].asUInt(), aUInt);
+    EXPECT_EQ(j1["a_uint"].asAbsUInt(), aUInt);
+    EXPECT_GT(j1["a_uint"], aLargeInt);
+    EXPECT_GT(j1["a_uint"], aSmallInt);
+    EXPECT_EQ(j1["a_large_int"].asInt(), aLargeInt);
+    EXPECT_EQ(j1["a_large_int"].asAbsUInt(), aLargeInt);
+    EXPECT_EQ(j1["a_large_int"].asUInt(), aLargeInt);
+    EXPECT_LT(j1["a_large_int"], aUInt);
+    EXPECT_EQ(j1["a_small_int"].asInt(), aSmallInt);
+    EXPECT_EQ(j1["a_small_int"].asAbsUInt(), static_cast<std::int64_t>(aSmallInt) * -1);
+    EXPECT_LT(j1["a_small_int"], aUInt);
+}
+
+TEST(json_value, rejects_an_unsigned_value_one_past_the_maximum)
+{
+    std::uint32_t const maxUInt = std::numeric_limits<std::uint32_t>::max();
 
     std::uint64_t const overflow = std::uint64_t(maxUInt) + 1;
-    {
-        std::string json = "{\"overflow\":";
-        json += std::to_string(overflow);
-        json += "}";
 
-        json::Value j2;
-        json::Reader r2;
+    std::string json = "{\"overflow\":";
+    json += std::to_string(overflow);
+    json += "}";
 
-        EXPECT_FALSE(r2.parse(json, j2));
-    }
+    json::Value j2;
+    json::Reader r2;
+
+    EXPECT_FALSE(r2.parse(json, j2));
+}
+
+TEST(json_value, rejects_a_signed_value_one_below_the_minimum)
+{
+    std::int32_t const minInt = std::numeric_limits<std::int32_t>::min();
 
     std::int64_t const underflow = std::int64_t(minInt) - 1;
-    {
-        std::string json = "{\"underflow\":";
-        json += std::to_string(underflow);
-        json += "}";
 
-        json::Value j3;
-        json::Reader r3;
+    std::string json = "{\"underflow\":";
+    json += std::to_string(underflow);
+    json += "}";
 
-        EXPECT_FALSE(r3.parse(json, j3));
-    }
+    json::Value j3;
+    json::Reader r3;
 
-    {
-        json::Value intString{std::to_string(overflow)};
-        EXPECT_THROW([&] { return intString.asUInt(); }(), beast::BadLexicalCast);
-        EXPECT_THROW([&] { return intString.asAbsUInt(); }(), json::Error);
+    EXPECT_FALSE(r3.parse(json, j3));
+}
 
-        intString = "4294967295";
-        EXPECT_EQ(intString.asUInt(), 4294967295u);
-        EXPECT_EQ(intString.asAbsUInt(), 4294967295u);
+TEST(json_value, converting_a_string_valued_json_number)
+{
+    std::uint32_t const maxUInt = std::numeric_limits<std::uint32_t>::max();
 
-        intString = "0";
-        EXPECT_EQ(intString.asUInt(), 0);
-        EXPECT_EQ(intString.asAbsUInt(), 0);
+    std::uint64_t const overflow = std::uint64_t(maxUInt) + 1;
 
-        intString = "-1";
-        EXPECT_THROW([&] { return intString.asUInt(); }(), beast::BadLexicalCast);
-        EXPECT_EQ(intString.asAbsUInt(), 1);
+    json::Value intString{std::to_string(overflow)};
+    EXPECT_THROW([&] { return intString.asUInt(); }(), beast::BadLexicalCast);
+    EXPECT_THROW([&] { return intString.asAbsUInt(); }(), json::Error);
 
-        intString = "-4294967295";
-        EXPECT_EQ(intString.asAbsUInt(), 4294967295);
+    intString = "4294967295";
+    EXPECT_EQ(intString.asUInt(), 4294967295u);
+    EXPECT_EQ(intString.asAbsUInt(), 4294967295u);
 
-        intString = "-4294967296";
-        EXPECT_THROW([&] { return intString.asAbsUInt(); }(), json::Error);
+    intString = "0";
+    EXPECT_EQ(intString.asUInt(), 0);
+    EXPECT_EQ(intString.asAbsUInt(), 0);
 
-        intString = "2147483648";
-        EXPECT_THROW([&] { return intString.asInt(); }(), beast::BadLexicalCast);
-        EXPECT_EQ(intString.asAbsUInt(), 2147483648);
+    intString = "-1";
+    EXPECT_THROW([&] { return intString.asUInt(); }(), beast::BadLexicalCast);
+    EXPECT_EQ(intString.asAbsUInt(), 1);
 
-        intString = "2147483647";
-        EXPECT_EQ(intString.asInt(), 2147483647);
-        EXPECT_EQ(intString.asAbsUInt(), 2147483647);
+    intString = "-4294967295";
+    EXPECT_EQ(intString.asAbsUInt(), 4294967295);
 
-        intString = "-2147483648";
-        EXPECT_EQ(intString.asInt(), -2147483648LL);  // MSVC wants the LL
-        EXPECT_EQ(intString.asAbsUInt(), 2147483648LL);
+    intString = "-4294967296";
+    EXPECT_THROW([&] { return intString.asAbsUInt(); }(), json::Error);
 
-        intString = "-2147483649";
-        EXPECT_THROW([&] { return intString.asInt(); }(), beast::BadLexicalCast);
-        EXPECT_EQ(intString.asAbsUInt(), 2147483649);
-    }
+    intString = "2147483648";
+    EXPECT_THROW([&] { return intString.asInt(); }(), beast::BadLexicalCast);
+    EXPECT_EQ(intString.asAbsUInt(), 2147483648);
 
-    {
-        json::Value intReal{4294967297.0};
-        EXPECT_THROW([&] { return intReal.asUInt(); }(), json::Error);
-        EXPECT_THROW([&] { return intReal.asAbsUInt(); }(), json::Error);
+    intString = "2147483647";
+    EXPECT_EQ(intString.asInt(), 2147483647);
+    EXPECT_EQ(intString.asAbsUInt(), 2147483647);
 
-        intReal = 4294967295.0;
-        EXPECT_EQ(intReal.asUInt(), 4294967295u);
-        EXPECT_EQ(intReal.asAbsUInt(), 4294967295u);
+    intString = "-2147483648";
+    EXPECT_EQ(intString.asInt(), -2147483648LL);  // MSVC wants the LL
+    EXPECT_EQ(intString.asAbsUInt(), 2147483648LL);
 
-        intReal = 0.0;
-        EXPECT_EQ(intReal.asUInt(), 0);
-        EXPECT_EQ(intReal.asAbsUInt(), 0);
+    intString = "-2147483649";
+    EXPECT_THROW([&] { return intString.asInt(); }(), beast::BadLexicalCast);
+    EXPECT_EQ(intString.asAbsUInt(), 2147483649);
+}
 
-        intReal = -1.0;
-        EXPECT_THROW([&] { return intReal.asUInt(); }(), json::Error);
-        EXPECT_EQ(intReal.asAbsUInt(), 1);
+TEST(json_value, converting_a_real_valued_json_number)
+{
+    json::Value intReal{4294967297.0};
+    EXPECT_THROW([&] { return intReal.asUInt(); }(), json::Error);
+    EXPECT_THROW([&] { return intReal.asAbsUInt(); }(), json::Error);
 
-        intReal = -4294967295.0;
-        EXPECT_EQ(intReal.asAbsUInt(), 4294967295);
+    intReal = 4294967295.0;
+    EXPECT_EQ(intReal.asUInt(), 4294967295u);
+    EXPECT_EQ(intReal.asAbsUInt(), 4294967295u);
 
-        intReal = -4294967296.0;
-        EXPECT_THROW([&] { return intReal.asAbsUInt(); }(), json::Error);
+    intReal = 0.0;
+    EXPECT_EQ(intReal.asUInt(), 0);
+    EXPECT_EQ(intReal.asAbsUInt(), 0);
 
-        intReal = 2147483648.0;
-        EXPECT_THROW([&] { return intReal.asInt(); }(), json::Error);
-        EXPECT_EQ(intReal.asAbsUInt(), 2147483648);
+    intReal = -1.0;
+    EXPECT_THROW([&] { return intReal.asUInt(); }(), json::Error);
+    EXPECT_EQ(intReal.asAbsUInt(), 1);
 
-        intReal = 2147483647.0;
-        EXPECT_EQ(intReal.asInt(), 2147483647);
-        EXPECT_EQ(intReal.asAbsUInt(), 2147483647);
+    intReal = -4294967295.0;
+    EXPECT_EQ(intReal.asAbsUInt(), 4294967295);
 
-        intReal = -2147483648.0;
-        EXPECT_EQ(intReal.asInt(), -2147483648LL);  // MSVC wants the LL
-        EXPECT_EQ(intReal.asAbsUInt(), 2147483648LL);
+    intReal = -4294967296.0;
+    EXPECT_THROW([&] { return intReal.asAbsUInt(); }(), json::Error);
 
-        intReal = -2147483649.0;
-        EXPECT_THROW([&] { return intReal.asInt(); }(), json::Error);
-        EXPECT_EQ(intReal.asAbsUInt(), 2147483649);
-    }
+    intReal = 2147483648.0;
+    EXPECT_THROW([&] { return intReal.asInt(); }(), json::Error);
+    EXPECT_EQ(intReal.asAbsUInt(), 2147483648);
+
+    intReal = 2147483647.0;
+    EXPECT_EQ(intReal.asInt(), 2147483647);
+    EXPECT_EQ(intReal.asAbsUInt(), 2147483647);
+
+    intReal = -2147483648.0;
+    EXPECT_EQ(intReal.asInt(), -2147483648LL);  // MSVC wants the LL
+    EXPECT_EQ(intReal.asAbsUInt(), 2147483648LL);
+
+    intReal = -2147483649.0;
+    EXPECT_THROW([&] { return intReal.asInt(); }(), json::Error);
+    EXPECT_EQ(intReal.asAbsUInt(), 2147483649);
 }
 
 TEST(json_value, copy)
@@ -909,220 +991,234 @@ TEST(json_value, compact)
     }
 }
 
-TEST(json_value, conversions)
+TEST(json_value, converts_null)
 {
-    // We have json::ValueType::Real but json::Value::asDouble.
-    // TODO: What's the thinking here?
-    {
-        // null
-        json::Value const val;
-        EXPECT_TRUE(val.isNull());
-        // val.asCString() should trigger an assertion failure
-        EXPECT_EQ(val.asString(), "");
-        EXPECT_EQ(val.asInt(), 0);
-        EXPECT_EQ(val.asUInt(), 0);
-        EXPECT_EQ(val.asAbsUInt(), 0);
-        EXPECT_EQ(val.asDouble(), 0.0);
-        EXPECT_FALSE(val.asBool());
+    // null
+    json::Value const val;
+    EXPECT_TRUE(val.isNull());
+    // val.asCString() should trigger an assertion failure
+    EXPECT_EQ(val.asString(), "");
+    EXPECT_EQ(val.asInt(), 0);
+    EXPECT_EQ(val.asUInt(), 0);
+    EXPECT_EQ(val.asAbsUInt(), 0);
+    EXPECT_EQ(val.asDouble(), 0.0);
+    EXPECT_FALSE(val.asBool());
 
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Null));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Int));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::UInt));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Real));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Boolean));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Array));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Object));
-    }
-    {
-        // int
-        json::Value const val = -1234;
-        EXPECT_TRUE(val.isInt());
-        // val.asCString() should trigger an assertion failure
-        EXPECT_EQ(val.asString(), "-1234");
-        EXPECT_EQ(val.asInt(), -1234);
-        EXPECT_THROW([&] { return val.asUInt(); }(), json::Error);
-        EXPECT_EQ(val.asAbsUInt(), 1234u);
-        EXPECT_EQ(val.asDouble(), -1234.0);
-        EXPECT_TRUE(val.asBool());
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Null));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Int));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::UInt));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Real));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Boolean));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Array));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Object));
+}
 
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Null));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Int));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::UInt));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Real));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Boolean));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
-    }
-    {
-        // uint
-        json::Value const val = 1234U;
-        EXPECT_TRUE(val.isUInt());
-        // val.asCString() should trigger an assertion failure
-        EXPECT_EQ(val.asString(), "1234");
-        EXPECT_EQ(val.asInt(), 1234);
-        EXPECT_EQ(val.asUInt(), 1234u);
-        EXPECT_EQ(val.asAbsUInt(), 1234u);
-        EXPECT_EQ(val.asDouble(), 1234.0);
-        EXPECT_TRUE(val.asBool());
+TEST(json_value, converts_int)
+{
+    // int
+    json::Value const val = -1234;
+    EXPECT_TRUE(val.isInt());
+    // val.asCString() should trigger an assertion failure
+    EXPECT_EQ(val.asString(), "-1234");
+    EXPECT_EQ(val.asInt(), -1234);
+    EXPECT_THROW([&] { return val.asUInt(); }(), json::Error);
+    EXPECT_EQ(val.asAbsUInt(), 1234u);
+    EXPECT_EQ(val.asDouble(), -1234.0);
+    EXPECT_TRUE(val.asBool());
 
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Null));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Int));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::UInt));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Real));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Boolean));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
-    }
-    {
-        // real
-        json::Value const val = 2.0;
-        EXPECT_TRUE(val.isDouble());
-        // val.asCString() should trigger an assertion failure
-        EXPECT_TRUE(std::regex_match(val.asString(), std::regex("^2\\.0*$")));
-        EXPECT_EQ(val.asInt(), 2);
-        EXPECT_EQ(val.asUInt(), 2u);
-        EXPECT_EQ(val.asAbsUInt(), 2u);
-        EXPECT_EQ(val.asDouble(), 2.0);
-        EXPECT_TRUE(val.asBool());
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Null));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Int));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::UInt));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Real));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Boolean));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
+}
 
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Null));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Int));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::UInt));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Real));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Boolean));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
-    }
-    {
-        // numeric string
-        json::Value const val = "54321";
-        EXPECT_TRUE(val.isString());
-        EXPECT_EQ(strcmp(val.asCString(), "54321"), 0);
-        EXPECT_EQ(val.asString(), "54321");
-        EXPECT_EQ(val.asInt(), 54321);
-        EXPECT_EQ(val.asUInt(), 54321u);
-        EXPECT_EQ(val.asAbsUInt(), 54321);
-        EXPECT_THROW([&] { return val.asDouble(); }(), json::Error);
-        EXPECT_TRUE(val.asBool());
+TEST(json_value, converts_uint)
+{
+    // uint
+    json::Value const val = 1234U;
+    EXPECT_TRUE(val.isUInt());
+    // val.asCString() should trigger an assertion failure
+    EXPECT_EQ(val.asString(), "1234");
+    EXPECT_EQ(val.asInt(), 1234);
+    EXPECT_EQ(val.asUInt(), 1234u);
+    EXPECT_EQ(val.asAbsUInt(), 1234u);
+    EXPECT_EQ(val.asDouble(), 1234.0);
+    EXPECT_TRUE(val.asBool());
 
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Null));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Int));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::UInt));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Real));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Boolean));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
-    }
-    {
-        // non-numeric string
-        json::Value const val(json::ValueType::String);
-        EXPECT_TRUE(val.isString());
-        EXPECT_EQ(val.asCString(), nullptr);
-        EXPECT_EQ(val.asString(), "");
-        EXPECT_THROW([&] { return val.asInt(); }(), std::exception);
-        EXPECT_THROW([&] { return val.asUInt(); }(), std::exception);
-        EXPECT_THROW([&] { return val.asAbsUInt(); }(), std::exception);
-        EXPECT_THROW([&] { return val.asDouble(); }(), std::exception);
-        EXPECT_TRUE(val.asBool() == false);
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Null));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Int));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::UInt));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Real));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Boolean));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
+}
 
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Null));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Int));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::UInt));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Real));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Boolean));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
-    }
-    {
-        // bool false
-        json::Value const val = false;
-        EXPECT_TRUE(val.isBool());
-        // val.asCString() should trigger an assertion failure
-        EXPECT_EQ(val.asString(), "false");
-        EXPECT_EQ(val.asInt(), 0);
-        EXPECT_EQ(val.asUInt(), 0);
-        EXPECT_EQ(val.asAbsUInt(), 0);
-        EXPECT_EQ(val.asDouble(), 0.0);
-        EXPECT_FALSE(val.asBool());
+TEST(json_value, converts_real)
+{
+    // real
+    json::Value const val = 2.0;
+    EXPECT_TRUE(val.isDouble());
+    // val.asCString() should trigger an assertion failure
+    EXPECT_TRUE(std::regex_match(val.asString(), std::regex("^2\\.0*$")));
+    EXPECT_EQ(val.asInt(), 2);
+    EXPECT_EQ(val.asUInt(), 2u);
+    EXPECT_EQ(val.asAbsUInt(), 2u);
+    EXPECT_EQ(val.asDouble(), 2.0);
+    EXPECT_TRUE(val.asBool());
 
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Null));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Int));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::UInt));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Real));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Boolean));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
-    }
-    {
-        // bool true
-        json::Value const val = true;
-        EXPECT_TRUE(val.isBool());
-        // val.asCString() should trigger an assertion failure
-        EXPECT_EQ(val.asString(), "true");
-        EXPECT_EQ(val.asInt(), 1);
-        EXPECT_EQ(val.asUInt(), 1);
-        EXPECT_EQ(val.asAbsUInt(), 1);
-        EXPECT_EQ(val.asDouble(), 1.0);
-        EXPECT_TRUE(val.asBool());
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Null));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Int));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::UInt));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Real));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Boolean));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
+}
 
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Null));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Int));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::UInt));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Real));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Boolean));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
-    }
-    {
-        // array type
-        json::Value const val(json::ValueType::Array);
-        EXPECT_TRUE(val.isArray());
-        // val.asCString should trigger an assertion failure
-        EXPECT_THROW([&] { return val.asString(); }(), json::Error);
-        EXPECT_THROW([&] { return val.asInt(); }(), json::Error);
-        EXPECT_THROW([&] { return val.asUInt(); }(), json::Error);
-        EXPECT_THROW([&] { return val.asAbsUInt(); }(), json::Error);
-        EXPECT_THROW([&] { return val.asDouble(); }(), json::Error);
-        EXPECT_FALSE(val.asBool());  // empty or not
+TEST(json_value, converts_numeric_string)
+{
+    // numeric string
+    json::Value const val = "54321";
+    EXPECT_TRUE(val.isString());
+    EXPECT_EQ(strcmp(val.asCString(), "54321"), 0);
+    EXPECT_EQ(val.asString(), "54321");
+    EXPECT_EQ(val.asInt(), 54321);
+    EXPECT_EQ(val.asUInt(), 54321u);
+    EXPECT_EQ(val.asAbsUInt(), 54321);
+    EXPECT_THROW([&] { return val.asDouble(); }(), json::Error);
+    EXPECT_TRUE(val.asBool());
 
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Null));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Int));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::UInt));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Real));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::String));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Boolean));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Array));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
-    }
-    {
-        // object type
-        json::Value const val(json::ValueType::Object);
-        EXPECT_TRUE(val.isObject());
-        // val.asCString should trigger an assertion failure
-        EXPECT_THROW([&] { return val.asString(); }(), json::Error);
-        EXPECT_THROW([&] { return val.asInt(); }(), json::Error);
-        EXPECT_THROW([&] { return val.asUInt(); }(), json::Error);
-        EXPECT_THROW([&] { return val.asAbsUInt(); }(), json::Error);
-        EXPECT_THROW([&] { return val.asDouble(); }(), json::Error);
-        EXPECT_FALSE(val.asBool());  // empty or not
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Null));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Int));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::UInt));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Real));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Boolean));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
+}
 
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Null));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Int));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::UInt));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Real));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::String));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Boolean));
-        EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
-        EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Object));
-    }
+TEST(json_value, converts_non_numeric_string)
+{
+    // non-numeric string
+    json::Value const val(json::ValueType::String);
+    EXPECT_TRUE(val.isString());
+    EXPECT_EQ(val.asCString(), nullptr);
+    EXPECT_EQ(val.asString(), "");
+    EXPECT_THROW([&] { return val.asInt(); }(), std::exception);
+    EXPECT_THROW([&] { return val.asUInt(); }(), std::exception);
+    EXPECT_THROW([&] { return val.asAbsUInt(); }(), std::exception);
+    EXPECT_THROW([&] { return val.asDouble(); }(), std::exception);
+    EXPECT_TRUE(val.asBool() == false);
+
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Null));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Int));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::UInt));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Real));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Boolean));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
+}
+
+TEST(json_value, converts_bool_false)
+{
+    // bool false
+    json::Value const val = false;
+    EXPECT_TRUE(val.isBool());
+    // val.asCString() should trigger an assertion failure
+    EXPECT_EQ(val.asString(), "false");
+    EXPECT_EQ(val.asInt(), 0);
+    EXPECT_EQ(val.asUInt(), 0);
+    EXPECT_EQ(val.asAbsUInt(), 0);
+    EXPECT_EQ(val.asDouble(), 0.0);
+    EXPECT_FALSE(val.asBool());
+
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Null));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Int));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::UInt));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Real));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Boolean));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
+}
+
+TEST(json_value, converts_bool_true)
+{
+    // bool true
+    json::Value const val = true;
+    EXPECT_TRUE(val.isBool());
+    // val.asCString() should trigger an assertion failure
+    EXPECT_EQ(val.asString(), "true");
+    EXPECT_EQ(val.asInt(), 1);
+    EXPECT_EQ(val.asUInt(), 1);
+    EXPECT_EQ(val.asAbsUInt(), 1);
+    EXPECT_EQ(val.asDouble(), 1.0);
+    EXPECT_TRUE(val.asBool());
+
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Null));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Int));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::UInt));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Real));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::String));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Boolean));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
+}
+
+TEST(json_value, converts_array_type)
+{
+    // array type
+    json::Value const val(json::ValueType::Array);
+    EXPECT_TRUE(val.isArray());
+    // val.asCString should trigger an assertion failure
+    EXPECT_THROW([&] { return val.asString(); }(), json::Error);
+    EXPECT_THROW([&] { return val.asInt(); }(), json::Error);
+    EXPECT_THROW([&] { return val.asUInt(); }(), json::Error);
+    EXPECT_THROW([&] { return val.asAbsUInt(); }(), json::Error);
+    EXPECT_THROW([&] { return val.asDouble(); }(), json::Error);
+    EXPECT_FALSE(val.asBool());  // empty or not
+
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Null));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Int));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::UInt));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Real));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::String));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Boolean));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Array));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Object));
+}
+
+TEST(json_value, converts_object_type)
+{
+    // object type
+    json::Value const val(json::ValueType::Object);
+    EXPECT_TRUE(val.isObject());
+    // val.asCString should trigger an assertion failure
+    EXPECT_THROW([&] { return val.asString(); }(), json::Error);
+    EXPECT_THROW([&] { return val.asInt(); }(), json::Error);
+    EXPECT_THROW([&] { return val.asUInt(); }(), json::Error);
+    EXPECT_THROW([&] { return val.asAbsUInt(); }(), json::Error);
+    EXPECT_THROW([&] { return val.asDouble(); }(), json::Error);
+    EXPECT_FALSE(val.asBool());  // empty or not
+
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Null));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Int));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::UInt));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Real));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::String));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Boolean));
+    EXPECT_FALSE(val.isConvertibleTo(json::ValueType::Array));
+    EXPECT_TRUE(val.isConvertibleTo(json::ValueType::Object));
 }
 
 TEST(json_value, access_members)

--- a/src/tests/libxrpl/shamap/SHAMap.cpp
+++ b/src/tests/libxrpl/shamap/SHAMap.cpp
@@ -115,28 +115,36 @@ protected:
         vuc.fill(v);
         return vuc;
     }
-};
-
-TEST_P(SHAMapTest, add_traverse_snapshot_build_tear_and_iterate)
-{
-    auto const testMode = GetParam();
-    tests::TestNodeFamily f{j_};
 
     // kH3 and kH4 differ only in the leaf, same terminal node (level 19)
-    constexpr uint256 kH1("092891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7");
-    constexpr uint256 kH2("436ccbac3347baa1f1e53baeef1f43334da88f1f6d70d963b833afd6dfa289fe");
-    constexpr uint256 kH3("b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
-    constexpr uint256 kH4("b92891fe4ef6cee585fdc6fda2e09eb4d386363158ec3321b8123e5a772c6ca8");
+    static constexpr uint256 kH1{
+        "092891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7"};
+    static constexpr uint256 kH2{
+        "436ccbac3347baa1f1e53baeef1f43334da88f1f6d70d963b833afd6dfa289fe"};
+    static constexpr uint256 kH3{
+        "b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"};
+    static constexpr uint256 kH4{
+        "b92891fe4ef6cee585fdc6fda2e09eb4d386363158ec3321b8123e5a772c6ca8"};
 
+    // SHAMap is neither copyable nor movable, so the map is configured in
+    // place rather than returned.
+    static void
+    applyBackingMode(SHAMap& map)
+    {
+        map.invariants();
+        if (!GetParam().backed)
+            map.setUnbacked();
+    }
+};
+
+TEST_P(SHAMapTest, add_and_traverse_in_key_order)
+{
+    tests::TestNodeFamily f{j_};
     SHAMap sMap{SHAMapType::FREE, f};
-    sMap.invariants();
-    if (!testMode.backed)
-        sMap.setUnbacked();
+    applyBackingMode(sMap);
 
     auto i1 = makeShamapitem(kH1, intToVuc(1));
     auto i2 = makeShamapitem(kH2, intToVuc(2));
-    auto i3 = makeShamapitem(kH3, intToVuc(3));
-    auto i4 = makeShamapitem(kH4, intToVuc(4));
 
     EXPECT_TRUE(sMap.addItem(SHAMapNodeType::TnTransactionNm, makeShamapitem(*i2))) << "no add";
     sMap.invariants();
@@ -150,14 +158,30 @@ TEST_P(SHAMapTest, add_traverse_snapshot_build_tear_and_iterate)
     EXPECT_FALSE(i == e || (*i != *i2)) << "bad traverse";
     ++i;
     EXPECT_EQ(i, e) << "bad traverse";
+}
+
+TEST_P(SHAMapTest, traverse_after_add_and_delete)
+{
+    tests::TestNodeFamily f{j_};
+    SHAMap sMap{SHAMapType::FREE, f};
+    applyBackingMode(sMap);
+
+    auto i1 = makeShamapitem(kH1, intToVuc(1));
+    auto i2 = makeShamapitem(kH2, intToVuc(2));
+    auto i3 = makeShamapitem(kH3, intToVuc(3));
+    auto i4 = makeShamapitem(kH4, intToVuc(4));
+
+    sMap.addItem(SHAMapNodeType::TnTransactionNm, makeShamapitem(*i2));
+    sMap.addItem(SHAMapNodeType::TnTransactionNm, makeShamapitem(*i1));
     sMap.addItem(SHAMapNodeType::TnTransactionNm, makeShamapitem(*i4));
     sMap.invariants();
     sMap.delItem(i2->key());
     sMap.invariants();
     sMap.addItem(SHAMapNodeType::TnTransactionNm, makeShamapitem(*i3));
     sMap.invariants();
-    i = sMap.begin();
-    e = sMap.end();
+
+    auto i = sMap.begin();
+    auto e = sMap.end();
     EXPECT_FALSE(i == e || (*i != *i1)) << "bad traverse";
     ++i;
     EXPECT_FALSE(i == e || (*i != *i3)) << "bad traverse";
@@ -165,6 +189,21 @@ TEST_P(SHAMapTest, add_traverse_snapshot_build_tear_and_iterate)
     EXPECT_FALSE(i == e || (*i != *i4)) << "bad traverse";
     ++i;
     EXPECT_EQ(i, e) << "bad traverse";
+}
+
+TEST_P(SHAMapTest, a_snapshot_is_unaffected_by_later_edits)
+{
+    tests::TestNodeFamily f{j_};
+    SHAMap sMap{SHAMapType::FREE, f};
+    applyBackingMode(sMap);
+
+    auto i1 = makeShamapitem(kH1, intToVuc(1));
+    auto i3 = makeShamapitem(kH3, intToVuc(3));
+    auto i4 = makeShamapitem(kH4, intToVuc(4));
+    sMap.addItem(SHAMapNodeType::TnTransactionNm, makeShamapitem(*i1));
+    sMap.addItem(SHAMapNodeType::TnTransactionNm, makeShamapitem(*i3));
+    sMap.addItem(SHAMapNodeType::TnTransactionNm, makeShamapitem(*i4));
+    sMap.invariants();
 
     SHAMapHash const mapHash = sMap.getHash();
     std::shared_ptr<SHAMap> const map2 = sMap.snapShot(false);
@@ -189,77 +228,82 @@ TEST_P(SHAMapTest, add_traverse_snapshot_build_tear_and_iterate)
     EXPECT_EQ(delta.begin()->second.second->key(), kH1);
 
     sMap.dump();
+}
+
+TEST_P(SHAMapTest, the_hash_after_each_add_is_undone_by_the_matching_delete)
+{
+    constexpr std::array kKeys{
+        uint256{"b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"b92881fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"b92691fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"b92791fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"b91891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"b99891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"f22891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"292891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+    };
+
+    constexpr std::array kHashes{
+        uint256{"B7387CFEA0465759ADC718E8C42B52D2309D179B326E239EB5075C64B6281F7F"},
+        uint256{"FBC195A9592A54AB44010274163CB6BA95F497EC5BA0A8831845467FB2ECE266"},
+        uint256{"4E7D2684B65DFD48937FFB775E20175C43AF0C94066F7D5679F51AE756795B75"},
+        uint256{"7A2F312EB203695FFD164E038E281839EEF06A1B99BFC263F3CECC6C74F93E07"},
+        uint256{"395A6691A372387A703FB0F2C6D2C405DAF307D0817F8F0E207596462B0E3A3E"},
+        uint256{"D044C0A696DE3169CC70AE216A1564D69DE96582865796142CE7D98A84D9DDE4"},
+        uint256{"76DCC77C4027309B5A91AD164083264D70B77B5E43E08AEDA5EBF94361143615"},
+        uint256{"DF4220E93ADC6F5569063A01B4DC79F8DB9553B6A3222ADE23DEA02BBE7230E5"},
+    };
+
+    tests::TestNodeFamily f{j_};
+    SHAMap map{SHAMapType::FREE, f};
+    applyBackingMode(map);
+
+    EXPECT_EQ(map.getHash(), beast::kZero);
+    for (std::size_t k = 0; k < kKeys.size(); ++k)
     {
-        constexpr std::array kKeys{
-            uint256{"b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"b92881fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"b92691fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"b92791fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"b91891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"b99891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"f22891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"292891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-        };
-
-        constexpr std::array kHashes{
-            uint256{"B7387CFEA0465759ADC718E8C42B52D2309D179B326E239EB5075C64B6281F7F"},
-            uint256{"FBC195A9592A54AB44010274163CB6BA95F497EC5BA0A8831845467FB2ECE266"},
-            uint256{"4E7D2684B65DFD48937FFB775E20175C43AF0C94066F7D5679F51AE756795B75"},
-            uint256{"7A2F312EB203695FFD164E038E281839EEF06A1B99BFC263F3CECC6C74F93E07"},
-            uint256{"395A6691A372387A703FB0F2C6D2C405DAF307D0817F8F0E207596462B0E3A3E"},
-            uint256{"D044C0A696DE3169CC70AE216A1564D69DE96582865796142CE7D98A84D9DDE4"},
-            uint256{"76DCC77C4027309B5A91AD164083264D70B77B5E43E08AEDA5EBF94361143615"},
-            uint256{"DF4220E93ADC6F5569063A01B4DC79F8DB9553B6A3222ADE23DEA02BBE7230E5"},
-        };
-
-        SHAMap map{SHAMapType::FREE, f};
-        if (!testMode.backed)
-            map.setUnbacked();
-
-        EXPECT_EQ(map.getHash(), beast::kZero);
-        for (std::size_t k = 0; k < kKeys.size(); ++k)
-        {
-            EXPECT_TRUE(map.addItem(
-                SHAMapNodeType::TnTransactionNm,
-                makeShamapitem(kKeys[k], intToVuc(static_cast<std::uint8_t>(k)))));
-            EXPECT_EQ(map.getHash().asUInt256(), kHashes[k]);
-            map.invariants();
-        }
-        for (std::size_t k = kKeys.size(); k-- > 0;)
-        {
-            EXPECT_EQ(map.getHash().asUInt256(), kHashes[k]);
-            EXPECT_TRUE(map.delItem(kKeys[k]));
-            map.invariants();
-        }
-        EXPECT_EQ(map.getHash(), beast::kZero);
+        EXPECT_TRUE(map.addItem(
+            SHAMapNodeType::TnTransactionNm,
+            makeShamapitem(kKeys[k], intToVuc(static_cast<std::uint8_t>(k)))));
+        EXPECT_EQ(map.getHash().asUInt256(), kHashes[k]);
+        map.invariants();
     }
 
+    // Removing the items in reverse must walk back through the same hashes.
+    for (std::size_t k = kKeys.size(); k-- > 0;)
     {
-        constexpr std::array kKeys{
-            uint256{"f22891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"b99891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"b92881fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"b92791fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"b92691fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"b91891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-            uint256{"292891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
-        };
-
-        tests::TestNodeFamily tf{j_};
-        SHAMap map{SHAMapType::FREE, tf};
-        if (!testMode.backed)
-            map.setUnbacked();
-        for (auto const& k : kKeys)
-        {
-            map.addItem(SHAMapNodeType::TnTransactionNm, makeShamapitem(k, intToVuc(0)));
-            map.invariants();
-        }
-
-        auto keyIndex = kKeys.size();
-        for (auto const& k : map)
-            EXPECT_EQ(k.key(), kKeys[--keyIndex]);
+        EXPECT_EQ(map.getHash().asUInt256(), kHashes[k]);
+        EXPECT_TRUE(map.delItem(kKeys[k]));
+        map.invariants();
     }
+    EXPECT_EQ(map.getHash(), beast::kZero);
+}
+
+TEST_P(SHAMapTest, iteration_yields_keys_in_ascending_order)
+{
+    // Listed in descending order, so iteration must reverse them.
+    constexpr std::array kKeys{
+        uint256{"f22891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"b99891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"b92881fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"b92791fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"b92691fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"b91891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+        uint256{"292891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8"},
+    };
+
+    tests::TestNodeFamily tf{j_};
+    SHAMap map{SHAMapType::FREE, tf};
+    applyBackingMode(map);
+    for (auto const& k : kKeys)
+    {
+        map.addItem(SHAMapNodeType::TnTransactionNm, makeShamapitem(k, intToVuc(0)));
+        map.invariants();
+    }
+
+    auto keyIndex = kKeys.size();
+    for (auto const& k : map)
+        EXPECT_EQ(k.key(), kKeys[--keyIndex]);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
## High Level Overview of Change

Follow up to previous gtest work - split multiple-in-one tests into individual test cases.
All test case names touched by this PR unified to snake_case.

### Context of Change

Gtest migration.

### API Impact

N/A