### PR TITLE
docs: Document additional config settings

### DIFF
--- a/cfg/validators-example.txt
+++ b/cfg/validators-example.txt
@@ -20,6 +20,18 @@
 #    n9KorY8QtTdRx7TVDpwnG9NvyxsDwHUKUEeDLY3AkiGncVaSXZi5
 #    n9MqiExBcoG19UXwoLjBJnhsxEhAZMuWwJDRdkyDz1EkEkwzQTNt
 #
+# [validator_keys]
+#
+#   An additional list of validation public keys to always accept as
+#   validators. Entries use the same format as [validators] and are merged
+#   with it at startup; this section exists mainly for backward compatibility.
+#   Providing [validators], [validator_keys], or [validator_list_keys]
+#   satisfies the requirement to configure at least one source of validators.
+#
+#   Examples:
+#    n9KorY8QtTdRx7TVDpwnG9NvyxsDwHUKUEeDLY3AkiGncVaSXZi5
+#    n9MqiExBcoG19UXwoLjBJnhsxEhAZMuWwJDRdkyDz1EkEkwzQTNt
+#
 # [validator_list_sites]
 #
 #   List of URIs serving lists of recommended validators.

--- a/cfg/validators-example.txt
+++ b/cfg/validators-example.txt
@@ -25,8 +25,6 @@
 #   An additional list of validation public keys to always accept as
 #   validators. Entries use the same format as [validators] and are merged
 #   with it at startup; this section exists mainly for backward compatibility.
-#   Providing [validators], [validator_keys], or [validator_list_keys]
-#   satisfies the requirement to configure at least one source of validators.
 #
 #   Examples:
 #    n9KorY8QtTdRx7TVDpwnG9NvyxsDwHUKUEeDLY3AkiGncVaSXZi5

--- a/cfg/xrpld-example.cfg
+++ b/cfg/xrpld-example.cfg
@@ -465,10 +465,10 @@
 #
 #   The maximum number of inbound peer connections. Optional.
 #
-#   Valid range: 0 to 1000. If set, you must also set [peers_out_max], and the
-#   legacy [peers_max] must not be set (when present, [peers_max] takes
-#   precedence and this setting is ignored). If unset, the server
-#   auto-configures a limit based on node size.
+#   Valid range: 0 to 1000. If set, you must also set [peers_out_max]. If the
+#   legacy [peers_max] is set, it takes precedence and this setting is
+#   ignored. If unset, the server auto-configures a limit based on node
+#   size.
 #
 #   Example:
 #
@@ -481,10 +481,10 @@
 #
 #   The maximum number of outbound peer connections. Optional.
 #
-#   Valid range: 10 to 1000. If set, you must also set [peers_in_max], and the
-#   legacy [peers_max] must not be set (when present, [peers_max] takes
-#   precedence and this setting is ignored). If unset, the server
-#   auto-configures a limit based on node size.
+#   Valid range: 10 to 1000. If set, you must also set [peers_in_max]. If the
+#   legacy [peers_max] is set, it takes precedence and this setting is
+#   ignored. If unset, the server auto-configures a limit based on node
+#   size.
 #
 #   Example:
 #

--- a/cfg/xrpld-example.cfg
+++ b/cfg/xrpld-example.cfg
@@ -688,7 +688,12 @@
 #
 #   Tunes how long the server suppresses and relays duplicate messages it has
 #   already seen (transactions, proposals, validations, etc.). A set of
-#   key/value pairs. Optional; the defaults are suitable for most operators.
+#   key/value pairs. Optional.
+#
+#   CAUTION: do not change these settings without a good reason and
+#   network-wide coordination. They affect how messages propagate between
+#   servers, so a server using different values than its peers can behave
+#   unexpectedly. The defaults are correct for nearly all deployments.
 #
 #   hold_time = <seconds>
 #
@@ -1393,7 +1398,8 @@
 #       1  Maintain the Transactions and AccountTransactions index tables
 #          (default).
 #       0  Do not maintain them. This saves disk space and I/O, but the
-#          "tx", "account_tx", and "tx_history" RPC commands will return
+#          "tx", "account_tx", and "tx_history" RPC commands, and the
+#          "account_history_tx_stream" subscribe option, will return
 #          "notEnabled".
 #
 #       This does NOT stop transactions from being stored: they remain in

--- a/cfg/xrpld-example.cfg
+++ b/cfg/xrpld-example.cfg
@@ -1244,21 +1244,22 @@
 #                           ledgers. Forward progress is not penalized. Minimum is 64.
 #                           Default is the online_delete value.
 #
-#   Optional keys for RocksDB only (ignored by NuDB). Most operators should
-#   leave these unset and let the server size them from [node_size]:
+#   Optional keys for RocksDB only (ignored by NuDB):
 #
 #       cache_mb            Size of the RocksDB block cache, in megabytes.
 #                           If unset, the server picks a value based on node
-#                           size (and raises a small default unless hard_set
-#                           is enabled).
+#                           size (4 to 128 MB). A value of exactly 256 is
+#                           raised to 1024 unless hard_set is enabled.
 #
 #       open_files          Maximum number of database files RocksDB may keep
-#                           open. If unset, the server picks a value based on
-#                           node size.
+#                           open. If unset, the RocksDB library default
+#                           applies. A value of exactly 2000 is raised to
+#                           8000 unless hard_set is enabled.
 #
 #       file_size_mb        Target size of each on-disk SST file, in megabytes.
-#                           If unset, the server picks a value based on node
-#                           size.
+#                           If unset, the RocksDB library default applies. A
+#                           value of exactly 8 is raised to 256 unless
+#                           hard_set is enabled.
 #
 #       file_size_mult      Multiplier applied to the target file size at each
 #                           successive level of the database.

--- a/cfg/xrpld-example.cfg
+++ b/cfg/xrpld-example.cfg
@@ -1643,9 +1643,10 @@
 #   Enables health-status reporting intended for an external load balancer
 #   (such as an AWS Elastic Load Balancer). When enabled, the server reports
 #   itself as unavailable while it is shutting down, not yet synchronized with
-#   the network, amendment-blocked, or without a valid validator list, so the
-#   load balancer can route traffic away from it. When disabled, these health
-#   checks always report the server as available.
+#   the network, missing recent ledger history, amendment-blocked, without a
+#   valid validator list, or under too much load, so the load balancer can
+#   route traffic away from it. When disabled, these health checks always
+#   report the server as available.
 #
 #   Defaults to disabled (0) when unset.
 #

--- a/cfg/xrpld-example.cfg
+++ b/cfg/xrpld-example.cfg
@@ -467,8 +467,8 @@
 #
 #   Valid range: 0 to 1000. If set, you must also set [peers_out_max]. If the
 #   legacy [peers_max] is set, it takes precedence and this setting is
-#   ignored. If unset, the server auto-configures a limit based on node
-#   size.
+#   ignored. If neither is set, the server uses a built-in default
+#   (currently 21 peers in total).
 #
 #   Example:
 #
@@ -483,8 +483,8 @@
 #
 #   Valid range: 10 to 1000. If set, you must also set [peers_in_max]. If the
 #   legacy [peers_max] is set, it takes precedence and this setting is
-#   ignored. If unset, the server auto-configures a limit based on node
-#   size.
+#   ignored. If neither is set, the server uses a built-in default
+#   (currently 21 peers in total).
 #
 #   Example:
 #

--- a/cfg/xrpld-example.cfg
+++ b/cfg/xrpld-example.cfg
@@ -461,6 +461,53 @@
 #
 #
 #
+# [peers_in_max]
+#
+#   The maximum number of inbound peer connections. Optional.
+#
+#   Valid range: 0 to 1000. If set, you must also set [peers_out_max], and the
+#   legacy [peers_max] must not be set (when present, [peers_max] takes
+#   precedence and this setting is ignored). If unset, the server
+#   auto-configures a limit based on node size.
+#
+#   Example:
+#
+#   [peers_in_max]
+#   100
+#
+#
+#
+# [peers_out_max]
+#
+#   The maximum number of outbound peer connections. Optional.
+#
+#   Valid range: 10 to 1000. If set, you must also set [peers_in_max], and the
+#   legacy [peers_max] must not be set (when present, [peers_max] takes
+#   precedence and this setting is ignored). If unset, the server
+#   auto-configures a limit based on node size.
+#
+#   Example:
+#
+#   [peers_out_max]
+#   20
+#
+#
+#
+# [network_quorum]
+#
+#   The minimum number of connected peers required before the server will
+#   consider the network "present" and begin participating in consensus.
+#   This is NOT the validation / UNL quorum.
+#
+#   Defaults to 1 if unset.
+#
+#   Example:
+#
+#   [network_quorum]
+#   3
+#
+#
+#
 # [node_seed]
 #
 #   This is used for clustering. To force a particular node seed or key, the
@@ -588,6 +635,77 @@
 #       growth during the network upgrade. They may be removed in a future
 #       release once the fleet has upgraded, and should not be relied upon as
 #       stable configuration.
+#
+# [reduce_relay]
+#
+#   Controls bandwidth-reduction features that limit how many duplicate
+#   messages this server forwards to its peers. A set of key/value pairs.
+#   All keys are optional.
+#
+#   vp_base_squelch_enable = <0 | 1>
+#
+#       If 1, reduce redundant validation and proposal traffic by selecting a
+#       limited set of peers to receive a given validator's messages and
+#       "squelching" the rest. Defaults to 0 (disabled).
+#
+#   vp_base_squelch_max_selected_peers = <number>
+#
+#       The number of peers selected as sources for each validator's messages
+#       when base squelching is enabled. Minimum 3. Defaults to 5.
+#
+#   tx_enable = <0 | 1>
+#
+#       If 1, relay transactions to only a subset of peers rather than all of
+#       them. Defaults to 0 (disabled).
+#
+#   tx_min_peers = <number>
+#
+#       Only apply transaction reduce-relay once the server has at least this
+#       many peers. Minimum 10. Defaults to 20.
+#
+#   tx_relay_percentage = <number>
+#
+#       The percentage of peers to relay transactions to when tx_enable is on.
+#       Valid range 10 to 100. Defaults to 25.
+#
+#   tx_metrics = <0 | 1>
+#
+#       If 1, collect and expose transaction reduce-relay metrics (for
+#       debugging and tuning). Defaults to 0.
+#
+#   Note: the older key "vp_enable" is a deprecated alias for
+#   "vp_base_squelch_enable"; do not set both.
+#
+#   Example:
+#
+#   [reduce_relay]
+#   vp_base_squelch_enable = 0
+#   tx_enable = 0
+#
+#
+#
+# [hashrouter]
+#
+#   Tunes how long the server suppresses and relays duplicate messages it has
+#   already seen (transactions, proposals, validations, etc.). A set of
+#   key/value pairs. Optional; the defaults are suitable for most operators.
+#
+#   hold_time = <seconds>
+#
+#       How long a seen message is held for de-duplication before it may be
+#       processed again. Minimum 12. Defaults to 300.
+#
+#   relay_time = <seconds>
+#
+#       How long to wait before relaying the same message again. Minimum 8,
+#       and must be less than or equal to hold_time. Defaults to 30.
+#
+#   Example:
+#
+#   [hashrouter]
+#   hold_time = 300
+#   relay_time = 30
+#
 #
 # [transaction_queue] EXPERIMENTAL
 #
@@ -1126,6 +1244,35 @@
 #                           ledgers. Forward progress is not penalized. Minimum is 64.
 #                           Default is the online_delete value.
 #
+#   Optional keys for RocksDB only (ignored by NuDB). Most operators should
+#   leave these unset and let the server size them from [node_size]:
+#
+#       cache_mb            Size of the RocksDB block cache, in megabytes.
+#                           If unset, the server picks a value based on node
+#                           size (and raises a small default unless hard_set
+#                           is enabled).
+#
+#       open_files          Maximum number of database files RocksDB may keep
+#                           open. If unset, the server picks a value based on
+#                           node size.
+#
+#       file_size_mb        Target size of each on-disk SST file, in megabytes.
+#                           If unset, the server picks a value based on node
+#                           size.
+#
+#       file_size_mult      Multiplier applied to the target file size at each
+#                           successive level of the database.
+#
+#       bg_threads          Number of background threads RocksDB uses for
+#                           compaction (lower priority work).
+#
+#       high_threads        Number of background threads RocksDB uses for
+#                           flushing memtables (higher priority work).
+#
+#       hard_set            0 or 1. If 1, use the cache_mb / open_files /
+#                           file_size_mb values exactly as given instead of
+#                           letting the server raise them. Default is 0.
+#
 #   Notes:
 #       The 'node_db' entry configures the primary, persistent storage.
 #
@@ -1233,6 +1380,46 @@
 #                           reached, older entries will be deleted.
 #                           See https://www.sqlite.org/pragma.html#pragma_journal_size_limit
 #                           for more details about the available options.
+#
+#
+# [ledger_tx_tables]
+#
+#   Controls the SQLite transaction index tables, which allow transactions to
+#   be looked up by hash or by account.
+#
+#   use_tx_tables = <0|1>
+#
+#       1  Maintain the Transactions and AccountTransactions index tables
+#          (default).
+#       0  Do not maintain them. This saves disk space and I/O, but the
+#          "tx", "account_tx", and "tx_history" RPC commands will return
+#          "notEnabled".
+#
+#       This does NOT stop transactions from being stored: they remain in
+#       each ledger in the node store ([node_db]). It only controls the
+#       searchable transaction index. To bound retained history, use
+#       [ledger_history] and the node_db online_delete settings instead.
+#
+#   Example (disable the searchable transaction index):
+#
+#   [ledger_tx_tables]
+#   use_tx_tables = 0
+#
+#
+# [sqdb]
+#
+#   Selects the backend used for the relational (book-keeping) databases that
+#   live under [database_path].
+#
+#   backend = <name>
+#
+#       The only supported value is "sqlite", which is also the default when
+#       this section is omitted. Any other value is rejected at startup.
+#
+#   Example:
+#
+#   [sqdb]
+#   backend = sqlite
 #
 #
 #-------------------------------------------------------------------------------
@@ -1360,6 +1547,60 @@
 #       Example:
 #           owner_reserve = 200000      # 0.2 XRP
 #
+# [amendments]
+#
+#   A list of protocol amendments this server votes in FAVOR of. List one
+#   amendment per line as its 64-character hex amendment ID, followed by a
+#   space and the amendment's name. Both the ID and the name are required.
+#   The server still only activates an amendment once the network reaches
+#   consensus on it.
+#
+#   Example:
+#
+#   [amendments]
+#   DB432C3A09D9D5DFC7859F39AE5FF767ABC59AED0A9FB441E83B814D8946C109 DID
+#
+# [veto_amendments]
+#
+#   A list of protocol amendments this server votes AGAINST. Same format as
+#   [amendments]: one amendment per line as its 64-character hex ID followed
+#   by a space and the amendment's name (both required).
+#
+#   Example:
+#
+#   [veto_amendments]
+#   DB432C3A09D9D5DFC7859F39AE5FF767ABC59AED0A9FB441E83B814D8946C109 DID
+#
+# [amendment_majority_time]
+#
+#   How long an amendment must hold a continuous majority (>= 80% of trusted
+#   validators) before it becomes eligible for activation. Specify a number
+#   followed by a unit: minutes, hours, days, or weeks. Minimum 15 minutes.
+#
+#   Defaults to 2 weeks if unset. Changing this is only meaningful on private
+#   or test networks where you control all validators.
+#
+#   Example:
+#
+#   [amendment_majority_time]
+#   2 weeks
+#
+# [features]
+#
+#   A list of protocol features (amendments) to treat as already enabled when
+#   building ledgers locally, given as feature names, one per line.
+#
+#   STANDALONE / TESTING ONLY. This bypasses the normal amendment process and
+#   does not coordinate with the rest of the network. Setting it on a server
+#   connected to a live network can cause that server to lose sync or stop
+#   processing transactions (downtime). Use it only in standalone mode or on
+#   a private test network.
+#
+#   Example:
+#
+#   [features]
+#   DID
+#
 #-------------------------------------------------------------------------------
 #
 # 9. Misc Settings
@@ -1385,6 +1626,33 @@
 #   | < ~16GB | tiny |  small | medium |
 #   | < ~24GB | tiny |  small |  large |
 #   | < ~32GB | tiny |  small |   huge |
+#
+# [sweep_interval]
+#
+#   How often, in seconds, the server sweeps its in-memory caches to release
+#   memory. Must be between 10 and 600 inclusive. If unset, the server derives
+#   an interval from [node_size].
+#
+#   Example:
+#
+#   [sweep_interval]
+#   60
+#
+# [elb_support]
+#
+#   Enables health-status reporting intended for an external load balancer
+#   (such as an AWS Elastic Load Balancer). When enabled, the server reports
+#   itself as unavailable while it is shutting down, not yet synchronized with
+#   the network, amendment-blocked, or without a valid validator list, so the
+#   load balancer can route traffic away from it. When disabled, these health
+#   checks always report the server as available.
+#
+#   Defaults to disabled (0) when unset.
+#
+#   Example:
+#
+#   [elb_support]
+#   1
 #
 # [signing_support]
 #


### PR DESCRIPTION
## Summary

The server reads a number of configuration settings that the shipped example
config (`cfg/xrpld-example.cfg`) and `cfg/validators-example.txt` never mention,
so operators can only discover them by reading the source. This PR adds
commented-out documentation for the operator-facing ones, with every value,
default, and constraint verified against the parsing code.

Everything added is commented out, so there is no behavior change.

### How these were found

Rather than work from the existing docs, each setting was found by enumerating
every config read-site in `src/xrpld` and `src/libxrpl` (`section(...)`,
`valueOr`/`value_or`, `exists`, `get`/`getIfExists`/`get<T>`, `set(...)`,
`getSingleSection`, `legacy`, and `operator[]`, resolving the section and key
constants in `include/xrpl/config/Constants.h`) and diffing that set against
everything documented in the two shipped files. Read-sites in `src/test` were
excluded, so every setting below is read by production code. Defaults and
constraints were then read directly from the source lines cited in the table.

## Changes

### `cfg/xrpld-example.cfg`

Peer Protocol:

- `[peers_in_max]` / `[peers_out_max]`: inbound/outbound peer connection
  limits. Must be set together; ignored if the legacy `[peers_max]` is set.
- `[network_quorum]`: minimum connected peers before joining consensus
  (default `1`; not the UNL/validation quorum).
- `[reduce_relay]`: bandwidth-reduction options: `vp_base_squelch_enable`
  (default off), `vp_base_squelch_max_selected_peers` (5), `tx_enable` (off),
  `tx_min_peers` (20), `tx_relay_percentage` (25), `tx_metrics` (off). The
  older `vp_enable` is documented as a deprecated alias.
- `[hashrouter]`: `hold_time` (default 300s, min 12) and `relay_time`
  (default 30s, min 8, must not exceed `hold_time`) for duplicate-message
  suppression/relay. Documented with a caution against changing them without
  network-wide coordination, mirroring the note in the code.

Database:

- `[ledger_tx_tables]` `use_tx_tables`: default `1`; `0` disables the SQLite
  transaction index tables, after which `tx`, `account_tx`, `tx_history`, and
  the `account_history_tx_stream` subscribe option return `notEnabled`. Does
  not stop transactions being stored in ledgers.
- `[node_db]` RocksDB-only tuning keys: `cache_mb`, `open_files`,
  `file_size_mb`, `file_size_mult`, `bg_threads`, `high_threads`, `hard_set`
  (documented as optional; only `cache_mb` is sized from `[node_size]` when
  unset, the rest fall back to RocksDB library defaults).
- `[sqdb]` `backend`: selects the relational-database backend; only `sqlite`
  is supported (and is the default).

Voting / amendments:

- `[amendments]` / `[veto_amendments]`: amendments this server votes for or
  against. Each line is a 64-char hex amendment ID followed by its name.
- `[amendment_majority_time]`: how long an amendment must hold majority before
  activation (default 2 weeks, min 15 minutes).
- `[features]`: force-enables features in locally-built ledgers. Documented
  with a clear note that it is for standalone/testing only and can cause a
  networked server to lose sync or stop processing (downtime).

Misc:

- `[sweep_interval]`: cache sweep interval in seconds (10 to 600; derived from
  `[node_size]` when unset).
- `[elb_support]`: default `0`; gates `serverOkay()` load-balancer health
  reporting.

### `cfg/validators-example.txt`

- `[validator_keys]`: an additional list of validator public keys, merged with
  `[validators]` at startup (kept for backward compatibility). Documented
  alongside its sibling validator sections.

## How to verify

| Setting | Default / constraint | Source of truth |
| --- | --- | --- |
| `peers_in_max` / `peers_out_max` | max 1000 / 10 to 1000; must pair | `src/xrpld/core/detail/Config.cpp:547-577` |
| `network_quorum` | default 1 | `src/xrpld/core/detail/Config.cpp:676` |
| `reduce_relay` keys | off / 5 / off / 20 / 25 / off | `src/xrpld/core/detail/Config.cpp:794-861` |
| `vp_enable` deprecated | error if set with `vp_base_squelch_enable` | `src/xrpld/core/detail/Config.cpp:801-813` |
| `hashrouter` hold/relay | 300s (min 12) / 30s (min 8, at most hold_time) | `src/xrpld/app/misc/detail/setup_HashRouter.cpp:26-48`; defaults `include/xrpl/core/HashRouter.h:112,117` |
| `use_tx_tables` | default true | `src/xrpld/core/detail/Config.cpp:413-414`; gated in `src/xrpld/app/rdb/backend/detail/SQLiteDatabase.cpp` |
| `node_db` RocksDB keys | optional; only `cache_mb` node-size derived | `src/libxrpl/nodestore/backend/RocksDBFactory.cpp:117-170`; `src/xrpld/app/misc/SHAMapStoreImp.cpp:117-127` |
| `sqdb` `backend` | default `sqlite`; only `sqlite` accepted | `src/libxrpl/rdb/SociDB.cpp:55-59` |
| `amendments` / `veto_amendments` | hex ID + name per line | `src/xrpld/app/main/Application.cpp:1245-1247`; parse `src/xrpld/app/misc/detail/AmendmentTable.cpp:50-80` |
| `amendment_majority_time` | default 2 weeks, min 15 min | `src/xrpld/core/detail/Config.cpp:959-993`; default `include/xrpl/protocol/SystemParameters.h:81` |
| `features` | feature names; standalone/test | `src/xrpld/core/detail/Config.cpp:1164-1176` |
| `sweep_interval` | 10 to 600s; node-size derived | `src/xrpld/core/detail/Config.cpp:740-747`; use `src/xrpld/app/main/Application.cpp:929-931` |
| `elb_support` | default 0 | `src/xrpld/app/main/Application.cpp:2106` |
| `validator_keys` | merged into `[validators]` | `src/xrpld/core/detail/Config.cpp:1080-1153` |

## Notes for reviewers

- Some advanced RocksDB configs that are read but unlikely to be useful to most
  operators (the raw `options`/`bbt_options` strings, `filter_bits`,
  `filter_full`, `block_size`, `universal_compaction`, and `rq_bundle`) were
  intentionally left undocumented to keep the example file focused. They can be
  added on request.

## Type of change

`docs:` documentation only, no functional change.
