### PR TITLE
fix: Stop a ledger built from a header from claiming to be immutable

### DIFF
--- a/.cspell.config.yaml
+++ b/.cspell.config.yaml
@@ -350,6 +350,7 @@ words:
   - unfund
   - unimpair
   - unjudged
+  - unpersistable
   - unroutable
   - unscalable
   - unserviced

--- a/include/xrpl/ledger/Ledger.h
+++ b/include/xrpl/ledger/Ledger.h
@@ -279,19 +279,19 @@ public:
     /**
      * Mark this ledger as immutable, so it can no longer be modified.
      *
-     * A ledger built or loaded locally cannot have an invalid map, since only a
-     * map syncing against hashes from outside can be proven impossible (see
-     * SHAMap::addKnownNode), so a caller on such a path may treat a false return
-     * as a broken internal invariant. A caller assembling a ledger from peer data
-     * may not: for it, false is an outcome a peer can produce.
+     * A locally built or loaded ledger can never fail this call: only a map
+     * syncing against externally supplied hashes can become Invalid (see
+     * SHAMap::addKnownNode). A ledger assembled from peer data can fail it;
+     * there, false is an expected outcome, not an internal invariant break.
      *
-     * @param rehash Whether to recompute the ledger hash from the header fields.
-     *        The transaction and account hashes are recomputed from the maps too,
-     *        but only the first time.
-     * @return false if either map is Invalid, leaving the immutable flag unset and
-     *         the header untouched. A map invalidated partway through can still
-     *         leave the other one immutable, so a false return means the ledger
-     *         must be discarded rather than retried.
+     * @param rehash Whether to recompute the ledger hash from the header
+     *        fields. The transaction and account hashes are recomputed from
+     *        the maps too, but only the first time and only if the header
+     *        did not supply them.
+     * @return false if either map is Invalid, leaving the immutable flag
+     *         unset and the header untouched. A map invalidated partway
+     *         through can still leave the other one immutable, so false means
+     *         the ledger must be discarded rather than retried.
      */
     [[nodiscard]] bool
     setImmutable(bool rehash = true);
@@ -482,6 +482,17 @@ private:
     }
 
     bool immutable_;
+
+    /**
+     * Whether the header's transaction and account hashes came from outside and
+     * so must not be derived from the maps.
+     *
+     * True only for a ledger built from a header, whose maps are then
+     * synced against the hashes it carries. Deriving them would turn a
+     * ledger verified against a hash we asked for into one that is merely
+     * self-consistent. Fixed at construction, unlike immutable_.
+     */
+    bool const mapHashesFromHeader_ = false;
 
     // A SHAMap containing the transactions associated with this ledger.
     SHAMap mutable txMap_;

--- a/src/libxrpl/ledger/Ledger.cpp
+++ b/src/libxrpl/ledger/Ledger.cpp
@@ -297,8 +297,12 @@ Ledger::Ledger(Ledger const& prevLedger, NetClock::time_point closeTime)
     }
 }
 
+// The maps start out Synching and are filled in afterwards, by an acquisition syncing against the
+// hashes the header carries or by a replay that only reads the header. So those hashes are input
+// rather than derived, and immutable_ stays false until setImmutable() finds both maps sound.
 Ledger::Ledger(LedgerHeader const& info, Rules rules, Family& family)
-    : immutable_(true)
+    : immutable_(false)
+    , mapHashesFromHeader_(true)
     , txMap_(SHAMapType::TRANSACTION, info.txHash, family)
     , stateMap_(SHAMapType::STATE, info.accountHash, family)
     , rules_(std::move(rules))
@@ -339,8 +343,9 @@ Ledger::setImmutable(bool rehash)
     // Read here but written to the header below, once the maps are settled: getHash() can unshare a
     // dirty tree, so it has to run while the map is still mutable, while a write to the header must
     // wait until both maps have made it. Skipped once the ledger is immutable, since its maps can
-    // no longer change.
-    bool const deriveMapHashes = !immutable_ && rehash;
+    // no longer change, and skipped when the header supplied these hashes: deriving them from a map
+    // that fell short of its target would relabel the ledger instead of failing.
+    bool const deriveMapHashes = !immutable_ && !mapHashesFromHeader_ && rehash;
     uint256 const txHash = deriveMapHashes ? txMap_.getHash().asUInt256() : uint256{};
     uint256 const accountHash = deriveMapHashes ? stateMap_.getHash().asUInt256() : uint256{};
 

--- a/src/tests/libxrpl/shamap/SHAMapSync.cpp
+++ b/src/tests/libxrpl/shamap/SHAMapSync.cpp
@@ -478,6 +478,61 @@ TEST_F(SHAMapSyncTest, refusedSettleLeavesTheHeaderAlone)
     EXPECT_EQ(ledger.header().hash, hashBefore);
 }
 
+// A ledger built from a header must not claim to be immutable before setImmutable() has found both
+// maps sound: they start out Synching and are filled in afterwards, and LedgerHistory::insert() and
+// LedgerReplayMsgHandler both gate on that claim to catch exactly that case.
+TEST_F(SHAMapSyncTest, ledgerFromHeaderIsNotImmutableUntilSettled)
+{
+    TestNodeFamily f{j_};
+    DeepChain const chain;
+
+    LedgerHeader header;
+    header.seq = 2;
+    header.txHash = chain.rootHash.asUInt256();
+    header.hash = calculateLedgerHash(header);
+
+    Ledger ledger{header, noAmendments(), f};
+
+    // Both maps are still syncing, so nothing about this ledger is settled.
+    EXPECT_TRUE(ledger.txMap().isSynching());
+    EXPECT_TRUE(ledger.stateMap().isSynching());
+    EXPECT_FALSE(ledger.isImmutable());
+
+    ASSERT_TRUE(chain.fill(ledger.txMap()));
+    ASSERT_TRUE(chain.addOffendingNode(ledger.txMap()).isInvalid());
+    ASSERT_FALSE(ledger.txMap().isValid());
+
+    EXPECT_FALSE(ledger.setImmutable());
+    EXPECT_FALSE(ledger.isImmutable());
+}
+
+// The header's own map hashes are what the maps are synced against, so settling must not adopt
+// whatever the maps happen to hash to. The transaction map is left empty while the header names a
+// chain root, so deriving the hashes would rewrite that field and the ledger hash both.
+TEST_F(SHAMapSyncTest, ledgerFromHeaderKeepsTheMapHashesItWasGiven)
+{
+    TestNodeFamily f{j_};
+    DeepChain const chain;
+
+    LedgerHeader header;
+    header.seq = 2;
+    header.txHash = chain.rootHash.asUInt256();
+    header.hash = calculateLedgerHash(header);
+    auto const verifiedHash = header.hash;
+
+    Ledger ledger{header, noAmendments(), f};
+    ASSERT_FALSE(ledger.isImmutable());
+
+    // Nothing was ever synced, so the map is empty and hashes to zero. Both maps are still valid,
+    // so settling succeeds.
+    ASSERT_TRUE(ledger.txMap().getHash().isZero());
+    ASSERT_TRUE(ledger.setImmutable());
+    EXPECT_TRUE(ledger.isImmutable());
+
+    EXPECT_EQ(ledger.header().txHash, chain.rootHash.asUInt256());
+    EXPECT_EQ(ledger.header().hash, verifiedHash);
+}
+
 // Invalid is terminal: setImmutable() and clearSynching() offer no way back out of it, however
 // many times they are called. setSynching() is left alone, since it is unreachable on an invalid
 // map today and says so with an UNREACHABLE that aborts under -Dassert.


### PR DESCRIPTION
Part 10/17 of a stack. Base: part 9 (`bthomee/shamap-invalid-09-settle-before-complete`).

## High Level Overview of Change

The `Ledger` constructor built from a `LedgerHeader` (used by acquisition and replay) now starts
`immutable_` false and only becomes immutable once `setImmutable()` confirms both maps are sound, instead
of claiming to be immutable from construction while its maps are still mid-sync.

### Context of Change

`Ledger(LedgerHeader const&, Rules, Family&)` starts at `immutable_` false. Its maps are constructed
`Synching` and filled in afterwards, by an acquisition syncing against the hashes the header carries or
by a replay that only reads the header, so the ledger is settled by `setImmutable()` once both maps are
sound rather than at construction. Every consumer of `isImmutable()` therefore sees an in-flight
acquisition for what it is, which is what `LedgerHistory::insert()` and `LedgerReplayMsgHandler` gate on.
`InboundLedger::done()` (part 9) already publishes completeness only after settling, so no reader
observes the flag before the ledger it describes is immutable.

`mapHashesFromHeader_` records that this constructor's transaction and account hashes are input rather
than derived, and `setImmutable()` therefore leaves them alone. Deriving them from the maps would turn a
ledger verified against a hash we asked for into one that is merely self-consistent: a map that fell
short of its target would be relabelled instead of refused. It is fixed at construction, unlike
`immutable_`, and set by this constructor alone, so every other constructor still derives its map
hashes.

Two gtest cases cover it: the first builds a ledger from a header naming a chain root, checks both maps
report as syncing and the ledger does not report as immutable, then abandons the transaction map and
checks settling refuses; the second leaves the transaction map empty while the header names that root,
so settling succeeds and both the named root and the ledger hash it was verified against are still what
the header carried.

### API Impact

- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)

