### PR TITLE
Fix inbound Delegate AccountDelete griefing via dest cancel

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -15,6 +15,7 @@
 // Add new amendments to the top of this list.
 // Keep it sorted in reverse chronological order.
 
+XRPL_FIX    (DelegateAccountDelete,       Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (Cleanup3_4_0,                Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(Sponsor,                     Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(BatchV1_1,                   Supported::Yes, VoteBehavior::DefaultNo)

--- a/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
+++ b/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
@@ -6,6 +6,7 @@
 #include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
 #include <xrpl/ledger/helpers/SponsorHelpers.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Protocol.h>
 #include <xrpl/protocol/SField.h>
@@ -60,10 +61,17 @@ DelegateSet::preclaim(PreclaimContext const& ctx)
         return tecPSEUDO_ACCOUNT;
 
     // Deleting the delegate object is invalid if it doesn’t exist.
-    if (ctx.tx.getFieldArray(sfPermissions).empty() &&
-        !ctx.view.exists(keylet::delegate(ctx.tx[sfAccount], ctx.tx[sfAuthorize])))
+    // Outbound: Account is the delegator. Inbound refuse (fixDelegateAccountDelete):
+    // Account is the authorized account and Authorize is the original delegator.
+    // O(1) keylet lookup, no owner-directory walk. See issue 7691.
+    if (ctx.tx.getFieldArray(sfPermissions).empty())
     {
-        return tecNO_ENTRY;
+        bool const outbound =
+            ctx.view.exists(keylet::delegate(ctx.tx[sfAccount], ctx.tx[sfAuthorize]));
+        bool const inboundRefuse = ctx.view.rules().enabled(fixDelegateAccountDelete) &&
+            ctx.view.exists(keylet::delegate(ctx.tx[sfAuthorize], ctx.tx[sfAccount]));
+        if (!outbound && !inboundRefuse)
+            return tecNO_ENTRY;
     }
 
     return tesSUCCESS;
@@ -96,7 +104,16 @@ DelegateSet::doApply()
 
     auto const& permissions = ctx_.tx.getFieldArray(sfPermissions);
     if (permissions.empty())
+    {
+        // Authorized account refuses an inbound Delegate. Lookup is
+        // keylet::delegate(delegator, dest) = delegate(Authorize, Account).
+        if (ctx_.view().rules().enabled(fixDelegateAccountDelete))
+        {
+            if (auto inbound = ctx_.view().peek(keylet::delegate(authAccount, accountID_)))
+                return deleteDelegate(view(), inbound, j_);
+        }
         return tecINTERNAL;  // LCOV_EXCL_LINE
+    }
 
     if (auto const ret = checkReserve(
             ctx_.getApplyViewContext(),

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -785,6 +785,61 @@ class Delegate_test : public beast::unit_test::Suite
     }
 
     void
+    testInboundDelegateRefuse()
+    {
+        // Regression for https://github.com/XRPLF/rippled/issues/7691
+        // Check/Escrow have dest-side cancel. Delegate did not, so inbound
+        // objects could permanently block AccountDelete. The authorized
+        // account can refuse inbound Delegates with an empty Permissions list
+        // (O(1) keylet lookup, no owner-directory walk).
+        testcase("authorized account can refuse inbound Delegate");
+        using namespace jtx;
+
+        Env env(*this);
+        Account const alice{"alice"};
+        Account const bob{"bob"};
+        Account const carol{"carol"};
+        env.fund(XRP(100000), alice, bob, carol);
+        env.close();
+
+        env(delegate::set(alice, bob, {"Payment"}));
+        env.close();
+
+        auto const delegateKey = keylet::delegate(alice.id(), bob.id());
+        BEAST_EXPECT(env.closed()->exists(delegateKey));
+
+        auto hasKey = [](xrpl::Dir const& dir, uint256 const& key) {
+            return std::any_of(  // NOLINT(modernize-use-ranges)
+                dir.begin(), dir.end(), [&](auto const& sle) { return sle->key() == key; });
+        };
+
+        BEAST_EXPECT(hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(alice.id())), delegateKey.key));
+        BEAST_EXPECT(hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(bob.id())), delegateKey.key));
+        BEAST_EXPECT(env.closed()->read(keylet::account(alice.id()))->getFieldU32(sfOwnerCount) == 1);
+
+        // bob (the authorized account) refuses the inbound Delegate.
+        env(delegate::set(bob, alice, {}));
+        env.close();
+
+        BEAST_EXPECT(!env.closed()->exists(delegateKey));
+        BEAST_EXPECT(
+            !hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(alice.id())), delegateKey.key));
+        BEAST_EXPECT(!hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(bob.id())), delegateKey.key));
+        BEAST_EXPECT(env.closed()->read(keylet::account(alice.id()))->getFieldU32(sfOwnerCount) == 0);
+
+        // alice can no longer have bob submit on her behalf.
+        env(pay(alice, carol, XRP(1)), delegate::As(bob), Ter(terNO_DELEGATE_PERMISSION));
+
+        for (std::uint32_t i = 0; i < 256; ++i)
+            env.close();
+
+        auto const deleteFee = drops(env.current()->fees().increment);
+        env(acctdelete(bob, carol), Fee(deleteFee));
+        env.close();
+        BEAST_EXPECT(!env.closed()->exists(keylet::account(bob.id())));
+    }
+
+    void
     testDelegateTransaction()
     {
         testcase("test delegate transaction");
@@ -2914,6 +2969,7 @@ class Delegate_test : public beast::unit_test::Suite
         testFee();
         testSequence();
         testAccountDelete();
+        testInboundDelegateRefuse();
         testDelegateTransaction();
         testPaymentGranular(all);
         testTrustSetGranular();


### PR DESCRIPTION
## Summary

Supersedes the approach in #8061. That PR walked the authorized account's owner directory to count inbound Delegates. As reviewed, a bound on Delegate entries still iterates every other owner-dir item (trustlines, offers, ...). Wrong direction.

**Fixes #7691**

Inbound Delegate objects live in the dest owner directory so AccountDelete can clean them up on dest deletion. Only the delegator could remove them, so filling dest's directory permanently blocked AccountDelete (`tefTOO_BIG` above 1000). Check/Escrow were not treated as the same bug because dest has cancel.

## Approach

Give the authorized account dest-side cancel, same shape as CheckCancel:

- `DelegateSet` with `Account` = dest, `Authorize` = original delegator, empty `Permissions`
- Deletes `keylet::delegate(delegator, dest)`
- O(1) keylet lookup, no owner-directory walk

Gated by `fixDelegateAccountDelete`.

Dest can then remove inbound Delegates until AccountDelete is allowed, so the denial is no longer permanent.
