### PR TITLE
fix: Report no ledger from a failed acquisition

### DIFF
--- a/src/test/app/InboundLedger_test.cpp
+++ b/src/test/app/InboundLedger_test.cpp
@@ -542,6 +542,9 @@ struct InboundLedger_test : public beast::unit_test::Suite
 
         BEAST_EXPECT(acquire->isFailed());
         BEAST_EXPECT(!acquire->isComplete());
+
+        // A failed acquisition must not hand back the partial ledger it built.
+        BEAST_EXPECT(acquire->getLedger() == nullptr);
     }
 
     /**
@@ -705,7 +708,8 @@ struct InboundLedger_test : public beast::unit_test::Suite
         BEAST_EXPECT(!acquire->isComplete());
         BEAST_EXPECT(peerSetPtr->requests() > requestsFromInit);
 
-        // done() remembered the hash, which is what stops the next round asking again.
+        // A failed acquisition holds no ledger to hand back, and done() remembered the hash.
+        BEAST_EXPECT(acquire->getLedger() == nullptr);
         BEAST_EXPECT(
             waitFor([&] { return env.app().getInboundLedgers().isFailure(kUnknownLedger); }));
     }

--- a/src/xrpld/app/ledger/InboundLedger.h
+++ b/src/xrpld/app/ledger/InboundLedger.h
@@ -102,10 +102,20 @@ public:
         return failed_;
     }
 
+    /**
+     * The acquired ledger, or nullptr if it is not yet available.
+     *
+     * Nullptr both before a header has been obtained, since there is
+     * nothing built yet to hand out, and once the acquisition has failed.
+     * A failed acquisition may still hold a partially built ledger, which
+     * must never be used, so failure reports nothing rather than rely on
+     * every caller to check isFailed() first. The pointer itself is kept,
+     * since getJson() reports on the partial maps of a failed acquire.
+     */
     std::shared_ptr<Ledger const>
     getLedger() const
     {
-        return ledger_;
+        return failed_ ? nullptr : ledger_;
     }
 
     std::uint32_t


### PR DESCRIPTION
Part 13/17 of a stack. Base: part 12 (`bthomee/shamap-invalid-12-batch-progress`).

## High Level Overview of Change

`InboundLedger::getLedger()` now returns nothing once the acquisition has failed, so a partially-built
(and potentially unsound) ledger can never leak out through the one accessor, without requiring every
caller to check `isFailed()` first.

### Context of Change

`InboundLedger::getLedger()` reports nothing once the acquisition has failed. A failed acquisition can
still hold a partially built ledger, and that ledger must never be used, so the guard sits at the one
accessor rather than resting on every caller checking `isFailed()` first. The pointer itself is kept,
since `getJson()` reports on the partial maps of a failed acquire, which is what an operator inspecting
one needs.

Two existing cases gain the assertion: the one whose transaction map is a chain found in a fetch pack,
and the one that waits out a whole timeout chain. Both already checked the failure itself; what's new is
that nothing is handed back with it.

### API Impact

None of the checkboxes below apply: this is an internal `xrpld` correctness fix with no `libxrpl`,
public-API, or peer-protocol surface.

