### PR TITLE
docs: Correct config documentation to match code

### DIFF
--- a/cfg/xrpld-example.cfg
+++ b/cfg/xrpld-example.cfg
@@ -339,7 +339,7 @@
 #       the least amount and 9 is the most amount. Higher levels require more
 #       CPU resources. Levels 1 through 3 use a fast compression algorithm,
 #       while levels 4 through 9 use a more compact algorithm which uses more
-#       CPU resources. If unspecified, a default of 3 is used.
+#       CPU resources. If unspecified, a default of 8 is used.
 #
 #   memory_level = [1..9]
 #
@@ -624,13 +624,15 @@
 #       At ledger close time, the median fee level of the transactions
 #       in that ledger is used as a multiplier in escalation
 #       calculations of the next ledger. This minimum value ensures that
-#       the escalation is significant. Default: 500.
+#       the escalation is significant. The value is expressed in fee
+#       levels. Default: 128000 (the base fee level of 256 multiplied by
+#       500).
 #
 #   minimum_txn_in_ledger = <number>
 #
 #       Minimum number of transactions that must be allowed into the
 #       ledger at the minimum required fee before the required fee
-#       escalates. Default: 5.
+#       escalates. Default: 32.
 #
 #   minimum_txn_in_ledger_standalone = <number>
 #
@@ -645,7 +647,7 @@
 #       reaches or exceeds this number. After that the limit may still
 #       change, but will stay above the target. If consensus is not
 #       healthy, the limit will be clamped to this value or lower.
-#       Default: 50.
+#       Default: 256.
 #
 #   maximum_txn_in_ledger = <number>
 #
@@ -1003,12 +1005,13 @@
 #
 #   Optional keys for NuDB and RocksDB:
 #
-#       cache_size          Size of cache for database records. Default is 16384.
-#                           Setting this value to 0 will use the default value.
+#       cache_size          Size of cache for database records. When unset,
+#                           a default derived from [node_size] is used
+#                           instead of a fixed value.
 #
 #       cache_age           Length of time in minutes to keep database records
-#                           cached. Default is 5 minutes. Setting this value to
-#                           0 will use the default value.
+#                           cached. When unset, a default derived from
+#                           [node_size] is used instead of a fixed value.
 #
 #                           Note: if cache_size or cache_age is not specified,
 #                           default values will be used for the unspecified

--- a/src/xrpld/app/rdb/README.md
+++ b/src/xrpld/app/rdb/README.md
@@ -11,10 +11,10 @@ Firstly, the interface `RelationalDatabase` is inherited by the classes `SQLiteD
 
 ## Configuration
 
-The config section `[relational_db]` has a property named `backend` whose value designates which database implementation will be used for node databases. Presently the only valid value for this property is `sqlite`:
+The config section `[sqdb]` has a property named `backend` whose value designates which database implementation will be used for node databases. Presently the only valid value for this property is `sqlite`:
 
 ```
-[relational_db]
+[sqdb]
 backend=sqlite
 ```
 


### PR DESCRIPTION
## Summary

Several documented defaults in `cfg/xrpld-example.cfg` no longer match the
values the code actually uses, and `src/xrpld/app/rdb/README.md` documents a
config section name (`[relational_db]`) that the code no longer reads (it reads
`[sqdb]`). This PR corrects the documentation to match the code. No behavior
change: comments and docs only.

## Changes

`cfg/xrpld-example.cfg` (comment-only):

- `compress_level`: documented default corrected from `3` to `8`.
- `transaction_queue.minimum_txn_in_ledger`: `5` to `32`.
- `transaction_queue.target_txn_in_ledger`: `50` to `256`.
- `transaction_queue.minimum_escalation_multiplier`: `500` to `128000`
  (the value is expressed in fee levels: base fee level `256` times `500`).
- `node_db` `cache_size` / `cache_age`: the documented fixed `16384` / `5 min`
  are stale; when unset, the effective values are derived from `[node_size]`.

`src/xrpld/app/rdb/README.md`:

- Correct the documented config section from `[relational_db]` to `[sqdb]`.

## How to verify

Each corrected value can be checked against the source:

| Documented value                | Old doc           | Corrected to      | Source of truth                                                                                                |
| ------------------------------- | ----------------- | ----------------- | -------------------------------------------------------------------------------------------------------------- |
| `compress_level` default        | 3                 | 8                 | `src/libxrpl/server/Port.cpp:309` (`valueOr(Keys::kCompressLevel, 8)`)                                         |
| `minimum_txn_in_ledger`         | 5                 | 32                | `src/xrpld/app/misc/TxQ.h:111` (`minimumTxnInLedger = 32`)                                                     |
| `target_txn_in_ledger`          | 50                | 256               | `src/xrpld/app/misc/TxQ.h:121` (`targetTxnInLedger = 256`)                                                     |
| `minimum_escalation_multiplier` | 500               | 128000            | `src/xrpld/app/misc/TxQ.h:106` (`minimumEscalationMultiplier = kBaseLevel * 500`, kBaseLevel = 256)            |
| `cache_size` / `cache_age`      | 16384 / 5 min     | node-size derived | `src/xrpld/app/misc/SHAMapStoreImp.cpp:198-205` (uses `SizedItem::TreeCacheSize` / `TreeCacheAge` when unset)  |
| README section name             | `[relational_db]` | `[sqdb]`          | `src/libxrpl/rdb/SociDB.cpp:55` (`config.section(Sections::kSqdb)`)                                            |

## Type of change

`docs:` documentation only, no functional change.
