### PR TITLE
fix: Signal an InboundLedger that fails on local data

### DIFF
--- a/src/test/app/InboundLedger_test.cpp
+++ b/src/test/app/InboundLedger_test.cpp
@@ -45,6 +45,16 @@ struct TestableInboundLedger final : InboundLedger
         ScopedLockType collectionLock(collectionMutex);
         init(collectionLock);
     }
+
+    /**
+     * Ask for more nodes, or judge what has been collected, as a fresh
+     * acquisition does.
+     */
+    void
+    triggerAdded()
+    {
+        trigger(nullptr, TriggerReason::Added);
+    }
 };
 
 struct InboundLedger_test : public beast::unit_test::Suite
@@ -230,6 +240,61 @@ struct InboundLedger_test : public beast::unit_test::Suite
     }
 
     /**
+     * An acquisition that fails on local data must still signal.
+     *
+     * Both entry points that reach tryDB() are covered, since without
+     * done() the object never signals, logFailure() never runs, and the
+     * hash never lands in recentFailures_ - so the same doomed ledger is
+     * asked for again on the next round. recentFailures_ is what the
+     * assertions watch, since it is the caller-visible consequence of
+     * having signalled.
+     *
+     * @param env The environment to run in.
+     */
+    void
+    testLocalFailureSignalsDone(jtx::Env& env)
+    {
+        testcase("An acquisition that fails locally still signals");
+
+        // A zero account hash is a ledger no acquisition can ever finish, and tryDB() says so as
+        // soon as it has the header.
+        auto const header = makeHeader(uint256{}, uint256{});
+        storeHeader(env, header);
+
+        BEAST_EXPECT(!env.app().getInboundLedgers().isFailure(header.hash));
+
+        // acquire() is the only caller of init(), and hands back nothing for a failed acquisition.
+        BEAST_EXPECT(
+            env.app().getInboundLedgers().acquire(
+                header.hash, header.seq, InboundLedger::Reason::GENERIC) == nullptr);
+
+        // The failure reached recentFailures_, which is what stops the next round asking again.
+        BEAST_EXPECT(waitFor([&] { return env.app().getInboundLedgers().isFailure(header.hash); }));
+
+        // The other route into tryDB(): a trigger() on an acquisition that has no header yet. A
+        // hash of its own, so the entry above cannot answer for it.
+        auto const otherHeader = makeHeader(uint256{1}, uint256{});
+        storeHeader(env, otherHeader);
+
+        auto viaTrigger = std::make_shared<TestableInboundLedger>(
+            env.app(),
+            otherHeader.hash,
+            otherHeader.seq,
+            InboundLedger::Reason::GENERIC,
+            stopwatch(),
+            std::make_unique<RequestCountingPeerSet>());
+
+        BEAST_EXPECT(!env.app().getInboundLedgers().isFailure(otherHeader.hash));
+
+        viaTrigger->triggerAdded();
+
+        BEAST_EXPECT(viaTrigger->isFailed());
+        BEAST_EXPECT(!viaTrigger->isComplete());
+        BEAST_EXPECT(
+            waitFor([&] { return env.app().getInboundLedgers().isFailure(otherHeader.hash); }));
+    }
+
+    /**
      * The retry timer re-asks, then gives up and signals.
      *
      * The only case that drives onTimer() rather than trigger() directly,
@@ -298,6 +363,7 @@ struct InboundLedger_test : public beast::unit_test::Suite
         jtx::Env env{*this};
 
         testLocalLedgerCompletesAcquire(env);
+        testLocalFailureSignalsDone(env);
 
         // Last: the only case that waits out a whole timeout chain.
         testTimerRetriesThenGivesUp(env);

--- a/src/xrpld/app/ledger/detail/InboundLedger.cpp
+++ b/src/xrpld/app/ledger/detail/InboundLedger.cpp
@@ -93,8 +93,13 @@ InboundLedger::init(ScopedLockType& collectionLock)
     collectionLock.unlock();
 
     tryDB(app_.getNodeFamily().db());
+    // Matches checkLocal(): without done() this object never signals, so logFailure() never runs
+    // and the hash never lands in recentFailures_.
     if (failed_)
+    {
+        done();
         return;
+    }
 
     if (!complete_)
     {
@@ -493,6 +498,8 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
         if (failed_)
         {
             JLOG(journal_.warn()) << " failed local for " << hash_;
+            // See init() for why done() must be called here rather than just returning.
+            done();
             return;
         }
     }


### PR DESCRIPTION
Part 3/17 of a stack. Base: part 2 (`bthomee/shamap-invalid-02-acquire-test-harness`).

## High Level Overview of Change

Fixes `InboundLedger` so a purely-local failure (`tryDB()` finding a header that can never be
satisfied, e.g. a hash/sequence mismatch or a zero account hash) actually signals the acquisition as
done and gets remembered as a failed hash, instead of silently leaving it to run out the clock before
anyone downstream is told.

### Context of Change

`tryDB()` decides an acquisition can never succeed on two paths: a header whose hash or sequence does
not match what was asked for, and a zero account hash. Both set `failed_`, and `init()` and `trigger()`
now call `done()` on that path, so the object signals whatever is waiting on it and `logFailure()`
records the hash in `recentFailures_`. That is what stops the next round asking for the same doomed
ledger. `checkLocal()` is the third route into `tryDB()` and already did the same, so all three now
agree.

`testLocalFailureSignalsDone` drives both of the entry points that were silent. The first goes through
`InboundLedgers::acquire()`, the only caller of `init()`; the second constructs an acquisition with no
header and triggers it, which is the `trigger()` route. Each uses a hash of its own, since
`recentFailures_` is shared and keyed by hash, and each asserts on `recentFailures_` rather than on the
flags, since being remembered as a failure is the caller-visible consequence of having signalled.

### API Impact

None of the checkboxes below apply: this is an internal `xrpld` correctness fix with no `libxrpl`,
public-API, or peer-protocol surface.

