### PR TITLE
fix: Restart the timer when reviving a timed-out TX-set acquisition

### DIFF
--- a/src/test/app/TransactionAcquire_test.cpp
+++ b/src/test/app/TransactionAcquire_test.cpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <memory>
 #include <set>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -436,13 +437,128 @@ struct TransactionAcquire_test : public beast::unit_test::Suite
     }
 
     /**
+     * A timed-out acquisition asks again, and examines data again, once
+     * stillNeed() revives it.
+     *
+     * The pending timer is private to TimeoutCounter, so this drives it
+     * through a real timeout chain rather than cancel(): cancel() alone
+     * never arms a timer, so reviving it afterwards would restart a chain
+     * that was never running in the first place, proving nothing about
+     * restarting one that timed out.
+     *
+     * @param env The environment to run in.
+     */
+    void
+    testRevivedAcquireCanRequestAgain(jtx::Env& env)
+    {
+        testcase("A revived acquire asks again and accepts data again");
+
+        DeepChain const chain{nextSeed()};
+
+        // One candidate, offered once by init(). RequestCountingPeerSet dedups by tracked id like
+        // the real peer set, so onTimer()'s later addPeers(1) calls never re-offer it; any further
+        // request to it has to come from onTimer()'s broadcast trigger(nullptr) instead.
+        auto const candidate = std::make_shared<ChargeRecordingPeer>();
+        auto peerSet =
+            std::make_unique<RequestCountingPeerSet>(std::vector<std::shared_ptr<Peer>>{candidate});
+        auto* const peerSetPtr = peerSet.get();
+
+        // A short interval, since this case waits out a whole timeout chain.
+        auto const acquire = std::make_shared<TransactionAcquire>(
+            env.app(), chain.rootHash.asUInt256(), std::move(peerSet), kFastRetry);
+
+        acquire->init(1);
+        BEAST_EXPECT(waitFor([&] { return peerSetPtr->requests() > 0; }));
+        BEAST_EXPECT(peerSetPtr->addedPeers() == std::set<Peer::id_t>{candidate->id()});
+
+        // A root that cannot hash to this acquisition's set, so polling with it never sets
+        // haveRoot_ and so cannot itself mask the acquisition failing on its own. See
+        // testTimerRetriesThenGivesUp, which probes the same way.
+        DeepChain const wrongChain{nextSeed()};
+        auto const probe = [&] {
+            return wasIgnored(acquire->takeNodes(
+                {{SHAMapNodeID{}, wrongChain.nodeAt(0)}}, std::make_shared<ChargeRecordingPeer>()));
+        };
+
+        // Nothing here ever reports progress, so onTimer() counts a timeout every tick; past
+        // kMaxTimeouts (20) it fails itself and stops examining data.
+        BEAST_EXPECT(waitFor(probe));
+        int const requestsBeforeRevival = peerSetPtr->requests();
+
+        // Revived, so the timer chain restarts. stillNeed() clamps timeouts_ down to
+        // kNormTimeouts rather than to zero, so the very next tick broadcasts to every peer
+        // already tracked - the only way a peer already selected once is asked again, and so
+        // what shows the timer chain was restarted rather than just the failed flag cleared.
+        acquire->stillNeed();
+        BEAST_EXPECT(waitFor([&] { return peerSetPtr->requests() > requestsBeforeRevival; }));
+
+        // Data is examined again too: the real root is accepted, and asks for the next level.
+        auto const peer = std::make_shared<ChargeRecordingPeer>();
+        auto const revived = acquire->takeNodes({{SHAMapNodeID{}, chain.nodeAt(0)}}, peer);
+        BEAST_EXPECT(!wasIgnored(revived));
+        BEAST_EXPECT(revived.isUseful());
+
+        // Stop the retry loop, which would otherwise keep asking for as long as this case runs.
+        acquire->cancel();
+    }
+
+    /**
+     * A running acquisition keeps the wait it already has.
+     *
+     * The other half of the same guard: consensus asks for a set it
+     * still needs once per round, so without the early return every ask
+     * would re-arm the timer and a set asked for more often than the
+     * interval would never tick at all. setTimer() cancels any pending
+     * wait, so calling stillNeed() faster than the interval is what
+     * makes that visible.
+     *
+     * Keeps the production interval, unlike the case above: the asking
+     * has to be clearly faster than the wait for a surviving tick to
+     * mean anything.
+     *
+     * @param env The environment to run in.
+     */
+    void
+    testStillNeedLeavesARunningAcquireAlone(jtx::Env& env)
+    {
+        testcase("A running acquire keeps the wait it has");
+
+        // One candidate, so every tick that survives produces a request.
+        auto const candidate = std::make_shared<ChargeRecordingPeer>();
+        auto peerSet =
+            std::make_unique<RequestCountingPeerSet>(std::vector<std::shared_ptr<Peer>>{candidate});
+        auto* const peerSetPtr = peerSet.get();
+
+        // An unrelated hash: nothing here feeds it data, so it stays incomplete and keeps asking.
+        auto const acquire =
+            std::make_shared<TransactionAcquire>(env.app(), uint256{43}, std::move(peerSet));
+
+        // init() asks the candidate once and arms the timer. That first request is not the one
+        // under test, so count from here.
+        acquire->init(1);
+        int const requestsFromInit = peerSetPtr->requests();
+
+        // Ask again far faster than the interval, the way a short consensus round would. Every ask
+        // clamps the timeout count, so the acquisition cannot give up while this runs.
+        auto const askAgainRepeatedly = [&] {
+            acquire->stillNeed();
+            std::this_thread::sleep_for(std::chrono::milliseconds{20});
+            return peerSetPtr->requests() > requestsFromInit;
+        };
+
+        // A tick gets through despite the asking, which it could not if each ask re-armed the wait.
+        BEAST_EXPECT(waitFor(askAgainRepeatedly));
+
+        acquire->cancel();
+    }
+
+    /**
      * The retry timer re-asks with no peer of its own, then gives up on
      * its own.
      *
-     * The only case that reaches onTimer(). Pins the two behaviors, not the
-     * thresholds they trip at: bounding those means asserting on wall clock.
-     * Both are read in one poll, so a fast interval cannot let the give-up land
-     * between the two readings.
+     * Pins the two behaviors, not the thresholds they trip at: bounding those
+     * means asserting on wall clock. Both are read in one poll, so a fast
+     * interval cannot let the give-up land between the two readings.
      *
      * @param env The environment to run in.
      */
@@ -498,8 +614,11 @@ struct TransactionAcquire_test : public beast::unit_test::Suite
         testDuplicateNonRootReplyIsFree(env);
         testUndeserializableNodeIsCharged(env);
         testInitAsksOnlyPeersWithTheSet(env);
+        testStillNeedLeavesARunningAcquireAlone(env);
 
-        // Last: the only case that waits out a whole timeout chain.
+        // Last: both wait out a whole timeout chain, and neither needs the cases above to have
+        // run first.
+        testRevivedAcquireCanRequestAgain(env);
         testTimerRetriesThenGivesUp(env);
     }
 

--- a/src/xrpld/app/ledger/detail/TransactionAcquire.cpp
+++ b/src/xrpld/app/ledger/detail/TransactionAcquire.cpp
@@ -53,6 +53,11 @@ TransactionAcquire::done()
 {
     // mtx_ is held, so this may only post real work rather than do it.
 
+    // Runs at most once per outcome, since every caller reaches here only after clearing
+    // TimeoutCounter's isDone() gate and setting complete_ or failed_. It can still run twice for
+    // two outcomes, since stillNeed() revives a timed-out set that can finish later - which is why
+    // this is unlatched, unlike InboundLedger::done() with its signaled_.
+
     if (failed_)
     {
         JLOG(journal_.debug()) << "Failed to acquire TX set " << hash_;
@@ -270,10 +275,20 @@ TransactionAcquire::init(int numPeers)
 void
 TransactionAcquire::stillNeed()
 {
-    ScopedLockType const sl(mtx_);
+    ScopedLockType sl(mtx_);
 
     timeouts_ = std::min<int>(timeouts_, kNormTimeouts);
+
+    // Nothing to revive: leave a running acquisition on the wait it has, rather than restarting it
+    // for every consensus round that asks for the set again.
+    if (!failed_)
+        return;
+
     failed_ = false;
+
+    // Restarting the timer is what resumes the acquisition. expires_after() cancels any pending
+    // wait, so this cannot leave two timer chains running.
+    setTimer(sl);
 }
 
 }  // namespace xrpl

--- a/src/xrpld/app/ledger/detail/TransactionAcquire.h
+++ b/src/xrpld/app/ledger/detail/TransactionAcquire.h
@@ -59,6 +59,13 @@ public:
     void
     init(int startPeers);
 
+    /**
+     * Resume a timed-out acquisition, or leave a running one alone.
+     *
+     * Always clamps the timeout count. An acquisition that failed has its timer
+     * chain stopped, so this also clears the failed flag and restarts the timer;
+     * one that is still running already has a timer pending.
+     */
     void
     stillNeed();
 


### PR DESCRIPTION
Part 11/17 of a stack. Base: part 10 (`bthomee/shamap-invalid-10-header-ledger-mutable`).

## High Level Overview of Change

`TransactionAcquire::stillNeed()` now restarts the retry timer whenever it revives a timed-out
acquisition, so a revived object actually resumes asking peers instead of silently waiting for
unprompted data.

### Context of Change

`TransactionAcquire::stillNeed()` restarts the retry timer whenever it revives an acquisition, so a
revived object resumes asking rather than waiting for a peer to send data unprompted. Restarting is what
resumes it: the timer chain is what drives `trigger()`, and a timed-out acquisition has none pending.
`expires_after()` cancels any pending wait, so this cannot leave two chains running.

It also returns early when there is nothing to revive, so an acquisition that is still running keeps the
wait it already has. Consensus asks for a set it still needs once per round, and re-arming on every ask
would push the next tick back each time, so a set asked for more often than the interval would never
tick at all.

Two cases cover the halves. The first drives a real timeout chain to failure — `cancel()` alone never
arms a timer, so reviving from a faked failure would only prove a timer starts, not that a timed-out one
restarts — then revives it and checks a request goes out and data is examined again. The restart is
observed through a candidate peer that can only be re-offered by `onTimer()`'s broadcast:
`RequestCountingPeerSet` dedups by tracked id like the real peer set, so `addPeers()` never re-offers a
peer already selected, and a request reaching it again after `stillNeed()` is what distinguishes an
armed acquisition from one whose failure flag was merely cleared. The second asks again faster than the
interval, the way a short consensus round would, and checks a tick still gets through.

### API Impact

None of the checkboxes below apply: this is an internal `xrpld` correctness fix with no `libxrpl`,
public-API, or peer-protocol surface.

