### PR TITLE
fix: Stop the pragma-once hook duplicating the directive

### DIFF
--- a/bin/pre-commit/fix_pragma_once.py
+++ b/bin/pre-commit/fix_pragma_once.py
@@ -9,15 +9,17 @@ Usage: ./bin/pre-commit/fix_pragma_once.py <file1> <file2> ...
 import sys
 from pathlib import Path
 
-PRAGMA_ONCE = "#pragma once\n\n"
+PRAGMA_ONCE = "#pragma once"
+# Written with a blank line after it, to match the existing headers.
+INSERTED = f"{PRAGMA_ONCE}\n\n"
 
 
 def fix_pragma_once(path: Path) -> bool:
     original = path.read_text(encoding="utf-8")
-    if PRAGMA_ONCE not in original:
-        path.write_text(PRAGMA_ONCE + original, encoding="utf-8")
-        return False
-    return True
+    if PRAGMA_ONCE in original:
+        return True
+    path.write_text(INSERTED + original, encoding="utf-8")
+    return False
 
 
 def main() -> int:

--- a/bin/pre-commit/test_fix_pragma_once.py
+++ b/bin/pre-commit/test_fix_pragma_once.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Tests for fix_pragma_once.py.
+
+Run directly (no test framework needed):
+    ./bin/pre-commit/test_fix_pragma_once.py
+or under pytest:
+    pytest bin/pre-commit/test_fix_pragma_once.py
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+from fix_pragma_once import fix_pragma_once
+
+
+def run_on(content: str) -> tuple[bool, str]:
+    """Run the hook over a header holding ``content``.
+
+    Returns ``(already_had_it, content_afterwards)``, mirroring the hook's own
+    return value: true when the file was left alone.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "header.h"
+        path.write_text(content, encoding="utf-8")
+        already_had_it = fix_pragma_once(path)
+        return already_had_it, path.read_text(encoding="utf-8")
+
+
+def test_missing_pragma_is_added() -> None:
+    already_had_it, result = run_on("int x;\n")
+    assert already_had_it is False
+    assert result == "#pragma once\n\nint x;\n"
+
+
+def test_pragma_with_blank_line_is_left_alone() -> None:
+    content = "#pragma once\n\nint x;\n"
+    assert run_on(content) == (True, content)
+
+
+def test_pragma_without_blank_line_is_left_alone() -> None:
+    # regression: the check looked for the directive plus a blank line, so a
+    # header that ran straight into its first include got a second directive
+    content = "#pragma once\n#include <cstdint>\n"
+    assert run_on(content) == (True, content)
+
+
+def test_pragma_below_a_copyright_banner_is_left_alone() -> None:
+    content = "// Copyright\n#pragma once\n#include <cstdint>\n"
+    assert run_on(content) == (True, content)
+
+
+def test_pragma_on_the_last_line_is_left_alone() -> None:
+    content = "// Copyright\n#pragma once\n"
+    assert run_on(content) == (True, content)
+
+
+def main() -> int:
+    tests = sorted(
+        (name, fn)
+        for name, fn in globals().items()
+        if name.startswith("test_") and callable(fn)
+    )
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"PASS {name}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"FAIL {name}: {exc!r}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## High Level Overview of Change

`bin/pre-commit/fix_pragma_once.py` gives a second `#pragma once` to any header that already has one but does not follow it with a blank line. This makes the presence check look for the directive on its own and keeps the blank line only in the text the hook writes. A header that really is missing the directive still gets it, exactly as before.

## Context of Change

The hook uses a single constant for two different jobs:

```python
PRAGMA_ONCE = "#pragma once\n\n"


def fix_pragma_once(path: Path) -> bool:
    original = path.read_text(encoding="utf-8")
    if PRAGMA_ONCE not in original:
        path.write_text(PRAGMA_ONCE + original, encoding="utf-8")
        return False
    return True
```

`PRAGMA_ONCE` is the directive plus a blank line, so `PRAGMA_ONCE not in original` is true for a header whose `#pragma once` runs straight into the next line. The hook reads that header as unguarded and prepends the constant. Given a file holding

```c
#pragma once
#include <cstdint>
```

it writes back

```c
#pragma once

#pragma once
#include <cstdint>
```

and exits 1, so the commit is blocked and the author is handed a file carrying the directive twice. `#pragma once` as the last line of a file goes the same way, for the same reason.

This has been the behaviour since the hook was added in b68e1f7 (#7580, 2026-06-24); the file has not been touched since. It does not fire on the tree today because every tracked `.h` and `.hpp` (861 files) happens to have the blank line, but `.pre-commit-config.yaml` runs the hook over every staged `.h` and `.hpp`, and it runs before `clang-format`, which will not collapse a duplicated directive. Any newly written or hand-edited header that puts its first include immediately under the guard hits this.

The fix splits the constant in two: `PRAGMA_ONCE` for the presence check, `INSERTED` for the text that is written.

## API Impact

None. This changes a pre-commit hook and adds a test for it. No source is recompiled, and there is no `libxrpl`, public API or peer protocol impact.

## Test Plan

`bin/pre-commit/test_fix_pragma_once.py` is new, written in the style of the existing `bin/pre-commit/test_check_doxygen_style.py`: it runs directly or under pytest and needs no test framework.

Three of its five cases fail against the copy of the hook on `develop` and pass with this change. Same test file, both runs, from `bin/pre-commit`:

```
$ python3 ./test_fix_pragma_once.py            # develop's fix_pragma_once.py
PASS test_missing_pragma_is_added
FAIL test_pragma_below_a_copyright_banner_is_left_alone: AssertionError()
FAIL test_pragma_on_the_last_line_is_left_alone: AssertionError()
PASS test_pragma_with_blank_line_is_left_alone
FAIL test_pragma_without_blank_line_is_left_alone: AssertionError()

2/5 passed

$ python3 ./test_fix_pragma_once.py            # with this change
PASS test_missing_pragma_is_added
PASS test_pragma_below_a_copyright_banner_is_left_alone
PASS test_pragma_on_the_last_line_is_left_alone
PASS test_pragma_with_blank_line_is_left_alone
PASS test_pragma_without_blank_line_is_left_alone

5/5 passed
```

The fixed hook leaves every header in the repository alone, and still adds the directive to one that has none:

```
$ python3 bin/pre-commit/fix_pragma_once.py $(git ls-files '*.h' '*.hpp') ; echo "exit=$?"
exit=0
$ git status --porcelain
$ printf '#include <cstdint>\n' >/tmp/none.h && python3 bin/pre-commit/fix_pragma_once.py /tmp/none.h ; echo "exit=$?"
exit=1
$ cat /tmp/none.h
#pragma once

#include <cstdint>
```

`black` 26.5.1 and `cspell-cli` 10.0.1, the versions pinned in `.pre-commit-config.yaml`, both report no findings on the two files.
