### PR TITLE
fix: Settle an acquired ledger before reporting it complete

### DIFF
--- a/src/test/app/InboundLedger_test.cpp
+++ b/src/test/app/InboundLedger_test.cpp
@@ -307,6 +307,65 @@ struct InboundLedger_test : public beast::unit_test::Suite
     }
 
     /**
+     * A ledger completed by a walk rather than by tryDB() is settled
+     * before it is reported complete.
+     *
+     * The other order is what lets an unsettled ledger escape: isComplete()
+     * is read without mtx_, so a second thread can act on it while done()
+     * is still settling, and a mutable ledger reaching
+     * LedgerHistory::insert() calls logicError(). The order itself is only
+     * visible to a concurrent reader, so what this case pins is the
+     * consequence - the acquisition never reports a ledger that is not
+     * immutable - and that trigger() completes an acquisition without
+     * itself setting the completion flag.
+     *
+     * @param env The environment to run in.
+     */
+    void
+    testWalkSettlesBeforeReportingComplete(jtx::Env& env)
+    {
+        testcase("A ledger completed by a walk is settled before it is reported");
+
+        auto const chain = DeepChain::toLeaf(2, nextSeed());
+        auto const header = makeHeader(chain);
+
+        // Everything except the leaf, so tryDB() can root the state map but its walk still has
+        // something to ask for. That is what leaves the completion to trigger().
+        storeHeader(env, header);
+        storeStateNodes(env, header, chain, chain.deepestDepth - 1);
+
+        auto acquire = std::make_shared<TestableInboundLedger>(
+            env.app(),
+            header.hash,
+            header.seq,
+            InboundLedger::Reason::GENERIC,
+            stopwatch(),
+            std::make_unique<RequestCountingPeerSet>());
+
+        BEAST_EXPECT(!acquire->checkLocal());
+        BEAST_EXPECT(!acquire->isComplete());
+        BEAST_EXPECT(!acquire->isFailed());
+
+        // Only now can the walk finish, so nothing but the walk can have completed this.
+        storeStateNodes(env, header, chain, chain.deepestDepth);
+
+        acquire->triggerAdded();
+
+        BEAST_EXPECT(acquire->isComplete());
+        BEAST_EXPECT(!acquire->isFailed());
+
+        auto const settled = acquire->getLedger();
+        BEAST_EXPECT(settled != nullptr);
+        if (settled)
+            BEAST_EXPECT(settled->isImmutable());
+
+        // done()'s success arm ran, so the ledger reached LedgerMaster and nothing was recorded as
+        // a failure.
+        BEAST_EXPECT(env.app().getLedgerMaster().getLedgerByHash(header.hash) != nullptr);
+        BEAST_EXPECT(!env.app().getInboundLedgers().isFailure(header.hash));
+    }
+
+    /**
      * A ledger whose map goes invalid on the way to being settled must be
      * discarded rather than delivered.
      *
@@ -660,6 +719,7 @@ struct InboundLedger_test : public beast::unit_test::Suite
         jtx::Env env{*this};
 
         testLocalLedgerCompletesAcquire(env);
+        testWalkSettlesBeforeReportingComplete(env);
         testInvalidatedLedgerFailsInDone(env);
         testLocalFailureSignalsDone(env);
         testLocalChainFailsAcquire(env);

--- a/src/xrpld/app/ledger/InboundLedger.h
+++ b/src/xrpld/app/ledger/InboundLedger.h
@@ -79,7 +79,13 @@ public:
     update(std::uint32_t seq);
 
     /**
-     * Returns true if we got all the data.
+     * Whether the acquisition succeeded and its ledger has been settled.
+     *
+     * Not merely "we got all the data": done() makes the ledger immutable
+     * before setting this, so a caller that sees it may use the ledger
+     * without checking anything else about it.
+     *
+     * @return Whether the ledger is complete and settled.
      */
     bool
     isComplete() const
@@ -158,8 +164,13 @@ protected:
     trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason);
 
     /**
-     * Settle the acquisition and signal whatever is waiting on it. Runs at most
-     * once. Call under mtx_, which the flags written here require.
+     * Settle the acquisition, publish its outcome, and signal whatever is
+     * waiting on it. Runs at most once.
+     *
+     * Settling comes first: isComplete() is read without mtx_, so an
+     * outcome published before the ledger is immutable could be acted on
+     * while the ledger is still mutable. Call under mtx_, which the flags
+     * written here require.
      */
     void
     done();

--- a/src/xrpld/app/ledger/detail/InboundLedger.cpp
+++ b/src/xrpld/app/ledger/detail/InboundLedger.cpp
@@ -458,9 +458,14 @@ InboundLedger::done()
     signaled_ = true;
     touch();
 
-    // Settled before the outcome below is logged or acted on, so nothing reports a ledger this
-    // function has since refused.
-    if (complete_ && !failed_ && ledger_)
+    // Settled here, and complete_ published only once it is settled. isComplete() is read without
+    // mtx_, by InboundLedgers::acquire() among others, so a ledger published as complete before
+    // setImmutable() succeeded could be taken by another thread while still mutable - and a mutable
+    // ledger reaching LedgerHistory::insert() or LedgerHolder::set() calls logicError(), which
+    // aborts a Release build. tryDB() already settles its own result and sets complete_ itself, so
+    // that path arrives here with the ledger immutable and only the reporting below left to do.
+    bool const haveEverything = haveHeader_ && haveState_ && haveTransactions_;
+    if (!failed_ && ledger_ && (complete_ || haveEverything))
     {
         XRPL_ASSERT(
             ledger_->header().seq < kXrpLedgerEarliestFees || ledger_->read(keylet::feeSettings()),
@@ -482,6 +487,7 @@ InboundLedger::done()
         }
         else
         {
+            complete_ = true;
             switch (reason_)
             {
                 case Reason::HISTORY:
@@ -623,11 +629,12 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
             }
             else
             {
+                // The tail of this function turns having every part into a completed acquisition,
+                // once done() has settled the ledger.
                 JLOG(journal_.info()) << "getNeededHashes says acquire is complete";
                 haveHeader_ = true;
                 haveTransactions_ = true;
                 haveState_ = true;
-                complete_ = true;
             }
         }
     }
@@ -690,7 +697,11 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
         {
             AccountStateSF filter(ledger_->stateMap().family().db(), app_.getLedgerMaster());
 
-            // Release the lock while we process the large state map
+            // Release the lock while we process the large state map. This is the only walk in this
+            // class that runs unlocked: onTimer() and the addPeers() callback both hold mtx_
+            // further up, and mtx_ is recursive, so their sl.unlock() releases nothing. So a
+            // second packet can be processed while this walk runs, which is why the map's own
+            // state is atomic and why the flags are re-read below.
             sl.unlock();
             auto nodes = ledger_->stateMap().getMissingNodes(kMissingNodesFind, &filter);
             sl.lock();
@@ -714,9 +725,6 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
                     // Sound rather than merely finished: the walk above cannot have abandoned the
                     // map without the test ahead of this one having caught it.
                     haveState_ = true;
-
-                    if (haveTransactions_)
-                        complete_ = true;
                 }
                 else
                 {
@@ -778,9 +786,6 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
                 else
                 {
                     haveTransactions_ = true;
-
-                    if (haveState_)
-                        complete_ = true;
                 }
             }
             else
@@ -805,12 +810,14 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
         }
     }
 
-    if (complete_ || failed_)
+    // Having every part is not yet a completed acquisition: done() settles the ledger first and
+    // only then publishes complete_. Called with mtx_ still held, as done() documents, so the flags
+    // it writes are not written unlocked; mtx_ is recursive, so a caller that already holds it is
+    // unaffected.
+    if (failed_ || (haveHeader_ && haveState_ && haveTransactions_))
     {
-        JLOG(journal_.debug()) << "Done:" << (complete_ ? " complete" : "")
-                               << (failed_ ? " failed " : " ") << ledger_->header().seq;
-        // Called with mtx_ still held, so the flags done() writes are not written unlocked; mtx_
-        // is recursive, so a caller that already holds it further up is unaffected.
+        JLOG(journal_.debug()) << "Done:" << (failed_ ? " failed " : " have everything ")
+                               << ledger_->header().seq;
         done();
     }
 }
@@ -1008,11 +1015,10 @@ InboundLedger::receiveNode(
             haveState_ = true;
         }
 
+        // done() settles the ledger before publishing complete_, so having every part is reported
+        // there rather than here.
         if (haveTransactions_ && haveState_)
-        {
-            complete_ = true;
             done();
-        }
     }
 }
 


### PR DESCRIPTION
Part 9/17 of a stack. Base: part 8 (`bthomee/shamap-invalid-08-judge-abandoned-map`).

## High Level Overview of Change

`InboundLedger::done()` now settles the ledger (`setImmutable()`) *before* publishing `complete_`,
closing a race where a concurrent reader — `isComplete()` is read without `mtx_`, including by
`InboundLedgers::acquire()` — could otherwise take a ledger whose maps are still mid-sync. A mutable
ledger reaching `LedgerHistory::insert()`, `LedgerHolder::set()` or `LedgerMaster::switchLCL()` calls
`logicError()`, which aborts a Release build.

### Context of Change

`isComplete()` is read without `mtx_`, by `InboundLedgers::acquire()` among others, so the flag must not
be published before the ledger it describes is settled. `done()` therefore owns the publication: it
settles the ledger and only then sets `complete_`, so no reader can see the flag before the ledger is
immutable, and its docstring and `isComplete()`'s now say so.

`trigger()` and `receiveNode()` report what they hold rather than what it amounts to: each sets the
have-flags and leaves the conclusion to `done()`, which `trigger()` reaches once it has every part or
has failed. `tryDB()` keeps setting `complete_` itself, since it settles its own result first, so
`done()` accepts either a flag already set or all three have-flags. `trigger()` calls `done()` with
`mtx_` still held; the mutex is recursive, so the call sites that already hold it further up are
unaffected.

`testWalkSettlesBeforeReportingComplete` drives an acquisition that only its own walk can finish: the
header and every state node except the deepest are local, so `checkLocal()` leaves it incomplete, and
the last node becomes available only afterwards. It asserts `isComplete()` together with
`getLedger()->isImmutable()` — a single thread cannot observe the ordering itself, so what the case pins
is the consequence: that `trigger()` still completes an acquisition without setting the flag out of
order.

### API Impact

None of the checkboxes below apply: this is an internal `xrpld` correctness fix with no `libxrpl`,
public-API, or peer-protocol surface.

