### PR TITLE
docs: Use consistent heading levels in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ If too broad, please consider splitting into multiple PRs.
 If there is a relevant task or issue, please link it here.
 -->
 
-### Context of Change
+## Context of Change
 
 <!--
 Please include the context of a change.
@@ -29,7 +29,7 @@ If a refactor, how is this better than the previous implementation?
 If there is a spec or design document for this feature, please link it here.
 -->
 
-### API Impact
+## API Impact
 
 <!--
 Please check [x] relevant options, delete irrelevant ones.


### PR DESCRIPTION
## High Level Overview of Change

The PR template's section headings were split across two levels: `High Level Overview of Change`, `Before / After`, `Test Plan` and `Future Tasks` were `##`, while `Context of Change` and `API Impact` were `###`. This change promotes those two to `##`, so every section of the template sits at the same level.

## Context of Change

All six sections of `.github/pull_request_template.md` are peers — none is nested inside another, and the template's own commented-out sections (`## Before / After`, `## Test Plan`, `## Future Tasks`) already used `##`. The two `###` headings were the only outliers, which GitHub renders at a visibly smaller size than their siblings. The effect is cosmetic in every PR opened from the template, and it also breaks the document outline: an `h3` with no `h2` parent above it is not a valid nesting for a screen reader or for any tool that builds a table of contents from heading depth.

Nothing in the template's guidance text or checkboxes changes, so authors see the same prompts and the same four API-impact boxes as before.

## API Impact

No public API, `libxrpl`, or peer protocol impact. The change touches one repository metadata file and no source, so there is no consensus-visible behaviour and nothing to recompile.

## Test Plan

`pre-commit run --files .github/pull_request_template.md` passes — prettier, cspell, trailing-whitespace and end-of-file hooks all report Passed, so the file is still canonically formatted markdown. This PR's own description is written against the updated template, so its rendered headings are the verification that all six sections now display uniformly.
