### PR TITLE
build: Sign RPM packages

### DIFF
--- a/.github/scripts/strategy-matrix/linux.json
+++ b/.github/scripts/strategy-matrix/linux.json
@@ -92,7 +92,7 @@
         "build_type": ["Release"],
         "arch": ["amd64"],
         "minimal": false,
-        "image": "ghcr.io/xrplf/xrpld/packaging-debian:sha-028ccea"
+        "image": "ghcr.io/xrplf/xrpld/packaging-debian:sha-a6983f8"
       }
     ],
 
@@ -102,7 +102,7 @@
         "build_type": ["Release"],
         "arch": ["amd64"],
         "minimal": false,
-        "image": "ghcr.io/xrplf/xrpld/packaging-rhel:sha-028ccea"
+        "image": "ghcr.io/xrplf/xrpld/packaging-rhel:sha-a6983f8"
       }
     ]
   }

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -49,3 +49,4 @@ jobs:
     secrets:
       remote_username: ${{ secrets.NEXUS_REMOTE_USERNAME }}
       remote_password: ${{ secrets.NEXUS_REMOTE_PASSWORD }}
+      signing_key: ${{ secrets.NEXUS_PACKAGES_PRIVATE_KEY }}

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -120,3 +120,4 @@ jobs:
     secrets:
       remote_username: ${{ secrets.NEXUS_REMOTE_USERNAME }}
       remote_password: ${{ secrets.NEXUS_REMOTE_PASSWORD }}
+      signing_key: ${{ secrets.NEXUS_PACKAGES_PRIVATE_KEY }}

--- a/.github/workflows/reusable-package.yml
+++ b/.github/workflows/reusable-package.yml
@@ -29,6 +29,9 @@ on:
       remote_password:
         description: "The password or token for that Nexus account."
         required: false
+      signing_key:
+        description: "Armoured PGP private key used to sign the RPMs. Required when publishing."
+        required: false
 
 defaults:
   run:
@@ -97,6 +100,14 @@ jobs:
           PKG_RELEASE: ${{ steps.release_info.outputs.pkg_release }}
           PKG_CHANNEL: ${{ steps.release_info.outputs.channel }}
         run: ./package/build_pkg.sh
+
+      # Before the upload, so the artifact and the published package are the
+      # same bytes. DEBs are not signed, so the key is never set on that job.
+      - name: Sign RPM
+        if: ${{ inputs.publish && matrix.distro == 'rhel' }}
+        env:
+          PKG_SIGNING_KEY: ${{ secrets.signing_key }}
+        run: ./package/sign_rpm.sh "${BUILD_DIR}"
 
       - name: Upload package artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/package/README.md
+++ b/package/README.md
@@ -9,6 +9,7 @@ a build configured with `-Dvalidator_keys=ON`.
 ```
 package/
   build_pkg.sh        Staging and build script (called by the CMake `package` target and CI)
+  sign_rpm.sh         Signs the built RPMs (called by CI when publishing)
   publish_pkg.sh      Uploads built packages to the XRPLF Nexus repositories (called by CI)
   rpm/
     xrpld.spec      RPM spec
@@ -32,7 +33,7 @@ package manager (`apt-get` -> deb, `dnf`/`yum` -> rpm).
 
 | Package type | Image (`package_configs.<distro>[].image` in `linux.json`) | Tools required                                      |
 | ------------ | ---------------------------------------------------------- | --------------------------------------------------- |
-| RPM          | `ghcr.io/xrplf/xrpld/packaging-rhel:sha-<sha>`             | `rpmbuild`                                          |
+| RPM          | `ghcr.io/xrplf/xrpld/packaging-rhel:sha-<sha>`             | `rpmbuild`, `rpmsign`                               |
 | DEB          | `ghcr.io/xrplf/xrpld/packaging-debian:sha-<sha>`           | `dpkg-buildpackage`, debhelper with compat level 13 |
 
 To print the full packaging matrix (artifact names and images) for the current
@@ -152,11 +153,14 @@ any `XRPLF` repository, `on-pr.yml` never. Both authenticate with the
 `NEXUS_REMOTE_USERNAME` / `NEXUS_REMOTE_PASSWORD` secrets already used for the
 Conan remote.
 
-Nexus owns the repository metadata; nothing here signs or indexes anything. Worth
-knowing:
+Nexus owns the repository metadata; nothing here indexes anything. Worth knowing:
 
 - Each apt-hosted repository needs a distribution and a PGP signing keypair
-  configured in Nexus, which rejects one created without a keypair.
+  configured in Nexus, which rejects one created without a keypair. Nexus signs
+  the apt metadata with it, never the packages.
+- Hosted yum repositories cannot be signed by Nexus at all, so `sign_rpm.sh`
+  signs the RPMs before they are uploaded, and rpm clients verify with
+  `gpgcheck=1` rather than `repo_gpgcheck=1`.
 - yum metadata is rebuilt asynchronously, so a successful publish is not
   immediately installable.
 - Each job uploads only what it built, and uploads are not transactional, so a
@@ -212,8 +216,12 @@ fail early.
 Flags are for explicit invocation; environment variables are intended for
 CMake/CI integration. The CI workflow and the CMake `package` target both invoke
 `build_pkg.sh` with no flags; CMake supplies `SRC_DIR`, `BUILD_DIR`, and
-`PKG_RELEASE` via env, while CI supplies `BUILD_DIR` and `PKG_RELEASE` via env
-and lets the script use defaults for the rest.
+`PKG_RELEASE` via env, while CI supplies `BUILD_DIR`, `PKG_RELEASE` and
+`PKG_CHANNEL` via env and lets the script use defaults for the rest.
+
+Signing is not part of this script. `sign_rpm.sh` does it in a separate CI step
+that only runs when publishing, so a published RPM is always signed and a local
+build never needs a key.
 
 It resolves `SRC_DIR` and `BUILD_DIR` to absolute paths, then calls
 `stage_common()` to copy the `xrpld` and `validator-keys` binaries, config files,

--- a/package/sign_rpm.sh
+++ b/package/sign_rpm.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sign the RPMs built by build_pkg.sh. Nexus cannot sign hosted yum metadata, so
+# the packages carry the signature themselves and rpm clients verify them with
+# gpgcheck=1.
+#
+# Usage: sign_rpm.sh [package-dir]
+#
+#   package-dir  searched recursively for *.rpm ('build' by default)
+#
+# PKG_SIGNING_KEY must hold an armoured PGP private key. It has no flag, to keep
+# the key out of the process list.
+#
+# There is no DEB equivalent: apt trusts the repository metadata, which Nexus
+# signs, rather than the packages themselves.
+
+pkg_dir="${1:-build}"
+
+mapfile -d '' rpms < <(find "${pkg_dir}" -type f -name '*.rpm' -print0)
+
+# Signing nothing would otherwise look like a successful signing.
+if [[ ${#rpms[@]} -eq 0 ]]; then
+    echo "sign_rpm.sh: no RPMs found in ${pkg_dir}." >&2
+    exit 1
+fi
+
+: "${PKG_SIGNING_KEY:?is required}"
+
+# Global, and expanded by the trap when it fires: the keyring holds an
+# unencrypted private key, so it must go even if signing fails.
+signing_home="$(mktemp -d)"
+trap 'rm -rf "${signing_home}"' EXIT
+export GNUPGHOME="${signing_home}"
+
+printf '%s' "${PKG_SIGNING_KEY}" | gpg --batch --quiet --import
+
+# Exactly one secret key, so that picking the first below is not a guess between
+# several.
+secrets="$(gpg --list-secret-keys --with-colons | grep -c '^sec:' || true)"
+if [[ "${secrets}" -ne 1 ]]; then
+    echo "sign_rpm.sh: PKG_SIGNING_KEY must hold exactly one secret key, found ${secrets}." >&2
+    exit 1
+fi
+
+key="$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/ { print $10; exit }')"
+echo "Signing ${#rpms[@]} RPM(s) with ${key}."
+
+# Loopback pinentry: the key is unattended, so there is no tty to prompt on.
+rpmsign \
+    --define "_gpg_name ${key}" \
+    --define "_gpg_sign_cmd_extra_args --pinentry-mode loopback --batch --yes" \
+    --addsign "${rpms[@]}"
+
+# rpmsign can exit 0 having attached nothing, and an unsigned package is only
+# rejected later, on the installing machine. Both header tags are checked
+# because an RSA signature lands in RSAHEADER and a DSA or EdDSA one in
+# DSAHEADER.
+for pkg in "${rpms[@]}"; do
+    signature="$(rpm --query --queryformat '%{RSAHEADER:pgpsig}%{DSAHEADER:pgpsig}' --package "${pkg}")"
+    if [[ "${signature}" == "(none)(none)" ]]; then
+        echo "sign_rpm.sh: ${pkg} is unsigned after rpmsign." >&2
+        exit 1
+    fi
+done


### PR DESCRIPTION
Nexus cannot sign hosted yum metadata, so the RPMs are signed before upload and clients verify them with gpgcheck=1.

sign_rpm.sh is a separate step that only runs when publishing the RPM leg, so a published RPM is always signed while local, PR and DEB builds need no key. It runs before the artifact upload, so the artifact and the published package are the same bytes.

This doesn't fix rpm upload itself, but should be merged before the fix - let's not have unsigned rpms at all.

<!--
This PR template helps you write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR. This avoids redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to this PR.
-->
