### PR TITLE
chore: Bump version to 3.4.0-rc1

### DIFF
--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -23,7 +23,7 @@ namespace {
 //------------------------------------------------------------------------------
 // clang-format off
 // NOLINTNEXTLINE(readability-identifier-naming)
-char const* const versionString = "3.4.0-r1"
+char const* const versionString = "3.4.0-rc1"
     // clang-format on
     ;
 

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -23,7 +23,7 @@ namespace {
 //------------------------------------------------------------------------------
 // clang-format off
 // NOLINTNEXTLINE(readability-identifier-naming)
-char const* const versionString = "3.4.0-b3"
+char const* const versionString = "3.4.0-r1"
     // clang-format on
     ;
 


### PR DESCRIPTION
This updates the release version to 3.4.0-rc1.
