### PR TITLE
fix: Bound Number's digit-drop loops

### DIFF
--- a/src/libxrpl/basics/Number.cpp
+++ b/src/libxrpl/basics/Number.cpp
@@ -223,6 +223,11 @@ class Number::Guard
     std::uint8_t sbit_ : 1 {0};  // the sign of the guard digits
 
 public:
+    // Decimal digits held in digits_, four bits each. After this many zero
+    // pushes digits_ holds only zeros and xbit_ has absorbed everything shifted
+    // off, so further pushes of zeros leave the Guard unchanged.
+    static constexpr int kGuardDigits = 8 * sizeof(digits_) / 4;
+
     internalrep const minMantissa;
     internalrep const maxMantissa;
     MantissaRange::CuspRoundingFix const cuspRoundingFix;
@@ -276,6 +281,18 @@ public:
     template <class T>
     void
     doDropDigit(T& mantissa, int& exponent) noexcept;
+
+    /**
+     * Drop digits from mantissa until the exponent increases to target. No-op if exponent is
+     * greater or equal to target already.
+     *
+     * Once the mantissa reaches zero every further drop pushes a zero digit, and this Guard stops
+     * changing after kGuardDigits of those. The rest of the drops would only advance the exponent,
+     * so jump it instead, to save at most 32768 * 2 - 35 loops.
+     */
+    template <class T>
+    void
+    dropDigitsTo(T& mantissa, int& exponent, int target) noexcept;
 
     // Modify the result to the correctly rounded value
     template <UnsignedMantissa T>
@@ -399,6 +416,23 @@ Number::Guard::doDropDigit<uint128_t>(uint128_t& mantissa, int& exponent) noexce
     // mantissa /= 10;
     push(divu10(mantissa));
     ++exponent;
+}
+
+template <class T>
+void
+Number::Guard::dropDigitsTo(T& mantissa, int& exponent, int target) noexcept
+{
+    while (exponent < target)
+    {
+        if (mantissa == 0)
+        {
+            for (int i = 0; i < kGuardDigits && exponent < target; ++i)
+                doDropDigit(mantissa, exponent);
+            exponent = target;
+            return;
+        }
+        doDropDigit(mantissa, exponent);
+    }
 }
 
 template <UnsignedMantissa T>
@@ -933,6 +967,8 @@ Number::operator+=(Number const& y)
         {
             // For Enabled330, there are three steps.
             // 1. First, shrink the mantissa of shrinkM/shrinkE while shrinkM ends in 0.
+            // Bounded by the mantissa, not the exponent: shrinkM is non-zero and normalized,
+            // so its leading digit is non-zero and stops the loop within 18 iterations.
             while (shrinkE < expandE && shrinkM % 10 == 0)
             {
                 g.doDropDigit(shrinkM, shrinkE);
@@ -950,10 +986,7 @@ Number::operator+=(Number const& y)
 
         // 3. Finally, shrink the mantissa of shrinkM/shrinkE until the exponents match. Any removed
         // digits will be put into the Guard. This is the only step for non-Enabled330 modes.
-        while (shrinkE < expandE)
-        {
-            g.doDropDigit(shrinkM, shrinkE);
-        }
+        g.dropDigitsTo(shrinkM, shrinkE, expandE);
     };
 
     // Shrink the mantissa and raise the exponent of the value with the lower exponent. Store any
@@ -1330,10 +1363,7 @@ operator rep() const
             g.setNegative();
             drops = -drops;
         }
-        while (offset < 0)
-        {
-            g.doDropDigit(drops, offset);
-        }
+        g.dropDigitsTo(drops, offset, 0);
         for (; offset > 0; --offset)
         {
             if (drops > kMaxRep / 10)


### PR DESCRIPTION
## High Level Overview of Change

Bounds two loops in `Number` that dropped mantissa digits one exponent unit at a time, so their iteration count no longer scales with the difference between two operands' exponents.

### Context of Change

`operator+=` aligns exponents by repeatedly calling `Guard::doDropDigit`, which divides the mantissa by 10 and increments the exponent. Termination is controlled by the exponent, not the mantissa, so once the mantissa reaches zero the loop keeps going, pushing zero digits into the Guard until the exponents match. With operands at opposite ends of the exponent range that is ~65,000 iterations, of which at most 35 do useful work. `operator rep()` has the same shape, up to ~32,000 iterations. Both have been present since `Number` was introduced in 2022, and are not reachable with ordinary XRP or IOU amounts, whose exponents stay in a narrow band.

The Guard holds 16 decimal digits in a shift register plus a sticky bit, so after 16 zero pushes it reaches a fixed point and further zero pushes cannot change it. Both loops now stop there and assign the exponent directly. The shared logic is factored into `Guard::dropDigitsTo`. Results are unchanged by construction.

Step 1 of the `Enabled330` alignment is left alone; it is bounded by the mantissa, because a normalized non-zero mantissa always has a non-zero leading digit. A comment records that.

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

## Before / After

Performance only; no behavioral change. Measured on `Number` directly (Apple M4 Pro, release build), worst-case operands:

| operation | before | after |
|---|---|---|
| `a + b`, opposite ends of the exponent range | 583.7 us | 0.55 us |
| `a - b`, same | 529.1 us | 0.52 us |
| `static_cast<int64_t>(1e-32700)` | 41.3 us | 0.14 us |

No concurrency impact.

## Test Plan


Existing `NumberTest` (30 cases) and the full `xrpl_tests` binary (917 cases) pass unchanged.

Equivalence was verified with two temporary local harnesses, neither included here.

**Guard invariant.** Uses a temporary `friend` to observe `Guard`'s private state directly.

**Differential.** Runs the same evaluations against builds with and without the change, and compares the results. Per-operation digests are identical.