### PR TITLE
fix: Count a duplicate as an answer when timing out a TX-set acquire

### DIFF
--- a/src/test/app/TransactionAcquire_test.cpp
+++ b/src/test/app/TransactionAcquire_test.cpp
@@ -317,6 +317,63 @@ struct TransactionAcquire_test : public beast::unit_test::Suite
     }
 
     /**
+     * A late reply is turned away before its nodes are deserialized.
+     *
+     * Observed through the fee tier, which is what the order is visible
+     * in: unparseable node data charges kFeeInvalidData when parsed, and
+     * nothing or kFeeUselessData when turned away first. See
+     * testUndeserializableNodeIsCharged, which feeds the same packet to a
+     * running acquisition and does get kFeeInvalidData.
+     *
+     * @param env The environment to run in.
+     */
+    void
+    testLateReplyIsTurnedAwayBeforeParsing(jtx::Env& env)
+    {
+        testcase("A late reply is turned away before its nodes are parsed");
+
+        auto const chain = DeepChain::toLeaf(3, nextSeed());
+        auto& inbound = env.app().getInboundTransactions();
+
+        uint256 const setHash = chain.rootHash.asUInt256();
+        BEAST_EXPECT(inbound.getSet(setHash, true) == nullptr);
+
+        // One peer supplies the whole chain, so it alone holds the allowance's one slot. Delivered
+        // in two replies rather than one, since only a peer we asked holds a slot at all, and it is
+        // the follow-up request the root-only reply provokes that puts this one in requestedPeers_.
+        // A single reply completing the set instead reaches trigger()'s no-nodes-missing exit,
+        // which settles the acquisition without ever asking its supplier for anything.
+        auto const rootPeer = std::make_shared<ChargeRecordingPeer>();
+        inbound.gotData(setHash, rootPeer, packetFor(chain, {{SHAMapNodeID{}, chain.nodeAt(0)}}));
+        inbound.gotData(setHash, rootPeer, packetFor(chain, chain.nodesBelowRoot()));
+
+        BEAST_EXPECT(waitForDeliveredSet(env, setHash) != nullptr);
+        BEAST_EXPECT(rootPeer->charges().empty());
+
+        // A single byte naming a wire type that does not exist, as in
+        // testUndeserializableNodeIsCharged.
+        auto const garbage = [&] {
+            auto packet = std::make_shared<protocol::TMLedgerData>();
+            packet->set_ledgerhash(setHash.data(), uint256::size());
+            packet->set_ledgerseq(0);
+            packet->set_type(protocol::liTS_CANDIDATE);
+
+            auto* const node = packet->add_nodes();
+            node->set_nodedata("\xff", 1);
+            node->set_id(SHAMapNodeID{}.getRawString());
+            return packet;
+        };
+
+        // Free, and never looked at: parsing would charge kFeeInvalidData for the byte instead.
+        inbound.gotData(setHash, rootPeer, garbage());
+        BEAST_EXPECT(rootPeer->charges().empty());
+
+        // The slot is spent, so this one is charged as a replay rather than as bad data.
+        inbound.gotData(setHash, rootPeer, garbage());
+        BEAST_EXPECT(rootPeer->charges() == std::vector{resource::kFeeUselessData});
+    }
+
+    /**
      * A chain reaching kLeafDepth must end the acquisition outright.
      *
      * @param env The environment to run in.
@@ -868,11 +925,9 @@ struct TransactionAcquire_test : public beast::unit_test::Suite
      * The recorded progress is what the verdict is for: it stops the
      * next timer tick from counting a timeout, so reporting only the
      * node the batch stopped on would push an acquisition that is
-     * genuinely advancing toward kMaxTimeouts, while recording progress
-     * for a batch we already had would hold a stalled one open. The flag
-     * is read rather than the returned tally, which only stands in for
-     * it, and cleared between batches so each reading is about the batch
-     * just fed.
+     * genuinely advancing toward kMaxTimeouts. The flag is read rather
+     * than the returned tally, which only stands in for it, and cleared
+     * between batches so each reading is about the batch just fed.
      *
      * @param env The environment to run in.
      */
@@ -912,16 +967,15 @@ struct TransactionAcquire_test : public beast::unit_test::Suite
         // The bad node is still charged for, at the recoverable tier.
         BEAST_EXPECT(peer->charges() == std::vector{resource::kFeeInvalidData});
 
-        // A batch of nothing but the root we already have: counted as a duplicate rather than
-        // reaching the clean exit with nothing counted, so it is neither reported as useful nor
-        // allowed to postpone the timeout.
+        // A batch of nothing but the root we already have: counted as a duplicate, so not useful,
+        // but it still postpones the timeout since this peer is one we asked and it answered.
         acquire->clearProgress();
         auto const repeatedRoot = acquire->takeNodes({{SHAMapNodeID{}, chain.nodeAt(0)}}, peer);
 
         BEAST_EXPECTS(tallyIs(repeatedRoot, 0, 0, 1), repeatedRoot.get());
         BEAST_EXPECT(repeatedRoot.isGood());
         BEAST_EXPECT(!repeatedRoot.isUseful());
-        BEAST_EXPECT(!acquire->madeProgress());
+        BEAST_EXPECT(acquire->madeProgress());
 
         // The same root alongside a node we do need: the duplicate is reported as one, and the
         // node that did hook in is what records the progress.
@@ -937,6 +991,119 @@ struct TransactionAcquire_test : public beast::unit_test::Suite
 
         // None of that cost the sender anything beyond the one bad node above.
         BEAST_EXPECT(peer->charges() == std::vector{resource::kFeeInvalidData});
+    }
+
+    /**
+     * A duplicate-only reply from a peer we asked still postpones the timeout.
+     *
+     * trigger() asks every peer it is given, so on a fan-out the slower
+     * responder's reply is entirely nodes the faster one already supplied.
+     * The flag asks whether the peers being waited on are answering, and
+     * such a peer has answered.
+     *
+     * @param env The environment to run in.
+     */
+    void
+    testDuplicateOnlyReplyFromAskedPeerCountsAsProgress(jtx::Env& env)
+    {
+        testcase("A duplicate-only reply from a peer we asked counts as progress");
+
+        DeepChain const chain{nextSeed()};
+
+        auto const acquire = std::make_shared<TestableTransactionAcquire>(
+            env.app(), chain.rootHash.asUInt256(), std::make_unique<RequestCountingPeerSet>());
+
+        // Two peers racing the same request. Each earns its place in requestedPeers_ the way a
+        // real one does: a reply that lands buys a targeted follow-up request, which enrolls it.
+        auto const slower = std::make_shared<ChargeRecordingPeer>();
+        auto const faster = std::make_shared<ChargeRecordingPeer>();
+
+        acquire->takeNodes({{SHAMapNodeID{}, chain.nodeAt(0)}}, slower);
+
+        std::vector<std::pair<SHAMapNodeID, SHAMapTreeNodePtr>> below;
+        below.emplace_back(SHAMapNodeID{1, uint256{}}, chain.nodeAt(1));
+        below.emplace_back(SHAMapNodeID{2, uint256{}}, chain.nodeAt(2));
+
+        auto const won = acquire->takeNodes(below, faster);
+        BEAST_EXPECTS(tallyIs(won, 2, 0, 0), won.get());
+        BEAST_EXPECT(acquire->madeProgress());
+
+        // The same nodes from the peer that lost the race: nothing useful, but not a stall.
+        acquire->clearProgress();
+        auto const lost = acquire->takeNodes(below, slower);
+
+        BEAST_EXPECTS(tallyIs(lost, 0, 0, 2), lost.get());
+        BEAST_EXPECT(!lost.isUseful());
+        BEAST_EXPECT(lost.isGood());
+        BEAST_EXPECT(acquire->madeProgress());
+
+        // Answering costs neither peer anything.
+        BEAST_EXPECT(slower->charges().empty());
+        BEAST_EXPECT(faster->charges().empty());
+
+        acquire->cancel();
+    }
+
+    /**
+     * Duplicates postpone a timeout only for a peer we asked, and only while
+     * the acquisition is still running.
+     *
+     * A peer nobody asked says nothing about whether the peers being waited
+     * on are answering, and a settled acquisition has no timer left to
+     * postpone - though it reports a late reply as a duplicate too, so the
+     * tally alone cannot tell the two apart.
+     *
+     * @param env The environment to run in.
+     */
+    void
+    testUnaskedDuplicatesCannotPostponeTimeout(jtx::Env& env)
+    {
+        testcase("Duplicates postpone a timeout only for a peer we asked");
+
+        DeepChain const chain{nextSeed()};
+
+        auto const acquire = std::make_shared<TestableTransactionAcquire>(
+            env.app(), chain.rootHash.asUInt256(), std::make_unique<RequestCountingPeerSet>());
+
+        auto const asked = std::make_shared<ChargeRecordingPeer>();
+        acquire->takeNodes({{SHAMapNodeID{}, chain.nodeAt(0)}}, asked);
+        BEAST_EXPECT(acquire->madeProgress());
+
+        // A peer no request ever went to, resending the root we already have.
+        auto const stranger = std::make_shared<ChargeRecordingPeer>();
+        acquire->clearProgress();
+        auto const unsolicited = acquire->takeNodes({{SHAMapNodeID{}, chain.nodeAt(0)}}, stranger);
+
+        BEAST_EXPECTS(tallyIs(unsolicited, 0, 0, 1), unsolicited.get());
+        BEAST_EXPECT(!acquire->madeProgress());
+
+        // Not charged either: a node that hashes into the map is data we would have asked for.
+        BEAST_EXPECT(stranger->charges().empty());
+
+        // Accepting that reply made trigger() send this peer a request for the nodes still
+        // missing, which is what puts it in requestedPeers_ - the set records who we asked. So it
+        // is a peer we asked from here on, and its next duplicate does count.
+        acquire->clearProgress();
+        static_cast<void>(acquire->takeNodes({{SHAMapNodeID{}, chain.nodeAt(0)}}, stranger));
+        BEAST_EXPECT(acquire->madeProgress());
+
+        acquire->cancel();
+
+        // A settled acquisition: a late reply from its own supplier, a peer squarely in
+        // requestedPeers_, is reported as a duplicate and still records nothing.
+        auto const finished = DeepChain::toLeaf(3, nextSeed());
+        auto const completed = std::make_shared<TestableTransactionAcquire>(
+            env.app(), finished.rootHash.asUInt256(), std::make_unique<RequestCountingPeerSet>());
+        auto const supplier = std::make_shared<ChargeRecordingPeer>();
+
+        completed->takeNodes({{SHAMapNodeID{}, finished.nodeAt(0)}}, supplier);
+        completed->takeNodes(finished.nodesBelowRoot(), supplier);
+
+        completed->clearProgress();
+        auto const late = completed->takeNodes({{SHAMapNodeID{}, finished.nodeAt(0)}}, supplier);
+
+        BEAST_EXPECT(wasIgnored(late));
+        BEAST_EXPECT(!completed->madeProgress());
     }
 
     /**
@@ -1158,6 +1325,7 @@ struct TransactionAcquire_test : public beast::unit_test::Suite
         testHappyPathCompletesAcquisition(env);
         testTwoPeersEachSupplyPartOfTheSet(env);
         testLateReplyAllowanceSurvivesGiveSet(env);
+        testLateReplyIsTurnedAwayBeforeParsing(env);
         testFabricatedChainFailsAcquire(env);
         testWrongNodeKeepsAcquireAlive(env);
         testBadRootKeepsAcquireAlive(env);
@@ -1171,6 +1339,8 @@ struct TransactionAcquire_test : public beast::unit_test::Suite
         testUndeserializableNodeIsCharged(env);
         testChargeIsNotDecidedAfterTheLock(env);
         testPartialBatchIsCounted(env);
+        testDuplicateOnlyReplyFromAskedPeerCountsAsProgress(env);
+        testUnaskedDuplicatesCannotPostponeTimeout(env);
         testInitAsksOnlyPeersWithTheSet(env);
         testStillNeedLeavesARunningAcquireAlone(env);
 

--- a/src/xrpld/app/ledger/detail/InboundTransactions.cpp
+++ b/src/xrpld/app/ledger/detail/InboundTransactions.cpp
@@ -143,6 +143,11 @@ public:
             return;
         }
 
+        // Asked before the loop below, which costs a hash per node, since a settled acquisition
+        // discards the result. Charges the peer itself when the reply is outside its allowance.
+        if (!ta->wantsReplyFrom(peer))
+            return;
+
         std::vector<std::pair<SHAMapNodeID, SHAMapTreeNodePtr>> data;
         data.reserve(packet.nodes().size());
 

--- a/src/xrpld/app/ledger/detail/TransactionAcquire.cpp
+++ b/src/xrpld/app/ledger/detail/TransactionAcquire.cpp
@@ -199,50 +199,67 @@ TransactionAcquire::takeNodes(
 {
     ScopedLockType sl(mtx_);
 
+    // Both read before the call, which settles the acquisition on some paths and trigger()s the
+    // sender on others, enrolling it in requestedPeers_.
+    bool const wasSettled = isDone();
+    bool const wasAsked = requestedPeers_.contains(peer->id());
+
     auto const san = takeNodesLocked(std::move(data), peer, sl);
 
-    // Recorded here rather than on each of takeNodesLocked()'s exits, several of which stop the
-    // batch early: a batch that advanced the map must keep the next timer tick from counting a
-    // timeout against it, and nothing in the compiler would catch an exit that forgot to say so.
+    // Recorded on this one exit rather than on each of takeNodesLocked()'s, several of which stop
+    // the batch early: a batch that answered must keep the next timer tick from counting a timeout
+    // against it, and nothing in the compiler would catch an exit that forgot to say so.
     //
-    // Useful rather than good: a batch of nothing but duplicates advanced nothing, so it records no
-    // progress even though it was not the sender's fault. That costs retry budget on the ordinary
-    // second responder to a fan-out and nothing else.
-    if (san.isUseful())
+    // A duplicate counts as an answer, since the flag decides whether onTimer() treats the
+    // acquisition as stalled and a peer sending nodes we already hold has answered. Only from a
+    // peer we asked, whose reply says something about the peers being waited on, and only while
+    // the acquisition was running, since a settled one has no timer left to postpone.
+    bool const answered = san.isUseful() || (san.getDuplicate() > 0 && wasAsked);
+    if (!wasSettled && answered)
         progress_ = true;
 
     return san;
+}
+
+void
+TransactionAcquire::chargeLateReply(std::shared_ptr<Peer> const& peer, ScopedLockType&)
+{
+    // One free reply per peer asked, since trigger() sends to every peer it is given and that many
+    // replies can be in flight when the set settles. Beyond that the sender is replaying, which is
+    // not free work while the object lingers until newRound() sweeps it.
+    //
+    // Keyed by identity rather than counted, so one peer's replays cannot exhaust the pass another
+    // peer in requestedPeers_ is still owed.
+    if (!requestedPeers_.contains(peer->id()) || !lateReplyGranted_.insert(peer->id()).second)
+        peer->charge(resource::kFeeUselessData, "tx_set data after the set was settled");
+}
+
+bool
+TransactionAcquire::wantsReplyFrom(std::shared_ptr<Peer> const& peer)
+{
+    ScopedLockType sl(mtx_);
+
+    if (!isDone())
+        return true;
+
+    JLOG(journal_.trace()) << (complete_ ? "TX set complete" : "TX set failed");
+    chargeLateReply(peer, sl);
+    return false;
 }
 
 SHAMapAddNode
 TransactionAcquire::takeNodesLocked(
     std::vector<std::pair<SHAMapNodeID, SHAMapTreeNodePtr>> data,
     std::shared_ptr<Peer> const& peer,
-    ScopedLockType&)
+    ScopedLockType& sl)
 {
-    // A reply that arrives after the set is settled - by completing it, or by a different packet
-    // failing it. trigger() sends to every peer it was given, so any of their replies, including
-    // another packet from the same peer whose data failed the set, can already be in flight and
-    // could not have known the outcome. Those are solicited, and free: one per peer we asked,
-    // which is what bounds the honest case.
-    //
-    // Past that bound, further data for this hash is a replay - a resend of data already
-    // accepted or now known worthless, not a first-time reply - and serving it is not free work.
-    // InboundTransactions::gotData() deserializes and hashes the whole node list before this
-    // point, up to kHardMaxReplyNodes of them, and the object lingers until newRound() sweeps it,
-    // so an unbounded number of replays would otherwise cost only the trivial per-message fee.
+    // A reply that arrives after the set is settled, from a caller that did not ask
+    // wantsReplyFrom() or that had the set settle after asking. Either way the allowance has not
+    // been spent for this reply, since a reply wantsReplyFrom() turned away never reaches here.
     if (isDone())
     {
         JLOG(journal_.trace()) << (complete_ ? "TX set complete" : "TX set failed");
-
-        // Free only the first time this specific peer shows up here, not merely the first
-        // reply of however many arrive: a peer outside requestedPeers_ was never asked at all,
-        // and one already in lateReplyGranted_ has already spent the one pass requestedPeers_
-        // earned it. Keyed by identity rather than counted, so one peer resending its own
-        // already-accepted reply cannot exhaust the pass a different, genuinely honest peer in
-        // requestedPeers_ is still owed.
-        if (!requestedPeers_.contains(peer->id()) || !lateReplyGranted_.insert(peer->id()).second)
-            peer->charge(resource::kFeeUselessData, "tx_set data after the set was settled");
+        chargeLateReply(peer, sl);
 
         // Reported as a duplicate rather than as bad, unless the map itself is why the set failed:
         // no reply for such a hash can ever be useful to anyone.

--- a/src/xrpld/app/ledger/detail/TransactionAcquire.h
+++ b/src/xrpld/app/ledger/detail/TransactionAcquire.h
@@ -75,6 +75,23 @@ public:
         std::vector<std::pair<SHAMapNodeID, SHAMapTreeNodePtr>> data,
         std::shared_ptr<Peer> const& peer);
 
+    /**
+     * Whether a reply from this peer is worth deserializing.
+     *
+     * A settled acquisition discards whatever a reply contains, so it spends the
+     * late-reply allowance here, before the caller turns a wire packet into
+     * nodes at a hash apiece.
+     *
+     * The answer can go stale, since mtx_ is released before takeNodes(), which
+     * recognizes a late reply of its own accord.
+     *
+     * @param peer The peer that sent the reply, charged here when the reply is
+     *        outside the allowance.
+     * @return Whether the reply should be parsed and handed to takeNodes().
+     */
+    [[nodiscard]] bool
+    wantsReplyFrom(std::shared_ptr<Peer> const& peer);
+
     void
     init(int startPeers);
 
@@ -150,7 +167,20 @@ private:
     takeNodesLocked(
         std::vector<std::pair<SHAMapNodeID, SHAMapTreeNodePtr>> data,
         std::shared_ptr<Peer> const& peer,
-        ScopedLockType&);
+        ScopedLockType& sl);
+
+    /**
+     * Spend this peer's one free late reply, or charge it for replaying.
+     *
+     * Shared by wantsReplyFrom() and takeNodesLocked(), the two places a late
+     * reply is recognized. Only one of them sees any given reply, so a reply is
+     * charged once.
+     *
+     * @param peer The peer that sent the reply.
+     * @param sl Proof mtx_ is held, which the allowance sets require.
+     */
+    void
+    chargeLateReply(std::shared_ptr<Peer> const& peer, ScopedLockType& sl);
 
     void
     onTimer(bool progress, ScopedLockType& sl) override;


### PR DESCRIPTION
Part 17/17 of a stack. Base: part 16 (`bthomee/shamap-invalid-16-late-reply-survives-giveset`).

## High Level Overview of Change

`TransactionAcquire::takeNodes()` now counts a reply of nothing but duplicates as an answer, so a
peer that loses a fan-out race no longer looks like a stall, and `InboundTransactions::gotData()`
asks whether a reply is wanted before it deserializes the node list rather than after.

### Context of Change

`takeNodes()` recorded progress only for a batch that hooked a node in, so a batch of nodes we
already held recorded none. `trigger()` sends to every peer it is given, so on a fan-out whichever
peer loses the race sends exactly such a batch, and `onTimer()` then treats a set that is plainly
being answered as stalled - spending retry budget on an acquisition that is making progress. A
duplicate now counts alongside a node hooked in, bounded two ways: only from a peer already in
`requestedPeers_`, whose reply says something about the peers being waited on, and only while the
acquisition was still running, since a settled one has no timer left to postpone. Both bounds are
read before the inner call, which enrolls the sender on some paths and settles the acquisition on
others.

`gotData()` also deserialized a whole node list, at a hash apiece, before `takeNodes()` could tell
it the set was already settled and the result would be discarded. `wantsReplyFrom()` moves that
decision ahead of the parse, and the late-reply allowance moves with it into `chargeLateReply()`,
shared with `takeNodesLocked()` so a reply is charged exactly once whichever site sees it. The
allowance itself is unchanged: one free reply per peer asked, keyed by identity.

`TransactionAcquire_test` covers the fan-out case, both bounds, and the parse order, which is
observable through the fee tier - unparseable node data charges `kFeeInvalidData` when parsed, and
nothing or `kFeeUselessData` when turned away first. One existing assertion in
`testPartialBatchIsCounted` is inverted, since it pinned the behavior this changes.

### API Impact

None of the checkboxes below apply: this is an internal `xrpld` correctness fix with no `libxrpl`,
public-API, or peer-protocol surface.
