### PR TITLE
fix: Enable reserve checking on ending sponsorship

### DIFF
--- a/src/libxrpl/tx/transactors/sponsor/SponsorshipTransfer.cpp
+++ b/src/libxrpl/tx/transactors/sponsor/SponsorshipTransfer.cpp
@@ -8,6 +8,7 @@
 #include <xrpl/ledger/ReadView.h>
 #include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/SponsorHelpers.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/TER.h>
@@ -412,9 +413,24 @@ SponsorshipTransfer::doApply()
             if (!oldSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
 
-            // The owner reclaims the reserve burden when the object is no longer sponsored.
-            // We do not check the sponsee's reserve here (via `checkReserve`) so that a sponsor can
-            // always end a sponsorship, even if the sponsee lacks sufficient reserve.
+            // The owner reclaims the reserve burden when the object is no longer
+            // sponsored, so it must be able to hold that reserve on its own once the
+            // sponsorship is removed. This mirrors the account-level End check below,
+            // keeping the behavior consistent across accounts and objects: a
+            // sponsorship can only be ended if the sponsee self-funds, another sponsor
+            // steps in (Reassign), or the object/account is deleted.
+            if (view().rules().enabled(fixCleanup3_4_0))
+            {
+                if (auto const ter = checkReserve(
+                        ctx_.getApplyViewContext(),
+                        sponseeSle,
+                        balanceBeforeFee(sponseeSle),
+                        SLE::pointer(),
+                        {.ownerCountDelta = ownerCountDelta},
+                        ctx_.journal);
+                    !isTesSuccess(ter))
+                    return ter;
+            }
 
             // Decrement sponsored count
             if (auto const ter = decrementSponsorCount(

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -1073,73 +1073,17 @@ public:
     }
 
     void
-    testObjectEndReserve(FeatureBitset features)
+    testTransferSponsor(FeatureBitset features)
     {
-        // dissolve sponsor: ending an object sponsorship now(fixCleanup3_4_0) requires the
-        // sponsee to be able to self-fund the object's reserve.
-
         testcase(
-            std::string("Object End reserve check ") +
+            std::string("Transfer Sponsor ") +
             (features[fixCleanup3_4_0] ? "(fixCleanup3_4_0 enabled)"
                                        : "(fixCleanup3_4_0 disabled)"));
         using namespace test::jtx;
 
-        // Ending an object sponsorship returns the reserve burden to the
-        // sponsee. With fixCleanup3_4_0 the sponsee must be able to self-fund
-        // the reclaimed object's reserve, so an under-funded End fails; without
-        // the fix the End succeeds regardless (legacy behavior).
-
-        Env env{*this, features};
-        Account const alice("alice");
-        Account const bob("bob");
-        Account const sponsor("sponsor");
-        env.fund(XRP(10000), alice, bob, sponsor);
-        env.close();
-
-        // Create a check owned by alice with a co-signed reserve sponsorship.
-        auto const seq = env.seq(alice);
-        env(check::create(alice, bob, XRP(1)),
-            sponsor::As(sponsor, spfSponsorReserve),
-            Sig(sfSponsorSignature, sponsor));
-        env.close();
-
-        auto const checkId = keylet::check(alice, SeqProxy::rawSequence(seq)).key;
-        BEAST_EXPECT(env.le(keylet::unchecked(checkId)) != nullptr);
-        BEAST_EXPECT(sponsoredOwnerCount(env, alice) == 1);
-        BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 1);
-
-        // Put alice one drop below the reserve required to hold the reclaimed
-        // object on her own.
-        adjustAccountXRPBalance(env, alice, reserve(env, 1) - drops(1));
-
-        if (features[fixCleanup3_4_0])
-        {
-            // Under-funded: End is rejected until alice can self-fund.
-            env(sponsor::transfer(alice, tfSponsorshipEnd, checkId), Ter(tecINSUFFICIENT_RESERVE));
-            env.close();
-
-            adjustAccountXRPBalance(env, alice, reserve(env, 1));
-        }
-
-        env(sponsor::transfer(alice, tfSponsorshipEnd, checkId));
-        env.close();
-
-        BEAST_EXPECT(sponsoredOwnerCount(env, alice) == 0);
-        BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 0);
-        BEAST_EXPECT(!env.le(keylet::account(sponsor))->isFieldPresent(sfSponsoringOwnerCount));
-        auto const sle = env.le(keylet::unchecked(checkId));
-        BEAST_EXPECT(!sle->isFieldPresent(sfSponsor));
-    }
-
-    void
-    testTransferSponsor()
-    {
-        testcase("Transfer Sponsor");
-        using namespace test::jtx;
-
         // Verify preflight checks
         {
-            Env env{*this, testableAmendments()};
+            Env env{*this, features};
             Account const alice("alice");
             Account const bob("bob");
             Account const sponsor("sponsor");
@@ -1223,7 +1167,7 @@ public:
 
         {
             // Invalid SponsorshipEnd permission (sponsor object/sponsor account)
-            Env env{*this, testableAmendments()};
+            Env env{*this, features};
             Account const alice("alice");
             Account const bob("bob");
             Account const charlie("charlie");
@@ -1268,7 +1212,7 @@ public:
 
         {
             // sponsor account
-            Env env{*this, testableAmendments()};
+            Env env{*this, features};
             Account const alice("alice");
             Account const bob("bob");
             Account const sponsor1("sponsor1");
@@ -1399,7 +1343,7 @@ public:
         }
         {
             // dissolve account sponsorship from sponsor
-            Env env{*this, testableAmendments()};
+            Env env{*this, features};
             Account const alice("alice");
             Account const bob("bob");
             Account const sponsor("sponsor");
@@ -1423,7 +1367,7 @@ public:
 
         {
             // sponsor object (co-signing)
-            Env env{*this, testableAmendments()};
+            Env env{*this, features};
             Account const alice("alice");
             Account const bob("bob");
             Account const sponsor1("sponsor1");
@@ -1532,9 +1476,19 @@ public:
             BEAST_EXPECT(sle2->isFieldPresent(sfSponsor));
             BEAST_EXPECT(sle2->getAccountID(sfSponsor) == sponsor2.id());
 
-            // dissolve sponsor: ending an object sponsorship now requires the
+            // dissolve sponsor: ending an object sponsorship now (fixCleanup3_4_0) requires the
             // sponsee to be able to self-fund the object's reserve.
-            adjustAccountXRPBalance(env, alice, reserve(env, 1));
+            adjustAccountXRPBalance(env, alice, reserve(env, 1) - drops(1));
+
+            if (features[fixCleanup3_4_0])
+            {
+                // Under-funded: End is rejected until alice can self-fund.
+                env(sponsor::transfer(alice, tfSponsorshipEnd, checkId),
+                    Ter(tecINSUFFICIENT_RESERVE));
+                env.close();
+
+                adjustAccountXRPBalance(env, alice, reserve(env, 1));
+            }
 
             env(sponsor::transfer(alice, tfSponsorshipEnd, checkId));
             env.close();
@@ -1568,7 +1522,7 @@ public:
         }
         {
             // sponsor object (pre-funded + no ltSponsorship entry)
-            Env env{*this, testableAmendments()};
+            Env env{*this, features};
             Account const alice("alice");
             Account const bob("bob");
             Account const sponsor1("sponsor1");
@@ -1602,7 +1556,7 @@ public:
         }
         {
             // sponsor object (pre-funded)
-            Env env{*this, testableAmendments()};
+            Env env{*this, features};
             Account const alice("alice");
             Account const bob("bob");
             Account const sponsor1("sponsor1");
@@ -1705,7 +1659,7 @@ public:
 
         {
             // Dissolve object sponsorship from sponsor(no-ltSponsorship)
-            Env env{*this, testableAmendments()};
+            Env env{*this, features};
             Account const alice("alice");
             Account const bob("bob");
             Account const sponsor("sponsor");
@@ -1745,7 +1699,7 @@ public:
 
         {
             // Dissolve object sponsorship from sponsor (with ltSponsorship)
-            Env env{*this, testableAmendments()};
+            Env env{*this, features};
             Account const alice("alice");
             Account const bob("bob");
             Account const sponsor("sponsor");
@@ -1803,7 +1757,7 @@ public:
 
             for (bool const isIssuerHigh : {false, true})
             {
-                Env env{*this, testableAmendments()};
+                Env env{*this, features};
                 env.fund(XRP(10000), alice, bob, sponsor);
                 env.close();
 
@@ -1847,7 +1801,7 @@ public:
 
         {
             // invalid transfer
-            Env env{*this, testableAmendments()};
+            Env env{*this, features};
             Account const alice("alice");
             Account const bob("bob");
             Account const sponsor("sponsor");
@@ -1884,7 +1838,7 @@ public:
         {
             // existing owner objects that are outside the v1 SponsorshipTransfer
             // object allow-list
-            Env env{*this, testableAmendments()};
+            Env env{*this, features};
             Account const alice("alice");
             Account const sponsor("sponsor");
             env.fund(XRP(10000), alice, sponsor);
@@ -5730,9 +5684,8 @@ protected:
         testPreFundAndCosign();
         testSponsoredFreeTierReserve();
 
-        testTransferSponsor();
-        testObjectEndReserve(jtx::testableAmendments());
-        testObjectEndReserve(jtx::testableAmendments() - fixCleanup3_4_0);
+        testTransferSponsor(jtx::testableAmendments());
+        testTransferSponsor(jtx::testableAmendments() - fixCleanup3_4_0);
         testLegacySignerListReserve();
         testSponsorFee();
         testSponsorAccount();

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -1073,6 +1073,66 @@ public:
     }
 
     void
+    testObjectEndReserve(FeatureBitset features)
+    {
+        // dissolve sponsor: ending an object sponsorship now(fixCleanup3_4_0) requires the
+        // sponsee to be able to self-fund the object's reserve.
+
+        testcase(
+            std::string("Object End reserve check ") +
+            (features[fixCleanup3_4_0] ? "(fixCleanup3_4_0 enabled)"
+                                       : "(fixCleanup3_4_0 disabled)"));
+        using namespace test::jtx;
+
+        // Ending an object sponsorship returns the reserve burden to the
+        // sponsee. With fixCleanup3_4_0 the sponsee must be able to self-fund
+        // the reclaimed object's reserve, so an under-funded End fails; without
+        // the fix the End succeeds regardless (legacy behavior).
+        bool const fix34 = features[fixCleanup3_4_0];
+
+        Env env{*this, features};
+        Account const alice("alice");
+        Account const bob("bob");
+        Account const sponsor("sponsor");
+        env.fund(XRP(10000), alice, bob, sponsor);
+        env.close();
+
+        // Create a check owned by alice with a co-signed reserve sponsorship.
+        auto const seq = env.seq(alice);
+        env(check::create(alice, bob, XRP(1)),
+            sponsor::As(sponsor, spfSponsorReserve),
+            Sig(sfSponsorSignature, sponsor));
+        env.close();
+
+        auto const checkId = keylet::check(alice, SeqProxy::rawSequence(seq)).key;
+        BEAST_EXPECT(env.le(keylet::unchecked(checkId)) != nullptr);
+        BEAST_EXPECT(sponsoredOwnerCount(env, alice) == 1);
+        BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 1);
+
+        // Put alice one drop below the reserve required to hold the reclaimed
+        // object on her own.
+        adjustAccountXRPBalance(env, alice, reserve(env, 1) - drops(1));
+
+        if (fix34)
+        {
+            // Under-funded: End is rejected until alice can self-fund.
+            env(sponsor::transfer(alice, tfSponsorshipEnd, checkId), Ter(tecINSUFFICIENT_RESERVE));
+            env.close();
+
+            adjustAccountXRPBalance(env, alice, reserve(env, 1));
+        }
+
+        env(sponsor::transfer(alice, tfSponsorshipEnd, checkId));
+        env.close();
+
+        BEAST_EXPECT(sponsoredOwnerCount(env, alice) == 0);
+        BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 0);
+        BEAST_EXPECT(!env.le(keylet::account(sponsor))->isFieldPresent(sfSponsoringOwnerCount));
+        auto const sle = env.le(keylet::unchecked(checkId));
+        BEAST_EXPECT(!sle->isFieldPresent(sfSponsor));
+    }
+
+    void
     testTransferSponsor()
     {
         testcase("Transfer Sponsor");
@@ -1473,9 +1533,9 @@ public:
             BEAST_EXPECT(sle2->isFieldPresent(sfSponsor));
             BEAST_EXPECT(sle2->getAccountID(sfSponsor) == sponsor2.id());
 
-            // dissolve sponsor: ending an object sponsorship succeeds even
-            // when the sponsee lacks sufficient reserve to reclaim the object.
-            adjustAccountXRPBalance(env, alice, reserve(env, 1) - drops(1));
+            // dissolve sponsor: ending an object sponsorship now requires the
+            // sponsee to be able to self-fund the object's reserve.
+            adjustAccountXRPBalance(env, alice, reserve(env, 1));
 
             env(sponsor::transfer(alice, tfSponsorshipEnd, checkId));
             env.close();
@@ -5672,6 +5732,8 @@ protected:
         testSponsoredFreeTierReserve();
 
         testTransferSponsor();
+        testObjectEndReserve(jtx::testableAmendments());
+        testObjectEndReserve(jtx::testableAmendments() - fixCleanup3_4_0);
         testLegacySignerListReserve();
         testSponsorFee();
         testSponsorAccount();

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -1088,7 +1088,6 @@ public:
         // sponsee. With fixCleanup3_4_0 the sponsee must be able to self-fund
         // the reclaimed object's reserve, so an under-funded End fails; without
         // the fix the End succeeds regardless (legacy behavior).
-        bool const fix34 = features[fixCleanup3_4_0];
 
         Env env{*this, features};
         Account const alice("alice");
@@ -1113,7 +1112,7 @@ public:
         // object on her own.
         adjustAccountXRPBalance(env, alice, reserve(env, 1) - drops(1));
 
-        if (fix34)
+        if (features[fixCleanup3_4_0])
         {
             // Under-funded: End is rejected until alice can self-fund.
             env(sponsor::transfer(alice, tfSponsorshipEnd, checkId), Ter(tecINSUFFICIENT_RESERVE));


### PR DESCRIPTION
## High Level Overview of Change

Enable reserve checking on ending sponsorship

### Context of Change

It was decided that sponsorship can't be ended if sponsee doesn't have enough funds to cover the reserve requirements (or new sponsor stepping in)


