### PR TITLE
fix: Harden DepositPreauth self-target and credential handling

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -15,6 +15,7 @@
 // Add new amendments to the top of this list.
 // Keep it sorted in reverse chronological order.
 
+XRPL_FIX    (DepositPreauthSelf,          Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(ConfidentialMPTKeyRotation,  Supported::No,  VoteBehavior::DefaultNo)
 XRPL_FIX    (Cleanup3_4_0,                Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(Sponsor,                     Supported::Yes, VoteBehavior::DefaultNo)

--- a/include/xrpl/tx/transactors/payment/DepositPreauth.h
+++ b/include/xrpl/tx/transactors/payment/DepositPreauth.h
@@ -11,6 +11,8 @@
 #include <xrpl/tx/ApplyContext.h>
 #include <xrpl/tx/Transactor.h>
 
+#include <cstdint>
+
 namespace xrpl {
 
 class DepositPreauth : public Transactor
@@ -48,6 +50,27 @@ public:
     // Interface used by AccountDelete
     static TER
     removeFromLedger(ApplyView& view, uint256 const& delIndex, beast::Journal j);
+
+private:
+    /**
+     * Number of DepositPreauth grants this transaction inserted.
+     */
+    std::uint32_t grantsCreated_{0};
+
+    /**
+     * Number of DepositPreauth grants this transaction erased.
+     */
+    std::uint32_t grantsRemoved_{0};
+
+    /**
+     * Set when a touched grant's owner is not the submitting account.
+     */
+    bool grantOwnerMismatch_{false};
+
+    /**
+     * Set when a created grant's credential array is not canonically sorted.
+     */
+    bool grantCredsNotCanonical_{false};
 };
 
 }  // namespace xrpl

--- a/src/libxrpl/tx/transactors/payment/DepositPreauth.cpp
+++ b/src/libxrpl/tx/transactors/payment/DepositPreauth.cpp
@@ -12,6 +12,7 @@
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Keylet.h>
+#include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/Protocol.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STArray.h>
@@ -72,8 +73,10 @@ DepositPreauth::preflight(PreflightContext const& ctx)
             return temINVALID_ACCOUNT_ID;
         }
 
-        // An account may not preauthorize itself.
-        if (optAuth && (target == ctx.tx[sfAccount]))
+        // An account may not preauthorize itself. The Unauthorize direction is
+        // amendment-gated because older ledgers rejected it later, in preclaim.
+        bool const selfTarget = (target == ctx.tx[sfAccount]);
+        if ((optAuth || (optUnauth && ctx.rules.enabled(fixDepositPreauthSelf))) && selfTarget)
         {
             JLOG(ctx.j.trace()) << "Malformed transaction: Attempting to DepositPreauth self.";
             return temCANNOT_PREAUTH_SELF;
@@ -133,9 +136,11 @@ DepositPreauth::preclaim(PreclaimContext const& ctx)
             auto const& issuer = o[sfIssuer];
             if (!ctx.view.exists(keylet::account(issuer)))
                 return tecNO_ISSUER;
+            // Duplicates are bad user input, not node corruption. Preflight
+            // already rejects them with the same code, so this stays unreachable.
             auto [it, ins] = sorted.emplace(issuer, o[sfCredentialType]);
             if (!ins)
-                return tefINTERNAL;  // LCOV_EXCL_LINE
+                return temMALFORMED;  // LCOV_EXCL_LINE
         }
 
         // Verify that the Preauth entry they asked to add is not already
@@ -145,11 +150,16 @@ DepositPreauth::preclaim(PreclaimContext const& ctx)
     }
     else if (ctx.tx.isFieldPresent(sfUnauthorizeCredentials))
     {
+        auto const sorted = credentials::makeSorted(ctx.tx.getFieldArray(sfUnauthorizeCredentials));
+
+        // makeSorted returns an empty set to report duplicates, and an empty set
+        // would otherwise build the keylet of the empty credential set. Preflight
+        // already rejects duplicates, so this stays unreachable.
+        if (sorted.empty())
+            return temMALFORMED;  // LCOV_EXCL_LINE
+
         // Verify that the Preauth entry is in the ledger.
-        if (!ctx.view.exists(
-                keylet::depositPreauth(
-                    account,
-                    credentials::makeSorted(ctx.tx.getFieldArray(sfUnauthorizeCredentials)))))
+        if (!ctx.view.exists(keylet::depositPreauth(account, sorted)))
             return tecNO_ENTRY;
     }
     return tesSUCCESS;
@@ -300,10 +310,48 @@ DepositPreauth::removeFromLedger(ApplyView& view, uint256 const& preauthIndex, b
     return tesSUCCESS;
 }
 
-void
-DepositPreauth::visitInvariantEntry(bool, SLE::const_ref, SLE::const_ref)
+namespace {
+
+// True when the array is strictly ascending by issuer then credential type,
+// which is what makeSorted produces and so also means duplicate-free.
+bool
+credentialsCanonical(STArray const& credentials)
 {
-    // No transaction-specific invariants yet (future work).
+    std::optional<std::pair<AccountID, Slice>> prev;
+    for (auto const& credential : credentials)
+    {
+        std::pair<AccountID, Slice> const current{
+            credential[sfIssuer], credential[sfCredentialType]};
+        if (prev && !(*prev < current))
+            return false;
+        prev = current;
+    }
+    return true;
+}
+
+}  // namespace
+
+void
+DepositPreauth::visitInvariantEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+{
+    // On deletion `after` holds the erased entry, so only isDelete is reliable.
+    auto const& sle = after ? after : before;
+    if (!sle || sle->getType() != ltDEPOSIT_PREAUTH)
+        return;
+
+    // An existing grant was modified rather than created or removed.
+    if (before && !isDelete)
+        return;
+
+    std::uint32_t& counter = isDelete ? grantsRemoved_ : grantsCreated_;
+    ++counter;
+
+    if (sle->getAccountID(sfAccount) != ctx_.tx[sfAccount])
+        grantOwnerMismatch_ = true;
+
+    if (!isDelete && sle->isFieldPresent(sfAuthorizeCredentials) &&
+        !credentialsCanonical(sle->getFieldArray(sfAuthorizeCredentials)))
+        grantCredsNotCanonical_ = true;
 }
 
 bool
@@ -311,10 +359,38 @@ DepositPreauth::finalizeInvariants(
     STTx const&,
     TER,
     XRPAmount,
-    ReadView const&,
-    beast::Journal const&)
+    ReadView const& view,
+    beast::Journal const& j)
 {
-    // No transaction-specific invariants yet (future work).
+    if (!view.rules().enabled(fixDepositPreauthSelf))
+        return true;
+
+    // LCOV_EXCL_START
+    // A violation means the transactor wrote a grant it should not have, so
+    // these branches are unreachable unless one of the paths above is broken.
+    if (grantOwnerMismatch_)
+    {
+        JLOG(j.fatal()) << "DepositPreauth invariant: grant owner is not the "
+                           "submitting account.";
+        return false;
+    }
+
+    // A failed transaction touches no grant, so only an excess is a violation.
+    if (grantsCreated_ + grantsRemoved_ > 1)
+    {
+        JLOG(j.fatal()) << "DepositPreauth invariant: " << grantsCreated_ + grantsRemoved_
+                        << " grants changed in one transaction.";
+        return false;
+    }
+
+    if (grantCredsNotCanonical_)
+    {
+        JLOG(j.fatal()) << "DepositPreauth invariant: credential array is not "
+                           "canonically sorted.";
+        return false;
+    }
+    // LCOV_EXCL_STOP
+
     return true;
 }
 

--- a/src/test/app/DepositAuth_test.cpp
+++ b/src/test/app/DepositAuth_test.cpp
@@ -17,6 +17,8 @@
 #include <test/jtx/require.h>
 #include <test/jtx/sendmax.h>
 #include <test/jtx/seq.h>
+#include <test/jtx/sig.h>
+#include <test/jtx/sponsor.h>
 #include <test/jtx/ter.h>
 #include <test/jtx/ticket.h>
 #include <test/jtx/trust.h>
@@ -501,6 +503,27 @@ struct DepositPreauth_test : public beast::unit_test::Suite
         // alice authorizes herself.
         env(deposit::auth(alice, alice), Ter(temCANNOT_PREAUTH_SELF));
         env.close();
+
+        // alice unauthorizes herself.  Before fixDepositPreauthSelf this
+        // slipped past preflight and was charged a fee by preclaim.
+        {
+            auto const baseFee = env.current()->fees().base;
+            PrettyAmount const aliceXrpBalance{env.balance(alice, XRP)};
+            if (features[fixDepositPreauthSelf])
+            {
+                env(deposit::unauth(alice, alice), Ter(temCANNOT_PREAUTH_SELF));
+                env.close();
+                // Preflight rejects the transaction, so alice keeps her fee.
+                BEAST_EXPECT(env.balance(alice, XRP) == aliceXrpBalance);
+            }
+            else
+            {
+                env(deposit::unauth(alice, alice), Ter(tecNO_ENTRY));
+                env.close();
+                // Reaching preclaim costs alice the transaction fee.
+                BEAST_EXPECT(env.balance(alice, XRP) == aliceXrpBalance - drops(baseFee));
+            }
+        }
 
         // alice authorizes an unfunded account.
         env(deposit::auth(alice, carol), Ter(tecNO_TARGET));
@@ -1477,12 +1500,117 @@ struct DepositPreauth_test : public beast::unit_test::Suite
     }
 
     void
+    testUnauthCredentialsDuplicates(FeatureBitset features)
+    {
+        testcase("Unauthorize credentials duplicates");
+
+        using namespace jtx;
+
+        Account const stock{"stock"};
+        Account const issuer{"issuer"};
+
+        Env env(*this, features);
+        env.fund(XRP(5000), stock, issuer);
+        env.close();
+
+        // A duplicated issuer and credential type pair is rejected by preflight,
+        // so it never reaches the keylet built from makeSorted.  This asserts
+        // the exact code rather than merely that the transaction failed.
+        std::vector<deposit::AuthorizeCredentials> const duplicated = {
+            {.issuer = issuer, .credType = "a"}, {.issuer = issuer, .credType = "a"}};
+
+        env(deposit::unauthCredentials(stock, duplicated), Ter(temMALFORMED));
+        env.close();
+
+        // A well-formed unauthorize for a grant that was never created still
+        // reports the missing entry, confirming the new emptiness check did not
+        // swallow the normal path.
+        std::vector<deposit::AuthorizeCredentials> const single = {
+            {.issuer = issuer, .credType = "b"}};
+
+        env(deposit::unauthCredentials(stock, single), Ter(tecNO_ENTRY));
+        env.close();
+    }
+
+    void
+    testInvariants(FeatureBitset features)
+    {
+        testcase("Invariants");
+
+        using namespace jtx;
+
+        Account const alice{"alice"};
+        Account const becky{"becky"};
+        Account const sponsor{"sponsor"};
+        Account const issuer{"issuer"};
+
+        Env env(*this, features);
+        env.fund(XRP(5000), alice, becky, sponsor, issuer);
+        env.close();
+
+        // Normal create and remove must satisfy the invariants, so a passing
+        // result here is what proves the hooks do not misfire.
+        env.require(Owners(alice, 0));
+        env(deposit::auth(alice, becky));
+        env.close();
+        env.require(Owners(alice, 1));
+
+        env(deposit::unauth(alice, becky));
+        env.close();
+        env.require(Owners(alice, 0));
+
+        // A credential grant writes a canonically sorted array; the invariant
+        // checks that ordering, so creating one exercises it.
+        std::vector<deposit::AuthorizeCredentials> const creds = {
+            {.issuer = issuer, .credType = "b"}, {.issuer = issuer, .credType = "a"}};
+
+        env(deposit::authCredentials(alice, creds));
+        env.close();
+        env.require(Owners(alice, 1));
+
+        env(deposit::unauthCredentials(alice, creds));
+        env.close();
+        env.require(Owners(alice, 0));
+
+        // A reserve-sponsored grant puts the owner-count delta on the sponsor
+        // instead of the grant owner, so the invariants assert nothing about
+        // owner counts.
+        if (features[featureSponsor])
+        {
+            BEAST_EXPECT(ownerCount(env, alice) == 0);
+            BEAST_EXPECT(sponsoredOwnerCount(env, alice) == 0);
+            BEAST_EXPECT(ownerCount(env, sponsor) == 0);
+            BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 0);
+
+            env(deposit::auth(alice, becky),
+                sponsor::As(sponsor, spfSponsorReserve),
+                Sig(sfSponsorSignature, sponsor));
+            env.close();
+
+            // Alice owns the grant, but the sponsor carries its reserve.
+            BEAST_EXPECT(ownerCount(env, alice) == 1);
+            BEAST_EXPECT(sponsoredOwnerCount(env, alice) == 1);
+            BEAST_EXPECT(ownerCount(env, sponsor) == 0);
+            BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 1);
+
+            // Removal finds the sponsor on the object and undoes both sides.
+            env(deposit::unauth(alice, becky));
+            env.close();
+            BEAST_EXPECT(ownerCount(env, alice) == 0);
+            BEAST_EXPECT(sponsoredOwnerCount(env, alice) == 0);
+            BEAST_EXPECT(ownerCount(env, sponsor) == 0);
+            BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 0);
+        }
+    }
+
+    void
     run() override
     {
         testEnable();
         auto const supported{jtx::testableAmendments()};
         testInvalid(supported);
         testInvalid(supported - fixCleanup3_3_0);
+        testInvalid(supported - fixDepositPreauthSelf);
         testPayment(supported - featureCredentials);
         testPayment(supported);
         testCredentialsPayment();
@@ -1490,6 +1618,10 @@ struct DepositPreauth_test : public beast::unit_test::Suite
         testCredentialsCreation();
         testExpiredCreds();
         testSortingCredentials();
+        testUnauthCredentialsDuplicates(supported);
+        testUnauthCredentialsDuplicates(supported - fixDepositPreauthSelf);
+        testInvariants(supported);
+        testInvariants(supported - fixDepositPreauthSelf);
     }
 };
 


### PR DESCRIPTION
## High Level Overview of Change

| Term | Meaning |
| - | - |
| DepositPreauth entry | A ledger entry letting one account accept payments from a named sender, or any holder of a named credential set. |
| `Authorize` / `Unauthorize` | The fields that create and remove a sender-based grant. Exactly one of the four grant fields may be present. |
| `fixDepositPreauthSelf` | The amendment added here. Gates both behavioural changes. |
| `credentials::makeSorted` | Canonicalises a credential array. It reports duplicates by returning an **empty** set, not an error. |
| `tem` / `tec` / `tef` | `tem` rejects locally: never relayed, no fee. `tec` applies it and claims the fee. `tef` is a node-local fault. |

Three changes to the DepositPreauth transactor:

1. `Unauthorize` naming the sender is rejected in preflight rather than in preclaim.
2. The duplicate-credential sentinel from `makeSorted` is tested before use on the `UnauthorizeCredentials` path.
3. The transactor's two invariant hooks are implemented.

Tests are in the second commit, so the code and its coverage land together.

## Context of Change

**Item 1 is a policy change, not a conformance fix.** XLS-0070 §7.2 enumerates this transaction's failure conditions, and self-targeting is not among them. xrpl.org documents `temCANNOT_PREAUTH_SELF` as applying to the `Authorize` field specifically, and `tecNO_ENTRY` as "tried to revoke a preauthorization that does not exist in the ledger" — which a self-unauthorize always is, because the matching entry can never be created: `Authorize` naming the sender has been rejected since the DepositPreauth amendment shipped in 2018. The current code is therefore conformant and returns the accurate code. What this change buys is that a transaction which cannot succeed is refused before relay and before a fee is claimed. If that is not judged worth an amendment, items 2 and 3 do not depend on it.

The spec backs the other two. §7.2 lists duplicate and empty credential arrays as failure conditions without naming codes, so the choice of code is the implementation's, and `temMALFORMED` fits bad input better than the `tefINTERNAL` it replaces. §7.3 states the entry "will store a sorted list of credentials", the authority for item 3's sortedness assertion.

**Three claims that prompted this work did not survive checking; recorded so they are not re-raised.** The self-target asymmetry was called a defect — per §7.2 it is not, hence item 1 as policy. The duplicate-credential path was called reachable node corruption — it is neither, since `credentials::checkArray` rejects duplicates before preclaim runs, so `tefINTERNAL` was mis-classified rather than live. An invariant asserting the owner-count delta matches the object delta was proposed and is **wrong**: `increaseOwnerCount` resolves a sponsor and routes the delta to it, so it would misfire on every reserve-sponsored grant. It is deliberately absent, and a sponsored-create test here pins that down.

**The invariant hooks are live.** [`Transactor::operator()()` calls `checkInvariants(result, fee, InvariantScope::Full)`](https://github.com/XRPLF/rippled/blob/d5bfe94f15ece0ba1b6c00004ee5b3f90383f2ab/src/libxrpl/tx/Transactor.cpp#L1640), which routes through `TxInvariantCheck` to this transactor's hooks, so a false return produces `tecINVARIANT_FAILED` on a transaction that would otherwise succeed. That is why item 3 is amendment-gated as well.

**Why it is safe.** Both behavioural changes are gated on `fixDepositPreauthSelf`: item 1's pre-amendment half is the unchanged `Authorize` test, and `finalizeInvariants` returns true immediately when the amendment is off. On a ledger without it every input produces today's result, and item 2 is unreachable per the `checkArray` ordering above. No consensus divergence.

## API Impact

- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)

`DepositPreauth` gains four private members that accumulate invariant state, changing its layout.

## Before / After

| Input | Before | After, amendment off | After, amendment on |
| - | - | - | - |
| `Authorize` == sender | `temCANNOT_PREAUTH_SELF` | unchanged | unchanged |
| `Unauthorize` == sender | `tecNO_ENTRY` | unchanged | `temCANNOT_PREAUTH_SELF` |

The hooks assert three properties of a touched grant: its `sfAccount` is the submitting account, at most one grant changes per transaction, and a created entry's `sfAuthorizeCredentials` is canonically sorted and so duplicate-free. Coverage exclusion covers only the violation branches, which cannot fire unless a write path above is broken.

## Test Plan

Cases added to `xrpl.app.DepositPreauth` cover self-target in both directions, duplicate and empty credential arrays, a created array's sort order, the hooks on a normal create and remove, and a sponsored create. Each amendment-sensitive case runs under both rule sets, so dropping the gate fails here rather than on a network.

```
./xrpld --unittest=xrpl.app.DepositPreauth
```

## Future Tasks

- xrpl.org's `temCANNOT_PREAUTH_SELF` wording goes stale when the amendment activates; needs an `XRPLF/xrpl-dev-portal` PR.
- The amendment name suits item 1 but not items 2 and 3. Happy to rename before merge.
