### PR TITLE
refactor: Use temINVALID_BYTECODE istead of temBAD_WASM

### DIFF
--- a/crates/xrpl-wasm-vm-ffi/src/lib.rs
+++ b/crates/xrpl-wasm-vm-ffi/src/lib.rs
@@ -1271,7 +1271,7 @@ mod tests {
     }
 
     /// A panic during a check is its own status rather than one more malformed
-    /// module: the far side answers a node-local failure, not `temBAD_WASM`.
+    /// module: the far side answers a node-local failure, not `temINVALID_BYTECODE`.
     #[test]
     fn a_panic_during_a_check_becomes_a_status_instead_of_an_unwind() {
         let crossed = guarded(

--- a/include/xrpl/protocol/TER.h
+++ b/include/xrpl/protocol/TER.h
@@ -132,7 +132,7 @@ enum TEMcodes : TERUnderlyingType {
 
     temBAD_MPT,
     temBAD_CIPHERTEXT,
-    temBAD_WASM,
+    temINVALID_BYTECODE,
 };
 
 //------------------------------------------------------------------------------

--- a/include/xrpl/tx/wasm/WasmVM.h
+++ b/include/xrpl/tx/wasm/WasmVM.h
@@ -37,7 +37,7 @@ runEscrowWasm(
 // That is what makes this callable from a transactor's `preflight`, which has no view
 // to build a host over.
 //
-// `temBAD_WASM` for every fault in the module - the transaction carries something this
+// `temINVALID_BYTECODE` for every fault in the module - the transaction carries something this
 // engine cannot run, so it is refused before it can reach the ledger.
 // `telFAILED_PROCESSING` if the engine itself failed: nothing was learned about the
 // module, and a defect here is not evidence that the transaction is malformed.

--- a/src/libxrpl/protocol/TER.cpp
+++ b/src/libxrpl/protocol/TER.cpp
@@ -205,7 +205,7 @@ transResults()
         MAKE_ERROR(temBAD_TRANSFER_FEE,          "Malformed: Transfer fee is outside valid range."),
         MAKE_ERROR(temINVALID_INNER_BATCH,       "Malformed: Invalid inner batch transaction."),
         MAKE_ERROR(temBAD_CIPHERTEXT,            "Malformed: Invalid ciphertext."),
-        MAKE_ERROR(temBAD_WASM,                  "Malformed: Provided WASM code is invalid."),
+        MAKE_ERROR(temINVALID_BYTECODE,          "Malformed: Provided byte code is invalid."),
 
         MAKE_ERROR(terRETRY,                  "Retry transaction."),
         MAKE_ERROR(terFUNDS_SPENT,            "DEPRECATED."),

--- a/src/libxrpl/tx/wasm/WasmVM.cpp
+++ b/src/libxrpl/tx/wasm/WasmVM.cpp
@@ -104,7 +104,7 @@ verdict(CheckStatus status)
         case CheckStatus::EntryPoint:
         case CheckStatus::Memory:
         case CheckStatus::Table:
-            return temBAD_WASM;
+            return temINVALID_BYTECODE;
 
         // The engine panicked: a defect in the engine, reported rather than fatal to
         // the node, and not the transaction's fault.

--- a/src/tests/libxrpl/tx/wasm/Preflight.cpp
+++ b/src/tests/libxrpl/tx/wasm/Preflight.cpp
@@ -62,8 +62,8 @@ TEST_F(PreflightTest, RunnableContractPasses)
 
 TEST_F(PreflightTest, GarbageIsRefused)
 {
-    EXPECT_EQ(preflightBytes(Bytes{}), temBAD_WASM);
-    EXPECT_EQ(preflightBytes(Bytes{0x00, 0x61, 0x73, 0x6d}), temBAD_WASM);
+    EXPECT_EQ(preflightBytes(Bytes{}), temINVALID_BYTECODE);
+    EXPECT_EQ(preflightBytes(Bytes{0x00, 0x61, 0x73, 0x6d}), temINVALID_BYTECODE);
 }
 
 // The engine takes wasm binaries, and text is not one. The suite writes its modules as text
@@ -73,7 +73,7 @@ TEST_F(PreflightTest, TextFormatModuleIsRefused)
 {
     Bytes const text{kRunnableWat.begin(), kRunnableWat.end()};
 
-    EXPECT_EQ(preflightBytes(text), temBAD_WASM);
+    EXPECT_EQ(preflightBytes(text), temINVALID_BYTECODE);
     EXPECT_EQ(preflight(kRunnableWat), tesSUCCESS) << "the same module, assembled first";
 }
 
@@ -86,7 +86,7 @@ TEST_F(PreflightTest, ImportOfAnUnknownHostFunctionIsRefused)
       (func (export "escrow_finish") (result i32) (call $f (i32.const 0))))
     )wat";
 
-    EXPECT_EQ(preflight(wat), temBAD_WASM);
+    EXPECT_EQ(preflight(wat), temINVALID_BYTECODE);
     EXPECT_THAT(logged(), testing::HasSubstr("no host function 'no_such_function'"));
 }
 
@@ -101,7 +101,7 @@ TEST_F(PreflightTest, ImportFromAnotherModuleIsRefused)
       (func (export "escrow_finish") (result i32) (i32.const 0)))
     )wat";
 
-    EXPECT_EQ(preflight(wat), temBAD_WASM);
+    EXPECT_EQ(preflight(wat), temINVALID_BYTECODE);
     EXPECT_THAT(logged(), testing::HasSubstr("is not from 'host_lib'"));
 }
 
@@ -115,7 +115,7 @@ TEST_F(PreflightTest, MemoryPastTheCapIsRefused)
       (func (export "escrow_finish") (result i32) (i32.const 0)))
     )wat";
 
-    EXPECT_EQ(preflight(tooMuch), temBAD_WASM);
+    EXPECT_EQ(preflight(tooMuch), temINVALID_BYTECODE);
     EXPECT_THAT(logged(), testing::HasSubstr("memory: initial memory of 129 pages"));
 
     constexpr std::string_view atTheCap = R"wat(
@@ -139,7 +139,7 @@ TEST_F(PreflightTest, TablePastTheCapIsRefused)
       (func (export "escrow_finish") (result i32) (i32.const 0)))
     )wat";
 
-    EXPECT_EQ(preflight(tooMuch), temBAD_WASM);
+    EXPECT_EQ(preflight(tooMuch), temINVALID_BYTECODE);
     EXPECT_THAT(logged(), testing::HasSubstr("table: initial table of 1025 elements"));
 
     constexpr std::string_view atTheCap = R"wat(
@@ -160,7 +160,7 @@ TEST_F(PreflightTest, MissingEntryPointIsRefused)
       (func (export "other") (result i32) (i32.const 0)))
     )wat";
 
-    EXPECT_EQ(preflight(wat), temBAD_WASM);
+    EXPECT_EQ(preflight(wat), temINVALID_BYTECODE);
     EXPECT_THAT(logged(), testing::HasSubstr("no entry point 'escrow_finish'"));
 }
 
@@ -172,7 +172,7 @@ TEST_F(PreflightTest, EntryPointOfTheWrongTypeIsRefused)
       (func (export "escrow_finish") (result i64) (i64.const 0)))
     )wat";
 
-    EXPECT_EQ(preflight(wat), temBAD_WASM);
+    EXPECT_EQ(preflight(wat), temINVALID_BYTECODE);
     EXPECT_THAT(logged(), testing::HasSubstr("has the wrong signature"));
 }
 
@@ -187,18 +187,18 @@ TEST_F(PreflightTest, EntryPointIsTheNameTheCallerGives)
     )wat";
 
     EXPECT_EQ(preflight(wat, "other"), tesSUCCESS);
-    EXPECT_EQ(preflight(wat), temBAD_WASM);
+    EXPECT_EQ(preflight(wat), temINVALID_BYTECODE);
 }
 
 // Every refusal is logged with the engine's own description and the TER: without it a node
-// operator has a `temBAD_WASM` and no way to tell a contract author which of the three
+// operator has a `temINVALID_BYTECODE` and no way to tell a contract author which of the three
 // stages refused the module.
 TEST_F(PreflightTest, RefusalNamesTheReasonAndTheTer)
 {
-    EXPECT_EQ(preflightBytes(Bytes{0x00, 0x61, 0x73, 0x6d}), temBAD_WASM);
+    EXPECT_EQ(preflightBytes(Bytes{0x00, 0x61, 0x73, 0x6d}), temINVALID_BYTECODE);
 
     EXPECT_THAT(logged(), testing::HasSubstr("compile: "));
-    EXPECT_THAT(logged(), testing::HasSubstr(transToken(temBAD_WASM)));
+    EXPECT_THAT(logged(), testing::HasSubstr(transToken(temINVALID_BYTECODE)));
 }
 
 // A module that passes screening still has to pass the run's own stages, and one that fails

--- a/src/tests/libxrpl/tx/wasm/WasmVM.cpp
+++ b/src/tests/libxrpl/tx/wasm/WasmVM.cpp
@@ -136,7 +136,7 @@ TEST_F(WasmVMTest, ModuleThatWillNotInstantiateIsChargedToTheContract)
     EXPECT_TRUE(outcome.error().cost.has_value());
 }
 
-// Preflight is meant to refuse these with `temBAD_WASM`; reaching apply means the screening
+// Preflight is meant to refuse these with `temINVALID_BYTECODE`; reaching apply means the screening
 // did not happen, which is the node's fault and not the transaction's.
 TEST_F(WasmVMTest, UnrunnableModuleIsNodeSideFault)
 {


### PR DESCRIPTION
<!--
This PR template helps you write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR. This avoids redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Use `temINVALID_BYTECODE` istead of `temBAD_WASM`.
<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to this PR.
-->
