### PR TITLE
refactor: Validate visitEntry SLE nullability via InvariantEntry

### DIFF
--- a/include/xrpl/tx/Transactor.h
+++ b/include/xrpl/tx/Transactor.h
@@ -578,9 +578,9 @@ private:
      * ordering is enforced.
      */
     void
-    visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after) final
+    visitEntry(InvariantEntry const& entry) final
     {
-        visitInvariantEntry(isDelete, before, after);
+        visitInvariantEntry(entry.isDelete(), entry.before(), entry.after());
     }
 
     [[nodiscard]] bool

--- a/include/xrpl/tx/Transactor.h
+++ b/include/xrpl/tx/Transactor.h
@@ -20,6 +20,7 @@
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/tx/ApplyContext.h>
 #include <xrpl/tx/applySteps.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 #include <xrpl/tx/invariants/InvariantRunner.h>
 
 #include <cstddef>

--- a/include/xrpl/tx/invariants/AMMInvariant.h
+++ b/include/xrpl/tx/invariants/AMMInvariant.h
@@ -4,7 +4,6 @@
 #include <xrpl/ledger/ReadView.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/STAmount.h>
-#include <xrpl/protocol/STLedgerEntry.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>

--- a/include/xrpl/tx/invariants/AMMInvariant.h
+++ b/include/xrpl/tx/invariants/AMMInvariant.h
@@ -8,6 +8,7 @@
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <optional>
 
@@ -27,7 +28,7 @@ public:
 
     ValidAMM() = default;
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);

--- a/include/xrpl/tx/invariants/DirectoryInvariant.h
+++ b/include/xrpl/tx/invariants/DirectoryInvariant.h
@@ -4,13 +4,10 @@
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/ledger/ReadView.h>
-#include <xrpl/protocol/STLedgerEntry.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/tx/invariants/InvariantEntry.h>
-
-#include <memory>
 
 namespace xrpl {
 

--- a/include/xrpl/tx/invariants/DirectoryInvariant.h
+++ b/include/xrpl/tx/invariants/DirectoryInvariant.h
@@ -8,6 +8,7 @@
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <memory>
 
@@ -20,7 +21,7 @@ class ValidBookDirectory
 
 public:
     void
-    visitEntry(bool, std::shared_ptr<SLE const> const&, std::shared_ptr<SLE const> const&);
+    visitEntry(InvariantEntry const&);
 
     bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);

--- a/include/xrpl/tx/invariants/FreezeInvariant.h
+++ b/include/xrpl/tx/invariants/FreezeInvariant.h
@@ -10,6 +10,7 @@
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <map>
 #include <optional>
@@ -44,7 +45,7 @@ class TransfersNotFrozen
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);

--- a/include/xrpl/tx/invariants/InvariantCheck.h
+++ b/include/xrpl/tx/invariants/InvariantCheck.h
@@ -9,6 +9,7 @@
 #include <xrpl/tx/invariants/AMMInvariant.h>
 #include <xrpl/tx/invariants/DirectoryInvariant.h>
 #include <xrpl/tx/invariants/FreezeInvariant.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 #include <xrpl/tx/invariants/LoanBrokerInvariant.h>
 #include <xrpl/tx/invariants/LoanInvariant.h>
 #include <xrpl/tx/invariants/MPTInvariant.h>
@@ -71,20 +72,13 @@ public:
     /**
      * @brief called for each ledger entry in the current transaction.
      *
-     * @param isDelete true if the SLE is being deleted.
-     * @param before ledger entry before modification by the transaction. `before` will be null if
-     *  the entry is new.
-     * @param after ledger entry after modification by the transaction. Always non-null. When
-     *  deleting, `after` may differ from `before`. Whether that is important is up to the
-     *  individual invariant check.
+     * @param entry validated, non-owning view of the modified ledger entry.
      *
-     * @note `after` IS NEVER NULL. `isDelete` is the only correct way to check for deletions.
-     *  Do not make logic or branching decisions on whether `after` is set, because it will
-     *  always be set. A null `after`, or a null `before` when `isDelete` is true, is a
-     *  programming error: `checkInvariants` throws `std::logic_error` before dispatch.
+     * @note `entry.after()` IS NEVER NULL. `entry.isDelete()` is the only
+     * correct way to check for deletions.
      */
     void
-    visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after);
+    visitEntry(InvariantEntry const& entry);
 
     /**
      * @brief called after all ledger entries have been visited to determine
@@ -122,7 +116,7 @@ class TransactionFeeCheck
 {
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     static bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);
@@ -142,7 +136,7 @@ class XRPNotCreated
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;
@@ -162,7 +156,7 @@ class AccountRootsNotDeleted
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;
@@ -189,7 +183,7 @@ class AccountRootsDeletedClean
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);
@@ -208,7 +202,7 @@ class XRPBalanceChecks
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;
@@ -225,7 +219,7 @@ class LedgerEntryTypesMatch
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;
@@ -243,7 +237,7 @@ class NoXRPTrustLines
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;
@@ -262,7 +256,7 @@ class NoDeepFreezeTrustLinesWithoutFreeze
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;
@@ -281,7 +275,7 @@ class NoBadOffers
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;
@@ -297,7 +291,7 @@ class NoZeroEscrow
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;
@@ -317,7 +311,7 @@ class ValidNewAccountRoot
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;
@@ -347,7 +341,7 @@ class ValidClawback
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;
@@ -367,7 +361,7 @@ class ValidPseudoAccounts
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);
@@ -387,7 +381,7 @@ class NoModifiedUnmodifiableFields
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);
@@ -403,7 +397,7 @@ class ValidAmounts
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;
@@ -420,7 +414,7 @@ class ObjectHasPseudoAccount
 {
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;

--- a/include/xrpl/tx/invariants/InvariantCheck.h
+++ b/include/xrpl/tx/invariants/InvariantCheck.h
@@ -79,10 +79,9 @@ public:
      *  individual invariant check.
      *
      * @note `after` IS NEVER NULL. `isDelete` is the only correct way to check for deletions.
-     *  Do not make logic or branching decisions on whether on `after` is set, because it will
-     *  always be set. Treat a null `after` as a programming error (with XRPL_ASSERT). An
-     *  invariant MAY check for null defensively, if it makes more sense, but an assertion is
-     *  preferred for new invariants.
+     *  Do not make logic or branching decisions on whether `after` is set, because it will
+     *  always be set. A null `after`, or a null `before` when `isDelete` is true, is a
+     *  programming error: `checkInvariants` throws `std::logic_error` before dispatch.
      */
     void
     visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after);

--- a/include/xrpl/tx/invariants/InvariantEntry.h
+++ b/include/xrpl/tx/invariants/InvariantEntry.h
@@ -4,6 +4,7 @@
 #include <xrpl/protocol/STLedgerEntry.h>
 
 #include <stdexcept>
+#include <utility>
 
 namespace xrpl {
 
@@ -17,8 +18,8 @@ class InvariantEntry
     SLE::const_pointer after_;
 
 public:
-    InvariantEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
-        : isDelete_(isDelete), before_(before), after_(after)
+    InvariantEntry(bool isDelete, SLE::const_pointer before, SLE::const_pointer after)
+        : isDelete_(isDelete), before_(std::move(before)), after_(std::move(after))
     {
         if (after_ == nullptr)
             Throw<std::logic_error>("InvariantEntry: after is never null");

--- a/include/xrpl/tx/invariants/InvariantEntry.h
+++ b/include/xrpl/tx/invariants/InvariantEntry.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <xrpl/basics/contract.h>
+#include <xrpl/protocol/STLedgerEntry.h>
+
+#include <stdexcept>
+
+namespace xrpl {
+
+/**
+ * A validated ledger entry visited by invariants.
+ */
+class InvariantEntry
+{
+    bool isDelete_;
+    SLE::const_pointer before_;
+    SLE::const_pointer after_;
+
+public:
+    InvariantEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+        : isDelete_(isDelete), before_(before), after_(after)
+    {
+        if (after_ == nullptr)
+            Throw<std::logic_error>("InvariantEntry: after is never null");
+        if (isDelete_ && before_ == nullptr)
+            Throw<std::logic_error>("InvariantEntry: deleted entry missing before state");
+    }
+
+    InvariantEntry(InvariantEntry const&) = delete;
+    InvariantEntry&
+    operator=(InvariantEntry const&) = delete;
+
+    [[nodiscard]] bool
+    isDelete() const
+    {
+        return isDelete_;
+    }
+
+    [[nodiscard]] SLE::const_ref
+    before() const
+    {
+        return before_;
+    }
+
+    [[nodiscard]] SLE::const_ref
+    after() const
+    {
+        return after_;
+    }
+};
+
+}  // namespace xrpl

--- a/include/xrpl/tx/invariants/InvariantRunner.h
+++ b/include/xrpl/tx/invariants/InvariantRunner.h
@@ -68,11 +68,13 @@ public:
      *
      * @param isDelete true if the SLE is being deleted.
      * @param before   the entry's state before the transaction (nullptr for
-     *                 newly created entries).
+     *                 newly created entries).  Never null when @p isDelete is
+     *                 true.
      * @param after    the entry's state after the transaction.  For deletions
      *                 this is the SLE being erased; use @p isDelete rather than
      *                 a null @p after to detect deletions.  @p after is
-     *                 never null.
+     *                 never null.  `checkInvariants` throws `std::logic_error`
+     *                 if these contracts are violated.
      */
     virtual void
     visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after) = 0;

--- a/include/xrpl/tx/invariants/InvariantRunner.h
+++ b/include/xrpl/tx/invariants/InvariantRunner.h
@@ -7,6 +7,7 @@
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/tx/ApplyContext.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <functional>
 #include <optional>
@@ -66,18 +67,10 @@ public:
     /**
      * @brief Called for each ledger entry modified by the transaction.
      *
-     * @param isDelete true if the SLE is being deleted.
-     * @param before   the entry's state before the transaction (nullptr for
-     *                 newly created entries).  Never null when @p isDelete is
-     *                 true.
-     * @param after    the entry's state after the transaction.  For deletions
-     *                 this is the SLE being erased; use @p isDelete rather than
-     *                 a null @p after to detect deletions.  @p after is
-     *                 never null.  `checkInvariants` throws `std::logic_error`
-     *                 if these contracts are violated.
+     * @param entry a validated, non-owning view of the modified entry.
      */
     virtual void
-    visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after) = 0;
+    visitEntry(InvariantEntry const& entry) = 0;
 
     /**
      * @brief Called after all entries have been visited.

--- a/include/xrpl/tx/invariants/InvariantRunner.h
+++ b/include/xrpl/tx/invariants/InvariantRunner.h
@@ -2,7 +2,6 @@
 
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/ledger/ReadView.h>
-#include <xrpl/protocol/STLedgerEntry.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>

--- a/include/xrpl/tx/invariants/LoanBrokerInvariant.h
+++ b/include/xrpl/tx/invariants/LoanBrokerInvariant.h
@@ -7,6 +7,7 @@
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <map>
 #include <vector>
@@ -48,7 +49,7 @@ class ValidLoanBroker
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);

--- a/include/xrpl/tx/invariants/LoanInvariant.h
+++ b/include/xrpl/tx/invariants/LoanInvariant.h
@@ -6,6 +6,7 @@
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <utility>
 #include <vector>
@@ -28,7 +29,7 @@ class ValidLoan
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);

--- a/include/xrpl/tx/invariants/MPTInvariant.h
+++ b/include/xrpl/tx/invariants/MPTInvariant.h
@@ -10,6 +10,7 @@
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/UintTypes.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <array>
 #include <cstdint>
@@ -54,12 +55,10 @@ public:
      * @brief Track MPT issuance and holding creations, deletions, and
      * mutations.
      *
-     * @param isDelete Whether the ledger entry is being deleted.
-     * @param before The ledger entry before transaction application.
-     * @param after The ledger entry after transaction application.
+     * @param entry The ledger entry change being checked.
      */
     void
-    visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after);
+    visitEntry(InvariantEntry const& entry);
 
     /**
      * @brief Verify MPT issuance invariants after transaction application.
@@ -106,12 +105,10 @@ public:
     /**
      * @brief Track MPT amount and outstanding amount changes.
      *
-     * @param isDelete Whether the ledger entry is being deleted.
-     * @param before The ledger entry before transaction application.
-     * @param after The ledger entry after transaction application.
+     * @param entry The ledger entry change being checked.
      */
     void
-    visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after);
+    visitEntry(InvariantEntry const& entry);
 
     /**
      * @brief Verify public MPT payment accounting invariants.
@@ -173,15 +170,10 @@ public:
     /**
      * @brief Track confidential MPT balance, issuance, and version changes.
      *
-     * @param isDelete Whether the ledger entry is being deleted.
-     * @param before The ledger entry before transaction application.
-     * @param after The ledger entry after transaction application.
+     * @param entry The ledger entry change being checked.
      */
     void
-    visitEntry(
-        bool isDelete,
-        std::shared_ptr<SLE const> const& before,
-        std::shared_ptr<SLE const> const& after);
+    visitEntry(InvariantEntry const& entry);
 
     /**
      * @brief Verify confidential MPT accounting and encrypted-field
@@ -220,15 +212,10 @@ public:
     /**
      * @brief Track MPT balance changes and deleted authorization state.
      *
-     * @param isDelete Whether the ledger entry is being deleted.
-     * @param before The ledger entry before transaction application.
-     * @param after The ledger entry after transaction application.
+     * @param entry The ledger entry change being checked.
      */
     void
-    visitEntry(
-        bool isDelete,
-        std::shared_ptr<SLE const> const& before,
-        std::shared_ptr<SLE const> const& after);
+    visitEntry(InvariantEntry const& entry);
 
     /**
      * @brief Verify MPT transfer authorization invariants.

--- a/include/xrpl/tx/invariants/NFTInvariant.h
+++ b/include/xrpl/tx/invariants/NFTInvariant.h
@@ -6,6 +6,7 @@
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <cstdint>
 
@@ -34,7 +35,7 @@ class ValidNFTokenPage
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;
@@ -62,7 +63,7 @@ class NFTokenCountTracking
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;

--- a/include/xrpl/tx/invariants/NFTInvariant.h
+++ b/include/xrpl/tx/invariants/NFTInvariant.h
@@ -2,7 +2,6 @@
 
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/ledger/ReadView.h>
-#include <xrpl/protocol/STLedgerEntry.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>

--- a/include/xrpl/tx/invariants/PermissionedDEXInvariant.h
+++ b/include/xrpl/tx/invariants/PermissionedDEXInvariant.h
@@ -4,7 +4,6 @@
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/ledger/ReadView.h>
-#include <xrpl/protocol/STLedgerEntry.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>

--- a/include/xrpl/tx/invariants/PermissionedDEXInvariant.h
+++ b/include/xrpl/tx/invariants/PermissionedDEXInvariant.h
@@ -8,6 +8,7 @@
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 namespace xrpl {
 
@@ -22,7 +23,7 @@ class ValidPermissionedDEX
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);

--- a/include/xrpl/tx/invariants/PermissionedDomainInvariant.h
+++ b/include/xrpl/tx/invariants/PermissionedDomainInvariant.h
@@ -6,6 +6,7 @@
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <cstddef>
 #include <vector>
@@ -35,7 +36,7 @@ class ValidPermissionedDomain
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);

--- a/include/xrpl/tx/invariants/PermissionedDomainInvariant.h
+++ b/include/xrpl/tx/invariants/PermissionedDomainInvariant.h
@@ -2,7 +2,6 @@
 
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/ledger/ReadView.h>
-#include <xrpl/protocol/STLedgerEntry.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>

--- a/include/xrpl/tx/invariants/SponsorshipInvariant.h
+++ b/include/xrpl/tx/invariants/SponsorshipInvariant.h
@@ -6,6 +6,7 @@
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <cstdint>
 
@@ -31,7 +32,7 @@ class SponsorshipOwnerCountsMatch
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;
@@ -52,7 +53,7 @@ class SponsorshipAccountCountMatchesField
 
 public:
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     [[nodiscard]] bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&) const;

--- a/include/xrpl/tx/invariants/SponsorshipInvariant.h
+++ b/include/xrpl/tx/invariants/SponsorshipInvariant.h
@@ -2,7 +2,6 @@
 
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/ledger/ReadView.h>
-#include <xrpl/protocol/STLedgerEntry.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>

--- a/include/xrpl/tx/invariants/VaultInvariant.h
+++ b/include/xrpl/tx/invariants/VaultInvariant.h
@@ -13,6 +13,7 @@
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <cstdint>
 #include <optional>
@@ -183,7 +184,7 @@ public:
     computeCoarsestScale(std::vector<DeltaInfo> const& numbers);
 
     void
-    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+    visitEntry(InvariantEntry const&);
 
     bool
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);

--- a/src/libxrpl/tx/invariants/AMMInvariant.cpp
+++ b/src/libxrpl/tx/invariants/AMMInvariant.cpp
@@ -36,23 +36,20 @@ ValidAMM::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
         return;
     }
 
-    if (after)
+    auto const type = after->getType();
+    // AMM object changed
+    if (type == ltAMM)
     {
-        auto const type = after->getType();
-        // AMM object changed
-        if (type == ltAMM)
-        {
-            ammAccount_ = after->getAccountID(sfAccount);
-            lptAMMBalanceAfter_ = after->getFieldAmount(sfLPTokenBalance);
-        }
-        // AMM pool changed
-        else if (
-            (type == ltRIPPLE_STATE && after->isFlag(lsfAMMNode)) ||
-            (type == ltACCOUNT_ROOT && after->isFieldPresent(sfAMMID)) ||
-            (type == ltMPTOKEN && after->isFlag(lsfMPTAMM)))
-        {
-            ammPoolChanged_ = true;
-        }
+        ammAccount_ = after->getAccountID(sfAccount);
+        lptAMMBalanceAfter_ = after->getFieldAmount(sfLPTokenBalance);
+    }
+    // AMM pool changed
+    else if (
+        (type == ltRIPPLE_STATE && after->isFlag(lsfAMMNode)) ||
+        (type == ltACCOUNT_ROOT && after->isFieldPresent(sfAMMID)) ||
+        (type == ltMPTOKEN && after->isFlag(lsfMPTAMM)))
+    {
+        ammPoolChanged_ = true;
     }
 
     if (before)

--- a/src/libxrpl/tx/invariants/AMMInvariant.cpp
+++ b/src/libxrpl/tx/invariants/AMMInvariant.cpp
@@ -18,6 +18,7 @@
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/TxFormats.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <string>
 

--- a/src/libxrpl/tx/invariants/AMMInvariant.cpp
+++ b/src/libxrpl/tx/invariants/AMMInvariant.cpp
@@ -24,8 +24,12 @@
 namespace xrpl {
 
 void
-ValidAMM::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+ValidAMM::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     if (isDelete)
     {
         if (before && before->getType() == ltAMM)

--- a/src/libxrpl/tx/invariants/DirectoryInvariant.cpp
+++ b/src/libxrpl/tx/invariants/DirectoryInvariant.cpp
@@ -12,9 +12,9 @@
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <algorithm>
-#include <memory>
 
 namespace xrpl {
 

--- a/src/libxrpl/tx/invariants/DirectoryInvariant.cpp
+++ b/src/libxrpl/tx/invariants/DirectoryInvariant.cpp
@@ -51,9 +51,8 @@ ValidBookDirectory::visitEntry(
     // point to an existing root.
 
     // Only validate newly-created directories and sfRootIndex changes;
-    // LedgerStateFix handles legacy bad exchange-rate metadata. Skip deletions
-    // because `after` is not guaranteed to be null.
-    if (badBookDirectory_ || isDelete || !after || after->getType() != ltDIR_NODE)
+    // LedgerStateFix handles legacy bad exchange-rate metadata. Skip deletions.
+    if (badBookDirectory_ || isDelete || after->getType() != ltDIR_NODE)
         return;
 
     auto const rootIndex = after->getFieldH256(sfRootIndex);

--- a/src/libxrpl/tx/invariants/DirectoryInvariant.cpp
+++ b/src/libxrpl/tx/invariants/DirectoryInvariant.cpp
@@ -41,11 +41,12 @@ badExchangeRate(SLE const& dir)
 }  // namespace
 
 void
-ValidBookDirectory::visitEntry(
-    bool isDelete,
-    std::shared_ptr<SLE const> const& before,
-    std::shared_ptr<SLE const> const& after)
+ValidBookDirectory::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     // New root directories must have matching exchange-rate metadata. New
     // child directories, and modified directories that change sfRootIndex, must
     // point to an existing root.

--- a/src/libxrpl/tx/invariants/FreezeInvariant.cpp
+++ b/src/libxrpl/tx/invariants/FreezeInvariant.cpp
@@ -25,8 +25,12 @@
 namespace xrpl {
 
 void
-TransfersNotFrozen::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+TransfersNotFrozen::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     /*
      * A trust line freeze state alone doesn't determine if a transfer is
      * frozen. The transfer must be examined "end-to-end" because both sides of

--- a/src/libxrpl/tx/invariants/FreezeInvariant.cpp
+++ b/src/libxrpl/tx/invariants/FreezeInvariant.cpp
@@ -116,13 +116,6 @@ TransfersNotFrozen::finalize(
 bool
 TransfersNotFrozen::isValidEntry(SLE::const_ref before, SLE::const_ref after)
 {
-    // `after` can never be null, even if the trust line is deleted.
-    XRPL_ASSERT(after, "xrpl::TransfersNotFrozen::isValidEntry : valid after.");
-    if (!after)
-    {
-        return false;
-    }
-
     if (after->getType() == ltACCOUNT_ROOT)
     {
         possibleIssuers_.emplace(after->at(sfAccount), after);

--- a/src/libxrpl/tx/invariants/FreezeInvariant.cpp
+++ b/src/libxrpl/tx/invariants/FreezeInvariant.cpp
@@ -17,6 +17,7 @@
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/tx/invariants/InvariantCheckPrivilege.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <algorithm>
 #include <optional>

--- a/src/libxrpl/tx/invariants/InvariantCheck.cpp
+++ b/src/libxrpl/tx/invariants/InvariantCheck.cpp
@@ -168,13 +168,6 @@ XRPNotCreated::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref a
         }
     }
 
-    if (!after)
-    {
-        // LCOV_EXCL_START
-        UNREACHABLE("xrpl::XRPNotCreated::visitEntry : after can't be null");
-        return;
-        // LCOV_EXCL_STOP
-    }
     switch (after->getType())
     {
         case ltACCOUNT_ROOT:
@@ -255,7 +248,7 @@ XRPBalanceChecks::visitEntry(bool, SLE::const_ref before, SLE::const_ref after)
     if (before && before->getType() == ltACCOUNT_ROOT)
         bad_ |= isBad((*before)[sfBalance]);
 
-    if (after && after->getType() == ltACCOUNT_ROOT)
+    if (after->getType() == ltACCOUNT_ROOT)
         bad_ |= isBad((*after)[sfBalance]);
 }
 
@@ -296,7 +289,7 @@ NoBadOffers::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref aft
     if (before && before->getType() == ltOFFER)
         bad_ |= isBad((*before)[sfTakerPays], (*before)[sfTakerGets]);
 
-    if (after && after->getType() == ltOFFER)
+    if (after->getType() == ltOFFER)
         bad_ |= isBad((*after)[sfTakerPays], (*after)[sfTakerGets]);
 }
 
@@ -364,7 +357,7 @@ NoZeroEscrow::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref af
     if (before && before->getType() == ltESCROW)
         bad_ |= isBad((*before)[sfAmount]);
 
-    if (after && after->getType() == ltESCROW)
+    if (after->getType() == ltESCROW)
         bad_ |= isBad((*after)[sfAmount]);
 
     auto checkAmount = [this](std::int64_t amount) {
@@ -374,7 +367,7 @@ NoZeroEscrow::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref af
 
     bool const overwriteFixEnabled = isFeatureEnabled(fixCleanup3_1_3, true);
 
-    if (after && after->getType() == ltMPTOKEN_ISSUANCE)
+    if (after->getType() == ltMPTOKEN_ISSUANCE)
     {
         auto const outstanding = (*after)[sfOutstandingAmount];
         checkAmount(outstanding);
@@ -393,7 +386,7 @@ NoZeroEscrow::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref af
         }
     }
 
-    if (after && after->getType() == ltMPTOKEN)
+    if (after->getType() == ltMPTOKEN)
     {
         auto const mptAmount = (*after)[sfMPTAmount];
         checkAmount(mptAmount);
@@ -601,29 +594,26 @@ AccountRootsDeletedClean::finalize(
 void
 LedgerEntryTypesMatch::visitEntry(bool, SLE::const_ref before, SLE::const_ref after)
 {
-    if (before && after && before->getType() != after->getType())
+    if (before && before->getType() != after->getType())
         typeMismatch_ = true;
 
-    if (after)
-    {
 #pragma push_macro("LEDGER_ENTRY")
 #undef LEDGER_ENTRY
 
 #define LEDGER_ENTRY(tag, ...) case tag:
 
-        switch (after->getType())
-        {
+    switch (after->getType())
+    {
 #include <xrpl/protocol/detail/ledger_entries.macro>
 
+        break;
+        default:
+            invalidTypeAdded_ = true;
             break;
-            default:
-                invalidTypeAdded_ = true;
-                break;
-        }
+    }
 
 #undef LEDGER_ENTRY
 #pragma pop_macro("LEDGER_ENTRY")
-    }
 }
 
 bool
@@ -657,7 +647,7 @@ NoXRPTrustLines::visitEntry(bool, SLE::const_ref, SLE::const_ref after)
 {
     bool const overwriteFixEnabled = isFeatureEnabled(fixCleanup3_1_3, true);
 
-    if (after && after->getType() == ltRIPPLE_STATE)
+    if (after->getType() == ltRIPPLE_STATE)
     {
         // checking the issue directly here instead of
         // relying on .native() just in case native somehow
@@ -695,7 +685,7 @@ NoXRPTrustLines::finalize(
 void
 NoDeepFreezeTrustLinesWithoutFreeze::visitEntry(bool, SLE::const_ref, SLE::const_ref after)
 {
-    if (after && after->getType() == ltRIPPLE_STATE)
+    if (after->getType() == ltRIPPLE_STATE)
     {
         bool const overwriteFixEnabled = isFeatureEnabled(fixCleanup3_1_3, true);
 
@@ -842,7 +832,7 @@ ValidClawback::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref a
         iou_.before = before;
     }
 
-    if (!isDelete && after && after->getType() == ltRIPPLE_STATE)
+    if (!isDelete && after->getType() == ltRIPPLE_STATE)
         iou_.after = after;
 
     if (before && before->getType() == ltMPTOKEN)
@@ -851,7 +841,7 @@ ValidClawback::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref a
         mpt_.before = before;
     }
 
-    if (!isDelete && after && after->getType() == ltMPTOKEN)
+    if (!isDelete && after->getType() == ltMPTOKEN)
         mpt_.after = after;
 }
 
@@ -1017,7 +1007,7 @@ ValidPseudoAccounts::visitEntry(bool isDelete, SLE::const_ref before, SLE::const
         return;
     }
 
-    if (after && after->getType() == ltACCOUNT_ROOT)
+    if (after->getType() == ltACCOUNT_ROOT)
     {
         bool const isPseudo = [&]() {
             // isPseudoAccount checks that any of the pseudo-account fields are
@@ -1217,7 +1207,7 @@ ValidAmounts::visitEntry(
     std::shared_ptr<SLE const> const&,
     std::shared_ptr<SLE const> const& after)
 {
-    if (!isDelete && after)
+    if (!isDelete)
         afterEntries_.push_back(after);
 }
 
@@ -1247,16 +1237,6 @@ ObjectHasPseudoAccount::visitEntry(bool isDelete, SLE::const_ref before, SLE::co
 {
     if (!isDelete)
         return;
-
-    // Before should never be null when isDelete = true
-    if (!before)
-    {
-        // LCOV_EXCL_START
-        UNREACHABLE(
-            "xrpl::ObjectHasPseudoAccount::visitEntry : deleted ledger entry missing before state");
-        return;
-        // LCOV_EXCL_STOP
-    }
 
     switch (before->getType())
     {

--- a/src/libxrpl/tx/invariants/InvariantCheck.cpp
+++ b/src/libxrpl/tx/invariants/InvariantCheck.cpp
@@ -29,11 +29,11 @@
 #include <xrpl/protocol/UintTypes.h>
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/tx/invariants/InvariantCheckPrivilege.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <algorithm>
 #include <cstdint>
 #include <functional>
-#include <memory>
 #include <optional>
 #include <sstream>
 #include <string>

--- a/src/libxrpl/tx/invariants/InvariantCheck.cpp
+++ b/src/libxrpl/tx/invariants/InvariantCheck.cpp
@@ -88,7 +88,7 @@ ledgerEntryTypeName(SLE const& sle)
 }
 
 void
-TransactionFeeCheck::visitEntry(bool, SLE::const_ref, SLE::const_ref)
+TransactionFeeCheck::visitEntry(InvariantEntry const&)
 {
     // nothing to do
 }
@@ -131,8 +131,12 @@ TransactionFeeCheck::finalize(
 //------------------------------------------------------------------------------
 
 void
-XRPNotCreated::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+XRPNotCreated::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     /* We go through all modified ledger entries, looking only at account roots,
      * escrow payments, and payment channels. We remove from the total any
      * previous XRP values and add to the total any new XRP values. The net
@@ -225,8 +229,11 @@ XRPNotCreated::finalize(
 //------------------------------------------------------------------------------
 
 void
-XRPBalanceChecks::visitEntry(bool, SLE::const_ref before, SLE::const_ref after)
+XRPBalanceChecks::visitEntry(InvariantEntry const& entry)
 {
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     auto isBad = [](STAmount const& balance) {
         if (!balance.native())
             return true;
@@ -272,8 +279,11 @@ XRPBalanceChecks::finalize(
 //------------------------------------------------------------------------------
 
 void
-NoBadOffers::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+NoBadOffers::visitEntry(InvariantEntry const& entry)
 {
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     auto isBad = [](STAmount const& pays, STAmount const& gets) {
         // An offer should never be negative
         if (pays < beast::kZero)
@@ -313,8 +323,11 @@ NoBadOffers::finalize(
 //------------------------------------------------------------------------------
 
 void
-NoZeroEscrow::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+NoZeroEscrow::visitEntry(InvariantEntry const& entry)
 {
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     auto isBad = [](STAmount const& amount) {
         // XRP case
         if (amount.native())
@@ -417,8 +430,11 @@ NoZeroEscrow::finalize(
 //------------------------------------------------------------------------------
 
 void
-AccountRootsNotDeleted::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref)
+AccountRootsNotDeleted::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+
     if (isDelete && before && before->getType() == ltACCOUNT_ROOT)
         accountsDeleted_++;
 }
@@ -469,8 +485,12 @@ AccountRootsNotDeleted::finalize(
 //------------------------------------------------------------------------------
 
 void
-AccountRootsDeletedClean::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+AccountRootsDeletedClean::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     if (isDelete && before && before->getType() == ltACCOUNT_ROOT)
         accountsDeleted_.emplace_back(before, after);
 }
@@ -592,8 +612,11 @@ AccountRootsDeletedClean::finalize(
 //------------------------------------------------------------------------------
 
 void
-LedgerEntryTypesMatch::visitEntry(bool, SLE::const_ref before, SLE::const_ref after)
+LedgerEntryTypesMatch::visitEntry(InvariantEntry const& entry)
 {
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     if (before && before->getType() != after->getType())
         typeMismatch_ = true;
 
@@ -643,8 +666,10 @@ LedgerEntryTypesMatch::finalize(
 //------------------------------------------------------------------------------
 
 void
-NoXRPTrustLines::visitEntry(bool, SLE::const_ref, SLE::const_ref after)
+NoXRPTrustLines::visitEntry(InvariantEntry const& entry)
 {
+    auto const& after = entry.after();
+
     bool const overwriteFixEnabled = isFeatureEnabled(fixCleanup3_1_3, true);
 
     if (after->getType() == ltRIPPLE_STATE)
@@ -683,8 +708,10 @@ NoXRPTrustLines::finalize(
 //------------------------------------------------------------------------------
 
 void
-NoDeepFreezeTrustLinesWithoutFreeze::visitEntry(bool, SLE::const_ref, SLE::const_ref after)
+NoDeepFreezeTrustLinesWithoutFreeze::visitEntry(InvariantEntry const& entry)
 {
+    auto const& after = entry.after();
+
     if (after->getType() == ltRIPPLE_STATE)
     {
         bool const overwriteFixEnabled = isFeatureEnabled(fixCleanup3_1_3, true);
@@ -726,8 +753,11 @@ NoDeepFreezeTrustLinesWithoutFreeze::finalize(
 //------------------------------------------------------------------------------
 
 void
-ValidNewAccountRoot::visitEntry(bool, SLE::const_ref before, SLE::const_ref after)
+ValidNewAccountRoot::visitEntry(InvariantEntry const& entry)
 {
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     if (!before && after->getType() == ltACCOUNT_ROOT)
     {
         accountsCreated_++;
@@ -824,8 +854,12 @@ clawbackTrustLineBalanceInHolderTerms(
 }
 
 void
-ValidClawback::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+ValidClawback::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     if (before && before->getType() == ltRIPPLE_STATE)
     {
         trustlinesChanged_++;
@@ -999,8 +1033,12 @@ ValidClawback::finalize(
 //------------------------------------------------------------------------------
 
 void
-ValidPseudoAccounts::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+ValidPseudoAccounts::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     if (isDelete)
     {
         // Deletion is ignored
@@ -1094,8 +1132,12 @@ ValidPseudoAccounts::finalize(
 //------------------------------------------------------------------------------
 
 void
-NoModifiedUnmodifiableFields::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+NoModifiedUnmodifiableFields::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     if (isDelete || !before)
     {
         // Creation and deletion are ignored
@@ -1202,11 +1244,11 @@ NoModifiedUnmodifiableFields::finalize(
 }
 
 void
-ValidAmounts::visitEntry(
-    bool isDelete,
-    std::shared_ptr<SLE const> const&,
-    std::shared_ptr<SLE const> const& after)
+ValidAmounts::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& after = entry.after();
+
     if (!isDelete)
         afterEntries_.push_back(after);
 }
@@ -1233,8 +1275,11 @@ ValidAmounts::finalize(
 }
 
 void
-ObjectHasPseudoAccount::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+ObjectHasPseudoAccount::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+
     if (!isDelete)
         return;
 

--- a/src/libxrpl/tx/invariants/InvariantRunner.cpp
+++ b/src/libxrpl/tx/invariants/InvariantRunner.cpp
@@ -10,6 +10,7 @@
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/tx/ApplyContext.h>
 #include <xrpl/tx/invariants/InvariantCheck.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <algorithm>
 #include <array>

--- a/src/libxrpl/tx/invariants/InvariantRunner.cpp
+++ b/src/libxrpl/tx/invariants/InvariantRunner.cpp
@@ -2,7 +2,6 @@
 
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/base_uint.h>
-#include <xrpl/basics/contract.h>
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/core/ServiceRegistry.h>
@@ -18,7 +17,6 @@
 #include <exception>
 #include <functional>
 #include <optional>
-#include <stdexcept>
 #include <tuple>
 #include <utility>
 
@@ -50,14 +48,11 @@ checkInvariantsHelper(
         auto checkers = getInvariantChecks();
 
         ctx.visit([&](uint256 const&, bool isDelete, SLE::const_ref before, SLE::const_ref after) {
-            if (after == nullptr)
-                Throw<std::logic_error>("checkInvariants: after is never null");
-            if (isDelete && before == nullptr)
-                Throw<std::logic_error>("checkInvariants: deleted entry missing before state");
+            InvariantEntry const entry{isDelete, before, after};
 
             if (txCheck)
-                txCheck->get().visitEntry(isDelete, before, after);
-            (..., std::get<Is>(checkers).visitEntry(isDelete, before, after));
+                txCheck->get().visitEntry(entry);
+            (..., std::get<Is>(checkers).visitEntry(entry));
         });
 
         if (txCheck)

--- a/src/libxrpl/tx/invariants/InvariantRunner.cpp
+++ b/src/libxrpl/tx/invariants/InvariantRunner.cpp
@@ -2,6 +2,7 @@
 
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/base_uint.h>
+#include <xrpl/basics/contract.h>
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/core/ServiceRegistry.h>
@@ -17,6 +18,7 @@
 #include <exception>
 #include <functional>
 #include <optional>
+#include <stdexcept>
 #include <tuple>
 #include <utility>
 
@@ -48,6 +50,11 @@ checkInvariantsHelper(
         auto checkers = getInvariantChecks();
 
         ctx.visit([&](uint256 const&, bool isDelete, SLE::const_ref before, SLE::const_ref after) {
+            if (after == nullptr)
+                Throw<std::logic_error>("checkInvariants: after is never null");
+            if (isDelete && before == nullptr)
+                Throw<std::logic_error>("checkInvariants: deleted entry missing before state");
+
             if (txCheck)
                 txCheck->get().visitEntry(isDelete, before, after);
             (..., std::get<Is>(checkers).visitEntry(isDelete, before, after));

--- a/src/libxrpl/tx/invariants/LoanBrokerInvariant.cpp
+++ b/src/libxrpl/tx/invariants/LoanBrokerInvariant.cpp
@@ -20,30 +20,27 @@
 namespace xrpl {
 
 void
-ValidLoanBroker::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+ValidLoanBroker::visitEntry(bool, SLE::const_ref before, SLE::const_ref after)
 {
-    if (after)
+    if (after->getType() == ltLOAN_BROKER)
     {
-        if (after->getType() == ltLOAN_BROKER)
-        {
-            auto& broker = brokers_[after->key()];
-            broker.brokerBefore = before;
-            broker.brokerAfter = after;
-        }
-        else if (after->getType() == ltACCOUNT_ROOT && after->isFieldPresent(sfLoanBrokerID))
-        {
-            auto const& loanBrokerID = after->at(sfLoanBrokerID);
-            // create an entry if one doesn't already exist
-            brokers_.emplace(loanBrokerID, BrokerInfo{});
-        }
-        else if (after->getType() == ltRIPPLE_STATE)
-        {
-            lines_.emplace_back(after);
-        }
-        else if (after->getType() == ltMPTOKEN)
-        {
-            mpts_.emplace_back(after);
-        }
+        auto& broker = brokers_[after->key()];
+        broker.brokerBefore = before;
+        broker.brokerAfter = after;
+    }
+    else if (after->getType() == ltACCOUNT_ROOT && after->isFieldPresent(sfLoanBrokerID))
+    {
+        auto const& loanBrokerID = after->at(sfLoanBrokerID);
+        // create an entry if one doesn't already exist
+        brokers_.emplace(loanBrokerID, BrokerInfo{});
+    }
+    else if (after->getType() == ltRIPPLE_STATE)
+    {
+        lines_.emplace_back(after);
+    }
+    else if (after->getType() == ltMPTOKEN)
+    {
+        mpts_.emplace_back(after);
     }
 }
 

--- a/src/libxrpl/tx/invariants/LoanBrokerInvariant.cpp
+++ b/src/libxrpl/tx/invariants/LoanBrokerInvariant.cpp
@@ -14,6 +14,7 @@
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/TxFormats.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <algorithm>
 

--- a/src/libxrpl/tx/invariants/LoanBrokerInvariant.cpp
+++ b/src/libxrpl/tx/invariants/LoanBrokerInvariant.cpp
@@ -20,8 +20,11 @@
 namespace xrpl {
 
 void
-ValidLoanBroker::visitEntry(bool, SLE::const_ref before, SLE::const_ref after)
+ValidLoanBroker::visitEntry(InvariantEntry const& entry)
 {
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     if (after->getType() == ltLOAN_BROKER)
     {
         auto& broker = brokers_[after->key()];

--- a/src/libxrpl/tx/invariants/LoanInvariant.cpp
+++ b/src/libxrpl/tx/invariants/LoanInvariant.cpp
@@ -20,8 +20,11 @@
 namespace xrpl {
 
 void
-ValidLoan::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+ValidLoan::visitEntry(InvariantEntry const& entry)
 {
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     if (after->getType() == ltLOAN)
     {
         loans_.emplace_back(before, after);

--- a/src/libxrpl/tx/invariants/LoanInvariant.cpp
+++ b/src/libxrpl/tx/invariants/LoanInvariant.cpp
@@ -9,11 +9,11 @@
 #include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/Protocol.h>
 #include <xrpl/protocol/SField.h>
-#include <xrpl/protocol/STLedgerEntry.h>
 #include <xrpl/protocol/STNumber.h>  // IWYU pragma: keep
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <cstdint>
 

--- a/src/libxrpl/tx/invariants/LoanInvariant.cpp
+++ b/src/libxrpl/tx/invariants/LoanInvariant.cpp
@@ -22,7 +22,7 @@ namespace xrpl {
 void
 ValidLoan::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
 {
-    if (after && after->getType() == ltLOAN)
+    if (after->getType() == ltLOAN)
     {
         loans_.emplace_back(before, after);
     }

--- a/src/libxrpl/tx/invariants/MPTInvariant.cpp
+++ b/src/libxrpl/tx/invariants/MPTInvariant.cpp
@@ -24,6 +24,7 @@
 #include <xrpl/protocol/UintTypes.h>
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/tx/invariants/InvariantCheckPrivilege.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <algorithm>
 #include <array>

--- a/src/libxrpl/tx/invariants/MPTInvariant.cpp
+++ b/src/libxrpl/tx/invariants/MPTInvariant.cpp
@@ -75,7 +75,7 @@ ValidMPTIssuance::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_re
     // on the hot path.
     bool const fix320Enabled = isFeatureEnabled(fixCleanup3_2_0);
 
-    if (after && after->getType() == ltMPTOKEN_ISSUANCE)
+    if (after->getType() == ltMPTOKEN_ISSUANCE)
     {
         if (isDelete)
         {
@@ -102,7 +102,7 @@ ValidMPTIssuance::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_re
         }
     }
 
-    if (after && after->getType() == ltMPTOKEN)
+    if (after->getType() == ltMPTOKEN)
     {
         if (isDelete)
         {
@@ -121,7 +121,7 @@ ValidMPTIssuance::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_re
 
     // Capture deleted RippleState SLEs so finalize() can verify none of
     // them were owned by a vault pseudo-account outside VaultDelete.
-    if (fix320Enabled && isDelete && after && after->getType() == ltRIPPLE_STATE)
+    if (fix320Enabled && isDelete && after->getType() == ltRIPPLE_STATE)
         deletedHoldings_.push_back(after);
 }
 
@@ -466,15 +466,12 @@ ValidMPTBalanceChanges::visitEntry(bool, SLE::const_ref before, SLE::const_ref a
     if (before && !update(*before, Order::Before))
         return;
 
-    if (after)
+    if (after->getType() == ltMPTOKEN_ISSUANCE)
     {
-        if (after->getType() == ltMPTOKEN_ISSUANCE)
-        {
-            overflow_ = (*after)[sfOutstandingAmount] > maxMPTAmount(*after);
-        }
-        if (!update(*after, Order::After))
-            return;
+        overflow_ = (*after)[sfOutstandingAmount] > maxMPTAmount(*after);
     }
+    if (!update(*after, Order::After))
+        return;
 }
 
 bool
@@ -581,7 +578,7 @@ ValidConfidentialMPToken::visitEntry(
         }
     }
 
-    if (after && after->getType() == ltMPTOKEN)
+    if (after->getType() == ltMPTOKEN)
     {
         uint192 const id = getMptID(after);
         auto& change = changes_[id];
@@ -633,7 +630,7 @@ ValidConfidentialMPToken::visitEntry(
             change.outstandingDelta, before->getFieldU64(sfOutstandingAmount));
     }
 
-    if (after && after->getType() == ltMPTOKEN_ISSUANCE)
+    if (after->getType() == ltMPTOKEN_ISSUANCE)
     {
         uint192 const id = getMptID(after);
         auto& change = changes_[id];
@@ -653,7 +650,7 @@ ValidConfidentialMPToken::visitEntry(
             change.badCOA = true;
     }
 
-    if (before && after && before->getType() == ltMPTOKEN && after->getType() == ltMPTOKEN)
+    if (before && before->getType() == ltMPTOKEN && after->getType() == ltMPTOKEN)
     {
         uint192 const id = getMptID(after);
 
@@ -830,8 +827,7 @@ ValidMPTTransfer::visitEntry(
     if (before)
         update(*before, true);
 
-    if (after)
-        update(*after, false);
+    update(*after, false);
 }
 
 bool

--- a/src/libxrpl/tx/invariants/MPTInvariant.cpp
+++ b/src/libxrpl/tx/invariants/MPTInvariant.cpp
@@ -66,8 +66,12 @@ subtractMPTAmountDelta(std::int64_t delta, std::uint64_t amount)
 }  // namespace
 
 void
-ValidMPTIssuance::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+ValidMPTIssuance::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     // The sfReferenceHolding tracking and the deleted-holding capture are
     // only meaningful post-fixCleanup3_2_0 (the field is never set
     // pre-amendment, and the holding-deletion rule does not apply).
@@ -416,8 +420,11 @@ ValidMPTIssuance::finalize(
 }
 
 void
-ValidMPTBalanceChanges::visitEntry(bool, SLE::const_ref before, SLE::const_ref after)
+ValidMPTBalanceChanges::visitEntry(InvariantEntry const& entry)
 {
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     if (overflow_)
         return;
 
@@ -470,8 +477,7 @@ ValidMPTBalanceChanges::visitEntry(bool, SLE::const_ref before, SLE::const_ref a
     {
         overflow_ = (*after)[sfOutstandingAmount] > maxMPTAmount(*after);
     }
-    if (!update(*after, Order::After))
-        return;
+    update(*after, Order::After);
 }
 
 bool
@@ -541,11 +547,12 @@ ValidMPTBalanceChanges::finalize(
 }
 
 void
-ValidConfidentialMPToken::visitEntry(
-    bool isDelete,
-    std::shared_ptr<SLE const> const& before,
-    std::shared_ptr<SLE const> const& after)
+ValidConfidentialMPToken::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     // Helper to get MPToken Issuance ID safely
     auto const getMptID = [](std::shared_ptr<SLE const> const& sle) -> uint192 {
         if (!sle)
@@ -796,11 +803,12 @@ ValidConfidentialMPToken::finalize(
 }
 
 void
-ValidMPTTransfer::visitEntry(
-    bool isDelete,
-    std::shared_ptr<SLE const> const& before,
-    std::shared_ptr<SLE const> const& after)
+ValidMPTTransfer::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     // Record the before/after MPTAmount for each (issuanceID, account) pair
     // so finalize() can determine whether a transfer actually occurred.
     auto update = [&](SLE const& sle, bool isBefore) {

--- a/src/libxrpl/tx/invariants/NFTInvariant.cpp
+++ b/src/libxrpl/tx/invariants/NFTInvariant.cpp
@@ -30,8 +30,7 @@ ValidNFTokenPage::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_re
     static constexpr uint256 const& kPageBits = nft::kPageMask;
     static constexpr uint256 kAccountBits = ~kPageBits;
 
-    if ((before && before->getType() != ltNFTOKEN_PAGE) ||
-        (after && after->getType() != ltNFTOKEN_PAGE))
+    if ((before && before->getType() != ltNFTOKEN_PAGE) || after->getType() != ltNFTOKEN_PAGE)
         return;
 
     auto check = [this, isDelete](SLE::const_ref sle) {
@@ -107,10 +106,9 @@ ValidNFTokenPage::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_re
         }
     }
 
-    if (after)
-        check(after);
+    check(after);
 
-    if (!isDelete && before && after)
+    if (!isDelete && before)
     {
         // If the NFTokenPage
         //  1. Has a NextMinPage field in before, but loses it in after, and
@@ -191,7 +189,7 @@ NFTokenCountTracking::visitEntry(bool, SLE::const_ref before, SLE::const_ref aft
         beforeBurnedTotal_ += (*before)[~sfBurnedNFTokens].value_or(0);
     }
 
-    if (after && after->getType() == ltACCOUNT_ROOT)
+    if (after->getType() == ltACCOUNT_ROOT)
     {
         afterMintedTotal_ += (*after)[~sfMintedNFTokens].value_or(0);
         afterBurnedTotal_ += (*after)[~sfBurnedNFTokens].value_or(0);

--- a/src/libxrpl/tx/invariants/NFTInvariant.cpp
+++ b/src/libxrpl/tx/invariants/NFTInvariant.cpp
@@ -18,6 +18,7 @@
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/protocol/nftPageMask.h>
 #include <xrpl/tx/invariants/InvariantCheckPrivilege.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <cstddef>
 #include <optional>

--- a/src/libxrpl/tx/invariants/NFTInvariant.cpp
+++ b/src/libxrpl/tx/invariants/NFTInvariant.cpp
@@ -25,8 +25,12 @@
 namespace xrpl {
 
 void
-ValidNFTokenPage::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+ValidNFTokenPage::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     static constexpr uint256 const& kPageBits = nft::kPageMask;
     static constexpr uint256 kAccountBits = ~kPageBits;
 
@@ -181,8 +185,11 @@ ValidNFTokenPage::finalize(
 
 //------------------------------------------------------------------------------
 void
-NFTokenCountTracking::visitEntry(bool, SLE::const_ref before, SLE::const_ref after)
+NFTokenCountTracking::visitEntry(InvariantEntry const& entry)
 {
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     if (before && before->getType() == ltACCOUNT_ROOT)
     {
         beforeMintedTotal_ += (*before)[~sfMintedNFTokens].value_or(0);

--- a/src/libxrpl/tx/invariants/PermissionedDEXInvariant.cpp
+++ b/src/libxrpl/tx/invariants/PermissionedDEXInvariant.cpp
@@ -21,24 +21,19 @@ namespace xrpl {
 void
 ValidPermissionedDEX::visitEntry(bool isDelete, SLE::const_ref, SLE::const_ref after)
 {
-    // Post-fixCleanup3_4_0: skip when after is null (defensive).
-    // Pre-amendment: original after-only path via the `if (after && ...)` checks below.
-    if (isFeatureEnabled(fixCleanup3_4_0) && !after)
-        return;
-
     auto trackDomain = [this, isDelete](uint256 const& domain) {
         domainsOld_.insert(domain);
         if (!isDelete)
             domains_.insert(domain);
     };
 
-    if (after && after->getType() == ltDIR_NODE)
+    if (after->getType() == ltDIR_NODE)
     {
         if (after->isFieldPresent(sfDomainID))
             trackDomain(after->getFieldH256(sfDomainID));
     }
 
-    if (after && after->getType() == ltOFFER)
+    if (after->getType() == ltOFFER)
     {
         if (after->isFieldPresent(sfDomainID))
         {

--- a/src/libxrpl/tx/invariants/PermissionedDEXInvariant.cpp
+++ b/src/libxrpl/tx/invariants/PermissionedDEXInvariant.cpp
@@ -19,8 +19,11 @@
 namespace xrpl {
 
 void
-ValidPermissionedDEX::visitEntry(bool isDelete, SLE::const_ref, SLE::const_ref after)
+ValidPermissionedDEX::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& after = entry.after();
+
     auto trackDomain = [this, isDelete](uint256 const& domain) {
         domainsOld_.insert(domain);
         if (!isDelete)

--- a/src/libxrpl/tx/invariants/PermissionedDEXInvariant.cpp
+++ b/src/libxrpl/tx/invariants/PermissionedDEXInvariant.cpp
@@ -15,6 +15,7 @@
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/TxFormats.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 namespace xrpl {
 

--- a/src/libxrpl/tx/invariants/PermissionedDomainInvariant.cpp
+++ b/src/libxrpl/tx/invariants/PermissionedDomainInvariant.cpp
@@ -15,6 +15,7 @@
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/TxFormats.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <vector>
 

--- a/src/libxrpl/tx/invariants/PermissionedDomainInvariant.cpp
+++ b/src/libxrpl/tx/invariants/PermissionedDomainInvariant.cpp
@@ -25,7 +25,7 @@ ValidPermissionedDomain::visitEntry(bool isDel, SLE::const_ref before, SLE::cons
 {
     if (before && before->getType() != ltPERMISSIONED_DOMAIN)
         return;
-    if (after && after->getType() != ltPERMISSIONED_DOMAIN)
+    if (after->getType() != ltPERMISSIONED_DOMAIN)
         return;
 
     auto check = [isDel](std::vector<SleStatus>& sleStatus, SLE::const_ref sle) {
@@ -54,8 +54,7 @@ ValidPermissionedDomain::visitEntry(bool isDel, SLE::const_ref before, SLE::cons
         sleStatus.emplace_back(ss);
     };
 
-    if (after)
-        check(sleStatus_, after);
+    check(sleStatus_, after);
 }
 
 bool

--- a/src/libxrpl/tx/invariants/PermissionedDomainInvariant.cpp
+++ b/src/libxrpl/tx/invariants/PermissionedDomainInvariant.cpp
@@ -21,8 +21,12 @@
 namespace xrpl {
 
 void
-ValidPermissionedDomain::visitEntry(bool isDel, SLE::const_ref before, SLE::const_ref after)
+ValidPermissionedDomain::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDel = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     if (before && before->getType() != ltPERMISSIONED_DOMAIN)
         return;
     if (after->getType() != ltPERMISSIONED_DOMAIN)

--- a/src/libxrpl/tx/invariants/SponsorshipInvariant.cpp
+++ b/src/libxrpl/tx/invariants/SponsorshipInvariant.cpp
@@ -10,6 +10,7 @@
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <cstdint>
 

--- a/src/libxrpl/tx/invariants/SponsorshipInvariant.cpp
+++ b/src/libxrpl/tx/invariants/SponsorshipInvariant.cpp
@@ -17,8 +17,12 @@ namespace xrpl {
 
 // Add new sponsorship-related invariants implementations
 void
-SponsorshipOwnerCountsMatch::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+SponsorshipOwnerCountsMatch::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     auto getSponsored = [](SLE::const_ref sle) -> std::uint32_t {
         if (sle && sle->getType() == ltACCOUNT_ROOT)
             return sle->getFieldU32(sfSponsoredOwnerCount);
@@ -116,8 +120,11 @@ SponsorshipOwnerCountsMatch::finalize(
 }
 
 void
-SponsorshipAccountCountMatchesField::visitEntry(bool, SLE::const_ref before, SLE::const_ref after)
+SponsorshipAccountCountMatchesField::visitEntry(InvariantEntry const& entry)
 {
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     auto getSponsoringAccountCount = [](SLE::const_ref sle) -> std::uint32_t {
         if (sle && sle->getType() == ltACCOUNT_ROOT)
             return sle->getFieldU32(sfSponsoringAccountCount);

--- a/src/libxrpl/tx/invariants/VaultInvariant.cpp
+++ b/src/libxrpl/tx/invariants/VaultInvariant.cpp
@@ -83,8 +83,12 @@ ValidVault::Shares::make(SLE const& from)
 }
 
 void
-ValidVault::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+ValidVault::visitEntry(InvariantEntry const& entry)
 {
+    auto const isDelete = entry.isDelete();
+    auto const& before = entry.before();
+    auto const& after = entry.after();
+
     // Number balanceDelta will capture the difference (delta) between "before"
     // state (zero if created) and "after" state (zero if destroyed), and
     // preserves value scale (exponent) to round values to the same scale during

--- a/src/libxrpl/tx/invariants/VaultInvariant.cpp
+++ b/src/libxrpl/tx/invariants/VaultInvariant.cpp
@@ -22,6 +22,7 @@
 #include <xrpl/protocol/TxFormats.h>
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/tx/invariants/InvariantCheckPrivilege.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 
 #include <algorithm>
 #include <cstdint>

--- a/src/libxrpl/tx/invariants/VaultInvariant.cpp
+++ b/src/libxrpl/tx/invariants/VaultInvariant.cpp
@@ -85,13 +85,6 @@ ValidVault::Shares::make(SLE const& from)
 void
 ValidVault::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
 {
-    // If `before` is empty, this means an object is being created, in which
-    // case `isDelete` must be false. Otherwise `before` and `after` are set and
-    // `isDelete` indicates whether an object is being deleted or modified.
-    XRPL_ASSERT(
-        after != nullptr && (before != nullptr || !isDelete),
-        "xrpl::ValidVault::visitEntry : some object is available");
-
     // Number balanceDelta will capture the difference (delta) between "before"
     // state (zero if created) and "after" state (zero if destroyed), and
     // preserves value scale (exponent) to round values to the same scale during
@@ -144,7 +137,7 @@ ValidVault::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref afte
         }
     }
 
-    if (!isDelete && after)
+    if (!isDelete)
     {
         switch (after->getType())
         {

--- a/src/test/app/invariants/InvariantsAMM_test.cpp
+++ b/src/test/app/invariants/InvariantsAMM_test.cpp
@@ -73,7 +73,7 @@ class InvariantsAMM_test : public InvariantsBase
             if (deletedLPBalance)
             {
                 auto const sleAMM = makeAMM(*deletedLPBalance);
-                invariant.visitEntry(true, sleAMM, sleAMM);
+                invariant.visitEntry(InvariantEntry{true, sleAMM, sleAMM});
             }
 
             bool const actual = invariant.finalize(

--- a/src/test/app/invariants/InvariantsAMM_test.cpp
+++ b/src/test/app/invariants/InvariantsAMM_test.cpp
@@ -71,7 +71,10 @@ class InvariantsAMM_test : public InvariantsBase
             ValidAMM invariant;
 
             if (deletedLPBalance)
-                invariant.visitEntry(true, makeAMM(*deletedLPBalance), nullptr);
+            {
+                auto const sleAMM = makeAMM(*deletedLPBalance);
+                invariant.visitEntry(true, sleAMM, sleAMM);
+            }
 
             bool const actual = invariant.finalize(
                 STTx{txType, [](STObject&) {}}, result, XRPAmount{}, *env.current(), jlog);

--- a/src/test/app/invariants/InvariantsMisc_test.cpp
+++ b/src/test/app/invariants/InvariantsMisc_test.cpp
@@ -40,6 +40,7 @@
 #include <xrpl/tx/ApplyContext.h>
 #include <xrpl/tx/Transactor.h>
 #include <xrpl/tx/applySteps.h>
+#include <xrpl/tx/invariants/InvariantEntry.h>
 #include <xrpl/tx/invariants/InvariantRunner.h>
 
 #include <array>
@@ -49,6 +50,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/src/test/app/invariants/InvariantsMisc_test.cpp
+++ b/src/test/app/invariants/InvariantsMisc_test.cpp
@@ -1184,6 +1184,39 @@ class InvariantsMisc_test : public InvariantsBase
     }
 
     void
+    testInvariantEntry()
+    {
+        testcase << "invariant entry validation";
+
+        SLE::const_pointer const null;
+        SLE::const_pointer const sle = std::make_shared<SLE>(keylet::amendments());
+
+        InvariantEntry const created{false, null, sle};
+        BEAST_EXPECT(!created.isDelete());
+        BEAST_EXPECT(!created.before());
+        BEAST_EXPECT(created.after() == sle);
+
+        auto const expectLogicError = [&](bool isDelete,
+                                          SLE::const_ref before,
+                                          SLE::const_ref after,
+                                          std::string_view message) {
+            try
+            {
+                InvariantEntry const entry{isDelete, before, after};
+                (void)entry;
+                BEAST_EXPECT(false);
+            }
+            catch (std::logic_error const& ex)
+            {
+                BEAST_EXPECT(std::string_view{ex.what()}.contains(message));
+            }
+        };
+
+        expectLogicError(false, null, null, "after is never null");
+        expectLogicError(true, null, sle, "deleted entry missing before state");
+    }
+
+    void
     testTxCheckException()
     {
         testcase << "txCheck exception";
@@ -1205,7 +1238,7 @@ class InvariantsMisc_test : public InvariantsBase
             }
 
             void
-            visitEntry(bool, SLE::const_ref, SLE::const_ref) override
+            visitEntry(InvariantEntry const&) override
             {
                 if (throwFrom == ThrowFrom::VisitEntry)
                     throw std::runtime_error("test-injected visitEntry exception");
@@ -1269,7 +1302,7 @@ class InvariantsMisc_test : public InvariantsBase
         struct FailingTxInvariantCheck : TxInvariantCheck
         {
             void
-            visitEntry(bool, SLE::const_ref, SLE::const_ref) override
+            visitEntry(InvariantEntry const&) override
             {
             }
 
@@ -1323,6 +1356,7 @@ class InvariantsMisc_test : public InvariantsBase
         testInvariantOverwrite(all_ - fixCleanup3_1_3);
         testObjectHasPseudoAccount();
         testSponsorship();
+        testInvariantEntry();
         testTxCheckException();
         testTxCheckFinalizeFalse();
     }

--- a/src/test/app/invariants/InvariantsPermissioned_test.cpp
+++ b/src/test/app/invariants/InvariantsPermissioned_test.cpp
@@ -667,7 +667,8 @@ class InvariantsPermissioned_test : public InvariantsBase
                 CurrentTransactionRulesGuard const rulesGuard(env.current()->rules());
 
                 ValidPermissionedDEX invariant;
-                invariant.visitEntry(isDelete, nullptr, sleOffer);
+                SLE::const_pointer const before = isDelete ? sleOffer : nullptr;
+                invariant.visitEntry(InvariantEntry{isDelete, before, sleOffer});
 
                 STTx const tx{ttOFFER_CREATE, [&pd2, &a1](STObject& tx) {
                                   tx.setFieldH256(sfDomainID, pd2);
@@ -793,7 +794,8 @@ class InvariantsPermissioned_test : public InvariantsBase
             view.rawInsert(makeRootPage(rootDir, directoryQuality + 1));
 
             ValidBookDirectory invariant;
-            invariant.visitEntry(false, nullptr, makeChildPage(rootDir));
+            auto const childPage = makeChildPage(rootDir);
+            invariant.visitEntry(InvariantEntry{false, nullptr, childPage});
 
             test::StreamSink sink{beast::Severity::Warning};
             beast::Journal const jlog{sink};
@@ -823,7 +825,7 @@ class InvariantsPermissioned_test : public InvariantsBase
             {
                 // add
                 ValidBookDirectory invariant;
-                invariant.visitEntry(false, nullptr, badRoot);
+                invariant.visitEntry(InvariantEntry{false, nullptr, badRoot});
 
                 BEAST_EXPECT(
                     !invariant.finalize(makeOfferCreateTx(), tesSUCCESS, XRPAmount{}, view, jlog));
@@ -831,7 +833,7 @@ class InvariantsPermissioned_test : public InvariantsBase
             {
                 // modify (without changing the sfRootIndex)
                 ValidBookDirectory invariant;
-                invariant.visitEntry(false, badRoot, badRoot);
+                invariant.visitEntry(InvariantEntry{false, badRoot, badRoot});
 
                 BEAST_EXPECT(
                     invariant.finalize(makeOfferCreateTx(), tesSUCCESS, XRPAmount{}, view, jlog));
@@ -843,7 +845,7 @@ class InvariantsPermissioned_test : public InvariantsBase
                 childAfter->setFieldH256(sfRootIndex, missingRootDir.key);
 
                 ValidBookDirectory invariant;
-                invariant.visitEntry(false, childBefore, childAfter);
+                invariant.visitEntry(InvariantEntry{false, childBefore, childAfter});
 
                 test::StreamSink missingRootSink{beast::Severity::Warning};
                 beast::Journal const missingRootJlog{missingRootSink};
@@ -858,7 +860,7 @@ class InvariantsPermissioned_test : public InvariantsBase
                 BEAST_EXPECT(!view.exists(rootDir));
 
                 ValidBookDirectory invariant;
-                invariant.visitEntry(true, badRoot, badRoot);
+                invariant.visitEntry(InvariantEntry{true, badRoot, badRoot});
                 BEAST_EXPECT(
                     invariant.finalize(makeOfferCreateTx(), tesSUCCESS, XRPAmount{}, view, jlog));
             }

--- a/src/test/app/invariants/InvariantsPermissioned_test.cpp
+++ b/src/test/app/invariants/InvariantsPermissioned_test.cpp
@@ -640,83 +640,66 @@ class InvariantsPermissioned_test : public InvariantsBase
     {
         using namespace test::jtx;
 
-        testcase << "PermissionedDEX null after";
+        testcase << "PermissionedDEX deleted offer after";
 
         // Tx is OfferCreate on pd2. Tracking pd1 fails the invariant iff that
-        // domain lands in the set finalize consults. after == null is never
-        // tracked (pre-340: after-only; post-340: early return) — same result,
-        // both sides are coverage/regression that we do not fall back to before.
-        auto const check = [this](
-                               FeatureBitset features,
-                               bool const afterIsNull,
-                               bool const isDelete,
-                               bool const expectInvariantFailure) {
-            Env env(*this, features);
+        // domain lands in the set finalize consults.
+        auto const check =
+            [this](FeatureBitset features, bool const isDelete, bool const expectInvariantFailure) {
+                Env env(*this, features);
 
-            Account const a1{"A1"};
-            Account const a2{"A2"};
-            env.fund(XRP(1000), a1, a2);
-            env.close();
+                Account const a1{"A1"};
+                Account const a2{"A2"};
+                env.fund(XRP(1000), a1, a2);
+                env.close();
 
-            [[maybe_unused]] auto [seq1, pd1] = createPermissionedDomainEnv(env, a1, a2);
-            [[maybe_unused]] auto [seq2, pd2] = createPermissionedDomainEnv(env, a1, a2);
-            env.close();
+                [[maybe_unused]] auto [seq1, pd1] = createPermissionedDomainEnv(env, a1, a2);
+                [[maybe_unused]] auto [seq2, pd2] = createPermissionedDomainEnv(env, a1, a2);
+                env.close();
 
-            auto sleOffer =
-                std::make_shared<SLE>(keylet::offer(a2.id(), SeqProxy::rawSequence(10)));
-            sleOffer->setAccountID(sfAccount, a2);
-            sleOffer->setFieldAmount(sfTakerPays, a1["USD"](10));
-            sleOffer->setFieldAmount(sfTakerGets, XRP(1));
-            sleOffer->setFieldH256(sfDomainID, pd1);
+                auto sleOffer =
+                    std::make_shared<SLE>(keylet::offer(a2.id(), SeqProxy::rawSequence(10)));
+                sleOffer->setAccountID(sfAccount, a2);
+                sleOffer->setFieldAmount(sfTakerPays, a1["USD"](10));
+                sleOffer->setFieldAmount(sfTakerGets, XRP(1));
+                sleOffer->setFieldH256(sfDomainID, pd1);
 
-            CurrentTransactionRulesGuard const rulesGuard(env.current()->rules());
+                CurrentTransactionRulesGuard const rulesGuard(env.current()->rules());
 
-            ValidPermissionedDEX invariant;
-            if (afterIsNull)
-            {
-                // Defensive path: after is null. Must not fall back to before.
-                invariant.visitEntry(isDelete, sleOffer, nullptr);
-            }
-            else
-            {
-                // Normal / real-erase path: after is the offer on pd1.
+                ValidPermissionedDEX invariant;
                 invariant.visitEntry(isDelete, nullptr, sleOffer);
-            }
 
-            STTx const tx{ttOFFER_CREATE, [&pd2, &a1](STObject& tx) {
-                              tx.setFieldH256(sfDomainID, pd2);
-                              tx.setFieldAmount(sfTakerPays, a1["USD"](10));
-                              tx.setFieldAmount(sfTakerGets, XRP(1));
-                          }};
+                STTx const tx{ttOFFER_CREATE, [&pd2, &a1](STObject& tx) {
+                                  tx.setFieldH256(sfDomainID, pd2);
+                                  tx.setFieldAmount(sfTakerPays, a1["USD"](10));
+                                  tx.setFieldAmount(sfTakerGets, XRP(1));
+                              }};
 
-            test::StreamSink sink{beast::Severity::Warning};
-            beast::Journal const jlog{sink};
-            bool const passed =
-                invariant.finalize(tx, tesSUCCESS, XRPAmount{}, *env.current(), jlog);
-            BEAST_EXPECT(passed != expectInvariantFailure);
-            if (expectInvariantFailure)
-            {
-                BEAST_EXPECT(sink.messages().str().contains("transaction consumed wrong domains"));
-            }
-            else
-            {
-                BEAST_EXPECT(sink.messages().str().empty());
-            }
-        };
+                test::StreamSink sink{beast::Severity::Warning};
+                beast::Journal const jlog{sink};
+                bool const passed =
+                    invariant.finalize(tx, tesSUCCESS, XRPAmount{}, *env.current(), jlog);
+                BEAST_EXPECT(passed != expectInvariantFailure);
+                if (expectInvariantFailure)
+                {
+                    BEAST_EXPECT(
+                        sink.messages().str().contains("transaction consumed wrong domains"));
+                }
+                else
+                {
+                    BEAST_EXPECT(sink.messages().str().empty());
+                }
+            };
 
         auto const pre = all_ - fixCleanup3_4_0;
         auto const post = all_;
 
-        // after == null: not tracked
-        check(pre, true, true, false);
-        check(post, true, true, false);
-
         // after == offer on pd1
         // pre-340: domainsOld_ (delete still inserted) → fail
-        check(pre, false, true, true);
+        check(pre, true, true);
         // post-340: isDelete → only domainsOld_ → pass; !isDelete → domains_ → fail
-        check(post, false, true, false);
-        check(post, false, false, true);
+        check(post, true, false);
+        check(post, false, true);
     }
 
     void


### PR DESCRIPTION
## Summary
- Enforce the `visitEntry` contract in one place: `after` is never null, and a deletion always has `before`. Checkers take a validated `InvariantEntry` instead of three loose arguments.
- `InvariantEntry` owns the `shared_ptr`s and throws `std::logic_error` on a contract break so the existing runner `try/catch` can fail the transaction in all builds (`tecINVARIANT_FAILED` / `tefINVARIANT_FAILED`), rather than using `XRPL_ASSERT` which is not testable and not fail-closed in release.
- Duplicate checker-level null guards are gone. A `rawErase` of a key that is not in the parent view now fails invariants instead of being silently skipped; that path is a transactor bug, so failing the transaction is the correct behavior.

Follow-up (not in this PR): migrate `Transactor::visitInvariantEntry` overrides to `InvariantEntry const&`.

## Test plan
- [x] `InvariantsMisc`, `InvariantsAMM`, `InvariantsPermissioned`, `InvariantsVault`, `LoanInvariants` — 0 failures
- [x] Full unit suite: `./xrpld -u --unittest-jobs 10` — 247 suites, 0 failures