### PR TITLE
fix: Recycle the escrow reserve in EscrowCancel and EscrowFinish

### DIFF
--- a/src/libxrpl/tx/transactors/escrow/EscrowCancel.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCancel.cpp
@@ -171,8 +171,8 @@ EscrowCancel::doApply()
 
     // Release the escrow's reserve before returning the funds. The owner is
     // also the receiver, so the return can re-create a holding they deleted
-    // while the escrow was pending, and the escrow must not be counted against
-    // that holding's reserve when the net owner count is unchanged.
+    // while the escrow was pending, and the escrow being removed must not be
+    // counted against that new holding's reserve.
     bool const recycleReserve = ctx_.view().rules().enabled(fixCleanup3_4_0);
     if (recycleReserve)
         decreaseOwnerCountForObject(ctx_.view(), sle, slep, 1, ctx_.journal);

--- a/src/libxrpl/tx/transactors/escrow/EscrowCancel.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCancel.cpp
@@ -218,8 +218,6 @@ EscrowCancel::doApply()
         }
     }
 
-    ctx_.view().update(sle);
-
     if (!recycleReserve)
         decreaseOwnerCountForObject(ctx_.view(), sle, slep, 1, ctx_.journal);
 

--- a/src/libxrpl/tx/transactors/escrow/EscrowCancel.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCancel.cpp
@@ -169,10 +169,8 @@ EscrowCancel::doApply()
     auto const sle = ctx_.view().peek(keylet::account(account));
     STAmount const amount = slep->getFieldAmount(sfAmount);
 
-    // Release the escrow's reserve before returning the funds. The owner is
-    // also the receiver, so the return can re-create a holding they deleted
-    // while the escrow was pending, and the escrow being removed must not be
-    // counted against that new holding's reserve.
+    // The return can re-create a holding the owner deleted while the escrow
+    // was pending; the removed escrow must not be counted against its reserve.
     bool const recycleReserve = ctx_.view().rules().enabled(fixCleanup3_4_0);
     if (recycleReserve)
         decreaseOwnerCountForObject(ctx_.view(), sle, slep, 1, ctx_.journal);

--- a/src/libxrpl/tx/transactors/escrow/EscrowCancel.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCancel.cpp
@@ -169,6 +169,14 @@ EscrowCancel::doApply()
     auto const sle = ctx_.view().peek(keylet::account(account));
     STAmount const amount = slep->getFieldAmount(sfAmount);
 
+    // Release the escrow's reserve before returning the funds. The owner is
+    // also the receiver, so the return can re-create a holding they deleted
+    // while the escrow was pending, and the escrow must not be counted against
+    // that holding's reserve when the net owner count is unchanged.
+    bool const recycleReserve = ctx_.view().rules().enabled(fixCleanup3_4_0);
+    if (recycleReserve)
+        decreaseOwnerCountForObject(ctx_.view(), sle, slep, 1, ctx_.journal);
+
     // Transfer amount back to the owner
     if (isXRP(amount))
     {
@@ -212,7 +220,10 @@ EscrowCancel::doApply()
         }
     }
 
-    decreaseOwnerCountForObject(ctx_.view(), sle, slep, 1, ctx_.journal);
+    ctx_.view().update(sle);
+
+    if (!recycleReserve)
+        decreaseOwnerCountForObject(ctx_.view(), sle, slep, 1, ctx_.journal);
 
     // Remove escrow from ledger
     ctx_.view().erase(slep);

--- a/src/libxrpl/tx/transactors/escrow/EscrowFinish.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowFinish.cpp
@@ -343,14 +343,14 @@ EscrowFinish::doApply()
         }
     }
 
-    // With the Sponsor amendment, release the escrow reserve before delivery.
-    // Token delivery can auto-create a destination holding, and the same
-    // sponsor (or the same account, for a self-escrow) may cover both the
-    // escrow being removed and the holding being created. Without the
-    // amendment, keep the legacy order: releasing early changes the reserve
-    // arithmetic for self-escrows and would break consensus if not gated.
-    bool const sponsorEnabled = ctx_.view().rules().enabled(featureSponsor);
-    if (sponsorEnabled)
+    // Release the escrow's reserve before delivery. Delivery can auto-create
+    // the destination's holding, and the escrow being removed must not be
+    // counted against that new holding's reserve. The escrow and the holding
+    // only share a reserve payer for a self-escrow, or when one sponsor covers
+    // both.
+    bool const recycleReserve =
+        ctx_.view().rules().enabled(featureSponsor) || ctx_.view().rules().enabled(fixCleanup3_4_0);
+    if (recycleReserve)
         decreaseOwnerCountForObject(ctx_.view(), account, slep, 1, ctx_.journal);
 
     STAmount const amount = slep->getFieldAmount(sfAmount);
@@ -402,8 +402,7 @@ EscrowFinish::doApply()
 
     ctx_.view().update(sled);
 
-    // Adjust source owner count (legacy position, pre-Sponsor)
-    if (!sponsorEnabled)
+    if (!recycleReserve)
         decreaseOwnerCountForObject(ctx_.view(), account, slep, 1, ctx_.journal);
 
     // Remove escrow from ledger

--- a/src/libxrpl/tx/transactors/escrow/EscrowFinish.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowFinish.cpp
@@ -343,11 +343,9 @@ EscrowFinish::doApply()
         }
     }
 
-    // Release the escrow's reserve before delivery. Delivery can auto-create
-    // the destination's holding, and the escrow being removed must not be
-    // counted against that new holding's reserve. The escrow and the holding
-    // only share a reserve payer for a self-escrow, or when one sponsor covers
-    // both.
+    // Delivery can auto-create the destination's holding; the removed escrow
+    // must not be counted against its reserve. The two share a reserve payer
+    // for a self-escrow, or when one sponsor covers both.
     bool const recycleReserve =
         ctx_.view().rules().enabled(featureSponsor) || ctx_.view().rules().enabled(fixCleanup3_4_0);
     if (recycleReserve)

--- a/src/test/app/EscrowToken_test.cpp
+++ b/src/test/app/EscrowToken_test.cpp
@@ -952,6 +952,102 @@ struct EscrowToken_test : public beast::unit_test::Suite
     }
 
     void
+    testIOUCancelReserveRecycle(FeatureBitset features)
+    {
+        testcase("IOU Cancel Reserve Recycle");
+        using namespace jtx;
+        using namespace std::literals;
+
+        // Creating an IOU escrow moves the owner's whole balance out of the
+        // trust line, so the owner can delete the now-zero line while the
+        // escrow is pending. Cancelling re-creates it: one object is destroyed
+        // and one created, leaving the owner's reserve requirement unchanged.
+        // Without fixCleanup3_4_0 the escrow is still counted when the new
+        // line's reserve is checked, so an owner funded for the final state is
+        // refused.
+        Env env{*this, features};
+        bool const fixEnabled = env.current()->rules().enabled(fixCleanup3_4_0);
+
+        auto const baseFee = env.current()->fees().base;
+        auto const alice = Account("alice");
+        auto const bob = Account("bob");
+        auto const gw = Account("gw");
+        auto const usd = gw["USD"];
+
+        env.fund(XRP(10'000), alice, bob, gw);
+        env.close();
+
+        env(fset(gw, asfAllowTrustLineLocking));
+        env.close();
+
+        env.trust(usd(10'000), alice);
+        env.close();
+
+        env(pay(gw, alice, usd(10'000)));
+        env.close();
+        BEAST_EXPECT(env.ownerCount(alice) == 1);
+
+        auto const cancelAfter = env.now() + 100s;
+        auto const seq = env.seq(alice);
+        env(escrow::create(alice, bob, usd(10'000)),
+            escrow::kFinishTime(env.now() + 1s),
+            escrow::kCancelTime(cancelAfter),
+            Fee(baseFee));
+        env.close();
+        BEAST_EXPECT(env.ownerCount(alice) == 2);
+
+        auto const trustLineKey = keylet::trustLine(alice.id(), gw.id(), usd.currency);
+        env(trust(alice, usd(0)));
+        env.close();
+        BEAST_EXPECT(!env.current()->exists(trustLineKey));
+        BEAST_EXPECT(env.ownerCount(alice) == 1);
+
+        // Leave alice holding the reserve for exactly one owned object. That
+        // is the escrow now and the re-created trust line after the cancel.
+        auto const oneObject = env.current()->fees().accountReserve(1, 1);
+        auto const twoObjects = env.current()->fees().accountReserve(2, 1);
+        auto const balance = env.balance(alice).value().xrp();
+        env(pay(alice, bob, drops(balance.drops() - oneObject.drops() - baseFee.drops() * 20)));
+        env.close();
+        BEAST_EXPECT(env.balance(alice).value().xrp() >= oneObject);
+        BEAST_EXPECT(env.balance(alice).value().xrp() < twoObjects);
+
+        for (; env.now() < cancelAfter; env.close())
+        {
+        }
+        env.close();
+        env.close();
+
+        auto const expectedResult = fixEnabled ? Ter(tesSUCCESS) : Ter(tecNO_LINE_INSUF_RESERVE);
+        env(escrow::cancel(alice, alice, seq), Fee(baseFee), expectedResult);
+        env.close();
+
+        auto const escrowKey = keylet::escrow(alice.id(), SeqProxy::rawSequence(seq));
+        if (fixEnabled)
+        {
+            BEAST_EXPECT(!env.le(escrowKey));
+            BEAST_EXPECT(env.current()->exists(trustLineKey));
+            BEAST_EXPECT(env.balance(alice, usd) == usd(10'000));
+            BEAST_EXPECT(env.ownerCount(alice) == 1);
+        }
+        else
+        {
+            // The tec keeps the escrow, so funding one more owner reserve lets
+            // the same cancel through.
+            BEAST_EXPECT(env.le(escrowKey) != nullptr);
+            BEAST_EXPECT(!env.current()->exists(trustLineKey));
+            BEAST_EXPECT(env.ownerCount(alice) == 1);
+
+            env(pay(bob, alice, drops(twoObjects.drops() - oneObject.drops())));
+            env.close();
+            env(escrow::cancel(alice, alice, seq), Fee(baseFee), Ter(tesSUCCESS));
+            env.close();
+            BEAST_EXPECT(!env.le(escrowKey));
+            BEAST_EXPECT(env.balance(alice, usd) == usd(10'000));
+        }
+    }
+
+    void
     testIOUBalances(FeatureBitset features)
     {
         testcase("IOU Balances");
@@ -4250,6 +4346,8 @@ public:
         }
         testMPTSplitEscrowTransferFee(all - fixCleanup3_4_0);
         testMPTSplitEscrowTransferFee(all);
+        testIOUCancelReserveRecycle(all - fixCleanup3_4_0);
+        testIOUCancelReserveRecycle(all);
     }
 };
 

--- a/src/test/app/EscrowToken_test.cpp
+++ b/src/test/app/EscrowToken_test.cpp
@@ -958,13 +958,9 @@ struct EscrowToken_test : public beast::unit_test::Suite
         using namespace jtx;
         using namespace std::literals;
 
-        // Creating an IOU escrow moves the owner's whole balance out of the
-        // trust line, so the owner can delete the now-zero line while the
-        // escrow is pending. Cancelling re-creates it: one object is destroyed
-        // and one created, leaving the owner's reserve requirement unchanged.
-        // Without fixCleanup3_4_0 the escrow is still counted when the new
-        // line's reserve is checked, so an owner funded for the final state is
-        // refused.
+        // Escrowing the whole IOU balance lets the owner delete the now-zero
+        // trust line, so cancelling has to re-create it: one object destroyed,
+        // one created, and the reserve requirement unchanged.
         Env env{*this, features};
         bool const fixEnabled = env.current()->rules().enabled(fixCleanup3_4_0);
 
@@ -1033,8 +1029,8 @@ struct EscrowToken_test : public beast::unit_test::Suite
         }
         else
         {
-            // The tec keeps the escrow, so funding one more owner reserve lets
-            // the same cancel through.
+            // The tec keeps the escrow, so one more owner reserve lets the
+            // retry through.
             BEAST_EXPECT(env.le(escrowKey) != nullptr);
             BEAST_EXPECT(!env.current()->exists(trustLineKey));
             BEAST_EXPECT(env.ownerCount(alice) == 1);

--- a/src/test/app/EscrowToken_test.cpp
+++ b/src/test/app/EscrowToken_test.cpp
@@ -1007,7 +1007,8 @@ struct EscrowToken_test : public beast::unit_test::Suite
         auto const oneObject = env.current()->fees().accountReserve(1, 1);
         auto const twoObjects = env.current()->fees().accountReserve(2, 1);
         auto const balance = env.balance(alice).value().xrp();
-        env(pay(alice, bob, drops(balance.drops() - oneObject.drops() - baseFee.drops() * 20)));
+        auto const feeCushion = baseFee.drops() * 20;
+        env(pay(alice, bob, drops(balance.drops() - oneObject.drops() - feeCushion)));
         env.close();
         BEAST_EXPECT(env.balance(alice).value().xrp() >= oneObject);
         BEAST_EXPECT(env.balance(alice).value().xrp() < twoObjects);

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -5467,14 +5467,12 @@ public:
         using namespace test::jtx;
         using namespace std::chrono_literals;
 
-        // Finishing a self-escrow (source == destination) whose trust line
-        // was deleted while the escrow was outstanding auto-creates the line,
-        // and the outcome of that reserve check depends on whether the escrow
-        // reserve is released before delivery. With the source's balance in the
-        // one-increment window [reserve(1), reserve(2)), releasing after
-        // delivery requires reserve(2) and fails, while releasing before it
-        // requires reserve(1) and succeeds. Either featureSponsor or
-        // fixCleanup3_4_0 releases it before delivery.
+        // Finishing a self-escrow (source == destination) whose trust line was
+        // deleted while the escrow was outstanding auto-creates the line. With
+        // the source's balance in the one-increment window
+        // [reserve(1), reserve(2)), the finish succeeds only when the escrow
+        // reserve is released before delivery, which either featureSponsor or
+        // fixCleanup3_4_0 does.
         auto runTest = [&](FeatureBitset features, TER expected) {
             Account const alice("alice");
             Account const gw("gw");
@@ -5539,11 +5537,7 @@ public:
             }
         };
 
-        // Neither amendment: the escrow still counts against the reserve while
-        // the auto-created line is checked.
         runTest(testableAmendments() - featureSponsor - fixCleanup3_4_0, tecNO_LINE_INSUF_RESERVE);
-
-        // Either amendment recycles the escrow reserve into the new line.
         runTest(testableAmendments() - featureSponsor, tesSUCCESS);
         runTest(testableAmendments() - fixCleanup3_4_0, tesSUCCESS);
         runTest(testableAmendments(), tesSUCCESS);

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -5470,10 +5470,11 @@ public:
         // Finishing a self-escrow (source == destination) whose trust line
         // was deleted while the escrow was outstanding auto-creates the line,
         // and the outcome of that reserve check depends on whether the escrow
-        // reserve is released before delivery (Sponsor) or after (legacy).
-        // With the source's balance in the one-increment window
-        // [reserve(1), reserve(2)), the legacy order requires reserve(2) and
-        // fails, while the Sponsor order requires reserve(1) and succeeds.
+        // reserve is released before delivery. With the source's balance in the
+        // one-increment window [reserve(1), reserve(2)), releasing after
+        // delivery requires reserve(2) and fails, while releasing before it
+        // requires reserve(1) and succeeds. Either featureSponsor or
+        // fixCleanup3_4_0 releases it before delivery.
         auto runTest = [&](FeatureBitset features, TER expected) {
             Account const alice("alice");
             Account const gw("gw");
@@ -5538,11 +5539,13 @@ public:
             }
         };
 
-        // Pre-amendment: legacy order — the escrow still counts against the
-        // reserve while the auto-created line is checked.
-        runTest(testableAmendments() - featureSponsor, tecNO_LINE_INSUF_RESERVE);
+        // Neither amendment: the escrow still counts against the reserve while
+        // the auto-created line is checked.
+        runTest(testableAmendments() - featureSponsor - fixCleanup3_4_0, tecNO_LINE_INSUF_RESERVE);
 
-        // Post-amendment: the escrow reserve is recycled into the new line.
+        // Either amendment recycles the escrow reserve into the new line.
+        runTest(testableAmendments() - featureSponsor, tesSUCCESS);
+        runTest(testableAmendments() - fixCleanup3_4_0, tesSUCCESS);
         runTest(testableAmendments(), tesSUCCESS);
     }
 


### PR DESCRIPTION
## High Level Overview of Change

`EscrowCancel` and `EscrowFinish` release the escrow's owner reserve before the funds move, gated on `fixCleanup3_4_0`.

### Context of Change

Creating an IOU escrow moves the owner's whole balance out of the trust line, so the owner can delete the now-zero line while the escrow is still pending. Returning those IOUs has to re-create the line, and `escrowUnlockApplyHelper` checks the reserve for one additional owner object before it calls `trustCreate`.

That check ran while the escrow was still counted in `sfOwnerCount`, because `decreaseOwnerCountForObject` came after the transfer. The transaction destroys one object and creates one, so the reserve requirement is unchanged, but the check asked for two. An owner holding between `accountReserve(n)` and `accountReserve(n + 1)` got `tecNO_LINE_INSUF_RESERVE` for a final state they could afford.

`EscrowCancel` is affected for every IOU escrow, since the owner is always the receiver. `EscrowFinish` is affected for a self-escrow, where the owner whose count is released is also the destination whose holding is created.

`EscrowFinish` already released the reserve first under `featureSponsor`, which covers the case of one sponsor paying for both objects. `fixCleanup3_4_0` is added as a second gate there so the unsponsored self-escrow is fixed whichever amendment activates first.

The failure is recoverable. The `tec` keeps the escrow, so funding one more owner reserve lets the same transaction through. MPT is not affected: `MPTokenAuthorize` returns `tecHAS_OBLIGATIONS` while `sfLockedAmount` is non-zero, so an MPT holding cannot be deleted with an escrow outstanding.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

## Test Plan

`testIOUCancelReserveRecycle` in `EscrowToken_test.cpp` funds the owner to exactly the reserve for one object, deletes the trust line while the escrow is pending, and cancels after `CancelAfter`. With the amendment it returns `tesSUCCESS`; without it, `tecNO_LINE_INSUF_RESERVE` followed by the top-up and retry, so the recoverable behavior stays covered.

`testSelfEscrowFinishReserveGate` in `Sponsor_test.cpp` already covered the finish side under `featureSponsor`. It now runs the reserve-refused case with both amendments off, and the success case under each amendment alone as well as both together.

`EscrowToken`, `Escrow` and `Sponsor` pass. Forcing the new ordering off in `EscrowCancel` fails the amendment-on run at the cancel, which confirms the test covers the change.
