### PR TITLE
fix: Treat an existing IOU line as a no-op in addEmptyHolding

### DIFF
--- a/include/xrpl/ledger/helpers/RippleStateHelpers.h
+++ b/include/xrpl/ledger/helpers/RippleStateHelpers.h
@@ -239,12 +239,14 @@ canTransfer(ReadView const& view, Issue const& issue, AccountID const& from, Acc
 //------------------------------------------------------------------------------
 
 /**
- * If the destination already holds this IOU, returns tecDUPLICATE and does
- * not consult issuer freeze or DefaultRipple (post-fixCleanup3_4_0).
- * Transactors that may create a new holding in doApply must call
- * canAddHolding() in preclaim with the same View and Asset. Do not call
- * canAddHolding() merely because addEmptyHolding() is invoked: that helper
- * does not check whether a holding already exists.
+ * After fixCleanup3_4_0, if the destination already holds this IOU, returns
+ * tecDUPLICATE and does not consult issuer freeze or DefaultRipple. Freeze
+ * and DefaultRipple still apply on the create path (DefaultRipple off is
+ * terNO_RIPPLE). Transactors that may create a new holding in doApply must
+ * call canAddHolding() in preclaim only when that destination does not
+ * already hold the asset. Do not call canAddHolding() merely because
+ * addEmptyHolding() is invoked: that helper does not check whether a
+ * holding already exists.
  */
 [[nodiscard]] TER
 addEmptyHolding(

--- a/include/xrpl/ledger/helpers/RippleStateHelpers.h
+++ b/include/xrpl/ledger/helpers/RippleStateHelpers.h
@@ -239,14 +239,13 @@ canTransfer(ReadView const& view, Issue const& issue, AccountID const& from, Acc
 //------------------------------------------------------------------------------
 
 /**
- * After fixCleanup3_4_0, if the destination already holds this IOU, returns
- * tecDUPLICATE and does not consult issuer freeze or DefaultRipple. Freeze
- * and DefaultRipple still apply on the create path (DefaultRipple off is
- * terNO_RIPPLE). Transactors that may create a new holding in doApply must
- * call canAddHolding() in preclaim only when that destination does not
- * already hold the asset. Do not call canAddHolding() merely because
- * addEmptyHolding() is invoked: that helper does not check whether a
- * holding already exists.
+ * XRP and the issuer itself are always tesSUCCESS. Otherwise, after
+ * fixCleanup3_4_0, an existing trust line returns tecDUPLICATE without
+ * consulting issuer freeze or DefaultRipple; both still apply on the create
+ * path (DefaultRipple off is terNO_RIPPLE). canAddHolding() ignores existing
+ * holdings, so transactors that may create a holding in doApply should gate
+ * their preclaim call on it: after the amendment only when no holding
+ * exists, before it always.
  */
 [[nodiscard]] TER
 addEmptyHolding(

--- a/include/xrpl/ledger/helpers/RippleStateHelpers.h
+++ b/include/xrpl/ledger/helpers/RippleStateHelpers.h
@@ -239,8 +239,12 @@ canTransfer(ReadView const& view, Issue const& issue, AccountID const& from, Acc
 //------------------------------------------------------------------------------
 
 /**
- * Any transactors that call addEmptyHolding() in doApply must call
- * canAddHolding() in preflight with the same View and Asset
+ * If the destination already holds this IOU, returns tecDUPLICATE and does
+ * not consult issuer freeze or DefaultRipple (post-fixCleanup3_4_0).
+ * Transactors that may create a new holding in doApply must call
+ * canAddHolding() in preclaim with the same View and Asset. Do not call
+ * canAddHolding() merely because addEmptyHolding() is invoked: that helper
+ * does not check whether a holding already exists.
  */
 [[nodiscard]] TER
 addEmptyHolding(

--- a/include/xrpl/ledger/helpers/TokenHelpers.h
+++ b/include/xrpl/ledger/helpers/TokenHelpers.h
@@ -319,6 +319,12 @@ transferRate(ReadView const& view, STAmount const& amount);
 [[nodiscard]] TER
 canAddHolding(ReadView const& view, Asset const& asset);
 
+/**
+ * True if the account already holds this asset (or is the issuer / XRP).
+ */
+[[nodiscard]] bool
+holdingExists(ReadView const& view, AccountID const& account, Asset const& asset);
+
 [[nodiscard]] TER
 addEmptyHolding(
     ApplyViewContext ctx,

--- a/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
@@ -184,6 +184,8 @@ addEmptyHolding(
     auto const mpt = ctx.view.peek(keylet::mptokenIssuance(mptID));
     if (!mpt)
         return tefINTERNAL;  // LCOV_EXCL_LINE
+    // Unlike IOU addEmptyHolding (post-fixCleanup3_4_0), a locked issuance is
+    // still rejected before the "MPToken already exists" short circuit.
     if (mpt->isFlag(lsfMPTLocked))
         return tefINTERNAL;  // LCOV_EXCL_LINE
     if (ctx.view.peek(keylet::mptoken(mptID, accountID)))

--- a/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
@@ -652,21 +652,27 @@ addEmptyHolding(
 
     auto const& issuerId = issue.getIssuer();
     auto const& currency = issue.currency;
-    if (isGlobalFrozen(ctx.view, issuerId))
-        return tecFROZEN;  // LCOV_EXCL_LINE
-
     auto const& srcId = issuerId;
     auto const& dstId = accountID;
     auto const high = srcId > dstId;
     auto const index = keylet::trustLine(srcId, dstId, currency);
+    // Post-fixCleanup3_4_0: an existing line is a no-op. Issuer freeze and
+    // DefaultRipple only matter when this function has to create a line.
+    bool const fix340Enabled = ctx.view.rules().enabled(fixCleanup3_4_0);
+    if (fix340Enabled && ctx.view.read(index))
+        return tecDUPLICATE;
+
+    if (isGlobalFrozen(ctx.view, issuerId))
+        return tecFROZEN;  // LCOV_EXCL_LINE
+
     auto const sleSrc = ctx.view.peek(keylet::account(srcId));
     auto const sleDst = ctx.view.peek(keylet::account(dstId));
     if (!sleDst || !sleSrc)
         return tefINTERNAL;  // LCOV_EXCL_LINE
     if (!sleSrc->isFlag(lsfDefaultRipple))
-        return tecINTERNAL;  // LCOV_EXCL_LINE
+        return fix340Enabled ? TER{terNO_RIPPLE} : tecINTERNAL;
     // If the line already exists, don't create it again.
-    if (ctx.view.read(index))
+    if (!fix340Enabled && ctx.view.read(index))
         return tecDUPLICATE;
 
     // A reserve sponsor only covers tx.Account's own objects.

--- a/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
@@ -669,6 +669,11 @@ addEmptyHolding(
     auto const sleDst = ctx.view.peek(keylet::account(dstId));
     if (!sleDst || !sleSrc)
         return tefINTERNAL;  // LCOV_EXCL_LINE
+    // Create path: DefaultRipple is still required. terNO_RIPPLE is
+    // intentional so VaultWithdraw / CoverWithdraw fail in preclaim via
+    // canAddHolding (retryable, no fee) rather than claiming a tec* fee
+    // in doApply. Transactor::operator() will not apply and will not
+    // convert it to tefINTERNAL.
     if (!sleSrc->isFlag(lsfDefaultRipple))
         return fix340Enabled ? TER{terNO_RIPPLE} : tecINTERNAL;
     // If the line already exists, don't create it again.

--- a/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
@@ -659,7 +659,7 @@ addEmptyHolding(
     // Post-fixCleanup3_4_0: an existing line is a no-op. Issuer freeze and
     // DefaultRipple only matter when this function has to create a line.
     bool const fix340Enabled = ctx.view.rules().enabled(fixCleanup3_4_0);
-    if (fix340Enabled && ctx.view.read(index))
+    if (fix340Enabled && ctx.view.exists(index))
         return tecDUPLICATE;
 
     if (isGlobalFrozen(ctx.view, issuerId))
@@ -672,7 +672,7 @@ addEmptyHolding(
     if (!sleSrc->isFlag(lsfDefaultRipple))
         return fix340Enabled ? TER{terNO_RIPPLE} : tecINTERNAL;
     // If the line already exists, don't create it again.
-    if (!fix340Enabled && ctx.view.read(index))
+    if (!fix340Enabled && ctx.view.exists(index))
         return tecDUPLICATE;
 
     // A reserve sponsor only covers tx.Account's own objects.

--- a/src/libxrpl/ledger/helpers/TokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/TokenHelpers.cpp
@@ -583,6 +583,32 @@ canAddHolding(ReadView const& view, Asset const& asset)
         asset.value());
 }
 
+[[nodiscard]] bool
+holdingExists(ReadView const& view, AccountID const& account, Issue const& issue)
+{
+    if (issue.native() || account == issue.getIssuer())
+        return true;
+    return view.exists(keylet::trustLine(account, issue));
+}
+
+[[nodiscard]] bool
+holdingExists(ReadView const& view, AccountID const& account, MPTIssue const& mptIssue)
+{
+    if (account == mptIssue.getIssuer())
+        return true;
+    return view.exists(keylet::mptoken(mptIssue.getMptID(), account));
+}
+
+[[nodiscard]] bool
+holdingExists(ReadView const& view, AccountID const& account, Asset const& asset)
+{
+    return std::visit(
+        [&]<ValidIssueType TIss>(TIss const& issue) -> bool {
+            return holdingExists(view, account, issue);
+        },
+        asset.value());
+}
+
 TER
 addEmptyHolding(
     ApplyViewContext ctx,

--- a/src/libxrpl/tx/transactors/lending/LoanBrokerCoverWithdraw.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanBrokerCoverWithdraw.cpp
@@ -65,6 +65,7 @@ LoanBrokerCoverWithdraw::preclaim(PreclaimContext const& ctx)
 {
     auto const fix320Enabled = ctx.view.rules().enabled(fixCleanup3_2_0);
     auto const fix330Enabled = ctx.view.rules().enabled(fixCleanup3_3_0);
+    auto const fix340Enabled = ctx.view.rules().enabled(fixCleanup3_4_0);
     auto const& tx = ctx.tx;
 
     auto const account = tx[sfAccount];
@@ -139,6 +140,12 @@ LoanBrokerCoverWithdraw::preclaim(PreclaimContext const& ctx)
     // Destination MPToken must exist (if asset is an MPT)
     if (auto const ter = requireAuth(ctx.view, vaultAsset, dstAcct, authType))
         return ter;
+
+    if (fix340Enabled && account == dstAcct && !holdingExists(ctx.view, dstAcct, vaultAsset))
+    {
+        if (auto const ter = canAddHolding(ctx.view, vaultAsset); !isTesSuccess(ter))
+            return ter;
+    }
 
     if (fix330Enabled)
     {

--- a/src/libxrpl/tx/transactors/lending/LoanSet.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanSet.cpp
@@ -372,8 +372,18 @@ LoanSet::preclaim(PreclaimContext const& ctx)
         }
     }
 
-    if (auto const ter = canAddHolding(ctx.view, asset))
-        return ter;
+    // canAddHolding does not look at existing lines. After
+    // fixCleanup3_4_0, addEmptyHolding is a no-op when the destination
+    // already holds the asset, so skip this gate unless a holding would
+    // actually be created (borrower always; broker owner if there is an
+    // origination fee).
+    auto const originationFee = tx[~sfLoanOriginationFee].value_or(Number{});
+    if (!ctx.view.rules().enabled(fixCleanup3_4_0) || !holdingExists(ctx.view, borrower, asset) ||
+        (originationFee != beast::kZero && !holdingExists(ctx.view, brokerOwner, asset)))
+    {
+        if (auto const ter = canAddHolding(ctx.view, asset))
+            return ter;
+    }
 
     // vaultPseudo is going to send funds, so it can't be frozen.
     if (auto const ret = checkFrozen(ctx.view, vaultPseudo, asset))

--- a/src/libxrpl/tx/transactors/lending/LoanSet.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanSet.cpp
@@ -372,11 +372,17 @@ LoanSet::preclaim(PreclaimContext const& ctx)
         }
     }
 
-    // canAddHolding does not look at existing lines. After
-    // fixCleanup3_4_0, addEmptyHolding is a no-op when the destination
-    // already holds the asset, so skip this gate unless a holding would
-    // actually be created (borrower always; broker owner if there is an
-    // origination fee).
+    // canAddHolding is an issuer-level check (DefaultRipple for IOU,
+    // lsfMPTCanTransfer for MPT); neither overload looks at the
+    // destination, so the holdingExists() clauses only decide whether a
+    // create path is reachable at all. It always runs before
+    // fixCleanup3_4_0: IOU addEmptyHolding checks DefaultRipple ahead of
+    // the existing-line case, so only preclaim can turn an existing line
+    // under a cleared DefaultRipple into terNO_RIPPLE rather than
+    // tecINTERNAL. After the amendment an existing line short-circuits to
+    // tecDUPLICATE, which doApply ignores, so run the check only when the
+    // borrower lacks a holding, or the origination fee is nonzero and the
+    // broker owner lacks one.
     auto const originationFee = tx[~sfLoanOriginationFee].value_or(Number{});
     if (!ctx.view.rules().enabled(fixCleanup3_4_0) || !holdingExists(ctx.view, borrower, asset) ||
         (originationFee != beast::kZero && !holdingExists(ctx.view, brokerOwner, asset)))

--- a/src/libxrpl/tx/transactors/vault/VaultWithdraw.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultWithdraw.cpp
@@ -205,6 +205,15 @@ VaultWithdraw::preclaim(PreclaimContext const& ctx)
     if (auto const ter = requireAuth(ctx.view, vaultAsset, dstAcct, authType); !isTesSuccess(ter))
         return ter;
 
+    // Fail early when self-destination would have to create a holding.
+    // Skip when a holding already exists: canAddHolding does not look at that,
+    // and would block a no-op create (the DefaultRipple-cleared self-withdraw).
+    if (fix340Enabled && account == dstAcct && !holdingExists(ctx.view, dstAcct, vaultAsset))
+    {
+        if (auto const ter = canAddHolding(ctx.view, vaultAsset); !isTesSuccess(ter))
+            return ter;
+    }
+
     // The checks above only establish that an account may hold the asset. A
     // private vault additionally restricts who may take part in it, so paying
     // its asset out to a third party requires both ends of that payout to be

--- a/src/test/app/lending/LoanPay_test.cpp
+++ b/src/test/app/lending/LoanPay_test.cpp
@@ -1447,9 +1447,9 @@ private:
             env.close();
 
             PrettyAsset const usd{issuer["USD"]};
-            env(trust(alice, usd(100'000)));
+            env(trust(alice, usd(10'000'000)));
             env.close();
-            env(pay(issuer, alice, usd(50'000)));
+            env(pay(issuer, alice, usd(2'000'000)));
             env.close();
 
             auto const broker = createVaultAndBroker(env, usd, alice);

--- a/src/test/app/lending/LoanPay_test.cpp
+++ b/src/test/app/lending/LoanPay_test.cpp
@@ -37,6 +37,7 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
+#include <string>
 #include <type_traits>
 
 namespace xrpl::test {
@@ -1419,6 +1420,69 @@ private:
         BEAST_EXPECT(stateAfter.nextPaymentDate == exactDueDate);
     }
 
+    // LoanPay does not call canAddHolding. addEmptyHolding recreates the
+    // broker-owner holding when the borrower is also the broker owner. After
+    // fixCleanup3_4_0 an existing line is a no-op even if DefaultRipple is
+    // off; pre-fix that path dies with tecINTERNAL.
+    void
+    testLoanPaySelfBrokerExistingLineDefaultRipple()
+    {
+        using namespace jtx;
+        using namespace loan;
+
+        auto run = [this](FeatureBitset features, TER expected) {
+            testcase(
+                std::string(
+                    "LoanPay broker-owner borrower existing line after "
+                    "issuer clears asfDefaultRipple (") +
+                (features[fixCleanup3_4_0] ? "post" : "pre") + "-fixCleanup3_4_0)");
+
+            Env env(*this, features);
+            Account const issuer{"issuer"};
+            Account const alice{"alice"};
+
+            env.fund(XRP(10'000), issuer, alice);
+            env.close();
+            env(fset(issuer, asfDefaultRipple));
+            env.close();
+
+            PrettyAsset const usd{issuer["USD"]};
+            env(trust(alice, usd(100'000)));
+            env.close();
+            env(pay(issuer, alice, usd(50'000)));
+            env.close();
+
+            auto const broker = createVaultAndBroker(env, usd, alice);
+            auto const brokerSle = env.le(keylet::loanBroker(broker.brokerID));
+            if (!BEAST_EXPECT(brokerSle))
+                return;
+            auto const loanKeylet =
+                keylet::loan(broker.brokerID, SeqProxy::rawSequence(brokerSle->at(sfLoanSequence)));
+
+            Number const serviceFee = usd(2).value();
+            env(set(alice, broker.brokerID, usd(1'000).value()),
+                Sig(sfCounterpartySignature, alice),
+                kLoanServiceFee(serviceFee),
+                Fee(env.current()->fees().base * 2));
+            env.close();
+
+            env(fclear(issuer, asfDefaultRipple));
+            env.close();
+            BEAST_EXPECT(env.le(keylet::trustLine(alice.id(), usd.raw().get<Issue>())));
+
+            auto const state = getCurrentState(env, broker, loanKeylet);
+            STAmount const payment{
+                usd,
+                roundPeriodicPayment(usd, state.periodicPayment + serviceFee, state.loanScale)};
+
+            env(pay(alice, loanKeylet.key, payment), Ter(expected));
+            env.close();
+        };
+
+        run(all_ - fixCleanup3_4_0, tecINTERNAL);
+        run(all_, tesSUCCESS);
+    }
+
     void
     runAmendmentIndependent()
     {
@@ -1429,6 +1493,7 @@ private:
         testLoanPayCatchUpFeeAtExactDueDatePostAmendment();
         testLoanPayCatchUpFeeAtExactDueDatePreAmendment();
         testRepayIntoUnauthorizedVault();
+        testLoanPaySelfBrokerExistingLineDefaultRipple();
     }
 
     // Tests run under each entry in amendmentCombinations().

--- a/src/test/app/lending/LoanSet_test.cpp
+++ b/src/test/app/lending/LoanSet_test.cpp
@@ -31,6 +31,7 @@
 #include <array>
 #include <cstdint>
 #include <functional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -764,6 +765,65 @@ private:
         });
     }
 
+    // LoanSet used to call canAddHolding unconditionally, so an existing
+    // borrower line still failed with terNO_RIPPLE after the issuer cleared
+    // DefaultRipple. After fixCleanup3_4_0, skip that gate when the holding
+    // already exists.
+    void
+    testLoanSetExistingLineAfterIssuerClearsDefaultRipple()
+    {
+        using namespace jtx;
+        using namespace loan;
+
+        auto run = [this](FeatureBitset features, TER expected) {
+            testcase(
+                std::string(
+                    "LoanSet existing borrower line after issuer "
+                    "clears asfDefaultRipple (") +
+                (features[fixCleanup3_4_0] ? "post" : "pre") + "-fixCleanup3_4_0)");
+
+            Env env(*this, features);
+            Account const issuer{"issuer"};
+            Account const lender{"lender"};
+            Account const borrower{"borrower"};
+
+            env.fund(XRP(10'000), issuer, lender, borrower);
+            env.close();
+            env(fset(issuer, asfDefaultRipple));
+            env.close();
+
+            PrettyAsset const usd{issuer["USD"]};
+            env(trust(lender, usd(100'000)));
+            env(trust(borrower, usd(100'000)));
+            env.close();
+            env(pay(issuer, lender, usd(50'000)));
+            env(pay(issuer, borrower, usd(1'000)));
+            env.close();
+            BEAST_EXPECT(env.le(keylet::trustLine(borrower.id(), usd.raw().get<Issue>())));
+
+            auto const broker = createVaultAndBroker(env, usd, lender);
+
+            env(fclear(issuer, asfDefaultRipple));
+            env.close();
+
+            Number const destBefore = env.balance(borrower, usd.raw()).number();
+            env(set(borrower, broker.brokerID, usd(100).value()),
+                Sig(sfCounterpartySignature, lender),
+                Fee(env.current()->fees().base * 2),
+                Ter(expected));
+            env.close();
+
+            Number const destAfter = env.balance(borrower, usd.raw()).number();
+            if (isTesSuccess(expected))
+                BEAST_EXPECT(destAfter == destBefore + Number{100});
+            else
+                BEAST_EXPECT(destAfter == destBefore);
+        };
+
+        run(all_ - fixCleanup3_4_0, terNO_RIPPLE);
+        run(all_, tesSUCCESS);
+    }
+
 public:
     void
     run() override
@@ -773,6 +833,7 @@ public:
             testLoanSet(features);
 
         testLoanSetClosedEnded();
+        testLoanSetExistingLineAfterIssuerClearsDefaultRipple();
     }
 };
 

--- a/src/test/app/lending/LoanSet_test.cpp
+++ b/src/test/app/lending/LoanSet_test.cpp
@@ -793,10 +793,10 @@ private:
             env.close();
 
             PrettyAsset const usd{issuer["USD"]};
-            env(trust(lender, usd(100'000)));
-            env(trust(borrower, usd(100'000)));
+            env(trust(lender, usd(10'000'000)));
+            env(trust(borrower, usd(10'000'000)));
             env.close();
-            env(pay(issuer, lender, usd(50'000)));
+            env(pay(issuer, lender, usd(2'000'000)));
             env(pay(issuer, borrower, usd(1'000)));
             env.close();
             BEAST_EXPECT(env.le(keylet::trustLine(borrower.id(), usd.raw().get<Issue>())));
@@ -815,9 +815,13 @@ private:
 
             Number const destAfter = env.balance(borrower, usd.raw()).number();
             if (isTesSuccess(expected))
+            {
                 BEAST_EXPECT(destAfter == destBefore + Number{100});
+            }
             else
+            {
                 BEAST_EXPECT(destAfter == destBefore);
+            }
         };
 
         run(all_ - fixCleanup3_4_0, terNO_RIPPLE);

--- a/src/test/app/vault/VaultBugs_test.cpp
+++ b/src/test/app/vault/VaultBugs_test.cpp
@@ -15,6 +15,7 @@
 #include <test/jtx/vault.h>
 
 #include <xrpl/basics/Number.h>
+#include <xrpl/basics/base_uint.h>
 #include <xrpl/basics/chrono.h>
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/json/json_forwards.h>

--- a/src/test/app/vault/VaultBugs_test.cpp
+++ b/src/test/app/vault/VaultBugs_test.cpp
@@ -1683,13 +1683,17 @@ private:
     // self-destination payout and only tolerates tecDUPLICATE, so
     // tecINTERNAL from a missing DefaultRipple flag aborted the
     // withdrawal. fixCleanup3_4_0 checks existence first and maps the
-    // create-path DefaultRipple miss to terNO_RIPPLE.
+    // create-path DefaultRipple miss to terNO_RIPPLE. Global freeze on an
+    // existing line is still rejected later by checkWithdrawFreeze.
     void
     testBugSelfWithdrawAfterIssuerClearsDefaultRipple()
     {
         using namespace test::jtx;
 
-        auto runExistingLine = [this](FeatureBitset features, TER selfExpected) {
+        auto runExistingLine = [this](
+                                   FeatureBitset features,
+                                   TER selfExpected,
+                                   bool issuerGlobalFreeze = false) {
             Env env(*this, features);
             Account const issuer{"issuer"};
             Account const alice{"alice"};
@@ -1721,22 +1725,51 @@ private:
 
             env(fclear(issuer, asfDefaultRipple));
             env.close();
+            if (issuerGlobalFreeze)
+            {
+                env(fset(issuer, asfGlobalFreeze));
+                env.close();
+            }
 
             BEAST_EXPECT(env.le(keylet::trustLine(alice.id(), usdIssue)));
 
-            // Alice's USD line is unchanged; a later deposit still succeeds.
-            env(vault.deposit({.depositor = alice, .id = vaultKeylet.key, .amount = usd(10)}));
-            env.close();
+            // Alice's USD line is unchanged; a later deposit still succeeds
+            // unless the issuer is globally frozen.
+            if (!issuerGlobalFreeze)
+            {
+                env(vault.deposit({.depositor = alice, .id = vaultKeylet.key, .amount = usd(10)}));
+                env.close();
+            }
+
+            Number const destBefore = env.balance(alice, usd.raw()).number();
+            Number const vaultBefore = env.le(vaultKeylet)->at(sfAssetsTotal);
+            Number const withdrawAmt{50};
 
             env(vault.withdraw({.depositor = alice, .id = vaultKeylet.key, .amount = usd(50)}),
                 Ter(selfExpected));
             env.close();
 
-            auto destTx =
-                vault.withdraw({.depositor = alice, .id = vaultKeylet.key, .amount = usd(50)});
-            destTx[sfDestination] = bob.human();
-            env(destTx);
-            env.close();
+            Number const destAfter = env.balance(alice, usd.raw()).number();
+            Number const vaultAfter = env.le(vaultKeylet)->at(sfAssetsTotal);
+            if (isTesSuccess(selfExpected))
+            {
+                BEAST_EXPECT(destAfter == destBefore + withdrawAmt);
+                BEAST_EXPECT(vaultAfter == vaultBefore - withdrawAmt);
+            }
+            else
+            {
+                BEAST_EXPECT(destAfter == destBefore);
+                BEAST_EXPECT(vaultAfter == vaultBefore);
+            }
+
+            if (!issuerGlobalFreeze)
+            {
+                auto destTx =
+                    vault.withdraw({.depositor = alice, .id = vaultKeylet.key, .amount = usd(50)});
+                destTx[sfDestination] = bob.human();
+                env(destTx);
+                env.close();
+            }
         };
 
         auto runDeletedLine = [this](FeatureBitset features, TER selfExpected) {
@@ -1815,8 +1848,25 @@ private:
             env.close();
             BEAST_EXPECT(env.le(keylet::trustLine(alice.id(), usdIssue)));
 
+            Number const destBefore = env.balance(alice, usd.raw()).number();
+            Number const coverBefore = env.le(brokerKeylet)->at(sfCoverAvailable);
+            Number const withdrawAmt{50};
+
             env(coverWithdraw(alice, brokerKeylet.key, usd(50).value()), Ter(selfExpected));
             env.close();
+
+            Number const destAfter = env.balance(alice, usd.raw()).number();
+            Number const coverAfter = env.le(brokerKeylet)->at(sfCoverAvailable);
+            if (isTesSuccess(selfExpected))
+            {
+                BEAST_EXPECT(destAfter == destBefore + withdrawAmt);
+                BEAST_EXPECT(coverAfter == coverBefore - withdrawAmt);
+            }
+            else
+            {
+                BEAST_EXPECT(destAfter == destBefore);
+                BEAST_EXPECT(coverAfter == coverBefore);
+            }
         };
 
         auto runPrivateVault = [this](FeatureBitset features, TER selfExpected, TER destExpected) {
@@ -1889,6 +1939,11 @@ private:
             "bug: VaultWithdraw to self succeeds after issuer clears "
             "asfDefaultRipple when the trust line exists (post-fixCleanup3_4_0)");
         runExistingLine(all_, tesSUCCESS);
+
+        testcase(
+            "bug: VaultWithdraw to self with an existing line still gets "
+            "tecFROZEN under asfGlobalFreeze (post-fixCleanup3_4_0)");
+        runExistingLine(all_, tecFROZEN, true);
 
         testcase(
             "bug: VaultWithdraw to self fails with tecINTERNAL after issuer "

--- a/src/test/app/vault/VaultBugs_test.cpp
+++ b/src/test/app/vault/VaultBugs_test.cpp
@@ -8,6 +8,7 @@
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
 #include <test/jtx/pay.h>
+#include <test/jtx/permissioned_domains.h>
 #include <test/jtx/sig.h>
 #include <test/jtx/ter.h>
 #include <test/jtx/trust.h>
@@ -1674,6 +1675,255 @@ private:
         }
     }
 
+    // addEmptyHolding() used to check isGlobalFrozen(issuer) and
+    // !lsfDefaultRipple before the "line already exists" tecDUPLICATE
+    // short circuit. doWithdraw() calls addEmptyHolding() for a
+    // self-destination payout and only tolerates tecDUPLICATE, so
+    // tecINTERNAL from a missing DefaultRipple flag aborted the
+    // withdrawal. fixCleanup3_4_0 checks existence first and maps the
+    // create-path DefaultRipple miss to terNO_RIPPLE.
+    void
+    testBugSelfWithdrawAfterIssuerClearsDefaultRipple()
+    {
+        using namespace test::jtx;
+
+        auto runExistingLine = [this](FeatureBitset features, TER selfExpected) {
+            Env env(*this, features);
+            Account const issuer{"issuer"};
+            Account const alice{"alice"};
+            Account const bob{"bob"};
+
+            env.fund(XRP(10'000), issuer, alice, bob);
+            env.close();
+            env(fset(issuer, asfDefaultRipple));
+            env.close();
+
+            PrettyAsset const usd{issuer["USD"]};
+            Issue const usdIssue = usd.raw().get<Issue>();
+            env(trust(alice, usd(10'000)));
+            env(trust(bob, usd(10'000)));
+            env.close();
+            env(pay(issuer, alice, usd(1'000)));
+            env.close();
+
+            Vault const vault{env};
+            auto [vaultTx, vaultKeylet] = vault.create({.owner = alice, .asset = usd});
+            env(vaultTx);
+            env.close();
+
+            env(vault.deposit({.depositor = alice, .id = vaultKeylet.key, .amount = usd(500)}));
+            env.close();
+
+            env(vault.withdraw({.depositor = alice, .id = vaultKeylet.key, .amount = usd(50)}));
+            env.close();
+
+            env(fclear(issuer, asfDefaultRipple));
+            env.close();
+
+            BEAST_EXPECT(env.le(keylet::trustLine(alice.id(), usdIssue)));
+
+            // Alice's USD line is unchanged; a later deposit still succeeds.
+            env(vault.deposit({.depositor = alice, .id = vaultKeylet.key, .amount = usd(10)}));
+            env.close();
+
+            env(vault.withdraw({.depositor = alice, .id = vaultKeylet.key, .amount = usd(50)}),
+                Ter(selfExpected));
+            env.close();
+
+            auto destTx =
+                vault.withdraw({.depositor = alice, .id = vaultKeylet.key, .amount = usd(50)});
+            destTx[sfDestination] = bob.human();
+            env(destTx);
+            env.close();
+        };
+
+        auto runDeletedLine = [this](FeatureBitset features, TER selfExpected) {
+            Env env(*this, features);
+            Account const issuer{"issuer"};
+            Account const alice{"alice"};
+
+            env.fund(XRP(10'000), issuer, alice);
+            env.close();
+            env(fset(issuer, asfDefaultRipple));
+            env.close();
+
+            PrettyAsset const usd{issuer["USD"]};
+            Issue const usdIssue = usd.raw().get<Issue>();
+            env(trust(alice, usd(10'000)));
+            env.close();
+            env(pay(issuer, alice, usd(500)));
+            env.close();
+
+            Vault const vault{env};
+            auto [vaultTx, vaultKeylet] = vault.create({.owner = alice, .asset = usd});
+            env(vaultTx);
+            env.close();
+
+            env(vault.deposit({.depositor = alice, .id = vaultKeylet.key, .amount = usd(500)}));
+            env.close();
+
+            env(trust(alice, usd(0)));
+            env.close();
+            BEAST_EXPECT(!env.le(keylet::trustLine(alice.id(), usdIssue)));
+            env(fclear(issuer, asfDefaultRipple));
+            env.close();
+
+            env(vault.withdraw({.depositor = alice, .id = vaultKeylet.key, .amount = usd(50)}),
+                Ter(selfExpected));
+            env.close();
+        };
+
+        auto runCoverWithdraw = [this](FeatureBitset features, TER selfExpected) {
+            using namespace loan_broker;
+
+            Env env(*this, features);
+            Account const issuer{"issuer"};
+            Account const alice{"alice"};
+
+            env.fund(XRP(10'000), issuer, alice);
+            env.close();
+            env(fset(issuer, asfDefaultRipple));
+            env.close();
+
+            PrettyAsset const usd{issuer["USD"]};
+            Issue const usdIssue = usd.raw().get<Issue>();
+            env(trust(alice, usd(10'000)));
+            env.close();
+            env(pay(issuer, alice, usd(1'000)));
+            env.close();
+
+            Vault const vault{env};
+            auto const [createTx, vaultKeylet, subscriptionDate] = vault.createClosedEnded(
+                {.owner = alice, .asset = usd, .subscriptionOffset = std::chrono::seconds{60}});
+            (void)subscriptionDate;
+            env(createTx);
+            env.close();
+
+            env(vault.deposit({.depositor = alice, .id = vaultKeylet.key, .amount = usd(500)}));
+            env.close();
+
+            auto const brokerKeylet =
+                keylet::loanBroker(alice.id(), SeqProxy::rawSequence(env.seq(alice)));
+            env(set(alice, vaultKeylet.key));
+            env.close();
+            env(coverDeposit(alice, brokerKeylet.key, usd(100).value()));
+            env.close();
+
+            env(fclear(issuer, asfDefaultRipple));
+            env.close();
+            BEAST_EXPECT(env.le(keylet::trustLine(alice.id(), usdIssue)));
+
+            env(coverWithdraw(alice, brokerKeylet.key, usd(50).value()), Ter(selfExpected));
+            env.close();
+        };
+
+        auto runPrivateVault = [this](FeatureBitset features, TER selfExpected, TER destExpected) {
+            Env env(*this, features);
+            Account const issuer{"issuer"};
+            Account const alice{"alice"};
+            Account const bob{"bob"};
+            Account const pdOwner{"pdOwner"};
+            Account const credIssuer{"credIssuer"};
+            std::string const credType = "credential";
+
+            env.fund(XRP(10'000), issuer, alice, bob, pdOwner, credIssuer);
+            env.close();
+            env(fset(issuer, asfDefaultRipple));
+            env.close();
+
+            PrettyAsset const usd{issuer["USD"]};
+            env(trust(alice, usd(10'000)));
+            env(trust(bob, usd(10'000)));
+            env.close();
+            env(pay(issuer, alice, usd(1'000)));
+            env.close();
+
+            Vault const vault{env};
+            auto [vaultTx, vaultKeylet] =
+                vault.create({.owner = alice, .asset = usd, .flags = tfVaultPrivate});
+            env(vaultTx);
+            env.close();
+
+            pdomain::Credentials const credentials{{.issuer = credIssuer, .credType = credType}};
+            env(pdomain::setTx(pdOwner, credentials));
+            auto const domainId = pdomain::getNewDomain(env.meta());
+            {
+                auto domainTx = vault.set({.owner = alice, .id = vaultKeylet.key});
+                domainTx[sfDomainID] = to_string(domainId);
+                env(domainTx);
+                env.close();
+            }
+
+            env(credentials::create(alice, credIssuer, credType));
+            env(credentials::accept(alice, credIssuer, credType));
+            env.close();
+
+            env(vault.deposit({.depositor = alice, .id = vaultKeylet.key, .amount = usd(500)}));
+            env.close();
+
+            env(fclear(issuer, asfDefaultRipple));
+            env.close();
+
+            env(vault.withdraw({.depositor = alice, .id = vaultKeylet.key, .amount = usd(50)}),
+                Ter(selfExpected));
+            env.close();
+
+            // Bob has a USD line but is not in the vault's domain; post-fixCleanup3_4_0
+            // that is not a usable destination.
+            auto destTx =
+                vault.withdraw({.depositor = alice, .id = vaultKeylet.key, .amount = usd(50)});
+            destTx[sfDestination] = bob.human();
+            env(destTx, Ter(destExpected));
+            env.close();
+        };
+
+        testcase(
+            "bug: VaultWithdraw to self fails with tecINTERNAL after issuer "
+            "clears asfDefaultRipple even though the trust line exists "
+            "(pre-fixCleanup3_4_0)");
+        runExistingLine(all_ - fixCleanup3_4_0, tecINTERNAL);
+
+        testcase(
+            "bug: VaultWithdraw to self succeeds after issuer clears "
+            "asfDefaultRipple when the trust line exists (post-fixCleanup3_4_0)");
+        runExistingLine(all_, tesSUCCESS);
+
+        testcase(
+            "bug: VaultWithdraw to self fails with tecINTERNAL after issuer "
+            "clears asfDefaultRipple and the trust line was deleted "
+            "(pre-fixCleanup3_4_0)");
+        runDeletedLine(all_ - fixCleanup3_4_0, tecINTERNAL);
+
+        testcase(
+            "bug: VaultWithdraw to self fails with terNO_RIPPLE after issuer "
+            "clears asfDefaultRipple and the trust line was deleted "
+            "(post-fixCleanup3_4_0)");
+        runDeletedLine(all_, terNO_RIPPLE);
+
+        testcase(
+            "bug: LoanBrokerCoverWithdraw to self fails with tecINTERNAL after "
+            "issuer clears asfDefaultRipple even though the trust line exists "
+            "(pre-fixCleanup3_4_0)");
+        runCoverWithdraw(all_ - fixCleanup3_4_0, tecINTERNAL);
+
+        testcase(
+            "bug: LoanBrokerCoverWithdraw to self succeeds after issuer clears "
+            "asfDefaultRipple when the trust line exists (post-fixCleanup3_4_0)");
+        runCoverWithdraw(all_, tesSUCCESS);
+
+        testcase(
+            "bug: private VaultWithdraw to self fails with tecINTERNAL after "
+            "issuer clears asfDefaultRipple; third-party dest still works "
+            "(pre-fixCleanup3_4_0)");
+        runPrivateVault(all_ - fixCleanup3_4_0, tecINTERNAL, tesSUCCESS);
+
+        testcase(
+            "bug: private VaultWithdraw to self succeeds after issuer clears "
+            "asfDefaultRipple; third-party dest is tecNO_AUTH "
+            "(post-fixCleanup3_4_0)");
+        runPrivateVault(all_, tesSUCCESS, tecNO_AUTH);
+    }
+
 public:
     void
     run() override
@@ -1695,6 +1945,7 @@ public:
         testBugClawbackRoundTripOvershoot();
         testBugWithdrawRoundTripOvershoot();
         testBugClawbackAfterLoanImpair();
+        testBugSelfWithdrawAfterIssuerClearsDefaultRipple();
     }
 };
 

--- a/src/test/app/vault/VaultBugs_test.cpp
+++ b/src/test/app/vault/VaultBugs_test.cpp
@@ -1869,23 +1869,67 @@ private:
             }
         };
 
-        auto runPrivateVault = [this](FeatureBitset features, TER selfExpected, TER destExpected) {
+        auto runDeletedCoverWithdraw = [this](FeatureBitset features, TER selfExpected) {
+            using namespace loan_broker;
+
             Env env(*this, features);
             Account const issuer{"issuer"};
             Account const alice{"alice"};
-            Account const bob{"bob"};
+
+            env.fund(XRP(10'000), issuer, alice);
+            env.close();
+            env(fset(issuer, asfDefaultRipple));
+            env.close();
+
+            PrettyAsset const usd{issuer["USD"]};
+            Issue const usdIssue = usd.raw().get<Issue>();
+            env(trust(alice, usd(10'000)));
+            env.close();
+            env(pay(issuer, alice, usd(600)));
+            env.close();
+
+            Vault const vault{env};
+            auto const [createTx, vaultKeylet, subscriptionDate] = vault.createClosedEnded(
+                {.owner = alice, .asset = usd, .subscriptionOffset = std::chrono::seconds{60}});
+            (void)subscriptionDate;
+            env(createTx);
+            env.close();
+
+            env(vault.deposit({.depositor = alice, .id = vaultKeylet.key, .amount = usd(500)}));
+            env.close();
+
+            auto const brokerKeylet =
+                keylet::loanBroker(alice.id(), SeqProxy::rawSequence(env.seq(alice)));
+            env(set(alice, vaultKeylet.key));
+            env.close();
+            env(coverDeposit(alice, brokerKeylet.key, usd(100).value()));
+            env.close();
+
+            env(trust(alice, usd(0)));
+            env.close();
+            BEAST_EXPECT(!env.le(keylet::trustLine(alice.id(), usdIssue)));
+            env(fclear(issuer, asfDefaultRipple));
+            env.close();
+
+            env(coverWithdraw(alice, brokerKeylet.key, usd(50).value()), Ter(selfExpected));
+            env.close();
+        };
+
+        auto runPrivateVault = [this](FeatureBitset features, TER selfExpected) {
+            Env env(*this, features);
+            Account const issuer{"issuer"};
+            Account const alice{"alice"};
             Account const pdOwner{"pdOwner"};
             Account const credIssuer{"credIssuer"};
             std::string const credType = "credential";
 
-            env.fund(XRP(10'000), issuer, alice, bob, pdOwner, credIssuer);
+            env.fund(XRP(10'000), issuer, alice, pdOwner, credIssuer);
             env.close();
             env(fset(issuer, asfDefaultRipple));
             env.close();
 
             PrettyAsset const usd{issuer["USD"]};
             env(trust(alice, usd(10'000)));
-            env(trust(bob, usd(10'000)));
             env.close();
             env(pay(issuer, alice, usd(1'000)));
             env.close();
@@ -1918,14 +1962,6 @@ private:
 
             env(vault.withdraw({.depositor = alice, .id = vaultKeylet.key, .amount = usd(50)}),
                 Ter(selfExpected));
-            env.close();
-
-            // Bob has a USD line but is not in the vault's domain; post-fixCleanup3_4_0
-            // that is not a usable destination.
-            auto destTx =
-                vault.withdraw({.depositor = alice, .id = vaultKeylet.key, .amount = usd(50)});
-            destTx[sfDestination] = bob.human();
-            env(destTx, Ter(destExpected));
             env.close();
         };
 
@@ -1969,16 +2005,27 @@ private:
         runCoverWithdraw(all_, tesSUCCESS);
 
         testcase(
-            "bug: private VaultWithdraw to self fails with tecINTERNAL after "
-            "issuer clears asfDefaultRipple; third-party dest still works "
+            "bug: LoanBrokerCoverWithdraw to self fails with tecINTERNAL after "
+            "issuer clears asfDefaultRipple and the trust line was deleted "
             "(pre-fixCleanup3_4_0)");
-        runPrivateVault(all_ - fixCleanup3_4_0, tecINTERNAL, tesSUCCESS);
+        runDeletedCoverWithdraw(all_ - fixCleanup3_4_0, tecINTERNAL);
+
+        testcase(
+            "bug: LoanBrokerCoverWithdraw to self fails with terNO_RIPPLE after "
+            "issuer clears asfDefaultRipple and the trust line was deleted "
+            "(post-fixCleanup3_4_0)");
+        runDeletedCoverWithdraw(all_, terNO_RIPPLE);
+
+        testcase(
+            "bug: private VaultWithdraw to self fails with tecINTERNAL after "
+            "issuer clears asfDefaultRipple even though the trust line exists "
+            "(pre-fixCleanup3_4_0)");
+        runPrivateVault(all_ - fixCleanup3_4_0, tecINTERNAL);
 
         testcase(
             "bug: private VaultWithdraw to self succeeds after issuer clears "
-            "asfDefaultRipple; third-party dest is tecNO_AUTH "
-            "(post-fixCleanup3_4_0)");
-        runPrivateVault(all_, tesSUCCESS, tecNO_AUTH);
+            "asfDefaultRipple when the trust line exists (post-fixCleanup3_4_0)");
+        runPrivateVault(all_, tesSUCCESS);
     }
 
     // Bug 1: a sponsored XRP VaultWithdraw to a distinct destination is


### PR DESCRIPTION
## Bug

### Issue
addEmptyHolding() in RippleStateHelpers.cpp evaluates issuer state (isGlobalFrozen and !lsfDefaultRipple) before checking whether the holding line already exists (tecDUPLICATE).

### Root Cause
Issuer preconditions returning tecINTERNAL or tecFROZEN run prior to the ctx.view.read(index) existing-line short circuit. When a holding line already exists, no line creation is required, so these checks should not run or fail the call.

### Impact
An IOU issuer clearing asfDefaultRipple causes all self-destination VaultWithdraw and LoanBrokerCoverWithdraw transactions for existing trust lines to fail with tecINTERNAL, locking depositor funds and burning fees on retries. Similarly, globally frozen assets evaluate tecFROZEN prematurely before checking line existence.

## Summary
- `addEmptyHolding` for IOUs checked issuer freeze and DefaultRipple before noticing the trust line already existed. `doWithdraw` (VaultWithdraw and LoanBrokerCoverWithdraw) only treats `tecDUPLICATE` as success, so an issuer clearing `asfDefaultRipple` made self-destination payouts fail with `tecINTERNAL` even when the destination already held the asset.
- Gated on `fixCleanup3_4_0`: existing line returns `tecDUPLICATE` first; creating a new line with DefaultRipple off returns `terNO_RIPPLE` instead of `tecINTERNAL`.
- VaultWithdraw and LoanBrokerCoverWithdraw call `canAddHolding` in preclaim only when the destination is self and `holdingExists` is false.

## Test plan
- [ ] `VaultBugs` self-withdraw with an existing line after DefaultRipple is cleared (pre `tecINTERNAL`, post `tesSUCCESS`)
- [ ] Deleted-line create path (pre `tecINTERNAL`, post `terNO_RIPPLE`)
- [ ] `LoanBrokerCoverWithdraw` to self with an existing line
- [ ] Private vault: self-withdraw vs non-member destination (`tecNO_AUTH` post-3.4.0)