### PR TITLE
Fix inbound Delegate griefing of AccountDelete

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -15,6 +15,7 @@
 // Add new amendments to the top of this list.
 // Keep it sorted in reverse chronological order.
 
+XRPL_FIX    (DelegateAccountDelete,       Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (Cleanup3_4_0,                Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(Sponsor,                     Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(BatchV1_1,                   Supported::Yes, VoteBehavior::DefaultNo)

--- a/src/libxrpl/tx/transactors/account/AccountDelete.cpp
+++ b/src/libxrpl/tx/transactors/account/AccountDelete.cpp
@@ -340,9 +340,17 @@ AccountDelete::preclaim(PreclaimContext const& ctx)
         if (nonObligationDeleter(nodeType) == nullptr)
             return tecHAS_OBLIGATIONS;
 
+        // Inbound Delegate objects sit in the authorized account's owner
+        // directory so AccountDelete can clean them up. They must not count
+        // toward kMaxDeletableDirEntries; a third party could otherwise fill
+        // the directory with inbound Delegations and permanently block
+        // AccountDelete. See https://github.com/XRPLF/rippled/issues/7691
+        bool const inboundDelegate = ctx.view.rules().enabled(fixDelegateAccountDelete) &&
+            nodeType == ltDELEGATE && (*sleItem)[sfAuthorize] == account;
+
         // We found a deletable directory entry.  Count it.  If we find too
         // many deletable directory entries then bail out.
-        if (++deletableDirEntryCount > kMaxDeletableDirEntries)
+        if (!inboundDelegate && ++deletableDirEntryCount > kMaxDeletableDirEntries)
             return tefTOO_BIG;
 
     } while (cdirNext(ctx.view, ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry));

--- a/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
+++ b/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
@@ -1,12 +1,17 @@
 #include <xrpl/tx/transactors/delegate/DelegateSet.h>
 
 #include <xrpl/basics/Log.h>
+#include <xrpl/basics/safe_cast.h>
 #include <xrpl/beast/utility/Journal.h>
+#include <xrpl/beast/utility/Zero.h>
 #include <xrpl/core/ServiceRegistry.h>
+#include <xrpl/ledger/ReadView.h>
 #include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
 #include <xrpl/ledger/helpers/SponsorHelpers.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
+#include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/Protocol.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STLedgerEntry.h>
@@ -20,6 +25,47 @@
 #include <unordered_set>
 
 namespace xrpl {
+
+namespace {
+
+// Count Delegate objects linked into authorize's owner directory (inbound).
+// Stops at kMaxDeletableDirEntries so the walk stays bounded.
+std::uint32_t
+countInboundDelegates(ReadView const& view, AccountID const& authorize)
+{
+    Keylet const ownerDirKeylet{keylet::ownerDir(authorize)};
+    if (dirIsEmpty(view, ownerDirKeylet))
+        return 0;
+
+    SLE::const_pointer sleDirNode{};
+    unsigned int uDirEntry{0};
+    uint256 dirEntry{beast::kZero};
+
+    if (!cdirFirst(view, ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry))
+        return 0;
+
+    std::uint32_t inbound{0};
+    do
+    {
+        auto const sleItem = view.read(keylet::child(dirEntry));
+        if (!sleItem)
+            continue;
+
+        auto const nodeType = safeCast<LedgerEntryType>((*sleItem)[sfLedgerEntryType]);
+        if (nodeType != ltDELEGATE)
+            continue;
+        if ((*sleItem)[sfAuthorize] != authorize)
+            continue;
+
+        ++inbound;
+        if (inbound >= kMaxDeletableDirEntries)
+            return inbound;
+    } while (cdirNext(view, ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry));
+
+    return inbound;
+}
+
+}  // namespace
 
 NotTEC
 DelegateSet::preflight(PreflightContext const& ctx)
@@ -64,6 +110,16 @@ DelegateSet::preclaim(PreclaimContext const& ctx)
         !ctx.view.exists(keylet::delegate(ctx.tx[sfAccount], ctx.tx[sfAuthorize])))
     {
         return tecNO_ENTRY;
+    }
+
+    // Cap inbound Delegates so AccountDelete of the authorized account cannot
+    // be forced to walk an unbounded owner directory. See issue 7691.
+    bool const creating = !ctx.tx.getFieldArray(sfPermissions).empty() &&
+        !ctx.view.exists(keylet::delegate(ctx.tx[sfAccount], ctx.tx[sfAuthorize]));
+    if (creating && ctx.view.rules().enabled(fixDelegateAccountDelete) &&
+        countInboundDelegates(ctx.view, ctx.tx[sfAuthorize]) >= kMaxDeletableDirEntries)
+    {
+        return tecDIR_FULL;
     }
 
     return tesSUCCESS;

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -784,6 +784,56 @@ class Delegate_test : public beast::unit_test::Suite
     }
 
     void
+    testInboundDelegateDoesNotBlockAccountDelete()
+    {
+        // Regression for https://github.com/XRPLF/rippled/issues/7691
+        // bob holds kMaxDeletableDirEntries of his own objects plus one inbound
+        // Delegate from alice. The inbound Delegate must not make AccountDelete
+        // return tefTOO_BIG.
+        testcase("inbound Delegates do not block AccountDelete");
+        using namespace jtx;
+
+        Env env(*this);
+        Account const alice{"alice"};
+        Account const bob{"bob"};
+        Account const gw{"gw"};
+        env.fund(XRP(10000000), alice, bob, gw);
+        env.close();
+
+        std::string currency{"AAA"};
+        static constexpr int kOfferCount{1000};
+        for (int i{0}; i < kOfferCount; ++i)
+        {
+            env(offer(bob, gw[currency](1), XRP(1)));
+            ++currency[0];
+            if (currency[0] > 'Z')
+            {
+                currency[0] = 'A';
+                ++currency[1];
+            }
+            if (currency[1] > 'Z')
+            {
+                currency[1] = 'A';
+                ++currency[2];
+            }
+        }
+        env.close();
+
+        env(delegate::set(alice, bob, {"Payment"}));
+        env.close();
+
+        for (std::uint32_t i = 0; i < 256; ++i)
+            env.close();
+
+        auto const deleteFee = drops(env.current()->fees().increment);
+        env(acctdelete(bob, gw), Fee(deleteFee));
+        env.close();
+
+        BEAST_EXPECT(!env.closed()->exists(keylet::account(bob.id())));
+        BEAST_EXPECT(!env.closed()->exists(keylet::delegate(alice.id(), bob.id())));
+    }
+
+    void
     testDelegateTransaction()
     {
         testcase("test delegate transaction");
@@ -2908,6 +2958,7 @@ class Delegate_test : public beast::unit_test::Suite
         testFee();
         testSequence();
         testAccountDelete();
+        testInboundDelegateDoesNotBlockAccountDelete();
         testDelegateTransaction();
         testPaymentGranular(all);
         testTrustSetGranular();


### PR DESCRIPTION
## Summary

DelegateSet inserts each Delegate object into the authorized account's owner directory (`sfDestinationNode`) so AccountDelete can find and clean up inbound delegations. That is required to prevent a deleted account from inheriting old Delegates after resurrection.

The same link also counted toward `kMaxDeletableDirEntries` (1000). Only the delegator can remove the object. A third party funding ~1000 delegator accounts can fill a victim directory with inbound Delegates and permanently block AccountDelete (`tefTOO_BIG`). Escrow/Check have dest-side cancel; Delegate does not.

**Fixes #7691**

## Merge Fix Details

New amendment `fixDelegateAccountDelete` (`Supported::Yes`, `VoteBehavior::DefaultNo`):

1. `AccountDelete::preclaim` does not count inbound Delegates (`ltDELEGATE` where `sfAuthorize` is the account being deleted) toward `kMaxDeletableDirEntries`. They remain deletable and are still removed in `doApply`.
2. `DelegateSet::preclaim` rejects creating a new inbound Delegate once the authorized account already has `kMaxDeletableDirEntries` inbound Delegates (`tecDIR_FULL`), so AccountDelete work stays bounded.

Files:

- `include/xrpl/protocol/detail/features.macro`
- `src/libxrpl/tx/transactors/account/AccountDelete.cpp`
- `src/libxrpl/tx/transactors/delegate/DelegateSet.cpp`
- `src/test/app/Delegate_test.cpp` (regression: 1000 own offers + 1 inbound Delegate, AccountDelete succeeds)
