### PR TITLE
fix: Count partial batch progress in a TX-set reply

### DIFF
--- a/src/test/app/TransactionAcquire_test.cpp
+++ b/src/test/app/TransactionAcquire_test.cpp
@@ -11,6 +11,7 @@
 #include <xrpl/shamap/SHAMap.h>
 #include <xrpl/shamap/SHAMapAddNode.h>
 #include <xrpl/shamap/SHAMapNodeID.h>
+#include <xrpl/shamap/SHAMapTreeNode.h>
 
 #include <xrpl.pb.h>
 
@@ -394,6 +395,81 @@ struct TransactionAcquire_test : public beast::unit_test::Suite
     }
 
     /**
+     * A batch that ends on a bad node still counts the good nodes ahead of it,
+     * and a batch that achieved nothing records no progress.
+     *
+     * The recorded progress is what the verdict is for: it stops the
+     * next timer tick from counting a timeout, so reporting only the
+     * node the batch stopped on would push an acquisition that is
+     * genuinely advancing toward kMaxTimeouts, while recording progress
+     * for a batch we already had would hold a stalled one open. The flag
+     * is read rather than the returned tally, which only stands in for
+     * it, and cleared between batches so each reading is about the batch
+     * just fed.
+     *
+     * @param env The environment to run in.
+     */
+    void
+    testPartialBatchIsCounted(jtx::Env& env)
+    {
+        testcase("A batch ending on a bad node still counts the good nodes");
+
+        DeepChain const chain{nextSeed()};
+
+        auto const acquire = std::make_shared<TestableTransactionAcquire>(
+            env.app(), chain.rootHash.asUInt256(), std::make_unique<RequestCountingPeerSet>());
+        auto const peer = std::make_shared<ChargeRecordingPeer>();
+
+        // The root is useful, so it records progress.
+        acquire->takeNodes({{SHAMapNodeID{}, chain.nodeAt(0)}}, peer);
+        BEAST_EXPECT(acquire->madeProgress());
+        acquire->clearProgress();
+
+        // Good nodes at depths 1 and 2, then a further chain node mislabeled at a position it
+        // cannot occupy. The map stays sound, so only the last node is bad.
+        std::vector<std::pair<SHAMapNodeID, SHAMapTreeNodePtr>> batch;
+        batch.emplace_back(SHAMapNodeID{1, uint256{}}, chain.nodeAt(1));
+        batch.emplace_back(SHAMapNodeID{2, uint256{}}, chain.nodeAt(2));
+        batch.emplace_back(SHAMapNodeID{9, uint256{}}, chain.nodeAt(3));
+
+        auto const san = acquire->takeNodes(batch, peer);
+
+        // The verdict names both halves rather than just the failure, and the two good nodes are
+        // what the next timer tick must not count as a timeout. The batch stops on the bad node,
+        // so exactly one is counted however many were left unexamined behind it.
+        BEAST_EXPECTS(tallyIs(san, 2, 1, 0), san.get());
+        BEAST_EXPECT(san.isUseful());
+        BEAST_EXPECT(acquire->madeProgress());
+        BEAST_EXPECT(acquire->isMapValid());
+
+        // A batch of nothing but the root we already have: counted as a duplicate rather than
+        // reaching the clean exit with nothing counted, so it is neither reported as useful nor
+        // allowed to postpone the timeout.
+        acquire->clearProgress();
+        auto const repeatedRoot = acquire->takeNodes({{SHAMapNodeID{}, chain.nodeAt(0)}}, peer);
+
+        BEAST_EXPECTS(tallyIs(repeatedRoot, 0, 0, 1), repeatedRoot.get());
+        BEAST_EXPECT(repeatedRoot.isGood());
+        BEAST_EXPECT(!repeatedRoot.isUseful());
+        BEAST_EXPECT(!acquire->madeProgress());
+
+        // The same root alongside a node we do need: the duplicate is reported as one, and the
+        // node that did hook in is what records the progress.
+        std::vector<std::pair<SHAMapNodeID, SHAMapTreeNodePtr>> mixed;
+        mixed.emplace_back(SHAMapNodeID{}, chain.nodeAt(0));
+        mixed.emplace_back(SHAMapNodeID{3, uint256{}}, chain.nodeAt(3));
+
+        auto const withDuplicateRoot = acquire->takeNodes(mixed, peer);
+
+        BEAST_EXPECTS(tallyIs(withDuplicateRoot, 1, 0, 1), withDuplicateRoot.get());
+        BEAST_EXPECT(withDuplicateRoot.isUseful());
+        BEAST_EXPECT(acquire->madeProgress());
+
+        // takeNodes() charges nobody: InboundTransactions::gotData() reads the verdict and decides.
+        BEAST_EXPECT(peer->charges().empty());
+    }
+
+    /**
      * init() asks only the peers that claim to have the set.
      *
      * addPeers() passes hasTxSet(hash_) as its filter and trigger() as its
@@ -613,6 +689,7 @@ struct TransactionAcquire_test : public beast::unit_test::Suite
         testDuplicateRootReplyIsFree(env);
         testDuplicateNonRootReplyIsFree(env);
         testUndeserializableNodeIsCharged(env);
+        testPartialBatchIsCounted(env);
         testInitAsksOnlyPeersWithTheSet(env);
         testStillNeedLeavesARunningAcquireAlone(env);
 

--- a/src/xrpld/app/ledger/detail/InboundTransactions.cpp
+++ b/src/xrpld/app/ledger/detail/InboundTransactions.cpp
@@ -173,8 +173,11 @@ public:
         {
             peer->charge(resource::kFeeInvalidData, "ledger_data invalid");
         }
-        else if (!san.isUseful())
+        else if (!san.isGood())
         {
+            // Good rather than useful: the verdict now tells a batch of nodes we already hold from
+            // one that was never examined, and a duplicate is what an honest second responder to
+            // trigger()'s fan-out sends.
             peer->charge(resource::kFeeUselessData, "ledger_data useless");
         }
     }

--- a/src/xrpld/app/ledger/detail/TransactionAcquire.cpp
+++ b/src/xrpld/app/ledger/detail/TransactionAcquire.cpp
@@ -192,8 +192,29 @@ TransactionAcquire::takeNodes(
     std::vector<std::pair<SHAMapNodeID, SHAMapTreeNodePtr>> data,
     std::shared_ptr<Peer> const& peer)
 {
-    ScopedLockType const sl(mtx_);
+    ScopedLockType sl(mtx_);
 
+    auto const san = takeNodesLocked(std::move(data), peer, sl);
+
+    // Recorded here rather than on each of takeNodesLocked()'s exits, several of which stop the
+    // batch early: a batch that advanced the map must keep the next timer tick from counting a
+    // timeout against it, and nothing in the compiler would catch an exit that forgot to say so.
+    //
+    // Useful rather than good: a batch of nothing but duplicates advanced nothing, so it records no
+    // progress even though it was not the sender's fault. That costs retry budget on the ordinary
+    // second responder to a fan-out and nothing else.
+    if (san.isUseful())
+        progress_ = true;
+
+    return san;
+}
+
+SHAMapAddNode
+TransactionAcquire::takeNodesLocked(
+    std::vector<std::pair<SHAMapNodeID, SHAMapTreeNodePtr>> data,
+    std::shared_ptr<Peer> const& peer,
+    ScopedLockType&)
+{
     if (complete_)
     {
         JLOG(journal_.trace()) << "TX set complete";
@@ -205,6 +226,10 @@ TransactionAcquire::takeNodes(
         JLOG(journal_.trace()) << "TX set failed";
         return SHAMapAddNode();
     }
+
+    // Accumulated across the batch, so a packet ending in one bad node still counts the nodes
+    // hooked in ahead of it, as InboundLedger::receiveNode() already does.
+    SHAMapAddNode san;
 
     try
     {
@@ -220,36 +245,45 @@ TransactionAcquire::takeNodes(
                 if (haveRoot_)
                 {
                     JLOG(journal_.debug()) << "Got root TXS node, already have it";
+                    san.incDuplicate();
+                    continue;
                 }
-                else if (!map_->addRootNode(SHAMapHash{hash_}, std::move(d.second), nullptr)
-                              .isGood())
+
+                auto const result =
+                    map_->addRootNode(SHAMapHash{hash_}, std::move(d.second), nullptr);
+                san += result;
+
+                if (!result.isGood())
                 {
                     JLOG(journal_.warn()) << "TX acquire got bad root node for TX set " << hash_
                                           << " from peer " << peer->id();
-                    return SHAMapAddNode::invalid();
+                    return san;
                 }
-                else
-                {
-                    haveRoot_ = true;
-                }
+
+                haveRoot_ = true;
+                continue;
             }
-            else if (!map_->addKnownNode(d.first, std::move(d.second), &sf).isGood())
+
+            auto const result = map_->addKnownNode(d.first, std::move(d.second), &sf);
+            san += result;
+
+            if (!result.isGood())
             {
                 JLOG(journal_.warn()) << "TX acquire got bad non-root node " << d.first
                                       << " for TX set " << hash_ << " from peer " << peer->id();
-                return SHAMapAddNode::invalid();
+                return san;
             }
         }
 
         trigger(peer);
-        progress_ = true;
-        return SHAMapAddNode::useful();
+        return san;
     }
     catch (std::exception const& ex)
     {
         JLOG(journal_.error()) << "Peer " << peer->id()
                                << " sent us junky transaction node data: " << ex.what();
-        return SHAMapAddNode::invalid();
+        san.incInvalid();
+        return san;
     }
 }
 

--- a/src/xrpld/app/ledger/detail/TransactionAcquire.h
+++ b/src/xrpld/app/ledger/detail/TransactionAcquire.h
@@ -51,6 +51,15 @@ public:
         std::chrono::milliseconds retryInterval = kRetryInterval);
     ~TransactionAcquire() override = default;
 
+    /**
+     * Add nodes a peer sent us to the set we are acquiring.
+     *
+     * @param data The nodes to add, each with its claimed position.
+     * @param peer The peer that sent them.
+     * @return The tally of useful, unwanted, and bad nodes in the batch. Useful and
+     *         bad can both be nonzero, since only the node the batch stops on is
+     *         bad.
+     */
     SHAMapAddNode
     takeNodes(
         std::vector<std::pair<SHAMapNodeID, SHAMapTreeNodePtr>> data,
@@ -77,6 +86,23 @@ protected:
 private:
     bool haveRoot_{false};
     std::unique_ptr<PeerSet> peerSet_;
+
+    /**
+     * Add nodes a peer sent us, on the lock takeNodes() holds.
+     *
+     * Split out so recording what the batch achieved happens on one exit rather
+     * than on each of the several this has, including the ones that stop the batch
+     * early.
+     *
+     * @param data The nodes to add, each with its claimed position.
+     * @param peer The peer that sent them.
+     * @return The tally of useful, unwanted, and bad nodes in the batch.
+     */
+    SHAMapAddNode
+    takeNodesLocked(
+        std::vector<std::pair<SHAMapNodeID, SHAMapTreeNodePtr>> data,
+        std::shared_ptr<Peer> const& peer,
+        ScopedLockType&);
 
     void
     onTimer(bool progress, ScopedLockType& sl) override;


### PR DESCRIPTION
Part 12/17 of a stack. Base: part 11 (`bthomee/shamap-invalid-11-revive-timer`).

## High Level Overview of Change

`TransactionAcquire::takeNodes()` now accumulates one combined verdict across a whole batch instead of
stopping at the first bad node, so a packet that ends badly still gets credit — and clears the
timeout-postponing progress flag — for the good nodes ahead of it, matching what
`InboundLedger::receiveNode()` already does.

### Context of Change

`TransactionAcquire::takeNodes()` accumulates one `SHAMapAddNode` across the batch and hands it back, so
a packet ending on one bad node still counts the nodes hooked in ahead of it. A root the set already
holds counts as a duplicate rather than passing unremarked, which is what tells a batch of nodes we
already have from one that was never examined at all.

The body moves to `takeNodesLocked()` and `takeNodes()` becomes a thin wrapper that takes the lock and
records what the batch achieved on the one exit — several of the inner exits stop the batch early, and
nothing in the compiler catches one that forgets to record progress. Progress turns on the batch being
useful rather than good, so a batch of nothing but duplicates records none: that flag is what keeps the
next timer tick from counting a timeout, and a reply carrying nothing new advanced nothing. It costs
retry budget on the ordinary second responder to a fan-out and nothing else.

`InboundTransactions::gotData()` asks `isGood()` rather than `isUseful()` for the useless-data charge,
which keeps that duplicate free — now that the verdict distinguishes a duplicate from an empty tally,
the useful test would charge for it while the batch that was never examined still needs charging.

`testPartialBatchIsCounted` feeds two good nodes followed by one at a position it cannot occupy, and
checks the verdict names both halves and that the flag is set; then a batch of nothing but a root
already held, checking it is good, not useful, and records nothing; then that root alongside a node the
set does need, checking the duplicate is reported as one while the other records the progress.

### API Impact

None of the checkboxes below apply: this is an internal `xrpld` correctness fix with no `libxrpl`,
public-API, or peer-protocol surface.

