### PR TITLE
Add TransactionProposal invariants for Cosign

### DIFF
--- a/include/xrpl/protocol_autogen/transactions/TransactionProposalCreate.h
+++ b/include/xrpl/protocol_autogen/transactions/TransactionProposalCreate.h
@@ -21,7 +21,7 @@ class TransactionProposalCreateBuilder;
  * Type: ttTRANSACTION_PROPOSAL_CREATE (92)
  * Delegable: Delegation::NotDelegable
  * Amendment: featureCosign
- * Privileges: NoPriv
+ * Privileges: Privilege::NoPriv
  *
  * Immutable wrapper around STTx providing type-safe field access.
  * Use TransactionProposalCreateBuilder to construct new transactions.

--- a/include/xrpl/tx/ApplyContext.h
+++ b/include/xrpl/tx/ApplyContext.h
@@ -135,6 +135,7 @@ public:
         XRPL_ASSERT(
             view_.has_value(),
             "xrpl::ApplyContext::getApplyViewContext : view_ emplaced in constructor");
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access) view_ emplaced in constructor
         return {.view = *view_, .tx = tx};
     }
 

--- a/include/xrpl/tx/invariants/CosignerInvariant.h
+++ b/include/xrpl/tx/invariants/CosignerInvariant.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <xrpl/beast/utility/Journal.h>
+#include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/STLedgerEntry.h>
+#include <xrpl/protocol/STTx.h>
+#include <xrpl/protocol/TER.h>
+#include <xrpl/protocol/XRPAmount.h>
+
+#include <cstdint>
+#include <map>
+#include <vector>
+
+namespace xrpl {
+
+class ReadView;
+
+/**
+ * @brief Invariants for TransactionProposal ledger entries.
+ *
+ * - A proposal's payload and metadata are immutable except for signature
+ *   fields and PreviousTxn bookkeeping.
+ * - Proposal reserve changes match proposal creation and deletion.
+ * - Only transaction types implementing proposal lifecycle operations may
+ *   create, modify, or delete proposals.
+ * - Collected signer arrays remain sorted, unique, and bounded.
+ */
+class ValidTransactionProposal
+{
+    struct Change
+    {
+        bool isDelete;
+        SLE::const_pointer before;
+        SLE::const_pointer after;
+    };
+
+    std::vector<Change> changes_;
+    std::map<AccountID, std::int64_t> ownerCountDelta_;
+    std::map<AccountID, std::int64_t> sponsoredOwnerCountDelta_;
+    std::map<AccountID, std::int64_t> sponsoringOwnerCountDelta_;
+    std::map<AccountID, std::int64_t> expectedOwnerCountDelta_;
+    std::map<AccountID, std::int64_t> expectedSponsoredOwnerCountDelta_;
+    std::map<AccountID, std::int64_t> expectedSponsoringOwnerCountDelta_;
+    std::uint32_t created_ = 0;
+    std::uint32_t modified_ = 0;
+    std::uint32_t deleted_ = 0;
+    bool invalidSignerArrays_ = false;
+
+public:
+    void
+    visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after);
+
+    [[nodiscard]] bool
+    finalize(STTx const& tx, TER result, XRPAmount, ReadView const& view, beast::Journal const& j)
+        const;
+};
+
+}  // namespace xrpl

--- a/include/xrpl/tx/invariants/InvariantCheck.h
+++ b/include/xrpl/tx/invariants/InvariantCheck.h
@@ -7,6 +7,7 @@
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/tx/invariants/AMMInvariant.h>
+#include <xrpl/tx/invariants/CosignerInvariant.h>
 #include <xrpl/tx/invariants/DirectoryInvariant.h>
 #include <xrpl/tx/invariants/FreezeInvariant.h>
 #include <xrpl/tx/invariants/LoanBrokerInvariant.h>
@@ -462,6 +463,7 @@ using InvariantChecks = std::tuple<
     ValidAmounts,
     ValidMPTTransfer,
     ObjectHasPseudoAccount,
+    ValidTransactionProposal,
     SponsorshipOwnerCountsMatch,
     SponsorshipAccountCountMatchesField>;
 

--- a/src/libxrpl/tx/invariants/CosignerInvariant.cpp
+++ b/src/libxrpl/tx/invariants/CosignerInvariant.cpp
@@ -1,0 +1,319 @@
+#include <xrpl/tx/invariants/CosignerInvariant.h>
+
+#include <xrpl/basics/Log.h>
+#include <xrpl/beast/utility/Journal.h>
+#include <xrpl/ledger/ReadView.h>
+#include <xrpl/ledger/helpers/ProposalHelpers.h>
+#include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/LedgerFormats.h>
+#include <xrpl/protocol/Protocol.h>
+#include <xrpl/protocol/SField.h>
+#include <xrpl/protocol/STArray.h>
+#include <xrpl/protocol/STLedgerEntry.h>
+#include <xrpl/protocol/STObject.h>
+#include <xrpl/protocol/STTx.h>
+#include <xrpl/protocol/TER.h>
+#include <xrpl/protocol/TxFormats.h>
+#include <xrpl/protocol/XRPAmount.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <utility>
+
+namespace xrpl {
+
+namespace {
+
+std::int64_t
+fieldDelta(bool isDelete, SLE::const_ref before, SLE::const_ref after, SField const& field)
+{
+    auto const value = [&field](SLE::const_ref sle) -> std::int64_t {
+        return sle ? sle->getFieldU32(field) : 0;
+    };
+    return (isDelete ? 0 : value(after)) - value(before);
+}
+
+void
+removeSignatureFields(STObject& tx)
+{
+    for (auto const* field : std::array<SField const*, 6>{
+             &sfSigningPubKey,
+             &sfTxnSignature,
+             &sfSigners,
+             &sfCounterpartySignature,
+             &sfSponsorSignature,
+             &sfBatchSigners})
+    {
+        if (tx.isFieldPresent(*field))
+            tx.makeFieldAbsent(*field);
+    }
+}
+
+std::pair<STObject, STObject>
+proposalObjectsWithoutBookkeeping(SLE const& before, SLE const& after)
+{
+    STObject beforeObject{static_cast<STObject const&>(before)};
+    STObject afterObject{static_cast<STObject const&>(after)};
+
+    for (auto const* field : std::array<SField const*, 2>{&sfPreviousTxnID, &sfPreviousTxnLgrSeq})
+    {
+        if (beforeObject.isFieldPresent(*field))
+            beforeObject.makeFieldAbsent(*field);
+        if (afterObject.isFieldPresent(*field))
+            afterObject.makeFieldAbsent(*field);
+    }
+
+    return {std::move(beforeObject), std::move(afterObject)};
+}
+
+bool
+onlySignatureFieldsChanged(SLE const& before, SLE const& after)
+{
+    auto [beforeObject, afterObject] = proposalObjectsWithoutBookkeeping(before, after);
+    auto beforeTx = beforeObject.getFieldObject(sfProposedTransaction);
+    auto afterTx = afterObject.getFieldObject(sfProposedTransaction);
+    removeSignatureFields(beforeTx);
+    removeSignatureFields(afterTx);
+    beforeObject.setFieldObject(sfProposedTransaction, beforeTx);
+    afterObject.setFieldObject(sfProposedTransaction, afterTx);
+
+    return beforeObject == afterObject;
+}
+
+bool
+onlySponsorChanged(SLE const& before, SLE const& after)
+{
+    auto [beforeObject, afterObject] = proposalObjectsWithoutBookkeeping(before, after);
+    if (beforeObject.isFieldPresent(sfSponsor))
+        beforeObject.makeFieldAbsent(sfSponsor);
+    if (afterObject.isFieldPresent(sfSponsor))
+        afterObject.makeFieldAbsent(sfSponsor);
+    return beforeObject == afterObject;
+}
+
+bool
+validSignerArray(STArray const& signers, std::size_t limit, SField const& elementName)
+{
+    if (signers.size() > limit)
+        return false;
+
+    std::optional<AccountID> previous;
+    for (auto const& signer : signers)
+    {
+        if (signer.getFName() != elementName || !signer.isFieldPresent(sfAccount))
+            return false;
+
+        auto const account = signer.getAccountID(sfAccount);
+        if (previous && account <= *previous)
+            return false;
+        previous = account;
+    }
+    return true;
+}
+
+bool
+validNestedSigners(STObject const& signature)
+{
+    return !signature.isFieldPresent(sfSigners) ||
+        validSignerArray(signature.getFieldArray(sfSigners), STTx::kMaxMultiSigners, sfSigner);
+}
+
+bool
+validSignerArrays(STObject const& proposedTx)
+{
+    if (!validNestedSigners(proposedTx))
+        return false;
+
+    for (auto const* field :
+         std::array<SField const*, 2>{&sfCounterpartySignature, &sfSponsorSignature})
+    {
+        if (proposedTx.isFieldPresent(*field) &&
+            !validNestedSigners(proposedTx.getFieldObject(*field)))
+            return false;
+    }
+
+    if (!proposedTx.isFieldPresent(sfBatchSigners))
+        return true;
+
+    auto const& batchSigners = proposedTx.getFieldArray(sfBatchSigners);
+    if (!validSignerArray(batchSigners, kMaxBatchSigners, sfBatchSigner))
+        return false;
+
+    return std::ranges::all_of(
+        batchSigners, [](auto const& batchSigner) { return validNestedSigners(batchSigner); });
+}
+
+template <class Map>
+bool
+deltasMatch(Map const& actual, Map const& expected)
+{
+    return std::ranges::all_of(expected, [&actual](auto const& item) {
+        auto const& [account, expectedDelta] = item;
+        auto const iter = actual.find(account);
+        auto const actualDelta = iter == actual.end() ? 0 : iter->second;
+        return actualDelta == expectedDelta;
+    });
+}
+
+}  // namespace
+
+void
+ValidTransactionProposal::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+{
+    // LedgerEntryTypesMatch owns malformed type transitions. Avoid interpreting
+    // either side using the other side's schema.
+    if (before && after && before->getType() != after->getType())
+        return;
+
+    if ((before && before->getType() == ltACCOUNT_ROOT) ||
+        (after && after->getType() == ltACCOUNT_ROOT))
+    {
+        auto const& accountSle = after ? after : before;
+        auto const account = accountSle->getAccountID(sfAccount);
+        ownerCountDelta_[account] += fieldDelta(isDelete, before, after, sfOwnerCount);
+        sponsoredOwnerCountDelta_[account] +=
+            fieldDelta(isDelete, before, after, sfSponsoredOwnerCount);
+        sponsoringOwnerCountDelta_[account] +=
+            fieldDelta(isDelete, before, after, sfSponsoringOwnerCount);
+    }
+
+    // A TransactionProposalCreate may itself consume a different Ticket.
+    // Account for that independent owner-count change so the proposal's
+    // five- or ten-unit reserve delta is still checked exactly.
+    if ((before && before->getType() == ltTICKET) || (after && after->getType() == ltTICKET))
+    {
+        auto const& ticket = before ? before : after;
+        auto const owner = ticket->getAccountID(sfAccount);
+        if (!before && !isDelete)
+        {
+            expectedOwnerCountDelta_[owner] += 1;
+        }
+        else if (before && isDelete)
+        {
+            expectedOwnerCountDelta_[owner] -= 1;
+        }
+    }
+
+    bool const proposalBefore = before && before->getType() == ltTRANSACTION_PROPOSAL;
+    bool const proposalAfter = after && after->getType() == ltTRANSACTION_PROPOSAL;
+    if (!proposalBefore && !proposalAfter)
+        return;
+
+    changes_.push_back({.isDelete = isDelete, .before = before, .after = after});
+
+    if (!proposalBefore)
+    {
+        ++created_;
+    }
+    else if (isDelete)
+    {
+        ++deleted_;
+    }
+    else
+    {
+        ++modified_;
+    }
+
+    if (!isDelete && proposalAfter &&
+        !validSignerArrays(after->getFieldObject(sfProposedTransaction)))
+        invalidSignerArrays_ = true;
+
+    auto recordReserveState = [&](SLE::const_ref sle, std::int64_t direction) {
+        auto const owner = sle->getAccountID(sfOwner);
+        auto const reserve =
+            proposal::proposalOwnerCount(sle->getFieldObject(sfProposedTransaction)) * direction;
+        expectedOwnerCountDelta_[owner] += reserve;
+        expectedSponsoredOwnerCountDelta_[owner] += sle->isFieldPresent(sfSponsor) ? reserve : 0;
+        if (sle->isFieldPresent(sfSponsor))
+            expectedSponsoringOwnerCountDelta_[sle->getAccountID(sfSponsor)] += reserve;
+    };
+
+    if (proposalBefore)
+        recordReserveState(before, -1);
+    if (!isDelete && proposalAfter)
+        recordReserveState(after, 1);
+}
+
+bool
+ValidTransactionProposal::finalize(
+    STTx const& tx,
+    TER result,
+    XRPAmount,
+    ReadView const& view,
+    beast::Journal const& j) const
+{
+    bool valid = true;
+
+    bool immutableFieldsChanged = false;
+    for (auto const& change : changes_)
+    {
+        if (!change.before || change.isDelete)
+            continue;
+
+        bool const allowed = tx.getTxnType() == ttSPONSORSHIP_TRANSFER
+            ? onlySponsorChanged(*change.before, *change.after)
+            : onlySignatureFieldsChanged(*change.before, *change.after);
+        immutableFieldsChanged |= !allowed;
+    }
+
+    if (immutableFieldsChanged)
+    {
+        JLOG(j.fatal()) << "Invariant failed: TransactionProposal immutable fields changed.";
+        valid = false;
+    }
+
+    if (invalidSignerArrays_)
+    {
+        JLOG(j.fatal()) << "Invariant failed: TransactionProposal signer arrays are not canonical.";
+        valid = false;
+    }
+
+    // Owner counts move for many reasons unrelated to proposals: an offer, an
+    // escrow, or simply paying with a ticket. The expected deltas model only a
+    // proposal's reserve plus the ticket the transaction itself consumed, so
+    // they describe the ledger accurately only once a proposal is involved.
+    bool const reserveMatches = changes_.empty() ||
+        (deltasMatch(ownerCountDelta_, expectedOwnerCountDelta_) &&
+         deltasMatch(sponsoredOwnerCountDelta_, expectedSponsoredOwnerCountDelta_) &&
+         deltasMatch(sponsoringOwnerCountDelta_, expectedSponsoringOwnerCountDelta_));
+    if (!reserveMatches)
+    {
+        JLOG(j.fatal())
+            << "Invariant failed: TransactionProposal reserve accounting is inconsistent.";
+        valid = false;
+    }
+
+    bool effectsMatch = false;
+    if (tx.getTxnType() == ttTRANSACTION_PROPOSAL_CREATE)
+    {
+        effectsMatch = isTesSuccess(result) ? created_ == 1 && modified_ == 0 && deleted_ == 0
+                                            : created_ == 0 && modified_ == 0 && deleted_ == 0;
+    }
+    else if (tx.getTxnType() == ttSPONSORSHIP_TRANSFER)
+    {
+        effectsMatch = isTesSuccess(result) ? created_ == 0 && modified_ <= 1 && deleted_ == 0
+                                            : created_ == 0 && modified_ == 0 && deleted_ == 0;
+    }
+    else
+    {
+        // TransactionProposalSign, TransactionProposalCancel, and automatic
+        // ticket cleanup are not part of this amendment branch yet. Extend
+        // this whitelist when each lifecycle operation is implemented.
+        effectsMatch = created_ == 0 && modified_ == 0 && deleted_ == 0;
+    }
+
+    if (!effectsMatch)
+    {
+        JLOG(j.fatal())
+            << "Invariant failed: TransactionProposal changes do not match transaction result.";
+        valid = false;
+    }
+
+    return valid || !view.rules().enabled(featureCosign);
+}
+
+}  // namespace xrpl

--- a/src/test/app/invariants/InvariantsTransactionProposal_test.cpp
+++ b/src/test/app/invariants/InvariantsTransactionProposal_test.cpp
@@ -1,0 +1,283 @@
+#include <test/app/invariants/InvariantsBase.h>
+#include <test/jtx/Account.h>
+#include <test/jtx/Env.h>
+#include <test/jtx/amount.h>
+#include <test/jtx/pay.h>
+#include <test/jtx/proposal.h>
+#include <test/jtx/utility.h>
+
+#include <xrpl/beast/unit_test/suite.h>
+#include <xrpl/beast/utility/Zero.h>
+#include <xrpl/ledger/ApplyView.h>
+#include <xrpl/ledger/helpers/ProposalHelpers.h>
+#include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/Indexes.h>
+#include <xrpl/protocol/Keylet.h>
+#include <xrpl/protocol/Protocol.h>
+#include <xrpl/protocol/SField.h>
+#include <xrpl/protocol/STArray.h>
+#include <xrpl/protocol/STLedgerEntry.h>
+#include <xrpl/protocol/STObject.h>
+#include <xrpl/protocol/STTx.h>
+#include <xrpl/protocol/TER.h>
+#include <xrpl/protocol/TxFormats.h>
+#include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/ApplyContext.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace xrpl::test {
+
+class InvariantsTransactionProposal_test : public InvariantsBase
+{
+    void
+    testTransactionProposalInvariants()
+    {
+        using namespace jtx;
+        using namespace std::chrono_literals;
+
+        // Submits a real proposal, so the entry is in the closed ledger before
+        // the precheck runs and the precheck can modify it.
+        std::optional<Keylet> liveProposalKeylet;
+        Preclose const precloseLiveProposal =
+            [&](Account const& owner, Account const& destination, Env& env) {
+                auto const ticketSeq = proposal::createTicket(env, owner);
+                auto const proposedTx =
+                    proposal::unsignedPayload(env, pay(owner, destination, XRP(1)), ticketSeq);
+                liveProposalKeylet = keylet::txProposal(owner.id(), ticketSeq);
+                env(proposal::create(owner, proposedTx, proposal::expiration(env, 100s)));
+                return BEAST_EXPECT(env.le(*liveProposalKeylet));
+            };
+
+        auto peekLiveProposal = [&](ApplyContext& ac) -> SLE::pointer {
+            if (!liveProposalKeylet)
+                return nullptr;
+            return ac.view().peek(*liveProposalKeylet);
+        };
+
+        testcase("TransactionProposal immutable payload");
+        doInvariantCheck(
+            {{"TransactionProposal immutable fields changed"}},
+            [&](Account const&, Account const&, ApplyContext& ac) {
+                auto sle = peekLiveProposal(ac);
+                if (!sle)
+                    return false;
+                auto proposedTx = sle->getFieldObject(sfProposedTransaction);
+                proposedTx.setFieldU32(
+                    sfTicketSequence, proposedTx.getFieldU32(sfTicketSequence) + 1);
+                sle->setFieldObject(sfProposedTransaction, proposedTx);
+                ac.view().update(sle);
+                return true;
+            },
+            XRPAmount{},
+            STTx{ttACCOUNT_SET, [](STObject&) {}},
+            {tecINVARIANT_FAILED, tefINVARIANT_FAILED},
+            precloseLiveProposal);
+
+        // Only stages the payload and the key it would live under; nothing
+        // reaches the ledger, so a precheck that inserts the entry by hand
+        // presents the invariant with a creation.
+        std::optional<STObject> stagedPayload;
+        std::optional<Keylet> stagedProposalKeylet;
+        Preclose const precloseStagedPayload =
+            [&](Account const& owner, Account const& destination, Env& env) {
+                auto const ticketSeq = proposal::createTicket(env, owner);
+                auto const proposedJson =
+                    proposal::unsignedPayload(env, pay(owner, destination, XRP(1)), ticketSeq);
+                stagedPayload.emplace(parse(proposedJson));
+                stagedProposalKeylet = keylet::txProposal(owner.id(), ticketSeq);
+                return true;
+            };
+
+        auto insertStagedProposal =
+            [&](Account const& owner, ApplyContext& ac, bool updateOwnerCount) {
+                if (!stagedPayload || !stagedProposalKeylet)
+                    return false;
+
+                auto sle = std::make_shared<SLE>(*stagedProposalKeylet);
+                sle->setAccountID(sfOwner, owner.id());
+                sle->setFieldObject(sfProposedTransaction, *stagedPayload);
+                sle->setFieldU32(sfExpiration, 1);
+                sle->setFieldU64(sfOwnerNode, 0);
+                ac.view().insert(sle);
+
+                if (updateOwnerCount)
+                {
+                    auto account = ac.view().peek(keylet::account(owner.id()));
+                    if (!account)
+                        return false;
+                    account->at(sfOwnerCount) += xrpl::proposal::proposalOwnerCount(*stagedPayload);
+                    ac.view().update(account);
+                }
+                return true;
+            };
+
+        testcase("TransactionProposal reserve accounting");
+        doInvariantCheck(
+            {{"TransactionProposal reserve accounting is inconsistent"}},
+            [&](Account const& owner, Account const&, ApplyContext& ac) {
+                return insertStagedProposal(owner, ac, false);
+            },
+            XRPAmount{},
+            STTx{ttTRANSACTION_PROPOSAL_CREATE, [](STObject&) {}},
+            {tecINVARIANT_FAILED, tefINVARIANT_FAILED},
+            precloseStagedPayload);
+
+        testcase("TransactionProposal effect whitelist");
+        doInvariantCheck(
+            {{"TransactionProposal changes do not match transaction result"}},
+            [&](Account const& owner, Account const&, ApplyContext& ac) {
+                return insertStagedProposal(owner, ac, true);
+            },
+            XRPAmount{},
+            STTx{ttACCOUNT_SET, [](STObject&) {}},
+            {tecINVARIANT_FAILED, tefINVARIANT_FAILED},
+            precloseStagedPayload);
+
+        // Distinct AccountIDs in ascending order, so an array built from them
+        // violates only the bound on its length.
+        auto ascendingAccounts = [](std::size_t count) {
+            std::vector<AccountID> accounts;
+            accounts.reserve(count);
+            for (std::size_t i = 0; i < count; ++i)
+            {
+                AccountID account{beast::kZero};
+                account.data()[0] = static_cast<std::uint8_t>(i + 1);
+                accounts.push_back(account);
+            }
+            return accounts;
+        };
+
+        auto signerArray = [](std::vector<AccountID> const& accounts) {
+            STArray signers{sfSigners};
+            for (auto const& account : accounts)
+            {
+                STObject signer{sfSigner};
+                signer.setAccountID(sfAccount, account);
+                signers.pushBack(signer);
+            }
+            return signers;
+        };
+
+        // No transaction type on this amendment branch collects signatures yet,
+        // so every rejection below has to be provoked by editing the stored
+        // payload directly.
+        auto testBrokenSignerArray = [&](std::string const& name, auto const& breakPayload) {
+            testcase("TransactionProposal canonical signer arrays: " + name);
+            doInvariantCheck(
+                {{"TransactionProposal signer arrays are not canonical"}},
+                [&](Account const&, Account const& signerAccount, ApplyContext& ac) {
+                    auto sle = peekLiveProposal(ac);
+                    if (!sle)
+                        return false;
+                    auto proposedTx = sle->getFieldObject(sfProposedTransaction);
+                    breakPayload(proposedTx, signerAccount);
+                    sle->setFieldObject(sfProposedTransaction, proposedTx);
+                    ac.view().update(sle);
+                    return true;
+                },
+                XRPAmount{},
+                STTx{ttACCOUNT_SET, [](STObject&) {}},
+                {tecINVARIANT_FAILED, tefINVARIANT_FAILED},
+                precloseLiveProposal);
+        };
+
+        testBrokenSignerArray("duplicate entries", [&](STObject& tx, Account const& signer) {
+            tx.setFieldArray(sfSigners, signerArray({signer.id(), signer.id()}));
+        });
+
+        testBrokenSignerArray("descending order", [&](STObject& tx, Account const&) {
+            auto accounts = ascendingAccounts(2);
+            std::ranges::reverse(accounts);
+            tx.setFieldArray(sfSigners, signerArray(accounts));
+        });
+
+        testBrokenSignerArray("past the multi-sign limit", [&](STObject& tx, Account const&) {
+            tx.setFieldArray(sfSigners, signerArray(ascendingAccounts(STTx::kMaxMultiSigners + 1)));
+        });
+
+        testBrokenSignerArray("entry without an Account", [](STObject& tx, Account const&) {
+            STArray signers{sfSigners};
+            signers.pushBack(STObject{sfSigner});
+            tx.setFieldArray(sfSigners, signers);
+        });
+
+        for (auto const* field :
+             std::array<SField const*, 2>{&sfCounterpartySignature, &sfSponsorSignature})
+        {
+            testBrokenSignerArray(
+                "duplicates under " + field->getName(), [&](STObject& tx, Account const& signer) {
+                    STObject signature{*field};
+                    signature.setFieldArray(sfSigners, signerArray({signer.id(), signer.id()}));
+                    tx.setFieldObject(*field, signature);
+                });
+        }
+
+        testBrokenSignerArray("past the batch-signer limit", [&](STObject& tx, Account const&) {
+            STArray batchSigners{sfBatchSigners};
+            for (auto const& account : ascendingAccounts(kMaxBatchSigners + 1))
+            {
+                STObject batchSigner{sfBatchSigner};
+                batchSigner.setAccountID(sfAccount, account);
+                batchSigners.pushBack(batchSigner);
+            }
+            tx.setFieldArray(sfBatchSigners, batchSigners);
+        });
+
+        testBrokenSignerArray(
+            "duplicates under a BatchSigner", [&](STObject& tx, Account const& signer) {
+                STObject batchSigner{sfBatchSigner};
+                batchSigner.setAccountID(sfAccount, signer.id());
+                batchSigner.setFieldArray(sfSigners, signerArray({signer.id(), signer.id()}));
+
+                STArray batchSigners{sfBatchSigners};
+                batchSigners.pushBack(batchSigner);
+                tx.setFieldArray(sfBatchSigners, batchSigners);
+            });
+
+        // Negative controls. These share the setup of the failure cases above,
+        // so they confirm each of those failures came from the defect it names
+        // rather than from the hand-built ledger state.
+        std::initializer_list<TER> const passTers = {tesSUCCESS, tesSUCCESS};
+
+        testcase("TransactionProposal well-formed create");
+        doInvariantCheck(
+            {},
+            [&](Account const& owner, Account const&, ApplyContext& ac) {
+                return insertStagedProposal(owner, ac, true);
+            },
+            XRPAmount{},
+            STTx{ttTRANSACTION_PROPOSAL_CREATE, [](STObject&) {}},
+            passTers,
+            precloseStagedPayload);
+
+        testcase("TransactionProposal left untouched");
+        doInvariantCheck(
+            {},
+            [&](Account const&, Account const&, ApplyContext& ac) {
+                return liveProposalKeylet && ac.view().read(*liveProposalKeylet) != nullptr;
+            },
+            XRPAmount{},
+            STTx{ttACCOUNT_SET, [](STObject&) {}},
+            passTers,
+            precloseLiveProposal);
+    }
+
+    void
+    run() override
+    {
+        testTransactionProposalInvariants();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(InvariantsTransactionProposal, app, xrpl);
+
+}  // namespace xrpl::test


### PR DESCRIPTION
## High Level Overview of Change

Adds `ValidTransactionProposal`, a global invariant for the `TransactionProposal` ledger entry, plus tests. No behavior change for valid transactions.

The invariant enforces four properties:

1. **Immutable payload.** `ProposedTransaction` may change only in its signature fields (`SigningPubKey`, `TxnSignature`, `Signers`, `CounterpartySignature`, `SponsorSignature`, `BatchSigners`, and nested `Signers`), plus `PreviousTxn` bookkeeping. `SponsorshipTransfer` may reassign the object's `Sponsor` and nothing else.
2. **Reserve accounting.** Creating or deleting a proposal moves the owner's `OwnerCount` by that proposal's own reserve size (5, or 10 for a proposed `Batch`), and moves `SponsoredOwnerCount` / `SponsoringOwnerCount` consistently when the reserve is sponsored.
3. **Effect whitelist.** Only transaction types implementing a proposal lifecycle operation may create, modify, or delete a proposal, with the exact counts the result allows. A failed `TransactionProposalCreate` must leave no trace; a successful one must create exactly one entry.
4. **Canonical signer arrays.** Collected signer arrays stay sorted by account, free of duplicates, and within `STTx::kMaxMultiSigners` (32) and `kMaxBatchSigners` (24).

### Context of Change

This is the invariant layer for the On-Chain Cosigner work ([XLS-0103](https://github.com/shawnxie999/XRPL-Standards/blob/cosign/XLS-0103-onchain-cosigner/README.md)). Properties 1 and 4 restate spec sections 4.2.1 and 6.1; property 2 restates section 4.4.

It is implemented as a **global** invariant rather than in `TransactionProposalCreate::visitInvariantEntry`, because the properties are about the ledger entry itself and must hold no matter which transactor touches it. That is what makes property 3 meaningful: as `TransactionProposalSign` and `TransactionProposalCancel` land, each has to be added to the whitelist deliberately, and until then no other transaction type can manufacture or mutate a proposal.

Reserve reconciliation is applied only once a transaction has actually touched a proposal. Owner counts also move for offers, escrows, and for the ticket a transaction consumes to pay for itself, so the modelled deltas describe the ledger accurately only when a proposal is in play.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

The invariant is gated on `featureCosign`, so it cannot change behavior on a ledger where the amendment is not enabled.

## Test Plan

Thirteen cases in `Invariants_test.cpp`. Eleven violate exactly one rule: a mutated `TicketSequence`; an insertion with no `OwnerCount` bump; an insertion from `AccountSet`; and eight signer-array cases covering duplicates, descending order, both length limits, an entry with no `Account`, and duplicates nested under `CounterpartySignature`, `SponsorSignature`, and a `BatchSigner`.

Two are negative controls asserting `tesSUCCESS`: a well-formed create, and a proposal left untouched. The first reuses the setup of the two failure cases above it and differs only in the `OwnerCount` bump and the transaction type, which pins each of those failures to the defect it names rather than to the hand-built ledger state.

The success path is also covered indirectly, since invariants run on every transaction in every test: the existing `TransactionProposalCreate` suite (17 cases, 1067 tests) exercises this invariant returning true, including sponsored create and sponsorship transfer.