### PR TITLE
fix: Add signature prefixes for sfCounterpartySignature and sfSponsorSignature

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -41,6 +41,7 @@ This section contains changes targeting a future version.
 
 ### Bugfixes
 
+- `sign`, `sign_for`, `submit`, `submit_multisigned`: With `fixCleanup3_4_0` enabled, a signature in `CounterpartySignature` or `SponsorSignature` covers a different prefix than the transaction's own signature, so a signature can no longer be moved from one of those roles into another. Clients that build these signatures themselves must use the new prefixes: `CPT` and `CPM` (single- and multi-signing) for `CounterpartySignature`, and `SPN` and `SPM` for `SponsorSignature`.
 - `get_aggregate_price`: Duplicate entries in the `oracles` request array are now ignored. [#6586](https://github.com/XRPLF/rippled/pull/6586)
 - Peer Crawler: The `port` field in `overlay.active[]` now consistently returns an integer instead of a string for outbound peers. [#6318](https://github.com/XRPLF/rippled/pull/6318)
 - `ping`: The `ip` field is no longer returned as an empty string for proxied connections without a forwarded-for header. It is now omitted, consistent with the behavior for identified connections. [#6730](https://github.com/XRPLF/rippled/pull/6730)

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -41,7 +41,7 @@ This section contains changes targeting a future version.
 
 ### Bugfixes
 
-- `sign`, `sign_for`: `signature_target` now returns `invalidParams` unless it names `CounterpartySignature` or `SponsorSignature`. It previously accepted any inner object field, such as `Book` or `NFToken`, and signed into it.
+- `sign`, `sign_for`, `submit`: `signature_target` now returns `invalidParams` unless it names `CounterpartySignature` or `SponsorSignature`. It previously accepted any inner object field, such as `Book` or `NFToken`, and signed into it.
 - `sign`, `sign_for`, `submit`, `submit_multisigned`: With `fixCleanup3_4_0` enabled, a signature in `CounterpartySignature` or `SponsorSignature` covers a different prefix than the transaction's own signature, so a signature can no longer be moved from one of those roles into another. Clients that build these signatures themselves must use the new prefixes: `CPT` and `CPM` (single- and multi-signing) for `CounterpartySignature`, and `SPN` and `SPM` for `SponsorSignature`.
 - `get_aggregate_price`: Duplicate entries in the `oracles` request array are now ignored. [#6586](https://github.com/XRPLF/rippled/pull/6586)
 - Peer Crawler: The `port` field in `overlay.active[]` now consistently returns an integer instead of a string for outbound peers. [#6318](https://github.com/XRPLF/rippled/pull/6318)

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -41,6 +41,7 @@ This section contains changes targeting a future version.
 
 ### Bugfixes
 
+- `sign`, `sign_for`: `signature_target` now returns `invalidParams` unless it names `CounterpartySignature` or `SponsorSignature`. It previously accepted any inner object field, such as `Book` or `NFToken`, and signed into it.
 - `sign`, `sign_for`, `submit`, `submit_multisigned`: With `fixCleanup3_4_0` enabled, a signature in `CounterpartySignature` or `SponsorSignature` covers a different prefix than the transaction's own signature, so a signature can no longer be moved from one of those roles into another. Clients that build these signatures themselves must use the new prefixes: `CPT` and `CPM` (single- and multi-signing) for `CounterpartySignature`, and `SPN` and `SPM` for `SponsorSignature`.
 - `get_aggregate_price`: Duplicate entries in the `oracles` request array are now ignored. [#6586](https://github.com/XRPLF/rippled/pull/6586)
 - Peer Crawler: The `port` field in `overlay.active[]` now consistently returns an integer instead of a string for outbound peers. [#6318](https://github.com/XRPLF/rippled/pull/6318)

--- a/include/xrpl/core/HashRouter.h
+++ b/include/xrpl/core/HashRouter.h
@@ -34,7 +34,10 @@ enum class HashRouterFlags : std::uint16_t {
     PRIVATE4 = 0x0800,
     // Used in EscrowFinish.cpp
     PRIVATE5 = 0x1000,
-    PRIVATE6 = 0x2000
+    PRIVATE6 = 0x2000,
+    // Used in apply.cpp
+    PRIVATE7 = 0x4000,
+    PRIVATE8 = 0x8000
 };
 
 constexpr HashRouterFlags

--- a/include/xrpl/protocol/HashPrefix.h
+++ b/include/xrpl/protocol/HashPrefix.h
@@ -92,6 +92,26 @@ enum class HashPrefix : std::uint32_t {
      * Batch
      */
     Batch = detail::makeHashPrefix('B', 'C', 'H'),
+
+    /**
+     * inner transaction to sign as the counterparty
+     */
+    CounterpartyTxSign = detail::makeHashPrefix('C', 'P', 'T'),
+
+    /**
+     * inner transaction to multi-sign as the counterparty
+     */
+    CounterpartyTxMultiSign = detail::makeHashPrefix('C', 'P', 'M'),
+
+    /**
+     * inner transaction to sign as the sponsor
+     */
+    SponsorTxSign = detail::makeHashPrefix('S', 'P', 'N'),
+
+    /**
+     * inner transaction to multi-sign as the sponsor
+     */
+    SponsorTxMultiSign = detail::makeHashPrefix('S', 'P', 'M'),
 };
 
 template <class Hasher>

--- a/include/xrpl/protocol/STTx.h
+++ b/include/xrpl/protocol/STTx.h
@@ -5,6 +5,7 @@
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/HashPrefix.h>
 #include <xrpl/protocol/PublicKey.h>
 #include <xrpl/protocol/Rules.h>
 #include <xrpl/protocol/SField.h>
@@ -105,11 +106,22 @@ public:
     [[nodiscard]] json::Value
     getJson(JsonOptions options, bool binary) const;
 
+    /**
+     * Sign the transaction.
+     * @param publicKey The public key for signing.
+     * @param secretKey The secret key for signing.
+     * @param signatureTarget Field in which to store the signature. If not
+     *     specified, the signature goes into the top level sfTxnSignature.
+     * @param prefix Prefix to insert before the serialized transaction when
+     *     hashing. Use signingPrefix to get the prefix that matches
+     *     signatureTarget.
+     */
     void
     sign(
         PublicKey const& publicKey,
         SecretKey const& secretKey,
-        std::optional<std::reference_wrapper<SField const>> signatureTarget = {});
+        std::optional<std::reference_wrapper<SField const>> signatureTarget = {},
+        HashPrefix prefix = HashPrefix::TxSign);
 
     /**
      * Check the signature.
@@ -165,16 +177,20 @@ private:
      * @param rules The current ledger rules.
      * @param sigObject Reference to object that contains the signature fields.
      *     Will be *this more often than not.
+     * @param sigField Field that holds sigObject: nullptr when sigObject is
+     *     *this, otherwise the field of the alternate signature, such as
+     *     sfSponsorSignature. Determines the signing prefix, which binds the
+     *     signature to the role that made it.
      * @return `true` if valid signature. If invalid, the error message string.
      */
     [[nodiscard]] std::expected<void, std::string>
-    checkSign(Rules const& rules, STObject const& sigObject) const;
+    checkSign(Rules const& rules, STObject const& sigObject, SField const* sigField) const;
 
     [[nodiscard]] std::expected<void, std::string>
-    checkSingleSign(STObject const& sigObject) const;
+    checkSingleSign(STObject const& sigObject, HashPrefix prefix) const;
 
     [[nodiscard]] std::expected<void, std::string>
-    checkMultiSign(Rules const& rules, STObject const& sigObject) const;
+    checkMultiSign(Rules const& rules, STObject const& sigObject, HashPrefix prefix) const;
 
     [[nodiscard]] std::expected<void, std::string>
     checkBatchSingleSign(STObject const& batchSigner, std::vector<uint256> const& txIds) const;

--- a/include/xrpl/protocol/STTx.h
+++ b/include/xrpl/protocol/STTx.h
@@ -144,7 +144,7 @@ public:
     checkSign(Rules const& rules) const;
 
     [[nodiscard]] std::expected<void, std::string>
-    checkBatchSign(Rules const& rules) const;
+    checkBatchSign() const;
 
     // SQL Functions with metadata.
     static std::string const&
@@ -201,16 +201,13 @@ private:
     checkSingleSign(STObject const& sigObject, HashPrefix prefix) const;
 
     [[nodiscard]] std::expected<void, std::string>
-    checkMultiSign(Rules const& rules, STObject const& sigObject, HashPrefix prefix) const;
+    checkMultiSign(STObject const& sigObject, HashPrefix prefix) const;
 
     [[nodiscard]] std::expected<void, std::string>
     checkBatchSingleSign(STObject const& batchSigner, std::vector<uint256> const& txIds) const;
 
     [[nodiscard]] std::expected<void, std::string>
-    checkBatchMultiSign(
-        STObject const& batchSigner,
-        Rules const& rules,
-        std::vector<uint256> const& txIds) const;
+    checkBatchMultiSign(STObject const& batchSigner, std::vector<uint256> const& txIds) const;
 
     void
     buildBatchTxns();

--- a/include/xrpl/protocol/STTx.h
+++ b/include/xrpl/protocol/STTx.h
@@ -14,6 +14,7 @@
 #include <xrpl/protocol/SecretKey.h>
 #include <xrpl/protocol/SeqProxy.h>
 #include <xrpl/protocol/Serializer.h>
+#include <xrpl/protocol/Sign.h>
 #include <xrpl/protocol/TxFormats.h>
 
 #include <boost/container/flat_set.hpp>
@@ -107,24 +108,35 @@ public:
     getJson(JsonOptions options, bool binary) const;
 
     /**
-     * Sign the transaction.
+     * Sign the transaction as its account.
+     *
      * @param publicKey The public key for signing.
      * @param secretKey The secret key for signing.
-     * @param signatureTarget Field in which to store the signature. If not
-     *     specified, the signature goes into the top level sfTxnSignature.
-     * @param prefix Prefix to insert before the serialized transaction when
-     *     hashing. Use signingPrefix to get the prefix that matches
-     *     signatureTarget.
+     */
+    void
+    sign(PublicKey const& publicKey, SecretKey const& secretKey);
+
+    /**
+     * Sign the transaction in one of its signature fields.
+     *
+     * The signature is bound to the role that made it, so it cannot be moved
+     * into another role.
+     *
+     * @param publicKey The public key for signing.
+     * @param secretKey The secret key for signing.
+     * @param role The role signing the transaction.
+     * @param rules The current ledger rules.
      */
     void
     sign(
         PublicKey const& publicKey,
         SecretKey const& secretKey,
-        std::optional<std::reference_wrapper<SField const>> signatureTarget = {},
-        HashPrefix prefix = HashPrefix::TxSign);
+        SignatureRole role,
+        Rules const& rules);
 
     /**
      * Check the signature.
+     *
      * @param rules The current ledger rules.
      * @return `true` if valid signature. If invalid, the error message string.
      */
@@ -174,17 +186,16 @@ public:
 private:
     /**
      * Check the signature.
+     *
      * @param rules The current ledger rules.
      * @param sigObject Reference to object that contains the signature fields.
      *     Will be *this more often than not.
-     * @param sigField Field that holds sigObject: nullptr when sigObject is
-     *     *this, otherwise the field of the alternate signature, such as
-     *     sfSponsorSignature. Determines the signing prefix, which binds the
-     *     signature to the role that made it.
+     * @param role The role that made the signature in sigObject. Determines
+     *     the signing prefix, which binds the signature to that role.
      * @return `true` if valid signature. If invalid, the error message string.
      */
     [[nodiscard]] std::expected<void, std::string>
-    checkSign(Rules const& rules, STObject const& sigObject, SField const* sigField) const;
+    checkSign(Rules const& rules, STObject const& sigObject, SignatureRole role) const;
 
     [[nodiscard]] std::expected<void, std::string>
     checkSingleSign(STObject const& sigObject, HashPrefix prefix) const;

--- a/include/xrpl/protocol/Sign.h
+++ b/include/xrpl/protocol/Sign.h
@@ -10,7 +10,6 @@
 #include <xrpl/protocol/SecretKey.h>
 #include <xrpl/protocol/Serializer.h>
 
-#include <functional>
 #include <optional>
 
 namespace xrpl {

--- a/include/xrpl/protocol/Sign.h
+++ b/include/xrpl/protocol/Sign.h
@@ -16,26 +16,53 @@
 namespace xrpl {
 
 /**
- * The hash prefix that binds a transaction signature to the role that made it:
- * the transaction itself, its counterparty, or its sponsor.
+ * The signature slots on a transaction.
  *
- * @param sigField Field holding the signature: nullptr (or an unseated
- * optional) for the top level signature, otherwise sfCounterpartySignature or
- * sfSponsorSignature.
+ * Each role signs different bytes, so a signature cannot be moved from the
+ * role that made it into another role. See signingPrefix.
+ */
+enum class SignatureRole {
+    /**
+     * The transaction's own signature, in sfTxnSignature or sfSigners.
+     */
+    Transaction,
+    /**
+     * The counterparty's signature, in sfCounterpartySignature.
+     */
+    Counterparty,
+    /**
+     * The sponsor's signature, in sfSponsorSignature.
+     */
+    Sponsor
+};
+
+/**
+ * The field that holds this role's signature.
+ *
+ * @return The signature field, or nullptr for SignatureRole::Transaction,
+ * whose signature lives at the top level of the transaction.
+ */
+[[nodiscard]] SField const*
+signatureField(SignatureRole role);
+
+/**
+ * The role that signs into the given field.
+ *
+ * @return The role, or an unseated optional if the field does not hold a
+ * transaction signature.
+ */
+[[nodiscard]] std::optional<SignatureRole>
+signatureRole(SField const& sigField);
+
+/**
+ * The hash prefix that binds a transaction signature to the role that made it.
+ *
+ * @param role The role making the signature.
  * @param multiSigning Whether the signature is a multi-signature.
  * @param rules The current ledger rules.
  */
 [[nodiscard]] HashPrefix
-signingPrefix(SField const* sigField, bool multiSigning, Rules const& rules);
-
-[[nodiscard]] inline HashPrefix
-signingPrefix(
-    std::optional<std::reference_wrapper<SField const>> sigField,
-    bool multiSigning,
-    Rules const& rules)
-{
-    return signingPrefix(sigField ? &sigField->get() : nullptr, multiSigning, rules);
-}
+signingPrefix(SignatureRole role, bool multiSigning, Rules const& rules);
 
 /**
  * Sign an STObject
@@ -76,15 +103,11 @@ verify(
 /**
  * Return a Serializer suitable for computing a multisigning TxnSignature.
  *
- * @param prefix Prefix to insert before the serialized object. Use
- * signingPrefix to get the prefix for a signature that goes into an
- * alternate field, such as sfSponsorSignature.
+ * @param prefix Prefix to insert before the serialized object. Get it from
+ * signingPrefix, so that the signature is bound to the role making it.
  */
 Serializer
-buildMultiSigningData(
-    STObject const& obj,
-    AccountID const& signingID,
-    HashPrefix prefix = HashPrefix::TxMultiSign);
+buildMultiSigningData(STObject const& obj, AccountID const& signingID, HashPrefix prefix);
 
 /**
  * Break the multi-signing hash computation into 2 parts for optimization.
@@ -100,7 +123,7 @@ buildMultiSigningData(
  *     signer's unique data.
  */
 Serializer
-startMultiSigningData(STObject const& obj, HashPrefix prefix = HashPrefix::TxMultiSign);
+startMultiSigningData(STObject const& obj, HashPrefix prefix);
 
 inline void
 finishMultiSigningData(AccountID const& signingID, Serializer& s)

--- a/include/xrpl/protocol/Sign.h
+++ b/include/xrpl/protocol/Sign.h
@@ -4,12 +4,38 @@
 #include <xrpl/protocol/HashPrefix.h>
 #include <xrpl/protocol/KeyType.h>
 #include <xrpl/protocol/PublicKey.h>
+#include <xrpl/protocol/Rules.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STObject.h>
 #include <xrpl/protocol/SecretKey.h>
 #include <xrpl/protocol/Serializer.h>
 
+#include <functional>
+#include <optional>
+
 namespace xrpl {
+
+/**
+ * The hash prefix that binds a transaction signature to the role that made it:
+ * the transaction itself, its counterparty, or its sponsor.
+ *
+ * @param sigField Field holding the signature: nullptr (or an unseated
+ * optional) for the top level signature, otherwise sfCounterpartySignature or
+ * sfSponsorSignature.
+ * @param multiSigning Whether the signature is a multi-signature.
+ * @param rules The current ledger rules.
+ */
+[[nodiscard]] HashPrefix
+signingPrefix(SField const* sigField, bool multiSigning, Rules const& rules);
+
+[[nodiscard]] inline HashPrefix
+signingPrefix(
+    std::optional<std::reference_wrapper<SField const>> sigField,
+    bool multiSigning,
+    Rules const& rules)
+{
+    return signingPrefix(sigField ? &sigField->get() : nullptr, multiSigning, rules);
+}
 
 /**
  * Sign an STObject
@@ -49,9 +75,16 @@ verify(
 
 /**
  * Return a Serializer suitable for computing a multisigning TxnSignature.
+ *
+ * @param prefix Prefix to insert before the serialized object. Use
+ * signingPrefix to get the prefix for a signature that goes into an
+ * alternate field, such as sfSponsorSignature.
  */
 Serializer
-buildMultiSigningData(STObject const& obj, AccountID const& signingID);
+buildMultiSigningData(
+    STObject const& obj,
+    AccountID const& signingID,
+    HashPrefix prefix = HashPrefix::TxMultiSign);
 
 /**
  * Break the multi-signing hash computation into 2 parts for optimization.
@@ -67,7 +100,7 @@ buildMultiSigningData(STObject const& obj, AccountID const& signingID);
  *     signer's unique data.
  */
 Serializer
-startMultiSigningData(STObject const& obj);
+startMultiSigningData(STObject const& obj, HashPrefix prefix = HashPrefix::TxMultiSign);
 
 inline void
 finishMultiSigningData(AccountID const& signingID, Serializer& s)

--- a/src/libxrpl/protocol/STTx.cpp
+++ b/src/libxrpl/protocol/STTx.cpp
@@ -233,9 +233,13 @@ STTx::sign(
     auto const sig = xrpl::sign(publicKey, secretKey, makeSlice(data));
 
     if (auto const target = signatureField(role))
+    {
         peekFieldObject(*target).setFieldVL(sfTxnSignature, sig);
+    }
     else
+    {
         setFieldVL(sfTxnSignature, sig);
+    }
 
     tid_ = getHash(HashPrefix::TransactionId);
 }

--- a/src/libxrpl/protocol/STTx.cpp
+++ b/src/libxrpl/protocol/STTx.cpp
@@ -256,7 +256,7 @@ STTx::checkSign(Rules const& rules, STObject const& sigObject, SignatureRole rol
         Blob const& signingPubKey = sigObject.getFieldVL(sfSigningPubKey);
         bool const multiSigning = signingPubKey.empty();
         auto const prefix = signingPrefix(role, multiSigning, rules);
-        return multiSigning ? checkMultiSign(rules, sigObject, prefix)
+        return multiSigning ? checkMultiSign(sigObject, prefix)
                             : checkSingleSign(sigObject, prefix);
     }
     catch (...)
@@ -289,14 +289,14 @@ STTx::checkSign(Rules const& rules) const
     // of signature checking.
     if (isFieldPresent(sfBatchSigners))
     {
-        if (auto const ret = checkBatchSign(rules); !ret)
+        if (auto const ret = checkBatchSign(); !ret)
             return ret;
     }
     return {};
 }
 
 std::expected<void, std::string>
-STTx::checkBatchSign(Rules const& rules) const
+STTx::checkBatchSign() const
 {
     try
     {
@@ -330,7 +330,7 @@ STTx::checkBatchSign(Rules const& rules) const
         for (auto const& signer : signers)
         {
             Blob const& signingPubKey = signer.getFieldVL(sfSigningPubKey);
-            auto const result = signingPubKey.empty() ? checkBatchMultiSign(signer, rules, txIds)
+            auto const result = signingPubKey.empty() ? checkBatchMultiSign(signer, txIds)
                                                       : checkBatchSingleSign(signer, txIds);
 
             if (!result)
@@ -479,8 +479,7 @@ std::expected<void, std::string>
 multiSignHelper(
     STObject const& sigObject,
     std::optional<AccountID> txnAccountID,
-    std::function<Serializer(AccountID const&)> makeMsg,
-    Rules const& rules)
+    std::function<Serializer(AccountID const&)> makeMsg)
 {
     // Make sure the MultiSigners are present.  Otherwise they are not
     // attempting multi-signing and we just have a bad SigningPubKey.
@@ -553,10 +552,7 @@ multiSignHelper(
 }
 
 std::expected<void, std::string>
-STTx::checkBatchMultiSign(
-    STObject const& batchSigner,
-    Rules const& rules,
-    std::vector<uint256> const& txIds) const
+STTx::checkBatchMultiSign(STObject const& batchSigner, std::vector<uint256> const& txIds) const
 {
     XRPL_ASSERT(getTxnType() == ttBATCH, "STTx::checkBatchMultiSign : batch transaction");
     // We can ease the computational load inside the loop a bit by
@@ -567,18 +563,15 @@ STTx::checkBatchMultiSign(
     serializeBatch(dataStart, getAccountID(sfAccount), getSeqProxy().value(), getFlags(), txIds);
     dataStart.addBitString(batchSignerAccount);
     return multiSignHelper(
-        batchSigner,
-        batchSignerAccount,
-        [&dataStart](AccountID const& accountID) -> Serializer {
+        batchSigner, batchSignerAccount, [&dataStart](AccountID const& accountID) -> Serializer {
             Serializer s = dataStart;
             finishMultiSigningData(accountID, s);
             return s;
-        },
-        rules);
+        });
 }
 
 std::expected<void, std::string>
-STTx::checkMultiSign(Rules const& rules, STObject const& sigObject, HashPrefix prefix) const
+STTx::checkMultiSign(STObject const& sigObject, HashPrefix prefix) const
 {
     // Used inside the loop in multiSignHelper to enforce that
     // the account owner may not multisign for themselves.
@@ -592,14 +585,11 @@ STTx::checkMultiSign(Rules const& rules, STObject const& sigObject, HashPrefix p
     // with the stuff that stays constant from signature to signature.
     Serializer dataStart = startMultiSigningData(*this, prefix);
     return multiSignHelper(
-        sigObject,
-        txnAccountID,
-        [&dataStart](AccountID const& accountID) -> Serializer {
+        sigObject, txnAccountID, [&dataStart](AccountID const& accountID) -> Serializer {
             Serializer s = dataStart;
             finishMultiSigningData(accountID, s);
             return s;
-        },
-        rules);
+        });
 }
 
 void

--- a/src/libxrpl/protocol/STTx.cpp
+++ b/src/libxrpl/protocol/STTx.cpp
@@ -168,10 +168,10 @@ STTx::getMentionedAccounts() const
 }
 
 static Blob
-getSigningData(STTx const& that)
+getSigningData(STTx const& that, HashPrefix prefix = HashPrefix::TxSign)
 {
     Serializer s;
-    s.add32(HashPrefix::TxSign);
+    s.add32(prefix);
     that.addWithoutSigningFields(s);
     return s.getData();
 }
@@ -216,9 +216,10 @@ void
 STTx::sign(
     PublicKey const& publicKey,
     SecretKey const& secretKey,
-    std::optional<std::reference_wrapper<SField const>> signatureTarget)
+    std::optional<std::reference_wrapper<SField const>> signatureTarget,
+    HashPrefix prefix)
 {
-    auto const data = getSigningData(*this);
+    auto const data = getSigningData(*this, prefix);
 
     auto const sig = xrpl::sign(publicKey, secretKey, makeSlice(data));
 
@@ -235,7 +236,7 @@ STTx::sign(
 }
 
 std::expected<void, std::string>
-STTx::checkSign(Rules const& rules, STObject const& sigObject) const
+STTx::checkSign(Rules const& rules, STObject const& sigObject, SField const* sigField) const
 {
     try
     {
@@ -244,8 +245,10 @@ STTx::checkSign(Rules const& rules, STObject const& sigObject) const
         // multi-signing.  Otherwise we're single-signing.
 
         Blob const& signingPubKey = sigObject.getFieldVL(sfSigningPubKey);
-        return signingPubKey.empty() ? checkMultiSign(rules, sigObject)
-                                     : checkSingleSign(sigObject);
+        bool const multiSigning = signingPubKey.empty();
+        auto const prefix = signingPrefix(sigField, multiSigning, rules);
+        return multiSigning ? checkMultiSign(rules, sigObject, prefix)
+                            : checkSingleSign(sigObject, prefix);
     }
     catch (...)
     {
@@ -256,20 +259,20 @@ STTx::checkSign(Rules const& rules, STObject const& sigObject) const
 std::expected<void, std::string>
 STTx::checkSign(Rules const& rules) const
 {
-    if (auto const ret = checkSign(rules, *this); !ret)
+    if (auto const ret = checkSign(rules, *this, nullptr); !ret)
         return ret;
 
     if (isFieldPresent(sfCounterpartySignature))
     {
         auto const counterSig = getFieldObject(sfCounterpartySignature);
-        if (auto const ret = checkSign(rules, counterSig); !ret)
+        if (auto const ret = checkSign(rules, counterSig, &sfCounterpartySignature); !ret)
             return std::unexpected("Counterparty: " + ret.error());
     }
 
     if (isFieldPresent(sfSponsorSignature))
     {
         auto const sponsorSignatureObj = getFieldObject(sfSponsorSignature);
-        if (auto const ret = checkSign(rules, sponsorSignatureObj); !ret)
+        if (auto const ret = checkSign(rules, sponsorSignatureObj, &sfSponsorSignature); !ret)
             return std::unexpected("Sponsor: " + ret.error());
     }
 
@@ -447,9 +450,9 @@ singleSignHelper(STObject const& sigObject, Slice const& data)
 }
 
 std::expected<void, std::string>
-STTx::checkSingleSign(STObject const& sigObject) const
+STTx::checkSingleSign(STObject const& sigObject, HashPrefix prefix) const
 {
-    auto const data = getSigningData(*this);
+    auto const data = getSigningData(*this, prefix);
     return singleSignHelper(sigObject, makeSlice(data));
 }
 
@@ -566,7 +569,7 @@ STTx::checkBatchMultiSign(
 }
 
 std::expected<void, std::string>
-STTx::checkMultiSign(Rules const& rules, STObject const& sigObject) const
+STTx::checkMultiSign(Rules const& rules, STObject const& sigObject, HashPrefix prefix) const
 {
     // Used inside the loop in multiSignHelper to enforce that
     // the account owner may not multisign for themselves.
@@ -578,7 +581,7 @@ STTx::checkMultiSign(Rules const& rules, STObject const& sigObject) const
     // We can ease the computational load inside the loop a bit by
     // pre-constructing part of the data that we hash.  Fill a Serializer
     // with the stuff that stays constant from signature to signature.
-    Serializer dataStart = startMultiSigningData(*this);
+    Serializer dataStart = startMultiSigningData(*this, prefix);
     return multiSignHelper(
         sigObject,
         txnAccountID,

--- a/src/libxrpl/protocol/STTx.cpp
+++ b/src/libxrpl/protocol/STTx.cpp
@@ -213,30 +213,35 @@ STTx::getSeqProxy() const
 }
 
 void
+STTx::sign(PublicKey const& publicKey, SecretKey const& secretKey)
+{
+    auto const data = getSigningData(*this);
+
+    setFieldVL(sfTxnSignature, xrpl::sign(publicKey, secretKey, makeSlice(data)));
+    tid_ = getHash(HashPrefix::TransactionId);
+}
+
+void
 STTx::sign(
     PublicKey const& publicKey,
     SecretKey const& secretKey,
-    std::optional<std::reference_wrapper<SField const>> signatureTarget,
-    HashPrefix prefix)
+    SignatureRole role,
+    Rules const& rules)
 {
-    auto const data = getSigningData(*this, prefix);
+    auto const data = getSigningData(*this, signingPrefix(role, false, rules));
 
     auto const sig = xrpl::sign(publicKey, secretKey, makeSlice(data));
 
-    if (signatureTarget)
-    {
-        auto& target = peekFieldObject(*signatureTarget);
-        target.setFieldVL(sfTxnSignature, sig);
-    }
+    if (auto const target = signatureField(role))
+        peekFieldObject(*target).setFieldVL(sfTxnSignature, sig);
     else
-    {
         setFieldVL(sfTxnSignature, sig);
-    }
+
     tid_ = getHash(HashPrefix::TransactionId);
 }
 
 std::expected<void, std::string>
-STTx::checkSign(Rules const& rules, STObject const& sigObject, SField const* sigField) const
+STTx::checkSign(Rules const& rules, STObject const& sigObject, SignatureRole role) const
 {
     try
     {
@@ -246,7 +251,7 @@ STTx::checkSign(Rules const& rules, STObject const& sigObject, SField const* sig
 
         Blob const& signingPubKey = sigObject.getFieldVL(sfSigningPubKey);
         bool const multiSigning = signingPubKey.empty();
-        auto const prefix = signingPrefix(sigField, multiSigning, rules);
+        auto const prefix = signingPrefix(role, multiSigning, rules);
         return multiSigning ? checkMultiSign(rules, sigObject, prefix)
                             : checkSingleSign(sigObject, prefix);
     }
@@ -259,20 +264,20 @@ STTx::checkSign(Rules const& rules, STObject const& sigObject, SField const* sig
 std::expected<void, std::string>
 STTx::checkSign(Rules const& rules) const
 {
-    if (auto const ret = checkSign(rules, *this, nullptr); !ret)
+    if (auto const ret = checkSign(rules, *this, SignatureRole::Transaction); !ret)
         return ret;
 
     if (isFieldPresent(sfCounterpartySignature))
     {
         auto const counterSig = getFieldObject(sfCounterpartySignature);
-        if (auto const ret = checkSign(rules, counterSig, &sfCounterpartySignature); !ret)
+        if (auto const ret = checkSign(rules, counterSig, SignatureRole::Counterparty); !ret)
             return std::unexpected("Counterparty: " + ret.error());
     }
 
     if (isFieldPresent(sfSponsorSignature))
     {
         auto const sponsorSignatureObj = getFieldObject(sfSponsorSignature);
-        if (auto const ret = checkSign(rules, sponsorSignatureObj, &sfSponsorSignature); !ret)
+        if (auto const ret = checkSign(rules, sponsorSignatureObj, SignatureRole::Sponsor); !ret)
             return std::unexpected("Sponsor: " + ret.error());
     }
 

--- a/src/libxrpl/protocol/STTx.cpp
+++ b/src/libxrpl/protocol/STTx.cpp
@@ -168,7 +168,7 @@ STTx::getMentionedAccounts() const
 }
 
 static Blob
-getSigningData(STTx const& that, HashPrefix prefix = HashPrefix::TxSign)
+getSigningData(STTx const& that, HashPrefix prefix)
 {
     Serializer s;
     s.add32(prefix);
@@ -215,7 +215,9 @@ STTx::getSeqProxy() const
 void
 STTx::sign(PublicKey const& publicKey, SecretKey const& secretKey)
 {
-    auto const data = getSigningData(*this);
+    // The account's own signature always covers the plain transaction prefix;
+    // see signingPrefix for the role signatures that do not.
+    auto const data = getSigningData(*this, HashPrefix::TxSign);
 
     setFieldVL(sfTxnSignature, xrpl::sign(publicKey, secretKey, makeSlice(data)));
     tid_ = getHash(HashPrefix::TransactionId);

--- a/src/libxrpl/protocol/Sign.cpp
+++ b/src/libxrpl/protocol/Sign.cpp
@@ -1,6 +1,5 @@
 #include <xrpl/protocol/Sign.h>
 
-#include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/HashPrefix.h>
@@ -12,27 +11,59 @@
 #include <xrpl/protocol/SecretKey.h>
 #include <xrpl/protocol/Serializer.h>
 
+#include <optional>
+
 namespace xrpl {
 
+SField const*
+signatureField(SignatureRole role)
+{
+    switch (role)
+    {
+        case SignatureRole::Counterparty:
+            return &sfCounterpartySignature;
+        case SignatureRole::Sponsor:
+            return &sfSponsorSignature;
+        case SignatureRole::Transaction:
+            break;
+    }
+    return nullptr;
+}
+
+std::optional<SignatureRole>
+signatureRole(SField const& sigField)
+{
+    if (sigField == sfCounterpartySignature)
+        return SignatureRole::Counterparty;
+    if (sigField == sfSponsorSignature)
+        return SignatureRole::Sponsor;
+    return std::nullopt;
+}
+
+// Signature validity depends on fixCleanup3_4_0, while checkValidity caches
+// its result by transaction ID alone (see kSfSiggood in tx/apply.cpp, held for
+// 300 seconds). Only a transaction that carries sfCounterpartySignature or
+// sfSponsorSignature is affected, and such a transaction is temDISABLED until
+// featureLendingProtocol or featureSponsor activates (Transactor::preflight1),
+// which must happen after this amendment. If that order ever changes, the
+// cached flags must record which prefixes verified the signature.
 HashPrefix
-signingPrefix(SField const* sigField, bool multiSigning, Rules const& rules)
+signingPrefix(SignatureRole role, bool multiSigning, Rules const& rules)
 {
     // Before fixCleanup3_4_0 every signature on a transaction covered the same
     // bytes, so a signature could be moved from one role to another.
-    if (sigField != nullptr && rules.enabled(fixCleanup3_4_0))
+    if (rules.enabled(fixCleanup3_4_0))
     {
-        if (*sigField == sfCounterpartySignature)
+        switch (role)
         {
-            return multiSigning ? HashPrefix::CounterpartyTxMultiSign
-                                : HashPrefix::CounterpartyTxSign;
+            case SignatureRole::Counterparty:
+                return multiSigning ? HashPrefix::CounterpartyTxMultiSign
+                                    : HashPrefix::CounterpartyTxSign;
+            case SignatureRole::Sponsor:
+                return multiSigning ? HashPrefix::SponsorTxMultiSign : HashPrefix::SponsorTxSign;
+            case SignatureRole::Transaction:
+                break;
         }
-        if (*sigField == sfSponsorSignature)
-            return multiSigning ? HashPrefix::SponsorTxMultiSign : HashPrefix::SponsorTxSign;
-
-        // LCOV_EXCL_START
-        if (*sigField != sfTransaction)
-            UNREACHABLE("xrpl::signingPrefix : unknown signature field");
-        // LCOV_EXCL_STOP
     }
 
     return multiSigning ? HashPrefix::TxMultiSign : HashPrefix::TxSign;

--- a/src/libxrpl/protocol/Sign.cpp
+++ b/src/libxrpl/protocol/Sign.cpp
@@ -5,6 +5,7 @@
 #include <xrpl/protocol/HashPrefix.h>
 #include <xrpl/protocol/KeyType.h>
 #include <xrpl/protocol/PublicKey.h>
+#include <xrpl/protocol/Rules.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STExchange.h>
 #include <xrpl/protocol/STObject.h>

--- a/src/libxrpl/protocol/Sign.cpp
+++ b/src/libxrpl/protocol/Sign.cpp
@@ -1,6 +1,8 @@
 #include <xrpl/protocol/Sign.h>
 
+#include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/HashPrefix.h>
 #include <xrpl/protocol/KeyType.h>
 #include <xrpl/protocol/PublicKey.h>
@@ -11,6 +13,30 @@
 #include <xrpl/protocol/Serializer.h>
 
 namespace xrpl {
+
+HashPrefix
+signingPrefix(SField const* sigField, bool multiSigning, Rules const& rules)
+{
+    // Before fixCleanup3_4_0 every signature on a transaction covered the same
+    // bytes, so a signature could be moved from one role to another.
+    if (sigField != nullptr && rules.enabled(fixCleanup3_4_0))
+    {
+        if (*sigField == sfCounterpartySignature)
+        {
+            return multiSigning ? HashPrefix::CounterpartyTxMultiSign
+                                : HashPrefix::CounterpartyTxSign;
+        }
+        if (*sigField == sfSponsorSignature)
+            return multiSigning ? HashPrefix::SponsorTxMultiSign : HashPrefix::SponsorTxSign;
+
+        // LCOV_EXCL_START
+        if (*sigField != sfTransaction)
+            UNREACHABLE("xrpl::signingPrefix : unknown signature field");
+        // LCOV_EXCL_STOP
+    }
+
+    return multiSigning ? HashPrefix::TxMultiSign : HashPrefix::TxSign;
+}
 
 void
 sign(
@@ -70,18 +96,18 @@ verify(STObject const& st, HashPrefix const& prefix, PublicKey const& pk, SF_VL 
 // So, if we support multiple levels of signing, then we'll need to
 // incorporate the "signing for" accounts into the signing data as well.
 Serializer
-buildMultiSigningData(STObject const& obj, AccountID const& signingID)
+buildMultiSigningData(STObject const& obj, AccountID const& signingID, HashPrefix prefix)
 {
-    Serializer s{startMultiSigningData(obj)};
+    Serializer s{startMultiSigningData(obj, prefix)};
     finishMultiSigningData(signingID, s);
     return s;
 }
 
 Serializer
-startMultiSigningData(STObject const& obj)
+startMultiSigningData(STObject const& obj, HashPrefix prefix)
 {
     Serializer s;
-    s.add32(HashPrefix::TxMultiSign);
+    s.add32(prefix);
     obj.addWithoutSigningFields(s);
     return s;
 }

--- a/src/libxrpl/protocol/Sign.cpp
+++ b/src/libxrpl/protocol/Sign.cpp
@@ -1,5 +1,6 @@
 #include <xrpl/protocol/Sign.h>
 
+#include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/HashPrefix.h>
@@ -21,13 +22,14 @@ signatureField(SignatureRole role)
 {
     switch (role)
     {
+        case SignatureRole::Transaction:
+            return nullptr;
         case SignatureRole::Counterparty:
             return &sfCounterpartySignature;
         case SignatureRole::Sponsor:
             return &sfSponsorSignature;
-        case SignatureRole::Transaction:
-            break;
     }
+    UNREACHABLE("xrpl::signatureField : unknown SignatureRole");
     return nullptr;
 }
 
@@ -41,32 +43,32 @@ signatureRole(SField const& sigField)
     return std::nullopt;
 }
 
-// Signature validity depends on fixCleanup3_4_0, while checkValidity caches
-// its result by transaction ID alone (see kSfSiggood in tx/apply.cpp, held for
-// 300 seconds). Only a transaction that carries sfCounterpartySignature or
-// sfSponsorSignature is affected, and such a transaction is temDISABLED until
-// featureLendingProtocol or featureSponsor activates (Transactor::preflight1),
-// which must happen after this amendment. If that order ever changes, the
-// cached flags must record which prefixes verified the signature.
+// Signature validity depends on fixCleanup3_4_0: a role signature covers
+// different bytes before and after the amendment activates. checkValidity
+// caches its verdict per transaction ID, so it keeps two separate cache slots
+// for role-signature transactions (kSfSiggoodOldPrefix / kSfSigbadOldPrefix in
+// tx/apply.cpp) to keep a pre-fix verdict from being reused in the post-fix
+// era, and vice versa. See the block comment in tx/apply.cpp for the details
+// and the reason both directions matter.
 HashPrefix
 signingPrefix(SignatureRole role, bool multiSigning, Rules const& rules)
 {
     // Before fixCleanup3_4_0 every signature on a transaction covered the same
     // bytes, so a signature could be moved from one role to another.
-    if (rules.enabled(fixCleanup3_4_0))
-    {
-        switch (role)
-        {
-            case SignatureRole::Counterparty:
-                return multiSigning ? HashPrefix::CounterpartyTxMultiSign
-                                    : HashPrefix::CounterpartyTxSign;
-            case SignatureRole::Sponsor:
-                return multiSigning ? HashPrefix::SponsorTxMultiSign : HashPrefix::SponsorTxSign;
-            case SignatureRole::Transaction:
-                break;
-        }
-    }
+    if (!rules.enabled(fixCleanup3_4_0))
+        return multiSigning ? HashPrefix::TxMultiSign : HashPrefix::TxSign;
 
+    switch (role)
+    {
+        case SignatureRole::Transaction:
+            return multiSigning ? HashPrefix::TxMultiSign : HashPrefix::TxSign;
+        case SignatureRole::Counterparty:
+            return multiSigning ? HashPrefix::CounterpartyTxMultiSign
+                                : HashPrefix::CounterpartyTxSign;
+        case SignatureRole::Sponsor:
+            return multiSigning ? HashPrefix::SponsorTxMultiSign : HashPrefix::SponsorTxSign;
+    }
+    UNREACHABLE("xrpl::signingPrefix : unknown SignatureRole");
     return multiSigning ? HashPrefix::TxMultiSign : HashPrefix::TxSign;
 }
 

--- a/src/libxrpl/tx/apply.cpp
+++ b/src/libxrpl/tx/apply.cpp
@@ -8,6 +8,7 @@
 #include <xrpl/core/ServiceRegistry.h>
 #include <xrpl/ledger/ApplyView.h>
 #include <xrpl/ledger/OpenView.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Rules.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STObject.h>
@@ -30,6 +31,31 @@ constexpr HashRouterFlags kSfSiggood = HashRouterFlags::PRIVATE2;    // Signatur
 constexpr HashRouterFlags kSfLocalbad = HashRouterFlags::PRIVATE3;   // Local checks failed
 constexpr HashRouterFlags kSfLocalgood = HashRouterFlags::PRIVATE4;  // Local checks passed
 
+// Before fixCleanup3_4_0, a signature in an alternate role field, such as
+// sfSponsorSignature, covered the same bytes as the top level signature. Which
+// bytes a role signature must cover therefore depends on whether the fix is
+// enabled, but the four flags above record only the verdict, not the rules that
+// produced it. A verdict reached under one prefix would otherwise be reused
+// under the other.
+//
+// The two flags below hold the verdict for the pre-fix prefixes, so the pre-fix
+// and post-fix verdicts occupy separate slots and neither is ever read in the
+// other's era. Nothing is cleared when the amendment activates: setFlags only
+// sets bits, so a stale pre-fix verdict simply stops being read and ages out
+// with the rest of the routing table.
+//
+// This is not one switchover at a single instant. The era is chosen per call
+// from the rules passed in, and callers do not agree on the rules: relay and
+// submit verify against the validated rules, which lag the open ledger rules
+// that preflight2 verifies against. At the amendment's flag ledger the same
+// transaction can therefore be checked under both prefixes, on the same node,
+// at the same time.
+//
+// Remove these two flags, and oldPrefixSig below, when Cleanup3_4_0 is retired
+// in features.macro.
+constexpr HashRouterFlags kSfSigbadOldPrefix = HashRouterFlags::PRIVATE7;
+constexpr HashRouterFlags kSfSiggoodOldPrefix = HashRouterFlags::PRIVATE8;
+
 //------------------------------------------------------------------------------
 
 std::pair<Validity, std::string>
@@ -48,21 +74,41 @@ checkValidity(HashRouter& router, STTx const& tx, Rules const& rules)
         return {Validity::SigBad, "Batch inner transactions are never considered validly signed."};
     }
 
-    if (any(flags & kSfSigbad))
+    // Pick the cache slot for this call's era; see kSfSiggoodOldPrefix above.
+    // Only a transaction that carries a role signature, and only while the fix
+    // is disabled, uses the separate slot. Every other transaction, and every
+    // transaction once the fix is enabled, uses the ordinary flags and verifies
+    // exactly once, so there is no steady state cost.
+    //
+    // Both directions matter. A good verdict from before the fix must not let a
+    // signature moved between roles survive the amendment, and a bad verdict
+    // from before the fix must not condemn a transaction that the new prefixes
+    // accept.
+    //
+    // Whether a transaction carries a role signature is fixed for its ID: the
+    // fields are kNotSigning, so they are excluded from the signed bytes, but
+    // they are still covered by the transaction ID. Repeat calls for one ID
+    // therefore always agree on which slot pair to use.
+    bool const oldPrefixSig = !rules.enabled(fixCleanup3_4_0) &&
+        (tx.isFieldPresent(sfSponsorSignature) || tx.isFieldPresent(sfCounterpartySignature));
+    auto const sigbadFlag = oldPrefixSig ? kSfSigbadOldPrefix : kSfSigbad;
+    auto const siggoodFlag = oldPrefixSig ? kSfSiggoodOldPrefix : kSfSiggood;
+
+    if (any(flags & sigbadFlag))
     {
         // Signature is known bad
         return {Validity::SigBad, "Transaction has bad signature."};
     }
 
-    if (!any(flags & kSfSiggood))
+    if (!any(flags & siggoodFlag))
     {
         auto const sigVerify = tx.checkSign(rules);
         if (!sigVerify)
         {
-            router.setFlags(id, kSfSigbad);
+            router.setFlags(id, sigbadFlag);
             return {Validity::SigBad, sigVerify.error()};
         }
-        router.setFlags(id, kSfSiggood);
+        router.setFlags(id, siggoodFlag);
     }
 
     // Signature is now known good
@@ -94,6 +140,10 @@ checkValidity(HashRouter& router, STTx const& tx, Rules const& rules)
 void
 forceValidity(HashRouter& router, uint256 const& txid, Validity validity)
 {
+    // Callers reach here when they deliberately skip signature verification,
+    // such as a cluster peer that trusts its neighbor's checks. No signature
+    // was verified, so there is no prefix era to record, and this writes the
+    // ordinary flags whether or not fixCleanup3_4_0 is enabled.
     HashRouterFlags flags = HashRouterFlags::UNDEFINED;
     switch (validity)
     {

--- a/src/libxrpl/tx/apply.cpp
+++ b/src/libxrpl/tx/apply.cpp
@@ -24,8 +24,8 @@
 
 namespace xrpl {
 
-// These are the same flags defined as HashRouterFlags::PRIVATE1-4 in
-// HashRouter.h
+// This file owns HashRouterFlags::PRIVATE1-4 and PRIVATE7-8 in HashRouter.h.
+// These are the first four; the other two are below.
 constexpr HashRouterFlags kSfSigbad = HashRouterFlags::PRIVATE1;     // Signature is bad
 constexpr HashRouterFlags kSfSiggood = HashRouterFlags::PRIVATE2;    // Signature is good
 constexpr HashRouterFlags kSfLocalbad = HashRouterFlags::PRIVATE3;   // Local checks failed

--- a/src/libxrpl/tx/apply.cpp
+++ b/src/libxrpl/tx/apply.cpp
@@ -141,9 +141,18 @@ void
 forceValidity(HashRouter& router, uint256 const& txid, Validity validity)
 {
     // Callers reach here when they deliberately skip signature verification,
-    // such as a cluster peer that trusts its neighbor's checks. No signature
-    // was verified, so there is no prefix era to record, and this writes the
-    // ordinary flags whether or not fixCleanup3_4_0 is enabled.
+    // such as a cluster peer that trusts its neighbor's checks, or a
+    // configuration that turns signature checks off. Nothing was verified, so
+    // there is no prefix era to record. Mark both of checkValidity's signature
+    // slots good: otherwise the forced verdict is ignored for a role-signature
+    // transaction until fixCleanup3_4_0 is enabled, and the signature the
+    // caller meant to skip gets verified after all. Marking both cannot leak a
+    // verdict across eras, because no verdict was reached, and this is the only
+    // place the distinction can be recorded: kSfSiggood alone does not say
+    // whether checkValidity verified a post-fix signature or a caller forced
+    // the result. An already cached bad verdict still wins, since checkValidity
+    // tests its bad flag first. Drop kSfSiggoodOldPrefix when Cleanup3_4_0 is
+    // retired.
     HashRouterFlags flags = HashRouterFlags::UNDEFINED;
     switch (validity)
     {
@@ -151,7 +160,7 @@ forceValidity(HashRouter& router, uint256 const& txid, Validity validity)
             flags |= kSfLocalgood;
             [[fallthrough]];
         case Validity::SigGoodOnly:
-            flags |= kSfSiggood;
+            flags |= kSfSiggood | kSfSiggoodOldPrefix;
             [[fallthrough]];
         case Validity::SigBad:
             // would be silly to call directly

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -376,11 +376,11 @@ public:
     }
 
     void
-    testSingleSigning()
+    testSingleSigning(FeatureBitset features)
     {
         testcase("Single signing");
         using namespace test::jtx;
-        Env env{*this, testableAmendments()};
+        Env env{*this, features};
         Account const alice("alice");
         Account const sponsor("sponsor");
         Account const invalid("invalid");
@@ -415,11 +415,11 @@ public:
     }
 
     void
-    testMultiSigning()
+    testMultiSigning(FeatureBitset features)
     {
         testcase("Multi signing");
         using namespace test::jtx;
-        Env env{*this, testableAmendments()};
+        Env env{*this, features};
         Account const alice("alice");
         Account const bob("bob");
         Account const sponsor("sponsor");
@@ -5678,8 +5678,12 @@ protected:
         testInvalidSponsorshipSet();
         testPseudoAccountSponsorship();
 
-        testSingleSigning();
-        testMultiSigning();
+        // The signing prefix of an alternate signature field changes with
+        // fixCleanup3_4_0, so sign and verify under both rule sets.
+        testSingleSigning(jtx::testableAmendments());
+        testSingleSigning(jtx::testableAmendments() - fixCleanup3_4_0);
+        testMultiSigning(jtx::testableAmendments());
+        testMultiSigning(jtx::testableAmendments() - fixCleanup3_4_0);
 
         testInvalidSponsorField();
 

--- a/src/test/app/lending/LoanLifecycle_test.cpp
+++ b/src/test/app/lending/LoanLifecycle_test.cpp
@@ -205,8 +205,14 @@ private:
         if (!BEAST_EXPECT(!createJson.isMember(jss::Signers)))
             counterpartyJson[sfSigners] = createJson[sfSigners];
 
-        // The duplicated signature works
-        createJson = env.json(createJson, Json(sfCounterpartySignature, counterpartyJson));
+        // The duplicated signature does not work: the counterparty signs a
+        // different prefix than the account.
+        env(env.json(createJson, Json(sfCounterpartySignature, counterpartyJson)),
+            Ter(telENV_RPC_FAILED));
+
+        // Signing the counterparty field itself works, even though the lender
+        // is both the borrower and the counterparty.
+        createJson = env.json(createJson, Sig(sfCounterpartySignature, lender));
         env(createJson);
 
         env.close();

--- a/src/test/app/lending/LoanMisc_test.cpp
+++ b/src/test/app/lending/LoanMisc_test.cpp
@@ -113,21 +113,26 @@ private:
             txJson[sfTransactionType] = "AccountSet";
             txJson[sfAccount] = borrower.human();
 
-            auto const borrowerSignParams = [&]() {
-                json::Value params{json::ValueType::Object};
-                params[jss::passphrase] = borrowerPass;
-                params[jss::key_type] = "ed25519";
-                params[jss::signature_target] = "Destination";
-                params[jss::tx_json] = txJson;
-                return params;
-            }();
-            auto const jSignBorrower = env.rpc("json", "sign", to_string(borrowerSignParams));
-            BEAST_EXPECT(
-                jSignBorrower.isMember(jss::result) &&
-                jSignBorrower[jss::result].isMember(jss::error) &&
-                jSignBorrower[jss::result][jss::error] == "invalidParams" &&
-                jSignBorrower[jss::result].isMember(jss::error_message) &&
-                jSignBorrower[jss::result][jss::error_message] == "Destination");
+            // "Destination" is not an inner object at all. "Book" is one, but
+            // it holds no transaction signature, so it is not a target either.
+            for (char const* target : {"Destination", "Book", "Signer"})
+            {
+                auto const borrowerSignParams = [&]() {
+                    json::Value params{json::ValueType::Object};
+                    params[jss::passphrase] = borrowerPass;
+                    params[jss::key_type] = "ed25519";
+                    params[jss::signature_target] = target;
+                    params[jss::tx_json] = txJson;
+                    return params;
+                }();
+                auto const jSignBorrower = env.rpc("json", "sign", to_string(borrowerSignParams));
+                BEAST_EXPECT(
+                    jSignBorrower.isMember(jss::result) &&
+                    jSignBorrower[jss::result].isMember(jss::error) &&
+                    jSignBorrower[jss::result][jss::error] == "invalidParams" &&
+                    jSignBorrower[jss::result].isMember(jss::error_message) &&
+                    jSignBorrower[jss::result][jss::error_message] == target);
+            }
         }
         {
             testcase("RPC LoanSet - sign and submit borrower initiated");

--- a/src/test/app/lending/LoanSecurity_test.cpp
+++ b/src/test/app/lending/LoanSecurity_test.cpp
@@ -1148,9 +1148,9 @@ private:
         }
         else
         {
-            // The lender paid the fee.
+            // The lender paid the fee, and the borrower got the loan.
             BEAST_EXPECT(env.balance(lender) == lenderBalance - feeAmt);
-            BEAST_EXPECT(env.balance(borrower) == borrowerBalance);
+            BEAST_EXPECT(env.balance(borrower).value() > borrowerBalance.value());
         }
     }
 

--- a/src/test/app/lending/LoanSecurity_test.cpp
+++ b/src/test/app/lending/LoanSecurity_test.cpp
@@ -5,6 +5,7 @@
 #include <test/jtx/amount.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/noop.h>
+#include <test/jtx/sponsor.h>
 #include <test/jtx/ter.h>
 #include <test/jtx/txflags.h>
 #include <test/jtx/vault.h>
@@ -1090,9 +1091,74 @@ private:
         }
     }
 
+    // Every signature on a transaction covered the same bytes before
+    // fixCleanup3_4_0, so a signature could be moved from the role that made
+    // it into another role. Here the lender signs a LoanSet as the
+    // counterparty, and the borrower copies that signature into the
+    // SponsorSignature, making the lender pay the fee without the lender ever
+    // agreeing to sponsor it.
+    void
+    testSignatureCopiedBetweenRoles(bool fixEnabled)
+    {
+        testcase(
+            std::string("Counterparty signature copied into the sponsor slot") +
+            (fixEnabled ? "" : " (pre-amendment)"));
+
+        using namespace jtx;
+        using namespace loan;
+
+        Env env(*this, fixEnabled ? all_ : all_ - fixCleanup3_4_0);
+        BEAST_EXPECT(env.enabled(fixCleanup3_4_0) == fixEnabled);
+
+        Account const lender{"lender"};
+        Account const borrower{"borrower"};
+
+        env.fund(XRP(100'000'000), lender, borrower);
+        env.close();
+
+        PrettyAsset const xrpAsset{xrpIssue(), 1'000'000};
+        auto const broker = createVaultAndBroker(env, xrpAsset, lender);
+
+        auto const feeAmt = XRP(1);
+
+        // The lender agrees to the loan by signing the Counterparty slot of a
+        // LoanSet that names the lender as the fee sponsor. The lender signs
+        // nothing else.
+        auto loanSet = env.json(
+            set(borrower, broker.brokerID, broker.asset(Number{1, 3}).value()),
+            sponsor::As(lender, spfSponsorFee),
+            Sig(sfCounterpartySignature, lender),
+            Fee(feeAmt));
+
+        // The borrower copies the lender's signature into the sponsor slot.
+        loanSet[sfSponsorSignature.jsonName] = loanSet[sfCounterpartySignature.jsonName];
+
+        auto const lenderBalance = env.balance(lender);
+        auto const borrowerBalance = env.balance(borrower);
+
+        env(loanSet, Ter(fixEnabled ? TER{telENV_RPC_FAILED} : TER{tesSUCCESS}));
+        env.close();
+
+        if (fixEnabled)
+        {
+            // The copied signature does not verify in the sponsor slot, so
+            // nothing happens at all.
+            BEAST_EXPECT(env.balance(lender) == lenderBalance);
+            BEAST_EXPECT(env.balance(borrower) == borrowerBalance);
+        }
+        else
+        {
+            // The lender paid the fee.
+            BEAST_EXPECT(env.balance(lender) == lenderBalance - feeAmt);
+            BEAST_EXPECT(env.balance(borrower) == borrowerBalance);
+        }
+    }
+
     void
     runAmendmentIndependent()
     {
+        testSignatureCopiedBetweenRoles(true);
+        testSignatureCopiedBetweenRoles(false);
         testRIPD3901();
         testImpairmentPaymentDateUnchanged();
         testImpairmentPaymentDatePreAmendment();

--- a/src/test/app/lending/LoanValidation_test.cpp
+++ b/src/test/app/lending/LoanValidation_test.cpp
@@ -6,7 +6,6 @@
 #include <test/jtx/envconfig.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/flags.h>
-#include <test/jtx/jtx_json.h>
 #include <test/jtx/mpt.h>
 #include <test/jtx/pay.h>
 #include <test/jtx/sponsor.h>

--- a/src/test/app/lending/LoanValidation_test.cpp
+++ b/src/test/app/lending/LoanValidation_test.cpp
@@ -522,15 +522,13 @@ private:
         auto const loanSetFee = Fee(env.current()->fees().base * 2);
         Number const principalRequest{1, 3};
 
-        auto createJson = env.json(set(lender, broker.brokerID, principalRequest), Fee(loanSetFee));
-
-        json::Value counterpartyJson{json::ValueType::Object};
-        counterpartyJson[sfTxnSignature] = createJson[sfTxnSignature];
-        counterpartyJson[sfSigningPubKey] = createJson[sfSigningPubKey];
-        if (!BEAST_EXPECT(!createJson.isMember(jss::Signers)))
-            counterpartyJson[sfSigners] = createJson[sfSigners];
-
-        createJson = env.json(createJson, Json(sfCounterpartySignature, counterpartyJson));
+        // The lender is both the borrower and the counterparty here, but the
+        // two roles sign different bytes, so each signature must be made for
+        // the field it goes into.
+        auto const createJson = env.json(
+            set(lender, broker.brokerID, principalRequest),
+            Sig(sfCounterpartySignature, lender),
+            Fee(loanSetFee));
         env(createJson);
 
         env.close();

--- a/src/test/app/tx/apply_test.cpp
+++ b/src/test/app/tx/apply_test.cpp
@@ -1,10 +1,17 @@
 // Copyright (c) 2020 Dev Null Productions
 
+#include <test/jtx/Account.h>
 #include <test/jtx/Env.h>
+#include <test/jtx/amount.h>
+#include <test/jtx/fee.h>
+#include <test/jtx/noop.h>
+#include <test/jtx/sig.h>
+#include <test/jtx/sponsor.h>
 
 #include <xrpl/basics/Slice.h>
 #include <xrpl/basics/StringUtilities.h>
 #include <xrpl/beast/unit_test/suite.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/Serializer.h>
 #include <xrpl/tx/apply.h>
@@ -22,6 +29,51 @@ public:
     {
         testcase("Require Fully Canonical Signature");
         testFullyCanonicalSigs();
+        testRoleSignatureCacheIsEraSpecific();
+    }
+
+    // A signature verdict reached before fixCleanup3_4_0 must not be honored
+    // after it, because the two eras require the sponsor signature to cover
+    // different bytes. The two calls below use one HashRouter and differ only in
+    // the rules, which is what the flag ledger looks like in practice: relay and
+    // submit verify against the validated rules, which lag the open ledger rules
+    // that preflight2 verifies against, so one transaction gets checked under
+    // both prefixes at the same time.
+    void
+    testRoleSignatureCacheIsEraSpecific()
+    {
+        testcase("Role signature cache is era specific");
+
+        using namespace test::jtx;
+
+        Env preFix{*this, testableAmendments() - fixCleanup3_4_0};
+        Env postFix{*this, testableAmendments()};
+        auto const postFixRules = postFix.current()->rules();
+
+        Account const alice{"alice"};
+        Account const sponsor{"sponsor"};
+        preFix.fund(XRP(10'000), alice, sponsor);
+        preFix.close();
+
+        // Signed while the fix is disabled, so the sponsor signature carries
+        // the old prefix, which is shared with the top level signature.
+        auto const jt = preFix.jt(
+            noop(alice),
+            Fee(XRP(1)),
+            sponsor::As(sponsor, spfSponsorFee),
+            Sig(sfSponsorSignature, sponsor));
+        BEAST_EXPECT(jt.stx);
+        if (!jt.stx)
+            return;
+
+        auto& router = preFix.app().getHashRouter();
+        BEAST_EXPECT(
+            checkValidity(router, *jt.stx, preFix.current()->rules()).first == Validity::Valid);
+
+        // Same router, asked again under the post-fix rules. The verdict above
+        // was reached under the old prefix and must not be reused, or a
+        // signature moved between roles would survive the amendment.
+        BEAST_EXPECT(checkValidity(router, *jt.stx, postFixRules).first == Validity::SigBad);
     }
 
     void

--- a/src/test/app/tx/apply_test.cpp
+++ b/src/test/app/tx/apply_test.cpp
@@ -34,6 +34,46 @@ public:
         testcase("Require Fully Canonical Signature");
         testFullyCanonicalSigs();
         testRoleSignatureCacheIsEraSpecific();
+        testForcedValidityIgnoresPrefixEra();
+    }
+
+    // forceValidity means the caller verified nothing and wants the result
+    // trusted, so it has to hold in both prefix eras. If it marked only the
+    // ordinary slot, a role-signature transaction would still be verified
+    // under pre-fix rules, defeating the cluster path and the configurations
+    // that turn signature checks off.
+    void
+    testForcedValidityIgnoresPrefixEra()
+    {
+        testcase("Forced validity ignores the prefix era");
+
+        using namespace test::jtx;
+
+        Env preFix{*this, testableAmendments() - fixCleanup3_4_0};
+        Env postFix{*this, testableAmendments()};
+        auto const preFixRules = preFix.current()->rules();
+
+        Account const alice{"alice"};
+        Account const sponsor{"sponsor"};
+        postFix.fund(XRP(10'000), alice, sponsor);
+        postFix.close();
+
+        // Signed under the post-fix rules, so this signature does not verify
+        // under the pre-fix prefix. Only the forced verdict can make the check
+        // below pass.
+        auto const jt = postFix.jt(
+            noop(alice),
+            Fee(XRP(1)),
+            sponsor::As(sponsor, spfSponsorFee),
+            Sig(sfSponsorSignature, sponsor));
+        if (!BEAST_EXPECT(jt.stx))
+            return;
+
+        // A router that has never seen this transaction, so the only cached
+        // state is what forceValidity writes.
+        auto& router = preFix.app().getHashRouter();
+        forceValidity(router, jt.stx->getTransactionID(), Validity::SigGoodOnly);
+        BEAST_EXPECT(checkValidity(router, *jt.stx, preFixRules).first != Validity::SigBad);
     }
 
     // A signature verdict reached under one prefix era must not be honored in

--- a/src/test/app/tx/apply_test.cpp
+++ b/src/test/app/tx/apply_test.cpp
@@ -2,6 +2,8 @@
 
 #include <test/jtx/Account.h>
 #include <test/jtx/Env.h>
+#include <test/jtx/JTx.h>
+#include <test/jtx/TestHelpers.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/fee.h>
 #include <test/jtx/noop.h>
@@ -11,7 +13,6 @@
 #include <xrpl/basics/Slice.h>
 #include <xrpl/basics/StringUtilities.h>
 #include <xrpl/beast/unit_test/suite.h>
-#include <xrpl/core/HashRouter.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STTx.h>
@@ -56,53 +57,72 @@ public:
 
         Account const alice{"alice"};
         Account const sponsor{"sponsor"};
-        preFix.fund(XRP(10'000), alice, sponsor);
-        preFix.close();
-        postFix.fund(XRP(10'000), alice, sponsor);
-        postFix.close();
-
-        // Direction 1: a good verdict under the old prefix must not let a
-        // signature moved between roles survive the amendment.
+        Account const counterparty{"counterparty"};
+        for (auto* env : {&preFix, &postFix})
         {
-            auto const jt = preFix.jt(
+            env->fund(XRP(10'000), alice, sponsor, counterparty);
+            env->close();
+        }
+
+        // Both directions for a transaction whose role signature sits in the
+        // field that makeTx signs. makeTx builds the transaction in the Env it
+        // is given, so the role signature carries that era's prefix.
+        auto checkBothDirections = [&](std::function<JTx(test::jtx::Env&)> const& makeTx) {
+            // Direction 1: a good verdict under the old prefix must not let a
+            // signature moved between roles survive the amendment.
+            {
+                auto const jt = makeTx(preFix);
+                if (!BEAST_EXPECT(jt.stx))
+                    return;
+
+                auto& router = preFix.app().getHashRouter();
+                BEAST_EXPECT(checkValidity(router, *jt.stx, preFixRules).first == Validity::Valid);
+
+                // Same router, asked again under the post-fix rules. The Valid
+                // verdict above was reached under the old prefix and must not
+                // be reused, or a signature moved between roles would survive
+                // the amendment.
+                BEAST_EXPECT(
+                    checkValidity(router, *jt.stx, postFixRules).first == Validity::SigBad);
+            }
+
+            // Direction 2: a bad verdict under the old prefix must not condemn
+            // a transaction that the new prefixes accept. A node whose
+            // validated rules still lag the open ledger will run this check
+            // pre-fix first and reject a correctly new-prefix-signed
+            // transaction; the post-fix check must then verify it afresh
+            // instead of reusing the pre-fix verdict.
+            {
+                auto const jt = makeTx(postFix);
+                if (!BEAST_EXPECT(jt.stx))
+                    return;
+
+                auto& router = postFix.app().getHashRouter();
+                BEAST_EXPECT(checkValidity(router, *jt.stx, preFixRules).first == Validity::SigBad);
+                BEAST_EXPECT(checkValidity(router, *jt.stx, postFixRules).first == Validity::Valid);
+            }
+        };
+
+        // sfSponsorSignature, which uses the SPN and SPM prefixes.
+        checkBothDirections([&](Env& env) {
+            return env.jt(
                 noop(alice),
                 Fee(XRP(1)),
                 sponsor::As(sponsor, spfSponsorFee),
                 Sig(sfSponsorSignature, sponsor));
-            BEAST_EXPECT(jt.stx);
-            if (!jt.stx)
-                return;
+        });
 
-            auto& router = preFix.app().getHashRouter();
-            BEAST_EXPECT(checkValidity(router, *jt.stx, preFixRules).first == Validity::Valid);
-
-            // Same router, asked again under the post-fix rules. The Valid
-            // verdict above was reached under the old prefix and must not be
-            // reused, or a signature moved between roles would survive the
-            // amendment.
-            BEAST_EXPECT(checkValidity(router, *jt.stx, postFixRules).first == Validity::SigBad);
-        }
-
-        // Direction 2: a bad verdict under the old prefix must not condemn a
-        // transaction that the new prefixes accept. A node whose validated
-        // rules still lag the open ledger will run this check pre-fix first
-        // and reject a correctly new-prefix-signed transaction; the post-fix
-        // check must then verify it afresh instead of reusing the pre-fix
-        // verdict.
-        {
-            auto const jt = postFix.jt(
-                noop(alice),
+        // sfCounterpartySignature, which uses its own prefixes, CPT and CPM,
+        // and only appears on a LoanSet. The transaction does not have to be
+        // applicable: checkValidity verifies signatures without consulting the
+        // ledger, so a placeholder LoanBrokerID is enough.
+        checkBothDirections([&](Env& env) {
+            return env.jt(
+                loan::set(alice, uint256{1}, Number{1}),
+                loan::kCounterparty(counterparty),
                 Fee(XRP(1)),
-                sponsor::As(sponsor, spfSponsorFee),
-                Sig(sfSponsorSignature, sponsor));
-            BEAST_EXPECT(jt.stx);
-            if (!jt.stx)
-                return;
-
-            auto& router = postFix.app().getHashRouter();
-            BEAST_EXPECT(checkValidity(router, *jt.stx, preFixRules).first == Validity::SigBad);
-            BEAST_EXPECT(checkValidity(router, *jt.stx, postFixRules).first == Validity::Valid);
-        }
+                Sig(sfCounterpartySignature, counterparty));
+        });
     }
 
     void

--- a/src/test/app/tx/apply_test.cpp
+++ b/src/test/app/tx/apply_test.cpp
@@ -11,9 +11,12 @@
 #include <xrpl/basics/Slice.h>
 #include <xrpl/basics/StringUtilities.h>
 #include <xrpl/beast/unit_test/suite.h>
+#include <xrpl/core/HashRouter.h>
 #include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/Serializer.h>
+#include <xrpl/protocol/TxFlags.h>
 #include <xrpl/tx/apply.h>
 
 #include <functional>
@@ -32,13 +35,13 @@ public:
         testRoleSignatureCacheIsEraSpecific();
     }
 
-    // A signature verdict reached before fixCleanup3_4_0 must not be honored
-    // after it, because the two eras require the sponsor signature to cover
-    // different bytes. The two calls below use one HashRouter and differ only in
-    // the rules, which is what the flag ledger looks like in practice: relay and
-    // submit verify against the validated rules, which lag the open ledger rules
-    // that preflight2 verifies against, so one transaction gets checked under
-    // both prefixes at the same time.
+    // A signature verdict reached under one prefix era must not be honored in
+    // the other, because the two eras require the sponsor signature to cover
+    // different bytes. Each direction below uses one HashRouter and differs
+    // only in the rules, which is what the flag ledger looks like in practice:
+    // relay and submit verify against the validated rules, which lag the open
+    // ledger rules that preflight2 verifies against, so one transaction gets
+    // checked under both prefixes at the same time.
     void
     testRoleSignatureCacheIsEraSpecific()
     {
@@ -48,32 +51,58 @@ public:
 
         Env preFix{*this, testableAmendments() - fixCleanup3_4_0};
         Env postFix{*this, testableAmendments()};
+        auto const preFixRules = preFix.current()->rules();
         auto const postFixRules = postFix.current()->rules();
 
         Account const alice{"alice"};
         Account const sponsor{"sponsor"};
         preFix.fund(XRP(10'000), alice, sponsor);
         preFix.close();
+        postFix.fund(XRP(10'000), alice, sponsor);
+        postFix.close();
 
-        // Signed while the fix is disabled, so the sponsor signature carries
-        // the old prefix, which is shared with the top level signature.
-        auto const jt = preFix.jt(
-            noop(alice),
-            Fee(XRP(1)),
-            sponsor::As(sponsor, spfSponsorFee),
-            Sig(sfSponsorSignature, sponsor));
-        BEAST_EXPECT(jt.stx);
-        if (!jt.stx)
-            return;
+        // Direction 1: a good verdict under the old prefix must not let a
+        // signature moved between roles survive the amendment.
+        {
+            auto const jt = preFix.jt(
+                noop(alice),
+                Fee(XRP(1)),
+                sponsor::As(sponsor, spfSponsorFee),
+                Sig(sfSponsorSignature, sponsor));
+            BEAST_EXPECT(jt.stx);
+            if (!jt.stx)
+                return;
 
-        auto& router = preFix.app().getHashRouter();
-        BEAST_EXPECT(
-            checkValidity(router, *jt.stx, preFix.current()->rules()).first == Validity::Valid);
+            auto& router = preFix.app().getHashRouter();
+            BEAST_EXPECT(checkValidity(router, *jt.stx, preFixRules).first == Validity::Valid);
 
-        // Same router, asked again under the post-fix rules. The verdict above
-        // was reached under the old prefix and must not be reused, or a
-        // signature moved between roles would survive the amendment.
-        BEAST_EXPECT(checkValidity(router, *jt.stx, postFixRules).first == Validity::SigBad);
+            // Same router, asked again under the post-fix rules. The Valid
+            // verdict above was reached under the old prefix and must not be
+            // reused, or a signature moved between roles would survive the
+            // amendment.
+            BEAST_EXPECT(checkValidity(router, *jt.stx, postFixRules).first == Validity::SigBad);
+        }
+
+        // Direction 2: a bad verdict under the old prefix must not condemn a
+        // transaction that the new prefixes accept. A node whose validated
+        // rules still lag the open ledger will run this check pre-fix first
+        // and reject a correctly new-prefix-signed transaction; the post-fix
+        // check must then verify it afresh instead of reusing the pre-fix
+        // verdict.
+        {
+            auto const jt = postFix.jt(
+                noop(alice),
+                Fee(XRP(1)),
+                sponsor::As(sponsor, spfSponsorFee),
+                Sig(sfSponsorSignature, sponsor));
+            BEAST_EXPECT(jt.stx);
+            if (!jt.stx)
+                return;
+
+            auto& router = postFix.app().getHashRouter();
+            BEAST_EXPECT(checkValidity(router, *jt.stx, preFixRules).first == Validity::SigBad);
+            BEAST_EXPECT(checkValidity(router, *jt.stx, postFixRules).first == Validity::Valid);
+        }
     }
 
     void

--- a/src/test/jtx/impl/multisign.cpp
+++ b/src/test/jtx/impl/multisign.cpp
@@ -64,7 +64,8 @@ Msig::operator()(Env& env, JTx& jt) const
 {
     auto const mySigners = signers;
     auto callback = [subField = subField, mySigners, &env](Env&, JTx& jtx) {
-        auto const prefix = signingPrefix(subField, true, env.current()->rules());
+        auto const prefix =
+            signingPrefix(jtx::signatureRole(subField), true, env.current()->rules());
         // Where to put the signature. Supports sfCounterPartySignature and
         // sfSponsorSignature.
         auto& sigObject = subField ? jtx[*subField] : jtx.jv;

--- a/src/test/jtx/impl/multisign.cpp
+++ b/src/test/jtx/impl/multisign.cpp
@@ -64,6 +64,7 @@ Msig::operator()(Env& env, JTx& jt) const
 {
     auto const mySigners = signers;
     auto callback = [subField = subField, mySigners, &env](Env&, JTx& jtx) {
+        auto const prefix = signingPrefix(subField, true, env.current()->rules());
         // Where to put the signature. Supports sfCounterPartySignature and
         // sfSponsorSignature.
         auto& sigObject = subField ? jtx[*subField] : jtx.jv;
@@ -95,7 +96,7 @@ Msig::operator()(Env& env, JTx& jt) const
             jo[jss::Account] = e.acct.human();
             jo[jss::SigningPubKey] = strHex(e.sig.pk().slice());
 
-            Serializer const ss{buildMultiSigningData(*st, e.acct.id())};
+            Serializer const ss{buildMultiSigningData(*st, e.acct.id(), prefix)};
             auto const sig = xrpl::sign(*publicKeyType(e.sig.pk().slice()), e.sig.sk(), ss.slice());
             jo[sfTxnSignature.getJsonName()] = strHex(Slice{sig.data(), sig.size()});
         }

--- a/src/test/jtx/impl/multisign.cpp
+++ b/src/test/jtx/impl/multisign.cpp
@@ -60,10 +60,10 @@ signers(Account const& account, NoneT)
 //------------------------------------------------------------------------------
 
 void
-Msig::operator()(Env& env, JTx& jt) const
+Msig::operator()(Env&, JTx& jt) const
 {
     auto const mySigners = signers;
-    auto callback = [subField = subField, mySigners, &env](Env&, JTx& jtx) {
+    auto callback = [subField = subField, mySigners](Env& env, JTx& jtx) {
         auto const prefix =
             signingPrefix(jtx::signatureRole(subField), true, env.current()->rules());
         // Where to put the signature. Supports sfCounterPartySignature and

--- a/src/test/jtx/impl/sig.cpp
+++ b/src/test/jtx/impl/sig.cpp
@@ -25,7 +25,10 @@ Sig::operator()(Env&, JTx& jt) const
             auto& sigObject = subField ? jtx[*subField] : jtx.jv;
 
             jtx::sign(
-                jtx.jv, account, sigObject, signingPrefix(subField, false, env.current()->rules()));
+                jtx.jv,
+                account,
+                sigObject,
+                signingPrefix(jtx::signatureRole(subField), false, env.current()->rules()));
         };
         if (subField_ == nullptr)
         {

--- a/src/test/jtx/impl/sig.cpp
+++ b/src/test/jtx/impl/sig.cpp
@@ -4,6 +4,9 @@
 #include <test/jtx/JTx.h>
 #include <test/jtx/utility.h>
 
+#include <xrpl/protocol/SField.h>
+#include <xrpl/protocol/Sign.h>
+
 namespace xrpl::test::jtx {
 
 void
@@ -17,11 +20,12 @@ Sig::operator()(Env&, JTx& jt) const
     {
         // VFALCO Inefficient pre-C++14
         auto const account = *account_;
-        auto callback = [subField = subField_, account](Env&, JTx& jtx) {
+        auto callback = [subField = subField_, account](Env& env, JTx& jtx) {
             // Where to put the signature. Supports sfCounterPartySignature and sfSponsorSignature.
             auto& sigObject = subField ? jtx[*subField] : jtx.jv;
 
-            jtx::sign(jtx.jv, account, sigObject);
+            jtx::sign(
+                jtx.jv, account, sigObject, signingPrefix(subField, false, env.current()->rules()));
         };
         if (subField_ == nullptr)
         {

--- a/src/test/jtx/impl/sig.cpp
+++ b/src/test/jtx/impl/sig.cpp
@@ -4,7 +4,6 @@
 #include <test/jtx/JTx.h>
 #include <test/jtx/utility.h>
 
-#include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/Sign.h>
 
 namespace xrpl::test::jtx {

--- a/src/test/jtx/impl/utility.cpp
+++ b/src/test/jtx/impl/utility.cpp
@@ -37,11 +37,11 @@ parse(json::Value const& jv)
 }
 
 void
-sign(json::Value& jv, Account const& account, json::Value& sigObject)
+sign(json::Value& jv, Account const& account, json::Value& sigObject, HashPrefix prefix)
 {
     sigObject[jss::SigningPubKey] = strHex(account.pk().slice());
     Serializer ss;
-    ss.add32(HashPrefix::TxSign);
+    ss.add32(prefix);
     parse(jv).addWithoutSigningFields(ss);
     auto const sig = xrpl::sign(account.pk(), account.sk(), ss.slice());
     sigObject[jss::TxnSignature] = strHex(Slice{sig.data(), sig.size()});

--- a/src/test/jtx/impl/utility.cpp
+++ b/src/test/jtx/impl/utility.cpp
@@ -19,9 +19,11 @@
 #include <xrpl/protocol/STParsedJSON.h>
 #include <xrpl/protocol/SecretKey.h>
 #include <xrpl/protocol/Serializer.h>
+#include <xrpl/protocol/Sign.h>
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/protocol/jss.h>
 
+#include <stdexcept>
 #include <utility>
 #include <vector>
 

--- a/src/test/jtx/impl/utility.cpp
+++ b/src/test/jtx/impl/utility.cpp
@@ -36,6 +36,16 @@ parse(json::Value const& jv)
     return std::move(*p.object);
 }
 
+SignatureRole
+signatureRole(SField const* subField)
+{
+    if (subField == nullptr)
+        return SignatureRole::Transaction;
+    if (auto const role = xrpl::signatureRole(*subField))
+        return *role;
+    Throw<std::runtime_error>(subField->getName() + " does not hold a transaction signature.");
+}
+
 void
 sign(json::Value& jv, Account const& account, json::Value& sigObject, HashPrefix prefix)
 {

--- a/src/test/jtx/utility.h
+++ b/src/test/jtx/utility.h
@@ -5,6 +5,7 @@
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/ledger/ReadView.h>
+#include <xrpl/protocol/HashPrefix.h>
 #include <xrpl/protocol/STObject.h>
 
 #include <stdexcept>
@@ -35,10 +36,17 @@ parse(json::Value const& jv);
 
 /**
  * Sign automatically into a specific Json field of the jv object.
+ * @param prefix Prefix to insert before the serialized transaction when
+ * hashing. Use signingPrefix to get the prefix that matches the field that
+ * holds sigObject.
  * @note This only works on accounts with multi-signing off.
  */
 void
-sign(json::Value& jv, Account const& account, json::Value& sigObject);
+sign(
+    json::Value& jv,
+    Account const& account,
+    json::Value& sigObject,
+    HashPrefix prefix = HashPrefix::TxSign);
 
 /**
  * Sign automatically.

--- a/src/test/jtx/utility.h
+++ b/src/test/jtx/utility.h
@@ -6,7 +6,9 @@
 #include <xrpl/json/json_value.h>
 #include <xrpl/ledger/ReadView.h>
 #include <xrpl/protocol/HashPrefix.h>
+#include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STObject.h>
+#include <xrpl/protocol/Sign.h>
 
 #include <stdexcept>
 #include <string>
@@ -35,7 +37,17 @@ STObject
 parse(json::Value const& jv);
 
 /**
+ * The role that signs into an optional signature subfield.
+ *
+ * @param subField The signature field, or nullptr for the transaction's own
+ * signature. Throws if the field does not hold a transaction signature.
+ */
+SignatureRole
+signatureRole(SField const* subField);
+
+/**
  * Sign automatically into a specific Json field of the jv object.
+ *
  * @param prefix Prefix to insert before the serialized transaction when
  * hashing. Use signingPrefix to get the prefix that matches the field that
  * holds sigObject.

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -20,6 +20,7 @@
 #include <xrpl/protocol/STParsedJSON.h>
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/SecretKey.h>
+#include <xrpl/protocol/Seed.h>
 #include <xrpl/protocol/Serializer.h>
 #include <xrpl/protocol/Sign.h>
 #include <xrpl/protocol/TxFormats.h>
@@ -29,6 +30,7 @@
 #include <cstdint>
 #include <cstring>
 #include <exception>
+#include <functional>
 #include <memory>
 #include <ostream>
 #include <regex>
@@ -69,7 +71,7 @@ public:
     // outlive the Rules; both are returned together.
     struct RulesFixture
     {
-        std::unordered_set<uint256, beast::Uhash<>> const noPresets{};
+        std::unordered_set<uint256, beast::Uhash<>> const noPresets;
         std::unordered_set<uint256, beast::Uhash<>> const fixPresets{fixCleanup3_4_0};
         Rules const legacy{noPresets};
         Rules const fixed{fixPresets};
@@ -214,6 +216,7 @@ public:
             sigObject.setFieldVL(sfSigningPubKey, keypair.first.slice());
             sigObject.setFieldVL(sfTxnSignature, tx.getSignature());
 
+            // NOLINTNEXTLINE(cppcoreguidelines-slicing)
             STObject copy{tx};
             copy.setFieldObject(sigField, sigObject);
             return STTx{std::move(copy)};

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -1,9 +1,13 @@
+#include <xrpl/basics/Number.h>
 #include <xrpl/basics/Slice.h>
 #include <xrpl/basics/base_uint.h>
+#include <xrpl/basics/safe_cast.h>
+#include <xrpl/basics/strHex.h>
 #include <xrpl/beast/hash/uhash.h>
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/json/to_string.h>  // IWYU pragma: keep
 #include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/HashPrefix.h>
 #include <xrpl/protocol/KeyType.h>
 #include <xrpl/protocol/PublicKey.h>
 #include <xrpl/protocol/Rules.h>
@@ -11,6 +15,7 @@
 #include <xrpl/protocol/SOTemplate.h>
 #include <xrpl/protocol/STAmount.h>
 #include <xrpl/protocol/STArray.h>
+#include <xrpl/protocol/STNumber.h>
 #include <xrpl/protocol/STObject.h>
 #include <xrpl/protocol/STParsedJSON.h>
 #include <xrpl/protocol/STTx.h>
@@ -55,6 +60,164 @@ public:
         testSTTx(KeyType::Ed25519);
         testObjectCtorErrors();
         testBatchInnerCtorErrors();
+        testSigningPrefixes();
+        testRoleSignatureBinding();
+    }
+
+    // Rules with no amendments enabled, and rules with only fixCleanup3_4_0
+    // enabled. Rules keep a reference to the presets, so the presets must
+    // outlive the Rules; both are returned together.
+    struct RulesFixture
+    {
+        std::unordered_set<uint256, beast::Uhash<>> const noPresets{};
+        std::unordered_set<uint256, beast::Uhash<>> const fixPresets{fixCleanup3_4_0};
+        Rules const legacy{noPresets};
+        Rules const fixed{fixPresets};
+    };
+
+    // A transaction with fixed contents, so its signing data is stable from
+    // run to run.
+    static STTx
+    makeFixedTx()
+    {
+        auto const keypair = generateKeyPair(KeyType::Secp256k1, generateSeed("masterpassphrase"));
+        return STTx(ttACCOUNT_SET, [&keypair](auto& obj) {
+            obj.setAccountID(sfAccount, calcAccountID(keypair.first));
+            obj.setFieldAmount(sfFee, STAmount(10ull));
+            obj.setFieldU32(sfSequence, 1);
+            obj.setFieldVL(sfSigningPubKey, keypair.first.slice());
+        });
+    }
+
+    void
+    testSigningPrefixes()
+    {
+        testcase("signing prefixes");
+
+        // The prefixes are protocol constants. Spell them out so that a typo
+        // in a prefix character fails here, and not in a downstream library.
+        BEAST_EXPECT(safeCast<std::uint32_t>(HashPrefix::TxSign) == 0x53545800);
+        BEAST_EXPECT(safeCast<std::uint32_t>(HashPrefix::TxMultiSign) == 0x534D5400);
+        BEAST_EXPECT(safeCast<std::uint32_t>(HashPrefix::CounterpartyTxSign) == 0x43505400);
+        BEAST_EXPECT(safeCast<std::uint32_t>(HashPrefix::CounterpartyTxMultiSign) == 0x43504D00);
+        BEAST_EXPECT(safeCast<std::uint32_t>(HashPrefix::SponsorTxSign) == 0x53504E00);
+        BEAST_EXPECT(safeCast<std::uint32_t>(HashPrefix::SponsorTxMultiSign) == 0x53504D00);
+
+        RulesFixture const r;
+
+        // Every role gets its own prefix once the fix is enabled.
+        BEAST_EXPECT(signingPrefix(nullptr, false, r.fixed) == HashPrefix::TxSign);
+        BEAST_EXPECT(signingPrefix(nullptr, true, r.fixed) == HashPrefix::TxMultiSign);
+        BEAST_EXPECT(
+            signingPrefix(&sfCounterpartySignature, false, r.fixed) ==
+            HashPrefix::CounterpartyTxSign);
+        BEAST_EXPECT(
+            signingPrefix(&sfCounterpartySignature, true, r.fixed) ==
+            HashPrefix::CounterpartyTxMultiSign);
+        BEAST_EXPECT(
+            signingPrefix(&sfSponsorSignature, false, r.fixed) == HashPrefix::SponsorTxSign);
+        BEAST_EXPECT(
+            signingPrefix(&sfSponsorSignature, true, r.fixed) == HashPrefix::SponsorTxMultiSign);
+
+        // Before the fix, every role signs the same bytes.
+        for (SField const* sigField :
+             {static_cast<SField const*>(nullptr), &sfCounterpartySignature, &sfSponsorSignature})
+        {
+            BEAST_EXPECT(signingPrefix(sigField, false, r.legacy) == HashPrefix::TxSign);
+            BEAST_EXPECT(signingPrefix(sigField, true, r.legacy) == HashPrefix::TxMultiSign);
+        }
+
+        // The bytes signed by an ordinary transaction must not move. Both the
+        // single- and the multi-signing data are pinned, and neither depends
+        // on the amendment.
+        auto const tx = makeFixedTx();
+        for (Rules const& rules : {r.legacy, r.fixed})
+        {
+            Serializer single;
+            single.add32(signingPrefix(nullptr, false, rules));
+            tx.addWithoutSigningFields(single);
+            BEAST_EXPECT(
+                strHex(single.peekData()) ==
+                "53545800120003220000000024000000016840000000000000"
+                "0A7321ED5F5AC8B98974A3CA843326D9B88CEBD0560177B456"
+                "1E0C6DF7A3A66D1E1D0C4B81145E7B112523F68D2F5E879DB4"
+                "EAC51C6698A69304");
+            BEAST_EXPECT(
+                to_string(single.getSHA512Half()) ==
+                "8D18B0BFCEFCB18AA5D2A21E14A34A1E3DAA0EE79C69AAB88C64B4B4C3AA9E3E");
+
+            auto const signer = calcAccountID(
+                generateKeyPair(KeyType::Secp256k1, generateSeed("multisigner")).first);
+            Serializer const multi =
+                buildMultiSigningData(tx, signer, signingPrefix(nullptr, true, rules));
+
+            // The multi-signing data is the single-signing data with a
+            // different prefix and the signer's account appended.
+            Serializer expected;
+            expected.add32(HashPrefix::TxMultiSign);
+            tx.addWithoutSigningFields(expected);
+            expected.addBitString(signer);
+            BEAST_EXPECT(strHex(multi.peekData()) == strHex(expected.peekData()));
+        }
+    }
+
+    void
+    testRoleSignatureBinding()
+    {
+        testcase("role signature binding");
+
+        RulesFixture const r;
+
+        auto const keypair = generateKeyPair(KeyType::Secp256k1, generateSeed("masterpassphrase"));
+        auto const account = calcAccountID(keypair.first);
+
+        // A transaction signed by its own account, with that signature copied
+        // into an alternate signature field. sfSponsorSignature is a common
+        // field; sfCounterpartySignature is only on a LoanSet.
+        auto makeCopiedSig = [&keypair, &account](SField const& sigField) {
+            bool const counterparty = sigField == sfCounterpartySignature;
+            STTx tx(counterparty ? ttLOAN_SET : ttACCOUNT_SET, [&](auto& obj) {
+                obj.setAccountID(sfAccount, account);
+                obj.setFieldAmount(sfFee, STAmount(10ull));
+                obj.setFieldU32(sfSequence, 1);
+                obj.setFieldVL(sfSigningPubKey, keypair.first.slice());
+                if (counterparty)
+                {
+                    obj.setFieldH256(sfLoanBrokerID, uint256{1});
+                    obj.setFieldNumber(
+                        sfPrincipalRequested, STNumber{sfPrincipalRequested, Number{1}});
+                }
+                else
+                {
+                    obj.setAccountID(sfSponsor, account);
+                    obj.setFieldU32(sfSponsorFlags, 0);
+                }
+            });
+            tx.sign(keypair.first, keypair.second);
+
+            STObject sigObject(sigField);
+            sigObject.setFieldVL(sfSigningPubKey, keypair.first.slice());
+            sigObject.setFieldVL(sfTxnSignature, tx.getSignature());
+
+            STObject copy{tx};
+            copy.setFieldObject(sigField, sigObject);
+            return STTx{std::move(copy)};
+        };
+
+        for (SField const& sigField :
+             {std::cref(sfCounterpartySignature), std::cref(sfSponsorSignature)})
+        {
+            auto const tx = makeCopiedSig(sigField);
+
+            // Before the fix, the copied signature verifies in the other role.
+            BEAST_EXPECT(tx.checkSign(r.legacy));
+
+            // With the fix, it does not.
+            auto const ret = tx.checkSign(r.fixed);
+            BEAST_EXPECT(!ret);
+            if (!ret)
+                BEAST_EXPECT(matches(ret.error().c_str(), "Invalid signature"));
+        }
     }
 
     void

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -136,15 +136,19 @@ public:
             Serializer single;
             single.add32(signingPrefix(nullptr, false, rules));
             tx.addWithoutSigningFields(single);
+            // 53545800 STX prefix, 120003 AccountSet, 2400000001 Sequence,
+            // 68400000000000000A Fee, 7321... SigningPubKey, 8114... Account.
             BEAST_EXPECT(
                 strHex(single.peekData()) ==
-                "53545800120003220000000024000000016840000000000000"
-                "0A7321ED5F5AC8B98974A3CA843326D9B88CEBD0560177B456"
-                "1E0C6DF7A3A66D1E1D0C4B81145E7B112523F68D2F5E879DB4"
-                "EAC51C6698A69304");
+                "53545800"
+                "120003"
+                "2400000001"
+                "68400000000000000A"
+                "73210330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020"
+                "8114B5F762798A53D543A014CAF8B297CFF8F2F937E8");
             BEAST_EXPECT(
                 to_string(single.getSHA512Half()) ==
-                "8D18B0BFCEFCB18AA5D2A21E14A34A1E3DAA0EE79C69AAB88C64B4B4C3AA9E3E");
+                "AB7473EA8D05527A7465229447B0E9B05365C72B87E921762AD30742B253F3E6");
 
             auto const signer = calcAccountID(
                 generateKeyPair(KeyType::Secp256k1, generateSeed("multisigner")).first);

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -96,36 +96,47 @@ public:
 
         // The prefixes are protocol constants. Spell them out so that a typo
         // in a prefix character fails here, and not in a downstream library.
-        BEAST_EXPECT(safeCast<std::uint32_t>(HashPrefix::TxSign) == 0x53545800);
-        BEAST_EXPECT(safeCast<std::uint32_t>(HashPrefix::TxMultiSign) == 0x534D5400);
-        BEAST_EXPECT(safeCast<std::uint32_t>(HashPrefix::CounterpartyTxSign) == 0x43505400);
-        BEAST_EXPECT(safeCast<std::uint32_t>(HashPrefix::CounterpartyTxMultiSign) == 0x43504D00);
-        BEAST_EXPECT(safeCast<std::uint32_t>(HashPrefix::SponsorTxSign) == 0x53504E00);
-        BEAST_EXPECT(safeCast<std::uint32_t>(HashPrefix::SponsorTxMultiSign) == 0x53504D00);
+        static_assert(safeCast<std::uint32_t>(HashPrefix::TxSign) == 0x53545800);
+        static_assert(safeCast<std::uint32_t>(HashPrefix::TxMultiSign) == 0x534D5400);
+        static_assert(safeCast<std::uint32_t>(HashPrefix::CounterpartyTxSign) == 0x43505400);
+        static_assert(safeCast<std::uint32_t>(HashPrefix::CounterpartyTxMultiSign) == 0x43504D00);
+        static_assert(safeCast<std::uint32_t>(HashPrefix::SponsorTxSign) == 0x53504E00);
+        static_assert(safeCast<std::uint32_t>(HashPrefix::SponsorTxMultiSign) == 0x53504D00);
 
         RulesFixture const r;
 
         // Every role gets its own prefix once the fix is enabled.
-        BEAST_EXPECT(signingPrefix(nullptr, false, r.fixed) == HashPrefix::TxSign);
-        BEAST_EXPECT(signingPrefix(nullptr, true, r.fixed) == HashPrefix::TxMultiSign);
         BEAST_EXPECT(
-            signingPrefix(&sfCounterpartySignature, false, r.fixed) ==
+            signingPrefix(SignatureRole::Transaction, false, r.fixed) == HashPrefix::TxSign);
+        BEAST_EXPECT(
+            signingPrefix(SignatureRole::Transaction, true, r.fixed) == HashPrefix::TxMultiSign);
+        BEAST_EXPECT(
+            signingPrefix(SignatureRole::Counterparty, false, r.fixed) ==
             HashPrefix::CounterpartyTxSign);
         BEAST_EXPECT(
-            signingPrefix(&sfCounterpartySignature, true, r.fixed) ==
+            signingPrefix(SignatureRole::Counterparty, true, r.fixed) ==
             HashPrefix::CounterpartyTxMultiSign);
         BEAST_EXPECT(
-            signingPrefix(&sfSponsorSignature, false, r.fixed) == HashPrefix::SponsorTxSign);
+            signingPrefix(SignatureRole::Sponsor, false, r.fixed) == HashPrefix::SponsorTxSign);
         BEAST_EXPECT(
-            signingPrefix(&sfSponsorSignature, true, r.fixed) == HashPrefix::SponsorTxMultiSign);
+            signingPrefix(SignatureRole::Sponsor, true, r.fixed) == HashPrefix::SponsorTxMultiSign);
 
         // Before the fix, every role signs the same bytes.
-        for (SField const* sigField :
-             {static_cast<SField const*>(nullptr), &sfCounterpartySignature, &sfSponsorSignature})
+        for (auto const role :
+             {SignatureRole::Transaction, SignatureRole::Counterparty, SignatureRole::Sponsor})
         {
-            BEAST_EXPECT(signingPrefix(sigField, false, r.legacy) == HashPrefix::TxSign);
-            BEAST_EXPECT(signingPrefix(sigField, true, r.legacy) == HashPrefix::TxMultiSign);
+            BEAST_EXPECT(signingPrefix(role, false, r.legacy) == HashPrefix::TxSign);
+            BEAST_EXPECT(signingPrefix(role, true, r.legacy) == HashPrefix::TxMultiSign);
         }
+
+        // Each role's field, and each signature field's role, agree.
+        BEAST_EXPECT(signatureField(SignatureRole::Transaction) == nullptr);
+        BEAST_EXPECT(*signatureField(SignatureRole::Counterparty) == sfCounterpartySignature);
+        BEAST_EXPECT(*signatureField(SignatureRole::Sponsor) == sfSponsorSignature);
+        BEAST_EXPECT(signatureRole(sfCounterpartySignature) == SignatureRole::Counterparty);
+        BEAST_EXPECT(signatureRole(sfSponsorSignature) == SignatureRole::Sponsor);
+        BEAST_EXPECT(!signatureRole(sfBook));
+        BEAST_EXPECT(!signatureRole(sfSigner));
 
         // The bytes signed by an ordinary transaction must not move. Both the
         // single- and the multi-signing data are pinned, and neither depends
@@ -134,7 +145,7 @@ public:
         for (Rules const& rules : {r.legacy, r.fixed})
         {
             Serializer single;
-            single.add32(signingPrefix(nullptr, false, rules));
+            single.add32(signingPrefix(SignatureRole::Transaction, false, rules));
             tx.addWithoutSigningFields(single);
             // 53545800 STX prefix, 120003 AccountSet, 2400000001 Sequence,
             // 68400000000000000A Fee, 7321... SigningPubKey, 8114... Account.
@@ -152,8 +163,8 @@ public:
 
             auto const signer = calcAccountID(
                 generateKeyPair(KeyType::Secp256k1, generateSeed("multisigner")).first);
-            Serializer const multi =
-                buildMultiSigningData(tx, signer, signingPrefix(nullptr, true, rules));
+            Serializer const multi = buildMultiSigningData(
+                tx, signer, signingPrefix(SignatureRole::Transaction, true, rules));
 
             // The multi-signing data is the single-signing data with a
             // different prefix and the signer's account appended.
@@ -1722,7 +1733,7 @@ public:
         auto const id2 = calcAccountID(kp2.first);
 
         // Get the stream of the transaction for use in multi-signing.
-        Serializer const s = buildMultiSigningData(txn, id2);
+        Serializer const s = buildMultiSigningData(txn, id2, HashPrefix::TxMultiSign);
 
         auto const saMultiSignature = sign(kp2.first, kp2.second, s.slice());
 

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -64,6 +64,7 @@ public:
         testBatchInnerCtorErrors();
         testSigningPrefixes();
         testRoleSignatureBinding();
+        testRoleMultiSignatureBinding();
     }
 
     // Rules with no amendments enabled, and rules with only fixCleanup3_4_0
@@ -230,11 +231,109 @@ public:
             // Before the fix, the copied signature verifies in the other role.
             BEAST_EXPECT(tx.checkSign(r.legacy));
 
-            // With the fix, it does not.
+            // With the fix, it does not, and the error names the role that
+            // failed so the two role checks cannot be confused.
             auto const ret = tx.checkSign(r.fixed);
             BEAST_EXPECT(!ret);
             if (!ret)
+            {
+                char const* const rolePrefix =
+                    sigField == sfCounterpartySignature ? "Counterparty: " : "Sponsor: ";
+                BEAST_EXPECT(ret.error().starts_with(rolePrefix));
                 BEAST_EXPECT(matches(ret.error().c_str(), "Invalid signature"));
+            }
+        }
+    }
+
+    // Multi-sign analogue of testRoleSignatureBinding. Both the top-level
+    // Signers array and a role slot's Signers array carry the same signer
+    // entry, signed under HashPrefix::TxMultiSign. Before the fix every role
+    // uses that same prefix, so the copied entry verifies in the role slot;
+    // after the fix the role slot verifies against CounterpartyTxMultiSign
+    // (CPM) or SponsorTxMultiSign (SPM) and the entry no longer matches.
+    void
+    testRoleMultiSignatureBinding()
+    {
+        testcase("role multi-signature binding");
+
+        RulesFixture const r;
+
+        auto const acctKp = generateKeyPair(KeyType::Secp256k1, generateSeed("masterpassphrase"));
+        auto const account = calcAccountID(acctKp.first);
+        // The signer must differ from the top-level account so that the
+        // multiSignHelper "account owner may not multisign for themselves"
+        // check passes for the top-level Signers array.
+        auto const signerKp = generateKeyPair(KeyType::Secp256k1, generateSeed("multisigner"));
+        auto const signerId = calcAccountID(signerKp.first);
+
+        auto makeCopiedMultiSig = [&](SField const& sigField) {
+            bool const counterparty = sigField == sfCounterpartySignature;
+            STTx const tx(counterparty ? ttLOAN_SET : ttACCOUNT_SET, [&](auto& obj) {
+                obj.setAccountID(sfAccount, account);
+                obj.setFieldAmount(sfFee, STAmount(10ull));
+                obj.setFieldU32(sfSequence, 1);
+                // Empty SigningPubKey selects the multi-sign path.
+                obj.setFieldVL(sfSigningPubKey, Slice{});
+                if (counterparty)
+                {
+                    obj.setFieldH256(sfLoanBrokerID, uint256{1});
+                    obj.setFieldNumber(
+                        sfPrincipalRequested, STNumber{sfPrincipalRequested, Number{1}});
+                }
+                else
+                {
+                    obj.setAccountID(sfSponsor, account);
+                    obj.setFieldU32(sfSponsorFlags, 0);
+                }
+            });
+
+            // Sign the top-level tx with TxMultiSign, which is what a
+            // multi-signer of the transaction itself would use.
+            Serializer const ss = buildMultiSigningData(tx, signerId, HashPrefix::TxMultiSign);
+            auto const sig = xrpl::sign(signerKp.first, signerKp.second, ss.slice());
+
+            STObject entry(sfSigner);
+            entry.setAccountID(sfAccount, signerId);
+            entry.setFieldVL(sfSigningPubKey, signerKp.first.slice());
+            entry.setFieldVL(sfTxnSignature, sig);
+            STArray signers(sfSigners, 1);
+            signers.pushBack(entry);
+
+            // Attach the Signers array to the top level so its own signature
+            // check succeeds, then copy the identical array into the role
+            // slot. Both arrays carry TxMultiSign-based signatures.
+            // NOLINTNEXTLINE(cppcoreguidelines-slicing)
+            STObject copy{tx};
+            copy.setFieldArray(sfSigners, signers);
+
+            STObject sigObject(sigField);
+            sigObject.setFieldVL(sfSigningPubKey, Slice{});
+            sigObject.setFieldArray(sfSigners, signers);
+            copy.setFieldObject(sigField, sigObject);
+            return STTx{std::move(copy)};
+        };
+
+        for (SField const& sigField :
+             {std::cref(sfCounterpartySignature), std::cref(sfSponsorSignature)})
+        {
+            auto const tx = makeCopiedMultiSig(sigField);
+
+            // Before the fix, both signature checks use TxMultiSign, so the
+            // copied Signers array verifies in the role slot as well.
+            BEAST_EXPECT(tx.checkSign(r.legacy));
+
+            // With the fix, the role slot uses its own multi-sign prefix
+            // (CPM or SPM) and the copied signature no longer verifies. The
+            // error must name the role that failed.
+            auto const ret = tx.checkSign(r.fixed);
+            BEAST_EXPECT(!ret);
+            if (!ret)
+            {
+                char const* const rolePrefix =
+                    sigField == sfCounterpartySignature ? "Counterparty: " : "Sponsor: ";
+                BEAST_EXPECT(ret.error().starts_with(rolePrefix));
+                BEAST_EXPECT(matches(ret.error().c_str(), "Invalid signature"));
+            }
         }
     }
 

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -1461,10 +1461,13 @@ NetworkOPsImp::preProcessTransaction(std::shared_ptr<Transaction>& transaction)
     // NOTE ximinez - I think this check is redundant,
     // but I'm not 100% sure yet.
     // If so, only cost is looking up HashRouter flags.
-    auto const [validity, reason] =
-        checkValidity(registry_.get().getHashRouter(), sttx, view->rules());
-    XRPL_ASSERT(
-        validity == Validity::Valid, "xrpl::NetworkOPsImp::processTransaction : valid validity");
+    //
+    // The verdict is not asserted to be Valid: SigBad is reachable during
+    // fixCleanup3_4_0 activation for role-signature transactions whose
+    // earlier checkValidity ran under lagging validated rules, and the
+    // handler below is the correct response.
+    auto const& viewRules = view->rules();
+    auto const [validity, reason] = checkValidity(registry_.get().getHashRouter(), sttx, viewRules);
 
     // Not concerned with local checks at this point.
     if (validity == Validity::SigBad)
@@ -1472,7 +1475,15 @@ NetworkOPsImp::preProcessTransaction(std::shared_ptr<Transaction>& transaction)
         JLOG(journal_.info()) << "Transaction has bad signature: " << reason;
         transaction->setStatus(TransStatus::INVALID);
         transaction->setResult(temBAD_SIGNATURE);
-        registry_.get().getHashRouter().setFlags(transaction->getID(), HashRouterFlags::BAD);
+        // See the matching guard in PeerImp::checkTransaction: only cache
+        // BAD for a role-signature transaction once fixCleanup3_4_0 is
+        // enabled on this node. Remove together with the amendment.
+        if (viewRules.enabled(fixCleanup3_4_0) ||
+            (!sttx.isFieldPresent(sfSponsorSignature) &&
+             !sttx.isFieldPresent(sfCounterpartySignature)))
+        {
+            registry_.get().getHashRouter().setFlags(transaction->getID(), HashRouterFlags::BAD);
+        }
         return false;
     }
 

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -1460,12 +1460,15 @@ NetworkOPsImp::preProcessTransaction(std::shared_ptr<Transaction>& transaction)
 
     // NOTE ximinez - I think this check is redundant,
     // but I'm not 100% sure yet.
-    // If so, only cost is looking up HashRouter flags.
     //
-    // The verdict is not asserted to be Valid: SigBad is reachable during
-    // fixCleanup3_4_0 activation for role-signature transactions whose
-    // earlier checkValidity ran under lagging validated rules, and the
-    // handler below is the correct response.
+    // For an ordinary transaction it is: the relay and submit paths have
+    // already run checkValidity, so this costs a HashRouter lookup. It is not
+    // redundant for a role-signature transaction while fixCleanup3_4_0 is
+    // activating. Those paths verify against the validated rules, which lag
+    // the open ledger rules used here, and checkValidity scopes a cached
+    // verdict to the rules that reached it, so this call can verify the
+    // signature again and come to a different answer. SigBad is therefore
+    // reachable, and the handler below is the correct response to it.
     auto const& viewRules = view->rules();
     auto const [validity, reason] = checkValidity(registry_.get().getHashRouter(), sttx, viewRules);
 

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -44,6 +44,7 @@
 #include <xrpl/ledger/Ledger.h>
 #include <xrpl/peerfinder/Slot.h>
 #include <xrpl/peerfinder/Types.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/KeyType.h>
 #include <xrpl/protocol/LedgerHeader.h>
 #include <xrpl/protocol/Protocol.h>
@@ -3087,8 +3088,9 @@ PeerImp::checkTransaction(
         if (checkSignature)
         {
             // Check the signature before handing off to the job queue.
-            if (auto [valid, validReason] = checkValidity(
-                    app_.getHashRouter(), *stx, app_.getLedgerMaster().getValidatedRules());
+            auto const& validatedRules = app_.getLedgerMaster().getValidatedRules();
+            if (auto [valid, validReason] =
+                    checkValidity(app_.getHashRouter(), *stx, validatedRules);
                 valid != Validity::Valid)
             {
                 if (!validReason.empty())
@@ -3096,9 +3098,20 @@ PeerImp::checkTransaction(
                     JLOG(pJournal_.debug()) << "Exception checking transaction: " << validReason;
                 }
 
-                // Probably not necessary to set HashRouterFlags::BAD, but
-                // doesn't hurt.
-                app_.getHashRouter().setFlags(stx->getTransactionID(), HashRouterFlags::BAD);
+                // For a role-signature transaction, only cache BAD once
+                // fixCleanup3_4_0 is enabled on this node: the SigBad verdict
+                // then covers the post-fix prefix and cannot flip back.
+                // Before the amendment activates, checkValidity's own
+                // era-scoped cache handles the repeat lookups; setting BAD
+                // would block a correctly new-prefix-signed transaction until
+                // the router entry ages out. Remove the guard together with
+                // the amendment.
+                if (validatedRules.enabled(fixCleanup3_4_0) ||
+                    (!stx->isFieldPresent(sfSponsorSignature) &&
+                     !stx->isFieldPresent(sfCounterpartySignature)))
+                {
+                    app_.getHashRouter().setFlags(stx->getTransactionID(), HashRouterFlags::BAD);
+                }
                 charge(resource::kFeeInvalidSignature, "check transaction signature failure");
                 return;
             }

--- a/src/xrpld/rpc/detail/TransactionSign.cpp
+++ b/src/xrpld/rpc/detail/TransactionSign.cpp
@@ -460,7 +460,8 @@ transactionPreProcessImpl(
     Role role,
     SigningForParams& signingArgs,
     std::chrono::seconds validatedLedgerAge,
-    Application& app)
+    Application& app,
+    Rules const& rules)
 {
     auto j = app.getJournal("RPCHandler");
 
@@ -482,13 +483,16 @@ transactionPreProcessImpl(
     }();
 
     // Make sure the signature target field is valid, if specified, and save the
-    // template for use later
+    // template for use later. Only a field that holds a transaction signature
+    // is a valid target; the signature is bound to that field's role.
     auto const signatureTemplate = signatureTarget
         ? InnerObjectFormats::getInstance().findSOTemplateBySField(*signatureTarget)
         : nullptr;
+    auto const signatureRoleOpt =
+        signatureTarget ? signatureRole(signatureTarget->get()) : SignatureRole::Transaction;
     if (signatureTarget)
     {
-        if (signatureTemplate == nullptr)
+        if (!signatureRoleOpt || signatureTemplate == nullptr)
         {  // Invalid target field
             return rpc::makeError(RpcInvalidParams, signatureTarget->get().getName());
         }
@@ -684,14 +688,11 @@ transactionPreProcessImpl(
     if (!passesLocalChecks(*stTx, reason))
         return rpc::makeError(RpcInvalidParams, reason);
 
-    // The signing prefix binds the signature to the field it goes into.
-    auto const prefix = signingPrefix(
-        signatureTarget, signingArgs.isMultiSigning(), app.getOpenLedger().current()->rules());
-
     // If multisign then return multiSignature, else set TxnSignature field.
     if (signingArgs.isMultiSigning())
     {
-        Serializer const s = buildMultiSigningData(*stTx, signingArgs.getSigner(), prefix);
+        Serializer const s = buildMultiSigningData(
+            *stTx, signingArgs.getSigner(), signingPrefix(*signatureRoleOpt, true, rules));
 
         auto multisig = xrpl::sign(pk, sk, s.slice());
 
@@ -699,7 +700,7 @@ transactionPreProcessImpl(
     }
     else if (signingArgs.isSingleSigning())
     {
-        stTx->sign(pk, sk, signatureTarget, prefix);
+        stTx->sign(pk, sk, *signatureRoleOpt, rules);
     }
 
     return TransactionPreProcessResult{std::move(stTx)};
@@ -1011,18 +1012,20 @@ transactionSign(
 {
     using namespace detail;
 
+    // Sign and verify against the same ruleset: a ledger close in between
+    // could change the signing prefix of an alternate signature field.
+    std::shared_ptr<ReadView const> const ledger = app.getOpenLedger().current();
     auto j = app.getJournal("RPCHandler");
     JLOG(j.debug()) << "transactionSign: " << jvRequest;
 
     // Add and amend fields based on the transaction type.
     SigningForParams signForParams;
-    TransactionPreProcessResult const preprocResult =
-        transactionPreProcessImpl(jvRequest, role, signForParams, validatedLedgerAge, app);
+    TransactionPreProcessResult const preprocResult = transactionPreProcessImpl(
+        jvRequest, role, signForParams, validatedLedgerAge, app, ledger->rules());
 
     if (!preprocResult.second)
         return preprocResult.first;
 
-    std::shared_ptr<ReadView const> const ledger = app.getOpenLedger().current();
     // Make sure the STTx makes a legitimate Transaction.
     std::pair<json::Value, Transaction::pointer> const txn =
         transactionConstructImpl(preprocResult.second, ledger->rules(), app);
@@ -1054,8 +1057,8 @@ transactionSubmit(
 
     // Add and amend fields based on the transaction type.
     SigningForParams signForParams;
-    TransactionPreProcessResult const preprocResult =
-        transactionPreProcessImpl(jvRequest, role, signForParams, validatedLedgerAge, app);
+    TransactionPreProcessResult const preprocResult = transactionPreProcessImpl(
+        jvRequest, role, signForParams, validatedLedgerAge, app, ledger->rules());
 
     if (!preprocResult.second)
         return preprocResult.first;
@@ -1222,8 +1225,8 @@ transactionSignFor(
     // Add and amend fields based on the transaction type.
     SigningForParams signForParams(*signerAccountID);
 
-    TransactionPreProcessResult const preprocResult =
-        transactionPreProcessImpl(jvRequest, role, signForParams, validatedLedgerAge, app);
+    TransactionPreProcessResult const preprocResult = transactionPreProcessImpl(
+        jvRequest, role, signForParams, validatedLedgerAge, app, ledger->rules());
 
     if (!preprocResult.second)
         return preprocResult.first;

--- a/src/xrpld/rpc/detail/TransactionSign.cpp
+++ b/src/xrpld/rpc/detail/TransactionSign.cpp
@@ -684,10 +684,14 @@ transactionPreProcessImpl(
     if (!passesLocalChecks(*stTx, reason))
         return rpc::makeError(RpcInvalidParams, reason);
 
+    // The signing prefix binds the signature to the field it goes into.
+    auto const prefix = signingPrefix(
+        signatureTarget, signingArgs.isMultiSigning(), app.getOpenLedger().current()->rules());
+
     // If multisign then return multiSignature, else set TxnSignature field.
     if (signingArgs.isMultiSigning())
     {
-        Serializer const s = buildMultiSigningData(*stTx, signingArgs.getSigner());
+        Serializer const s = buildMultiSigningData(*stTx, signingArgs.getSigner(), prefix);
 
         auto multisig = xrpl::sign(pk, sk, s.slice());
 
@@ -695,7 +699,7 @@ transactionPreProcessImpl(
     }
     else if (signingArgs.isSingleSigning())
     {
-        stTx->sign(pk, sk, signatureTarget);
+        stTx->sign(pk, sk, signatureTarget, prefix);
     }
 
     return TransactionPreProcessResult{std::move(stTx)};


### PR DESCRIPTION
## High Level Overview of Change

This PR adds new hash prefixes for single- and multi-signing in `sfCounterpartySignature`
and `sfSponsorSignature`, gated on `fixCleanup3_4_0`.

| Field | Single-sign | Multi-sign |
| --- | --- | --- |
| `CounterpartySignature` | `CPT` | `CPM` |
| `SponsorSignature` | `SPN` | `SPM` |

### Context of Change

Before the fix, every signature on a transaction covered the same bytes, so a signature
made for one role could be copied into another. `LoanSecurity_test::testSignatureCopiedBetweenRoles`
covers the concrete case: a lender signs the `CounterpartySignature` slot of a `LoanSet`
that names the lender as fee sponsor, and the borrower copies that signature into
`SponsorSignature`, making the lender pay the fee without ever agreeing to sponsor it.

#### Signature cache scoping

`checkValidity` caches its verdict in the `HashRouter` keyed on transaction ID alone.
Because the fix changes which bytes a role signature covers, a verdict reached before
activation would otherwise be reused after it, and the reverse. The callers do not even
agree on the rules: relay and submit verify against the validated rules, which lag the
open ledger rules that `preflight2` uses. At the flag ledger, one transaction can be
checked under both prefixes on the same node at the same time.

`apply.cpp` therefore holds the pre-fix verdict in its own pair of flags,
`kSfSiggoodOldPrefix` / `kSfSigbadOldPrefix` (`HashRouterFlags::PRIVATE7` / `PRIVATE8`),
so a verdict reached in one era is never read in the other. Both directions matter: a
stale good verdict must not let a moved signature survive the amendment, and a stale bad
verdict must not condemn a transaction that the new prefixes accept. Transactions without
a role signature, and all transactions once the fix is enabled, use the original flags and
verify exactly once, so there is no steady-state cost. Both flags come out when
`Cleanup3_4_0` is retired in `features.macro`.

`HashRouterFlags::BAD` also short-circuits `checkValidity` by transaction ID and is not
era-scoped, so `PeerImp::checkTransaction` and `NetworkOPsImp::preProcessTransaction` skip
the `BAD` write for a role-signature transaction until the node's own rules enable the fix.

#### Activation order

The era-scoped cache makes the change safe in any activation order. Without it, this PR
would require `fixCleanup3_4_0` to activate strictly before `featureSponsor` and
`featureLendingProtocol`: with the features live first, an ordinary in-flight sponsored
transaction at the fix's flag ledger would be accepted by nodes holding a stale good
verdict and rejected by nodes computing it fresh, which is a ledger-content disagreement.
All three amendments are `VoteBehavior::DefaultNo`, so the order is decided by validator
voting and they could activate in the same flag ledger. That is why the invariant is
enforced in code rather than documented as a deployment requirement.

### API Impact

`API-CHANGELOG.md` is updated in this PR:

- `sign`, `sign_for`, `submit`: `signature_target` now returns `invalidParams` unless it
  names `CounterpartySignature` or `SponsorSignature`. It previously accepted any inner
  object field. This validation is not amendment-gated, since it is local signing only.
- `sign`, `sign_for`, `submit`, `submit_multisigned`: with `fixCleanup3_4_0` enabled,
  clients that build these signatures themselves must use the new prefixes.

`libxrpl` signature changes:

- `STTx::sign` is now two overloads: `sign(pk, sk)` for the account's own signature, and
  `sign(pk, sk, role, rules)`, which derives the prefix internally.
- `buildMultiSigningData` and `startMultiSigningData` take a `HashPrefix`.
- New `signingPrefix(SignatureRole, bool, Rules const&)` and `SignatureRole` in `Sign.h`.
- `checkBatchSign`, `checkMultiSign`, and `checkBatchMultiSign` no longer take `Rules`,
  since the amendment decision is now folded into the prefix.

- [ ] Public API: New feature (new methods and/or new fields)
- [x] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

## Test Plan

- `xrpl.protocol.STTx` — role signature binding: a signature copied between roles fails
  under the new prefixes, and each role's error names the role that failed.
- `xrpl.tx.Apply` — the era-scoped cache, both directions, for `sfSponsorSignature` and
  `sfCounterpartySignature`.
- `xrpl.tx.LoanSecurity` — the counterparty-into-sponsor copy, run with and without the
  amendment: `tesSUCCESS` before, rejected with balances unchanged after.
- `xrpl.app.Sponsor` — single and multi signing under both rule sets.
