### PR TITLE
style: Precommit hook for gtest naming

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         language: python
         types_or: [c++, c]
       - id: fix-gtest-names
-        name: fix gtest test-case names to snake_case
+        name: "fix gtest names: CamelCase suite, snake_case test case"
         entry: ./bin/pre-commit/fix_gtest_names.py
         language: python
         additional_dependencies: [inflection==0.5.1]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,12 @@ repos:
         entry: ./bin/pre-commit/check_doxygen_style.py
         language: python
         types_or: [c++, c]
+      - id: fix-gtest-names
+        name: fix gtest test-case names to snake_case
+        entry: ./bin/pre-commit/fix_gtest_names.py
+        language: python
+        additional_dependencies: [inflection==0.5.1]
+        types_or: [c++, c]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: f4d7745e17a28aad7eed2f4874ca8d1568c11c4c # frozen: v22.1.8

--- a/bin/pre-commit/fix_gtest_names.py
+++ b/bin/pre-commit/fix_gtest_names.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+"""
+Rewrites gtest test-case names to snake_case, which is the required style in
+this project.
+
+Only the test-case name (the second macro argument) is touched: the first names
+a fixture class or mirrors the type under test, so it follows the project's
+type-naming style instead. The gtest `DISABLED_` prefix is kept verbatim.
+
+Names are converted with `inflection`, which folds acronyms the way a reader
+expects: `SetAndResetAccountTxnID` -> `set_and_reset_account_txn_id`, not
+`set_and_reset_account_txn_i_d`.
+
+Usage: ./bin/pre-commit/fix_gtest_names.py <file1> <file2> ...
+"""
+
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+import inflection
+
+# A test-case definition, `MACRO(SuiteOrFixture, TestName)`, anchored at the
+# start of a line so that commented-out definitions and project macros that
+# merely look similar (`TEST_EXPECT(...)`) are left alone. The `\s*` between
+# arguments allows for a definition clang-format wrapped over several lines.
+PATTERN = re.compile(
+    r"(?P<head>^[ \t]*(?:TEST|TEST_F|TEST_P|TYPED_TEST|TYPED_TEST_P)\s*\(\s*"
+    r"(?P<suite>\w+)\s*,\s*)(?P<name>\w+)(?P<tail>\s*\))",
+    re.MULTILINE,
+)
+
+DISABLED = "DISABLED_"
+
+
+def convert(name: str) -> str:
+    """Returns the name in snake_case, keeping any `DISABLED_` prefix."""
+    prefix = DISABLED if name.startswith(DISABLED) else ""
+    return prefix + inflection.underscore(name[len(prefix) :])
+
+
+def fix_source(text: str) -> tuple[str, list[str]]:
+    """Returns the corrected text and one `line: message` report per bad name."""
+    # gtest joins the suite and test names into one class name, so two test
+    # cases whose joined names agree cannot coexist: `TEST(a, b_c)` and
+    # `TEST(a_b, c)` both define `a_b_c_Test`. A rename that would introduce
+    # such a clash is reported for a human instead of applied.
+    joined = Counter(
+        f"{m['suite']}_{convert(m['name'])}" for m in PATTERN.finditer(text)
+    )
+    reports = []
+
+    def rewrite(match: re.Match) -> str:
+        old = match["name"]
+        new = convert(old)
+        if new == old:
+            return match[0]
+        line = text.count("\n", 0, match.start()) + 1
+        if joined[f"{match['suite']}_{new}"] > 1:
+            reports.append(
+                f"{line}: cannot rename '{old}' to '{new}': another test case in "
+                f"suite '{match['suite']}' already generates that name"
+            )
+            return match[0]
+        reports.append(f"{line}: renamed '{old}' to '{new}'")
+        return match["head"] + new + match["tail"]
+
+    return PATTERN.sub(rewrite, text), reports
+
+
+def fix_names(path: Path) -> bool:
+    """Corrects one file's test-case names, reporting each on stdout."""
+    original = path.read_text(encoding="utf-8")
+    fixed, reports = fix_source(original)
+    for report in reports:
+        print(f"{path}:{report}")
+    if fixed != original:
+        path.write_text(fixed, encoding="utf-8")
+    return not reports
+
+
+def main() -> int:
+    files = [Path(f) for f in sys.argv[1:]]
+    success = True
+
+    for path in files:
+        success &= fix_names(path)
+
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/pre-commit/fix_gtest_names.py
+++ b/bin/pre-commit/fix_gtest_names.py
@@ -1,16 +1,21 @@
 #!/usr/bin/env python3
 
 """
-Rewrites gtest test-case names to snake_case, which is the required style in
-this project.
+Rewrites gtest names to the required style in this project: the suite name is
+CamelCase, the test-case name is snake_case.
 
-Only the test-case name (the second macro argument) is touched: the first names
-a fixture class or mirrors the type under test, so it follows the project's
-type-naming style instead. The gtest `DISABLED_` prefix is kept verbatim.
+    TEST(SuiteName, test_case_name)
 
-Names are converted with `inflection`, which folds acronyms the way a reader
-expects: `SetAndResetAccountTxnID` -> `set_and_reset_account_txn_id`, not
+The gtest `DISABLED_` prefix is kept verbatim on either name.
+
+Test-case names are converted with `inflection`, which folds acronyms the way a
+reader expects: `SetAndResetAccountTxnID` -> `set_and_reset_account_txn_id`, not
 `set_and_reset_account_txn_i_d`.
+
+The first argument of `TEST_F`, `TEST_P`, `TYPED_TEST` and `TYPED_TEST_P` is a
+fixture class rather than a free identifier, so rewriting it here would leave
+the class it names behind. Those are reported for a human to rename (clang-tidy
+checks the class declaration itself, via readability-identifier-naming).
 
 Usage: ./bin/pre-commit/fix_gtest_names.py <file1> <file2> ...
 """
@@ -27,18 +32,49 @@ import inflection
 # merely look similar (`TEST_EXPECT(...)`) are left alone. The `\s*` between
 # arguments allows for a definition clang-format wrapped over several lines.
 PATTERN = re.compile(
-    r"(?P<head>^[ \t]*(?:TEST|TEST_F|TEST_P|TYPED_TEST|TYPED_TEST_P)\s*\(\s*"
-    r"(?P<suite>\w+)\s*,\s*)(?P<name>\w+)(?P<tail>\s*\))",
+    r"(?P<head>^[ \t]*(?P<macro>TYPED_TEST_P|TYPED_TEST|TEST_F|TEST_P|TEST)\s*\(\s*)"
+    r"(?P<suite>\w+)(?P<mid>\s*,\s*)(?P<name>\w+)(?P<tail>\s*\))",
     re.MULTILINE,
 )
+
+# The macros whose first argument names a fixture class, not a free identifier.
+FIXTURE_MACROS = ("TEST_F", "TEST_P", "TYPED_TEST", "TYPED_TEST_P")
 
 DISABLED = "DISABLED_"
 
 
-def convert(name: str) -> str:
-    """Returns the name in snake_case, keeping any `DISABLED_` prefix."""
-    prefix = DISABLED if name.startswith(DISABLED) else ""
-    return prefix + inflection.underscore(name[len(prefix) :])
+def _split_disabled(name: str) -> tuple[str, str]:
+    """Splits off gtest's `DISABLED_` prefix, which is kept verbatim."""
+    if name.startswith(DISABLED):
+        return DISABLED, name[len(DISABLED) :]
+    return "", name
+
+
+def snake_case(name: str) -> str:
+    """Returns the name in snake_case."""
+    prefix, core = _split_disabled(name)
+    return prefix + inflection.underscore(core)
+
+
+def camel_case(name: str) -> str:
+    """Returns the name in CamelCase, capitalizing each underscored word.
+
+    Only the letters that have to change are touched, so acronyms survive:
+    `inflection.camelize` would turn `SHAMapTest` into `ShaMapTest`, whereas
+    here it is already CamelCase and stays put. `json_value` -> `JsonValue`,
+    `parseStatmRSSkB` -> `ParseStatmRSSkB`.
+    """
+    prefix, core = _split_disabled(name)
+    return prefix + "".join(w[:1].upper() + w[1:] for w in core.split("_") if w)
+
+
+def _corrected(match: re.Match) -> tuple[str, str]:
+    """Returns the suite and test-case names this definition should end up with."""
+    suite = match["suite"]
+    return (
+        suite if match["macro"] in FIXTURE_MACROS else camel_case(suite),
+        snake_case(match["name"]),
+    )
 
 
 def fix_source(text: str) -> tuple[str, list[str]]:
@@ -47,31 +83,38 @@ def fix_source(text: str) -> tuple[str, list[str]]:
     # cases whose joined names agree cannot coexist: `TEST(a, b_c)` and
     # `TEST(a_b, c)` both define `a_b_c_Test`. A rename that would introduce
     # such a clash is reported for a human instead of applied.
-    joined = Counter(
-        f"{m['suite']}_{convert(m['name'])}" for m in PATTERN.finditer(text)
-    )
+    joined = Counter("_".join(_corrected(m)) for m in PATTERN.finditer(text))
     reports = []
 
     def rewrite(match: re.Match) -> str:
-        old = match["name"]
-        new = convert(old)
-        if new == old:
-            return match[0]
+        suite, name = match["suite"], match["name"]
+        new_suite, new_name = _corrected(match)
         line = text.count("\n", 0, match.start()) + 1
-        if joined[f"{match['suite']}_{new}"] > 1:
+
+        if match["macro"] in FIXTURE_MACROS and camel_case(suite) != suite:
             reports.append(
-                f"{line}: cannot rename '{old}' to '{new}': another test case in "
-                f"suite '{match['suite']}' already generates that name"
+                f"{line}: fixture '{suite}' is not CamelCase: rename the class "
+                f"to '{camel_case(suite)}' by hand"
+            )
+        if (new_suite, new_name) == (suite, name):
+            return match[0]
+        if joined[f"{new_suite}_{new_name}"] > 1:
+            reports.append(
+                f"{line}: cannot rename '{suite}, {name}' to '{new_suite}, "
+                f"{new_name}': another test case already generates that name"
             )
             return match[0]
-        reports.append(f"{line}: renamed '{old}' to '{new}'")
-        return match["head"] + new + match["tail"]
+        if new_suite != suite:
+            reports.append(f"{line}: renamed suite '{suite}' to '{new_suite}'")
+        if new_name != name:
+            reports.append(f"{line}: renamed test case '{name}' to '{new_name}'")
+        return match["head"] + new_suite + match["mid"] + new_name + match["tail"]
 
     return PATTERN.sub(rewrite, text), reports
 
 
 def fix_names(path: Path) -> bool:
-    """Corrects one file's test-case names, reporting each on stdout."""
+    """Corrects one file's gtest names, reporting each on stdout."""
     original = path.read_text(encoding="utf-8")
     fixed, reports = fix_source(original)
     for report in reports:

--- a/bin/pre-commit/test_fix_gtest_names.py
+++ b/bin/pre-commit/test_fix_gtest_names.py
@@ -11,7 +11,7 @@ or under pytest:
 import sys
 import textwrap
 
-from fix_gtest_names import convert, fix_source
+from fix_gtest_names import camel_case, fix_source, snake_case
 
 
 def dedent(text: str) -> str:
@@ -35,22 +35,39 @@ def reports(text: str) -> list[str]:
 
 
 def test_snake_case_conversion() -> None:
-    assert convert("BadInputs") == "bad_inputs"
-    assert convert("mulDiv") == "mul_div"
-    assert convert("already_snake") == "already_snake"
-    assert convert("base64") == "base64"
+    assert snake_case("BadInputs") == "bad_inputs"
+    assert snake_case("mulDiv") == "mul_div"
+    assert snake_case("already_snake") == "already_snake"
+    assert snake_case("base64") == "base64"
 
 
-def test_acronyms_stay_whole() -> None:
-    assert convert("SetAndResetAccountTxnID") == "set_and_reset_account_txn_id"
-    assert convert("XRPToIOU") == "xrp_to_iou"
-    assert convert("STAmountMath") == "st_amount_math"
+def test_snake_case_keeps_acronyms_whole() -> None:
+    assert snake_case("SetAndResetAccountTxnID") == "set_and_reset_account_txn_id"
+    assert snake_case("XRPToIOU") == "xrp_to_iou"
+    assert snake_case("STAmountMath") == "st_amount_math"
+
+
+def test_camel_case_conversion() -> None:
+    assert camel_case("json_value") == "JsonValue"
+    assert camel_case("mulDiv") == "MulDiv"
+    assert camel_case("scope") == "Scope"
+    assert camel_case("base64") == "Base64"
+
+
+def test_camel_case_leaves_acronyms_alone() -> None:
+    # `inflection.camelize` would give `ShaMapTest` / `ParseStatmRsSkB` here.
+    assert camel_case("SHAMapTest") == "SHAMapTest"
+    assert camel_case("parseStatmRSSkB") == "ParseStatmRSSkB"
+    assert camel_case("XRPAmount") == "XRPAmount"
+    assert camel_case("CSPRNG") == "CSPRNG"
 
 
 def test_disabled_prefix_preserved() -> None:
-    assert convert("DISABLED_FooBar") == "DISABLED_foo_bar"
-    assert convert("DISABLED_foo_bar") == "DISABLED_foo_bar"
-    assert convert("DISABLED_") == "DISABLED_"
+    assert snake_case("DISABLED_FooBar") == "DISABLED_foo_bar"
+    assert snake_case("DISABLED_foo_bar") == "DISABLED_foo_bar"
+    assert snake_case("DISABLED_") == "DISABLED_"
+    assert camel_case("DISABLED_foo_bar") == "DISABLED_FooBar"
+    assert camel_case("DISABLED_") == "DISABLED_"
 
 
 # --- what counts as a test definition ---------------------------------------
@@ -73,10 +90,11 @@ def test_all_macros_recognized() -> None:
         """)
 
 
-def test_suite_and_fixture_names_untouched() -> None:
+def test_conforming_definitions_untouched() -> None:
     code = """
     TEST(AccountSet, bad_inputs)
     TEST_F(MutexMakeTest, default_constructor)
+    TEST(SHAMap, DISABLED_slow_path)
     """
     assert reports(code) == []
     assert fixed(code) == dedent(code)
@@ -117,18 +135,50 @@ def test_indented_and_wrapped_definitions() -> None:
 # --- rewriting --------------------------------------------------------------
 
 
-def test_only_the_name_is_rewritten() -> None:
+def test_only_the_two_names_are_rewritten() -> None:
     code = """
-    TEST(SuiteName, mulDiv)
+    TEST(mulDiv, mulDiv)
     {
         auto const mulDiv = 1;  // mulDiv stays
     }
     """
     assert fixed(code) == dedent("""
-        TEST(SuiteName, mul_div)
+        TEST(MulDiv, mul_div)
         {
             auto const mulDiv = 1;  // mulDiv stays
         }
+        """)
+
+
+def test_suite_name_camel_cased() -> None:
+    code = """
+    TEST(json_value, limits)
+    TEST(scope, ScopeExit)
+    """
+    assert reports(code) == [
+        "1: renamed suite 'json_value' to 'JsonValue'",
+        "2: renamed suite 'scope' to 'Scope'",
+        "2: renamed test case 'ScopeExit' to 'scope_exit'",
+    ]
+    assert fixed(code) == dedent("""
+        TEST(JsonValue, limits)
+        TEST(Scope, scope_exit)
+        """)
+
+
+def test_fixture_reported_but_not_renamed() -> None:
+    # The first argument names a class, so only a human (or clang-tidy) can
+    # rename it; the test-case name is still fixed.
+    code = """
+    TEST_F(my_fixture, someTest)
+    """
+    assert reports(code) == [
+        "1: fixture 'my_fixture' is not CamelCase: rename the class to "
+        "'MyFixture' by hand",
+        "1: renamed test case 'someTest' to 'some_test'",
+    ]
+    assert fixed(code) == dedent("""
+        TEST_F(my_fixture, some_test)
         """)
 
 
@@ -141,8 +191,8 @@ def test_reports_carry_line_numbers() -> None:
     TEST(Suite, secondName)
     """
     assert reports(code) == [
-        "3: renamed 'firstName' to 'first_name'",
-        "5: renamed 'secondName' to 'second_name'",
+        "3: renamed test case 'firstName' to 'first_name'",
+        "5: renamed test case 'secondName' to 'second_name'",
     ]
 
 
@@ -156,20 +206,23 @@ def test_collision_reported_and_not_applied() -> None:
     TEST(Suite, mul_div)
     """
     assert reports(code) == [
-        "1: cannot rename 'mulDiv' to 'mul_div': another test case in suite "
-        "'Suite' already generates that name"
+        "1: cannot rename 'Suite, mulDiv' to 'Suite, mul_div': another test "
+        "case already generates that name"
     ]
     assert fixed(code) == dedent(code)
 
 
-def test_collision_across_generated_class_names() -> None:
-    # `Suite_a_b_c_Test` from both spellings.
+def test_collision_between_converging_suites() -> None:
+    # Both suites camel-case to `SuiteA`, so both would define
+    # `SuiteA_one_test_Test`.
     code = """
-    TEST(Suite_a, bC)
-    TEST(Suite, a_b_c)
+    TEST(SuiteA, oneTest)
+    TEST(Suite_a, one_test)
     """
-    assert len(reports(code)) == 1
-    assert "cannot rename 'bC'" in reports(code)[0]
+    assert [r.split(":")[1].strip() for r in reports(code)] == [
+        "cannot rename 'SuiteA, oneTest' to 'SuiteA, one_test'",
+        "cannot rename 'Suite_a, one_test' to 'SuiteA, one_test'",
+    ]
     assert fixed(code) == dedent(code)
 
 

--- a/bin/pre-commit/test_fix_gtest_names.py
+++ b/bin/pre-commit/test_fix_gtest_names.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Tests for fix_gtest_names.py.
+
+Run directly (no test framework needed):
+    ./bin/pre-commit/test_fix_gtest_names.py
+or under pytest:
+    pytest bin/pre-commit/test_fix_gtest_names.py
+"""
+
+import sys
+import textwrap
+
+from fix_gtest_names import convert, fix_source
+
+
+def dedent(text: str) -> str:
+    """Removes a fixture's common indentation and its leading newline.
+
+    Lets fixtures be written as indented triple-quoted here-docs while keeping
+    honest 1-based line numbers.
+    """
+    return textwrap.dedent(text).lstrip("\n")
+
+
+def fixed(text: str) -> str:
+    return fix_source(dedent(text))[0]
+
+
+def reports(text: str) -> list[str]:
+    return fix_source(dedent(text))[1]
+
+
+# --- conversion --------------------------------------------------------------
+
+
+def test_snake_case_conversion() -> None:
+    assert convert("BadInputs") == "bad_inputs"
+    assert convert("mulDiv") == "mul_div"
+    assert convert("already_snake") == "already_snake"
+    assert convert("base64") == "base64"
+
+
+def test_acronyms_stay_whole() -> None:
+    assert convert("SetAndResetAccountTxnID") == "set_and_reset_account_txn_id"
+    assert convert("XRPToIOU") == "xrp_to_iou"
+    assert convert("STAmountMath") == "st_amount_math"
+
+
+def test_disabled_prefix_preserved() -> None:
+    assert convert("DISABLED_FooBar") == "DISABLED_foo_bar"
+    assert convert("DISABLED_foo_bar") == "DISABLED_foo_bar"
+    assert convert("DISABLED_") == "DISABLED_"
+
+
+# --- what counts as a test definition ---------------------------------------
+
+
+def test_all_macros_recognized() -> None:
+    code = """
+    TEST(Suite, oneName)
+    TEST_F(Fixture, twoName)
+    TEST_P(Fixture, threeName)
+    TYPED_TEST(Fixture, fourName)
+    TYPED_TEST_P(Fixture, fiveName)
+    """
+    assert fixed(code) == dedent("""
+        TEST(Suite, one_name)
+        TEST_F(Fixture, two_name)
+        TEST_P(Fixture, three_name)
+        TYPED_TEST(Fixture, four_name)
+        TYPED_TEST_P(Fixture, five_name)
+        """)
+
+
+def test_suite_and_fixture_names_untouched() -> None:
+    code = """
+    TEST(AccountSet, bad_inputs)
+    TEST_F(MutexMakeTest, default_constructor)
+    """
+    assert reports(code) == []
+    assert fixed(code) == dedent(code)
+
+
+def test_lookalikes_ignored() -> None:
+    code = """
+    // TEST(Suite, notATest)
+    TEST_EXPECT(someCall())
+    TEST_EXPECTS(amount == value, amount.getText())
+    INSTANTIATE_TEST_SUITE_P(Prefix, Fixture, testValues());
+    auto x = TEST(Suite, notATest);
+    TYPED_TEST_SUITE(Fixture, MyTypes);
+    """
+    assert reports(code) == []
+    assert fixed(code) == dedent(code)
+
+
+def test_indented_and_wrapped_definitions() -> None:
+    code = """
+    namespace ripple {
+        TEST(Suite, indentedName)
+    }
+    TEST_F(
+        SomeVeryLongFixtureName,
+        wrappedName)
+    """
+    assert fixed(code) == dedent("""
+        namespace ripple {
+            TEST(Suite, indented_name)
+        }
+        TEST_F(
+            SomeVeryLongFixtureName,
+            wrapped_name)
+        """)
+
+
+# --- rewriting --------------------------------------------------------------
+
+
+def test_only_the_name_is_rewritten() -> None:
+    code = """
+    TEST(SuiteName, mulDiv)
+    {
+        auto const mulDiv = 1;  // mulDiv stays
+    }
+    """
+    assert fixed(code) == dedent("""
+        TEST(SuiteName, mul_div)
+        {
+            auto const mulDiv = 1;  // mulDiv stays
+        }
+        """)
+
+
+def test_reports_carry_line_numbers() -> None:
+    code = """
+    #include <foo.h>
+
+    TEST(Suite, firstName)
+
+    TEST(Suite, secondName)
+    """
+    assert reports(code) == [
+        "3: renamed 'firstName' to 'first_name'",
+        "5: renamed 'secondName' to 'second_name'",
+    ]
+
+
+# --- collisions -------------------------------------------------------------
+
+
+def test_collision_reported_and_not_applied() -> None:
+    # Both would define `Suite_mul_div_Test`.
+    code = """
+    TEST(Suite, mulDiv)
+    TEST(Suite, mul_div)
+    """
+    assert reports(code) == [
+        "1: cannot rename 'mulDiv' to 'mul_div': another test case in suite "
+        "'Suite' already generates that name"
+    ]
+    assert fixed(code) == dedent(code)
+
+
+def test_collision_across_generated_class_names() -> None:
+    # `Suite_a_b_c_Test` from both spellings.
+    code = """
+    TEST(Suite_a, bC)
+    TEST(Suite, a_b_c)
+    """
+    assert len(reports(code)) == 1
+    assert "cannot rename 'bC'" in reports(code)[0]
+    assert fixed(code) == dedent(code)
+
+
+def test_same_name_in_different_suites_is_not_a_collision() -> None:
+    code = """
+    TEST(SuiteOne, mulDiv)
+    TEST(SuiteTwo, mulDiv)
+    """
+    assert fixed(code) == dedent("""
+        TEST(SuiteOne, mul_div)
+        TEST(SuiteTwo, mul_div)
+        """)
+
+
+def main() -> int:
+    tests = sorted(
+        (name, fn)
+        for name, fn in globals().items()
+        if name.startswith("test_") and callable(fn)
+    )
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"PASS {name}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"FAIL {name}: {exc!r}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tests/libxrpl/basics/MallocTrim.cpp
+++ b/src/tests/libxrpl/basics/MallocTrim.cpp
@@ -49,7 +49,7 @@ TEST(MallocTrimReport, structure)
 }
 
 #if defined(__GLIBC__) && BOOST_OS_LINUX
-TEST(parseStatmRSSkB, standard_format)
+TEST(ParseStatmRSSkB, standard_format)
 {
     using xrpl::detail::parseStatmRSSkB;
 
@@ -121,7 +121,7 @@ TEST(parseStatmRSSkB, standard_format)
 }
 #endif
 
-TEST(mallocTrim, without_debug_logging)
+TEST(MallocTrim, without_debug_logging)
 {
     beast::Journal const journal{beast::Journal::getNullSink()};
 
@@ -144,7 +144,7 @@ TEST(mallocTrim, without_debug_logging)
 #endif
 }
 
-TEST(mallocTrim, empty_tag)
+TEST(MallocTrim, empty_tag)
 {
     beast::Journal const journal{beast::Journal::getNullSink()};
     MallocTrimReport const report = mallocTrim("", journal);
@@ -157,7 +157,7 @@ TEST(mallocTrim, empty_tag)
 #endif
 }
 
-TEST(mallocTrim, with_debug_logging)
+TEST(MallocTrim, with_debug_logging)
 {
     struct DebugSink : public beast::Journal::Sink
     {
@@ -194,7 +194,7 @@ TEST(mallocTrim, with_debug_logging)
 #endif
 }
 
-TEST(mallocTrim, repeated_calls)
+TEST(MallocTrim, repeated_calls)
 {
     beast::Journal const journal{beast::Journal::getNullSink()};
 

--- a/src/tests/libxrpl/basics/RangeSet.cpp
+++ b/src/tests/libxrpl/basics/RangeSet.cpp
@@ -10,7 +10,7 @@
 
 using namespace xrpl;
 
-TEST(RangeSet, prevMissing)
+TEST(RangeSet, prev_missing)
 {
     // Set will include:
     // [ 0, 5]
@@ -36,7 +36,7 @@ TEST(RangeSet, prevMissing)
     }
 }
 
-TEST(RangeSet, toString)
+TEST(RangeSet, to_string)
 {
     RangeSet<std::uint32_t> set;
     EXPECT_EQ(to_string(set), "empty");
@@ -54,7 +54,7 @@ TEST(RangeSet, toString)
     EXPECT_EQ(to_string(set), "1-2,6");
 }
 
-TEST(RangeSet, fromString)
+TEST(RangeSet, from_string)
 {
     RangeSet<std::uint32_t> set;
 

--- a/src/tests/libxrpl/basics/StringUtilities.cpp
+++ b/src/tests/libxrpl/basics/StringUtilities.cpp
@@ -290,7 +290,7 @@ TEST_F(StringUtilitiesTest, to_string)
     EXPECT_EQ(result, "hello");
 }
 
-TEST_F(StringUtilitiesTest, trimWhitespace)
+TEST_F(StringUtilitiesTest, trim_whitespace)
 {
     EXPECT_EQ(trimWhitespace(""), "");
     EXPECT_EQ(trimWhitespace("   "), "");
@@ -303,7 +303,7 @@ TEST_F(StringUtilitiesTest, trimWhitespace)
     EXPECT_EQ(trimWhitespace("  a b\tc  "), "a b\tc");
 }
 
-TEST_F(StringUtilitiesTest, toLower)
+TEST_F(StringUtilitiesTest, to_lower)
 {
     EXPECT_EQ(toLower(""), "");
     EXPECT_EQ(toLower("ABC"), "abc");
@@ -318,7 +318,7 @@ TEST_F(StringUtilitiesTest, toLower)
 // Both helpers are documented as depending only on their input. Guard that by
 // checking the bytes just outside ASCII, which a locale-aware isspace/tolower
 // could classify differently.
-TEST_F(StringUtilitiesTest, trimAndLowerIgnoreLocale)
+TEST_F(StringUtilitiesTest, trim_and_lower_ignore_locale)
 {
     // 0xA0 is NO-BREAK SPACE in Latin-1 and is whitespace to some locales.
     std::string const nbsp("\xA0", 1);

--- a/src/tests/libxrpl/basics/base64.cpp
+++ b/src/tests/libxrpl/basics/base64.cpp
@@ -14,7 +14,7 @@ check(std::string const& in, std::string const& out)
     EXPECT_EQ(base64Decode(encoded), in);
 }
 
-TEST(base64, base64)
+TEST(Base64, base64)
 {
     // cspell: disable
     check("", "");

--- a/src/tests/libxrpl/basics/base_uint.cpp
+++ b/src/tests/libxrpl/basics/base_uint.cpp
@@ -128,7 +128,7 @@ struct BaseUintTest : public ::testing::Test
 
 using BaseUintDeathTest = BaseUintTest;
 
-TEST_F(BaseUintDeathTest, fromRaw_size_mismatch)
+TEST_F(BaseUintDeathTest, from_raw_size_mismatch)
 {
     // ENABLE_VOIDSTAR is a debug build, but does not crash on failed asserts. Rather than twist
     // these tests into knots to make them work, just skip them.

--- a/src/tests/libxrpl/basics/contract.cpp
+++ b/src/tests/libxrpl/basics/contract.cpp
@@ -6,7 +6,7 @@
 
 using namespace xrpl;
 
-TEST(contract, contract)
+TEST(Contract, contract)
 {
     try
     {

--- a/src/tests/libxrpl/basics/mulDiv.cpp
+++ b/src/tests/libxrpl/basics/mulDiv.cpp
@@ -7,7 +7,7 @@
 
 using namespace xrpl;
 
-TEST(mulDiv, mul_div)
+TEST(MulDiv, mul_div)
 {
     auto const max = std::numeric_limits<std::uint64_t>::max();
     std::uint64_t const max32 = std::numeric_limits<std::uint32_t>::max();

--- a/src/tests/libxrpl/basics/mulDiv.cpp
+++ b/src/tests/libxrpl/basics/mulDiv.cpp
@@ -7,7 +7,7 @@
 
 using namespace xrpl;
 
-TEST(mulDiv, mulDiv)
+TEST(mulDiv, mul_div)
 {
     auto const max = std::numeric_limits<std::uint64_t>::max();
     std::uint64_t const max32 = std::numeric_limits<std::uint32_t>::max();

--- a/src/tests/libxrpl/basics/scope.cpp
+++ b/src/tests/libxrpl/basics/scope.cpp
@@ -6,7 +6,7 @@
 
 using namespace xrpl;
 
-TEST(scope, scope_exit)
+TEST(Scope, scope_exit)
 {
     // ScopeExit always executes the functor on destruction,
     // unless release() is called
@@ -56,7 +56,7 @@ TEST(scope, scope_exit)
     EXPECT_EQ(i, 5);
 }
 
-TEST(scope, scope_fail)
+TEST(Scope, scope_fail)
 {
     // ScopeFail executes the functor on destruction only
     // if an exception is unwinding, unless release() is called
@@ -106,7 +106,7 @@ TEST(scope, scope_fail)
     EXPECT_EQ(i, 5);
 }
 
-TEST(scope, scope_success)
+TEST(Scope, scope_success)
 {
     // ScopeSuccess executes the functor on destruction only
     // if an exception is not unwinding, unless release() is called

--- a/src/tests/libxrpl/basics/scope.cpp
+++ b/src/tests/libxrpl/basics/scope.cpp
@@ -6,7 +6,7 @@
 
 using namespace xrpl;
 
-TEST(scope, ScopeExit)
+TEST(scope, scope_exit)
 {
     // ScopeExit always executes the functor on destruction,
     // unless release() is called
@@ -56,7 +56,7 @@ TEST(scope, ScopeExit)
     EXPECT_EQ(i, 5);
 }
 
-TEST(scope, ScopeFail)
+TEST(scope, scope_fail)
 {
     // ScopeFail executes the functor on destruction only
     // if an exception is unwinding, unless release() is called
@@ -106,7 +106,7 @@ TEST(scope, ScopeFail)
     EXPECT_EQ(i, 5);
 }
 
-TEST(scope, ScopeSuccess)
+TEST(scope, scope_success)
 {
     // ScopeSuccess executes the functor on destruction only
     // if an exception is not unwinding, unless release() is called

--- a/src/tests/libxrpl/basics/tagged_integer.cpp
+++ b/src/tests/libxrpl/basics/tagged_integer.cpp
@@ -105,7 +105,7 @@ static_assert(
 
 using TagInt = TaggedInteger<std::int32_t, Tag1>;
 
-TEST(tagged_integer, comparison_operators)
+TEST(TaggedInteger, comparison_operators)
 {
     TagInt const zero(0);
     TagInt const one(1);
@@ -131,7 +131,7 @@ TEST(tagged_integer, comparison_operators)
     EXPECT_FALSE(one <= zero);
 }
 
-TEST(tagged_integer, increment_decrement_operators)
+TEST(TaggedInteger, increment_decrement_operators)
 {
     TagInt const zero(0);
     TagInt const one(1);
@@ -146,7 +146,7 @@ TEST(tagged_integer, increment_decrement_operators)
     EXPECT_EQ(a, zero);
 }
 
-TEST(tagged_integer, arithmetic_operators)
+TEST(TaggedInteger, arithmetic_operators)
 {
     TagInt const a{-2};
     EXPECT_EQ(+a, TagInt{-2});
@@ -166,7 +166,7 @@ TEST(tagged_integer, arithmetic_operators)
     EXPECT_EQ((TagInt{16} >> TagInt{2}), TagInt{4});
 }
 
-TEST(tagged_integer, assignment_operators)
+TEST(TaggedInteger, assignment_operators)
 {
     TagInt a{-2};
     TagInt b{0};

--- a/src/tests/libxrpl/crypto/csprng.cpp
+++ b/src/tests/libxrpl/crypto/csprng.cpp
@@ -6,7 +6,7 @@
 
 using namespace xrpl;
 
-TEST(csprng, get_values)
+TEST(Csprng, get_values)
 {
     auto& engine = cryptoPrng();
     auto randVal = engine();

--- a/src/tests/libxrpl/json/Value.cpp
+++ b/src/tests/libxrpl/json/Value.cpp
@@ -21,7 +21,7 @@
 
 namespace xrpl {
 
-TEST(json_value, limits)
+TEST(JsonValue, limits)
 {
     using namespace json;
     static_assert(Value::kMinInt == Int(~(UInt(-1) / 2)));
@@ -29,7 +29,7 @@ TEST(json_value, limits)
     static_assert(Value::kMaxUInt == UInt(-1));
 }
 
-TEST(json_value, construct_and_compare_json_static_string)
+TEST(JsonValue, construct_and_compare_json_static_string)
 {
     static constexpr char kSample[]{"Contents of a json::StaticString"};
 
@@ -52,7 +52,7 @@ TEST(json_value, construct_and_compare_json_static_string)
     EXPECT_NE(kTest3, str);
 }
 
-TEST(json_value, different_types)
+TEST(JsonValue, different_types)
 {
     // Exercise ValueType constructor
     static constexpr json::StaticString kStaticStr{"staticStr"};
@@ -206,7 +206,7 @@ TEST(json_value, different_types)
     }
 }
 
-TEST(json_value, compare_strings)
+TEST(JsonValue, compare_strings)
 {
     auto doCompare = [&](json::Value const& lhs,
                          json::Value const& rhs,
@@ -560,7 +560,7 @@ TEST(json_value, compare_strings)
 #pragma pop_macro("DO_COMPARE")
 }
 
-TEST(json_value, bool)
+TEST(JsonValue, bool)
 {
     EXPECT_FALSE(json::Value());
 
@@ -583,7 +583,7 @@ TEST(json_value, bool)
     EXPECT_TRUE(bool(object));
 }
 
-TEST(json_value, bad_json)
+TEST(JsonValue, bad_json)
 {
     char const* s(R"({"method":"ledger","params":[{"ledger_index":1e300}]})");
 
@@ -607,7 +607,7 @@ parseValue(std::string const& doc)
 
 }  // namespace
 
-TEST(json_value, parse_double_valid)
+TEST(JsonValue, parse_double_valid)
 {
     // 1e300 is large but still representable, so it parses (unlike the out-of-range cases below).
     for (auto const& [text, expected] :
@@ -627,14 +627,14 @@ TEST(json_value, parse_double_valid)
     }
 }
 
-TEST(json_value, parse_double_out_of_range)
+TEST(JsonValue, parse_double_out_of_range)
 {
     // Magnitudes with no finite double representation are rejected.
     for (char const* oor : {"1e400", "-1e400", "0.001e500", "1e-400", "-1e-400", "123e-500"})
         EXPECT_FALSE(parseValue(oor).has_value()) << oor;
 }
 
-TEST(json_value, parse_double_malformed)
+TEST(JsonValue, parse_double_malformed)
 {
     // readNumber() collects any run of digits and '.eE+-' into a single Double
     // token, so these malformed tokens reach decodeDouble. Each has a valid
@@ -644,7 +644,7 @@ TEST(json_value, parse_double_malformed)
         EXPECT_FALSE(parseValue(bad).has_value()) << bad;
 }
 
-TEST(json_value, edge_cases)
+TEST(JsonValue, edge_cases)
 {
     std::uint32_t const maxUInt = std::numeric_limits<std::uint32_t>::max();
     std::int32_t const maxInt = std::numeric_limits<std::int32_t>::max();
@@ -791,7 +791,7 @@ TEST(json_value, edge_cases)
     }
 }
 
-TEST(json_value, copy)
+TEST(JsonValue, copy)
 {
     json::Value v1{2.5};
     EXPECT_TRUE(v1.isDouble());
@@ -812,7 +812,7 @@ TEST(json_value, copy)
     EXPECT_EQ(v1, v2);
 }
 
-TEST(json_value, move)
+TEST(JsonValue, move)
 {
     json::Value v1{2.5};
     EXPECT_TRUE(v1.isDouble());
@@ -831,7 +831,7 @@ TEST(json_value, move)
     EXPECT_NE(v1, v2);  // NOLINT(bugprone-use-after-move)
 }
 
-TEST(json_value, comparisons)
+TEST(JsonValue, comparisons)
 {
     json::Value a, b;
     auto testEquals = [&](std::string const& name) {
@@ -886,7 +886,7 @@ TEST(json_value, comparisons)
     testGreaterThan("big");
 }
 
-TEST(json_value, compact)
+TEST(JsonValue, compact)
 {
     json::Value j;
     json::Reader r;
@@ -909,7 +909,7 @@ TEST(json_value, compact)
     }
 }
 
-TEST(json_value, conversions)
+TEST(JsonValue, conversions)
 {
     // We have json::ValueType::Real but json::Value::asDouble.
     // TODO: What's the thinking here?
@@ -1125,7 +1125,7 @@ TEST(json_value, conversions)
     }
 }
 
-TEST(json_value, access_members)
+TEST(JsonValue, access_members)
 {
     json::Value val;
     EXPECT_EQ(val.type(), json::ValueType::Null);
@@ -1218,7 +1218,7 @@ TEST(json_value, access_members)
     }
 }
 
-TEST(json_value, remove_members)
+TEST(JsonValue, remove_members)
 {
     json::Value val;
     EXPECT_EQ(val.removeMember(std::string("member")).type(), json::ValueType::Null);
@@ -1245,7 +1245,7 @@ TEST(json_value, remove_members)
     EXPECT_EQ(val.size(), 0);
 }
 
-TEST(json_value, iterator)
+TEST(JsonValue, iterator)
 {
     {
         // Iterating an array.
@@ -1331,7 +1331,7 @@ TEST(json_value, iterator)
     }
 }
 
-TEST(json_value, nest_limits)
+TEST(JsonValue, nest_limits)
 {
     json::Reader r;
     {
@@ -1377,7 +1377,7 @@ TEST(json_value, nest_limits)
     }
 }
 
-TEST(json_value, memory_leak)
+TEST(JsonValue, memory_leak)
 {
     // When run with the address sanitizer, this test confirms there is no
     // memory leak with the scenarios below.

--- a/src/tests/libxrpl/json/Value.cpp
+++ b/src/tests/libxrpl/json/Value.cpp
@@ -29,7 +29,7 @@ TEST(json_value, limits)
     static_assert(Value::kMaxUInt == UInt(-1));
 }
 
-TEST(json_value, construct_and_compare_Json_StaticString)
+TEST(json_value, construct_and_compare_json_static_string)
 {
     static constexpr char kSample[]{"Contents of a json::StaticString"};
 

--- a/src/tests/libxrpl/server/InfoSub.cpp
+++ b/src/tests/libxrpl/server/InfoSub.cpp
@@ -12,7 +12,7 @@ using namespace xrpl;
 // by subscribing the real cap through a WebSocket, which would exceed the frame
 // limit and drop the connection before the check runs) lets the boundary be
 // asserted exactly.
-TEST(InfoSubSubscriptionCap, Boundary)
+TEST(InfoSubSubscriptionCap, boundary)
 {
     constexpr std::size_t cap = kMaxSubscriptionsPerConnection;
 
@@ -30,7 +30,7 @@ TEST(InfoSubSubscriptionCap, Boundary)
     EXPECT_TRUE(exceedsSubscriptionCap(cap - 1, 2));
 }
 
-TEST(InfoSubSubscriptionCap, NoOverflow)
+TEST(InfoSubSubscriptionCap, no_overflow)
 {
     constexpr std::size_t cap = kMaxSubscriptionsPerConnection;
     constexpr std::size_t max = std::numeric_limits<std::size_t>::max();
@@ -41,7 +41,7 @@ TEST(InfoSubSubscriptionCap, NoOverflow)
     EXPECT_TRUE(exceedsSubscriptionCap(cap, max));
 }
 
-TEST(InfoSubSubscriptionCap, ExplicitCap)
+TEST(InfoSubSubscriptionCap, explicit_cap)
 {
     // A configured override is honored: the boundary tracks the passed cap, not
     // the built-in default. This is the seam doSubscribe uses to enforce a

--- a/src/tests/libxrpl/tx/AccountSet.cpp
+++ b/src/tests/libxrpl/tx/AccountSet.cpp
@@ -43,7 +43,7 @@
 
 namespace xrpl::test {
 
-TEST(AccountSet, NullAccountSet)
+TEST(AccountSet, null_account_set)
 {
     TxTest env;
 
@@ -60,7 +60,7 @@ TEST(AccountSet, NullAccountSet)
     EXPECT_EQ(accountRoot.getFlags(), 0);
 }
 
-TEST(AccountSet, MostFlags)
+TEST(AccountSet, most_flags)
 {
     Account const alice("alice");
 
@@ -175,7 +175,7 @@ TEST(AccountSet, MostFlags)
     });
 }
 
-TEST(AccountSet, SetAndResetAccountTxnID)
+TEST(AccountSet, set_and_reset_account_txn_id)
 {
     TxTest env;
     Account const alice("alice");
@@ -206,7 +206,7 @@ TEST(AccountSet, SetAndResetAccountTxnID)
     EXPECT_EQ(nowFlags, origFlags);
 }
 
-TEST(AccountSet, SetNoFreeze)
+TEST(AccountSet, set_no_freeze)
 {
     TxTest env;
     Account const alice("alice");
@@ -249,7 +249,7 @@ TEST(AccountSet, SetNoFreeze)
     EXPECT_TRUE(env.getAccountRoot(alice).isFlag(lsfNoFreeze));
 }
 
-TEST(AccountSet, Domain)
+TEST(AccountSet, domain)
 {
     TxTest env;
     Account const alice("alice");
@@ -317,7 +317,7 @@ TEST(AccountSet, Domain)
     }
 }
 
-TEST(AccountSet, MessageKey)
+TEST(AccountSet, message_key)
 {
     TxTest env;
     Account const alice("alice");
@@ -358,7 +358,7 @@ TEST(AccountSet, MessageKey)
         telBAD_PUBLIC_KEY);
 }
 
-TEST(AccountSet, WalletID)
+TEST(AccountSet, wallet_id)
 {
     TxTest env;
     Account const alice("alice");
@@ -391,7 +391,7 @@ TEST(AccountSet, WalletID)
     EXPECT_FALSE(env.getAccountRoot(alice).hasWalletLocator());
 }
 
-TEST(AccountSet, EmailHash)
+TEST(AccountSet, email_hash)
 {
     TxTest env;
     Account const alice("alice");
@@ -422,7 +422,7 @@ TEST(AccountSet, EmailHash)
     EXPECT_FALSE(env.getAccountRoot(alice).hasEmailHash());
 }
 
-TEST(AccountSet, TransferRate)
+TEST(AccountSet, transfer_rate)
 {
     struct TestCase
     {
@@ -473,7 +473,7 @@ TEST(AccountSet, TransferRate)
     }
 }
 
-TEST(AccountSet, BadInputs)
+TEST(AccountSet, bad_inputs)
 {
     TxTest env;
     Account const alice("alice");
@@ -553,7 +553,7 @@ TEST(AccountSet, BadInputs)
         tecNO_ALTERNATIVE_KEY);
 }
 
-TEST(AccountSet, RequireAuthWithDir)
+TEST(AccountSet, require_auth_with_dir)
 {
     TxTest env;
     Account const alice("alice");
@@ -601,7 +601,7 @@ TEST(AccountSet, RequireAuthWithDir)
         tesSUCCESS);
 }
 
-TEST(AccountSet, Ticket)
+TEST(AccountSet, ticket)
 {
     TxTest env;
     Account const alice("alice");
@@ -660,7 +660,7 @@ TEST(AccountSet, Ticket)
         tefNO_TICKET);
 }
 
-TEST(AccountSet, BadSigningKey)
+TEST(AccountSet, bad_signing_key)
 {
     TxTest env;
     Account const alice("alice");
@@ -684,7 +684,7 @@ TEST(AccountSet, BadSigningKey)
     EXPECT_FALSE(result.applied);
 }
 
-TEST(AccountSet, Gateway)
+TEST(AccountSet, gateway)
 {
     Account const alice("alice");
     Account const bob("bob");


### PR DESCRIPTION
## High Level Overview of Change

While migrating to gtest we introduced a lot of tests with different naming conventions. Majority is in snake_case but there were outliers in CamelCase and mixed case too.
This PR introduces a hook that automatically detects and fixes wrong style for these names.

### Context of Change

Gtest migration.

### API Impact

N/A