### PR TITLE
fix: Keep a settled acquisition registered so late replies stay bounded

### DIFF
--- a/src/test/app/TransactionAcquire_test.cpp
+++ b/src/test/app/TransactionAcquire_test.cpp
@@ -264,6 +264,59 @@ struct TransactionAcquire_test : public beast::unit_test::Suite
     }
 
     /**
+     * The late-reply allowance must survive giveSet(), through the real
+     * dispatch rather than by calling takeNodes() directly.
+     *
+     * giveSet() only resets the acquisition when something else supplied
+     * the set (see the fromAcquire guard), so a reply arriving after
+     * completion still reaches getAcquire() and takeNodesLocked()'s
+     * allowance instead of gotData()'s unconditional ta == nullptr charge.
+     * Driven end to end through InboundTransactions::gotData(), including
+     * the async job done() hands off to, since every other late-reply test
+     * in this suite calls takeNodes() directly and so never exercises that
+     * path.
+     *
+     * @param env The environment to run in.
+     */
+    void
+    testLateReplyAllowanceSurvivesGiveSet(jtx::Env& env)
+    {
+        testcase("The late-reply allowance survives giveSet()");
+
+        auto const chain = DeepChain::toLeaf(3, nextSeed());
+        auto& inbound = env.app().getInboundTransactions();
+
+        uint256 const setHash = chain.rootHash.asUInt256();
+        BEAST_EXPECT(inbound.getSet(setHash, true) == nullptr);
+
+        // One peer supplies the whole chain, so it alone earns the one targeted follow-up
+        // request the root reply buys, and so the allowance's one slot.
+        auto const rootPeer = std::make_shared<ChargeRecordingPeer>();
+        inbound.gotData(setHash, rootPeer, packetFor(chain, {{SHAMapNodeID{}, chain.nodeAt(0)}}));
+        BEAST_EXPECT(rootPeer->charges().empty());
+
+        inbound.gotData(setHash, rootPeer, packetFor(chain, chain.nodesBelowRoot()));
+        BEAST_EXPECT(rootPeer->charges().empty());
+
+        // Proves the acquisition completed and handed off through the real done()/giveSet()
+        // path, rather than this case racing takeNodes() directly the way the rest of the
+        // suite does.
+        auto const delivered = waitForDeliveredSet(env, setHash);
+        BEAST_EXPECT(delivered != nullptr);
+
+        // Without keeping the acquisition registered past giveSet(), gotData() would take the
+        // ta == nullptr branch here and charge this outright - the allowance in
+        // takeNodesLocked() would never get a chance to run at all. rootPeer's own late reply
+        // is the one whose slot this is, and is free.
+        inbound.gotData(setHash, rootPeer, packetFor(chain, {{SHAMapNodeID{}, chain.nodeAt(0)}}));
+        BEAST_EXPECT(rootPeer->charges().empty());
+
+        // A second reply from rootPeer has already spent that slot: this one is a replay.
+        inbound.gotData(setHash, rootPeer, packetFor(chain, {{SHAMapNodeID{}, chain.nodeAt(0)}}));
+        BEAST_EXPECT(rootPeer->charges() == std::vector{resource::kFeeUselessData});
+    }
+
+    /**
      * A chain reaching kLeafDepth must end the acquisition outright.
      *
      * @param env The environment to run in.
@@ -1104,6 +1157,7 @@ struct TransactionAcquire_test : public beast::unit_test::Suite
 
         testHappyPathCompletesAcquisition(env);
         testTwoPeersEachSupplyPartOfTheSet(env);
+        testLateReplyAllowanceSurvivesGiveSet(env);
         testFabricatedChainFailsAcquire(env);
         testWrongNodeKeepsAcquireAlive(env);
         testBadRootKeepsAcquireAlive(env);

--- a/src/xrpld/app/ledger/detail/InboundTransactions.cpp
+++ b/src/xrpld/app/ledger/detail/InboundTransactions.cpp
@@ -197,7 +197,14 @@ public:
                 inboundSet.set = set;
             }
 
-            inboundSet.acquire.reset();
+            // Only reset when something other than the acquisition itself gave us the set:
+            // dropping it here cancels an acquisition still in flight, which is correct when a
+            // set arrived some other way, but not when this call IS that acquisition completing.
+            // Keeping it alive until newRound() sweeps the entry is what lets a late reply for
+            // this hash still reach getAcquire() above, and so takeNodesLocked()'s "one free per
+            // peer asked" allowance, rather than the ta == nullptr branch charging it outright.
+            if (!fromAcquire)
+                inboundSet.acquire.reset();
         }
 
         if (isNew)


### PR DESCRIPTION
Part 16/17 of a stack. Base: part 15 (`bthomee/shamap-invalid-15-invalidated-map-receivenode`).

## High Level Overview of Change

`InboundTransactions::giveSet()` now keeps a completed acquisition registered when the acquisition
itself is what supplied the set, so a late reply for that hash still reaches the late-reply allowance
instead of being charged outright.

### Context of Change

`giveSet()` used to reset the map entry's `acquire` pointer unconditionally once a set arrived, so any
reply for that hash arriving after completion took `gotData()`'s `ta == nullptr` branch from then on —
charged outright, with no allowance in play at all, since `takeNodesLocked()` was never reached to apply
one. The tests added for the allowance in part 14 called `acquire->takeNodes()` directly, bypassing
`gotData()`/`giveSet()` entirely, so they never exercised this gap: the real production entry point for
peer replies never got as far as the allowance at all.

`giveSet()` now only resets the entry's `acquire` pointer when something other than the acquisition
itself supplied the set — a set arriving some other way still cancels an acquisition genuinely in
flight, but the acquisition completing on its own is not that. Keeping it alive until `newRound()` sweeps
the entry is what lets a late reply for this hash still reach `getAcquire()` and, through it,
`takeNodesLocked()`'s allowance.

This is a Copilot review finding on part 14 (`#8093`), split out into its own branch rather than folded
in: unlike the late-reply allowance bound fixed there, this gap is unchanged pre-existing behavior, not
something this stack makes worse, so there is no urgency tying it to that PR's release.

Covered by a new `TransactionAcquire` gtest/boost case driven end to end through
`InboundTransactions::gotData()`, including the async job `done()` hands off to, so the real completion
path is what proves the allowance survives it.

### API Impact

None of the checkboxes below apply: this is an internal `xrpld` correctness fix with no `libxrpl`,
public-API, or peer-protocol surface.

