### PR TITLE
fix: Enforce pseudo-account directory contents with an invariant

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -17,6 +17,7 @@
 
 XRPL_FIX    (Cleanup3_5_0,                Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(ConfidentialMPTKeyRotation,  Supported::No,  VoteBehavior::DefaultNo)
+XRPL_FIX    (PseudoAccountOwnership,      Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (Cleanup3_4_0,                Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(Sponsor,                     Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(BatchV1_1,                   Supported::Yes, VoteBehavior::DefaultNo)

--- a/include/xrpl/tx/invariants/InvariantCheck.h
+++ b/include/xrpl/tx/invariants/InvariantCheck.h
@@ -15,6 +15,7 @@
 #include <xrpl/tx/invariants/NFTInvariant.h>
 #include <xrpl/tx/invariants/PermissionedDEXInvariant.h>
 #include <xrpl/tx/invariants/PermissionedDomainInvariant.h>
+#include <xrpl/tx/invariants/PseudoAccountInvariant.h>
 #include <xrpl/tx/invariants/SponsorshipInvariant.h>
 #include <xrpl/tx/invariants/VaultInvariant.h>
 
@@ -454,6 +455,7 @@ using InvariantChecks = std::tuple<
     ValidAMM,
     NoModifiedUnmodifiableFields,
     ValidPseudoAccounts,
+    ValidPseudoAccountOwnership,
     ValidLoanBroker,
     ValidLoan,
     ValidVault,

--- a/include/xrpl/tx/invariants/PseudoAccountInvariant.h
+++ b/include/xrpl/tx/invariants/PseudoAccountInvariant.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <xrpl/basics/base_uint.h>
+#include <xrpl/beast/utility/Journal.h>
+#include <xrpl/ledger/ReadView.h>
+#include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/STLedgerEntry.h>
+#include <xrpl/protocol/STTx.h>
+#include <xrpl/protocol/TER.h>
+#include <xrpl/protocol/XRPAmount.h>
+
+#include <map>
+#include <vector>
+
+namespace xrpl {
+
+/**
+ * @brief Invariant: pseudo-accounts own only the object types their kind
+ * expects.
+ *
+ * Each pseudo-account kind has a fixed set of ledger entry types that may
+ * appear in its owner directory:
+ * - AMM: the AMM entry, trust lines (IOU pool assets and LP tokens), and
+ *   MPToken holdings (MPT pool assets),
+ * - Vault: the share MPTokenIssuance, the asset holding (MPToken or trust
+ *   line), and the LoanBrokers operating on the vault,
+ * - LoanBroker: its Loans and the cover holding (MPToken or trust line).
+ *
+ * A pseudo-account cannot sign transactions, so an unexpected object linked
+ * into its owner directory could never be accepted or removed by it. It would
+ * pin the directory and block deletion of the owning object. The transactors
+ * refuse to create such objects; this invariant is the backstop if any of
+ * those guards is bypassed.
+ */
+class ValidPseudoAccountOwnership
+{
+    // Entries newly linked into owner directories, keyed by the directory
+    // owner. Whether an owner is a pseudo-account is decided in finalize,
+    // where the view is available.
+    std::map<AccountID, std::vector<uint256>> added_;
+
+public:
+    void
+    visitEntry(bool, SLE::const_ref, SLE::const_ref);
+
+    bool
+    finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);
+};
+
+}  // namespace xrpl

--- a/src/libxrpl/tx/invariants/PseudoAccountInvariant.cpp
+++ b/src/libxrpl/tx/invariants/PseudoAccountInvariant.cpp
@@ -1,0 +1,112 @@
+#include <xrpl/tx/invariants/PseudoAccountInvariant.h>
+
+#include <xrpl/basics/Log.h>
+#include <xrpl/beast/utility/Journal.h>
+#include <xrpl/ledger/ReadView.h>
+#include <xrpl/ledger/helpers/AccountRootHelpers.h>
+#include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/Indexes.h>
+#include <xrpl/protocol/LedgerFormats.h>
+#include <xrpl/protocol/SField.h>
+#include <xrpl/protocol/STLedgerEntry.h>
+#include <xrpl/protocol/STTx.h>
+#include <xrpl/protocol/STVector256.h>
+#include <xrpl/protocol/TER.h>
+#include <xrpl/protocol/XRPAmount.h>
+
+#include <algorithm>
+#include <optional>
+#include <set>
+#include <string>
+
+namespace xrpl {
+
+void
+ValidPseudoAccountOwnership::visitEntry(bool isDelete, SLE::const_ref before, SLE::const_ref after)
+{
+    if (isDelete)
+        return;
+
+    // Only owner directory pages carry sfOwner; book directories don't.
+    if (!after || after->getType() != ltDIR_NODE || !after->isFieldPresent(sfOwner))
+        return;
+
+    auto const& afterIndexes = after->getFieldV256(sfIndexes);
+    if (afterIndexes.empty())
+        return;
+
+    auto& added = added_[after->getAccountID(sfOwner)];
+    if (!before)
+    {
+        added.insert(added.end(), afterIndexes.begin(), afterIndexes.end());
+        return;
+    }
+
+    auto const& beforeIndexes = before->getFieldV256(sfIndexes);
+    for (auto const& index : afterIndexes)
+    {
+        if (std::ranges::find(beforeIndexes, index) == beforeIndexes.end())
+            added.push_back(index);
+    }
+}
+
+bool
+ValidPseudoAccountOwnership::finalize(
+    STTx const&,
+    TER const,
+    XRPAmount const,
+    ReadView const& view,
+    beast::Journal const& j)
+{
+    if (!view.rules().enabled(fixPseudoAccountOwnership))
+        return true;
+
+    for (auto const& [owner, indexes] : added_)
+    {
+        auto const root = view.read(keylet::account(owner));
+        if (!root || !isPseudoAccount(root))
+            continue;
+
+        // The object types each pseudo-account kind may own. A kind missing
+        // here fails the check: adding a pseudo-account kind must add its
+        // allowed set on purpose.
+        auto const allowed = [&root]() -> std::optional<std::set<LedgerEntryType>> {
+            if (root->isFieldPresent(sfAMMID))
+                return std::set<LedgerEntryType>{ltAMM, ltRIPPLE_STATE, ltMPTOKEN};
+            if (root->isFieldPresent(sfVaultID))
+            {
+                return std::set<LedgerEntryType>{
+                    ltMPTOKEN_ISSUANCE, ltMPTOKEN, ltRIPPLE_STATE, ltLOAN_BROKER};
+            }
+            if (root->isFieldPresent(sfLoanBrokerID))
+                return std::set<LedgerEntryType>{ltLOAN, ltMPTOKEN, ltRIPPLE_STATE};
+            return std::nullopt;
+        }();
+
+        for (auto const& index : indexes)
+        {
+            auto const sle = view.read(keylet::unchecked(index));
+            if (!sle)
+            {
+                // A directory entry without a ledger object is a dangling
+                // link; that defect belongs to other invariants.
+                continue;
+            }
+
+            if (!allowed || !allowed->contains(sle->getType()))
+            {
+                auto const item = LedgerFormats::getInstance().findByType(sle->getType());
+                JLOG(j.fatal()) << "Invariant failed: pseudo-account " << toBase58(owner)
+                                << " may not own an object of type "
+                                << (item != nullptr ? item->getName()
+                                                    : std::to_string(sle->getType()));
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+}  // namespace xrpl

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -579,10 +579,17 @@ struct Credentials_test : public beast::unit_test::Suite
                 if (!BEAST_EXPECT(sleVault))
                     return;
                 Account const vaultPseudo{"vault", sleVault->at(sfAccount)};
-                auto const expectedResult =
-                    features[fixCleanup3_3_0] ? Ter(tecPSEUDO_ACCOUNT) : Ter(tesSUCCESS);
+                // Without the CredentialCreate guard, the ownership invariant
+                // is the backstop that rejects the pin.
+                auto const expectedResult = [&]() -> TER {
+                    if (features[fixCleanup3_3_0])
+                        return tecPSEUDO_ACCOUNT;
+                    if (features[fixPseudoAccountOwnership])
+                        return tecINVARIANT_FAILED;
+                    return tesSUCCESS;
+                }();
 
-                env(credentials::create(vaultPseudo, issuer, credType), expectedResult);
+                env(credentials::create(vaultPseudo, issuer, credType), Ter(expectedResult));
                 env.close();
             }
         }

--- a/src/test/app/invariants/InvariantsPseudoAccount_test.cpp
+++ b/src/test/app/invariants/InvariantsPseudoAccount_test.cpp
@@ -1,4 +1,5 @@
 #include <test/app/invariants/InvariantsBase.h>
+#include <test/jtx/AMM.h>
 #include <test/jtx/Account.h>
 #include <test/jtx/Env.h>
 #include <test/jtx/TestHelpers.h>
@@ -10,6 +11,7 @@
 #include <test/unit_test/SuiteJournal.h>
 
 #include <xrpl/basics/Number.h>
+#include <xrpl/basics/Slice.h>
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/beast/utility/Journal.h>
@@ -28,6 +30,7 @@
 #include <xrpl/protocol/STLedgerEntry.h>
 #include <xrpl/protocol/STObject.h>
 #include <xrpl/protocol/STTx.h>
+#include <xrpl/protocol/SeqProxy.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/TxFormats.h>
@@ -731,11 +734,165 @@ class InvariantsPseudoAccount_test : public InvariantsBase
         }
     }
 
+    // Fabricate a credential with the given subject and link it into the
+    // subject's owner directory, as a transactor bug bypassing the
+    // CredentialCreate guard would.
+    static bool
+    pinCredential(AccountID const& subject, AccountID const& issuer, ApplyContext& ac)
+    {
+        Slice const credType{"FN130", 5};
+        auto cred = std::make_shared<SLE>(keylet::credential(subject, issuer, credType));
+        cred->setAccountID(sfSubject, subject);
+        cred->setAccountID(sfIssuer, issuer);
+        cred->setFieldVL(sfCredentialType, credType);
+        auto const page =
+            ac.view().dirInsert(keylet::ownerDir(subject), cred->key(), describeOwnerDir(subject));
+        if (!page)
+            return false;
+        cred->setFieldU64(sfSubjectNode, *page);
+        ac.view().insert(cred);
+        return true;
+    }
+
+    void
+    testVaultOwnership()
+    {
+        using namespace jtx;
+
+        std::optional<Keylet> vaultKeylet;
+        Preclose const createVault = [&](Account const& a1, Account const&, Env& env) -> bool {
+            Vault const vault{env};
+            auto [tx, k] = vault.create({.owner = a1, .asset = xrpIssue()});
+            env(tx);
+            env.close();
+            vaultKeylet = k;
+            return true;
+        };
+
+        auto const vaultPseudo = [&](ApplyContext& ac) -> std::optional<AccountID> {
+            if (!vaultKeylet)
+                return std::nullopt;
+            auto const sleVault = ac.view().read(*vaultKeylet);
+            if (!sleVault)
+                return std::nullopt;
+            return sleVault->at(sfAccount);
+        };
+
+        testcase << "vault pseudo-account pinned by a credential";
+        doInvariantCheck(
+            {"may not own an object of type Credential"},
+            [&](Account const&, Account const& a2, ApplyContext& ac) {
+                auto const pseudo = vaultPseudo(ac);
+                return pseudo && pinCredential(*pseudo, a2.id(), ac);
+            },
+            XRPAmount{},
+            STTx{ttACCOUNT_SET, [](STObject&) {}},
+            {tecINVARIANT_FAILED, tefINVARIANT_FAILED},
+            createVault);
+
+        testcase << "vault pseudo-account pinned by a check";
+        vaultKeylet.reset();
+        doInvariantCheck(
+            {"may not own an object of type Check"},
+            [&](Account const&, Account const& a2, ApplyContext& ac) {
+                auto const pseudo = vaultPseudo(ac);
+                if (!pseudo)
+                    return false;
+
+                auto const sleAcct = ac.view().peek(keylet::account(a2.id()));
+                if (!sleAcct)
+                    return false;
+
+                auto check = std::make_shared<SLE>(
+                    keylet::check(a2.id(), SeqProxy::rawSequence((*sleAcct)[sfSequence])));
+                check->setAccountID(sfAccount, a2.id());
+                check->setAccountID(sfDestination, *pseudo);
+                auto const page = ac.view().dirInsert(
+                    keylet::ownerDir(*pseudo), check->key(), describeOwnerDir(*pseudo));
+                if (!page)
+                    return false;
+                check->setFieldU64(sfDestinationNode, *page);
+                ac.view().insert(check);
+                return true;
+            },
+            XRPAmount{},
+            STTx{ttACCOUNT_SET, [](STObject&) {}},
+            {tecINVARIANT_FAILED, tefINVARIANT_FAILED},
+            createVault);
+
+        testcase << "no ownership enforcement before the amendment";
+        vaultKeylet.reset();
+        doInvariantCheck(
+            makeEnv(all_ - fixPseudoAccountOwnership),
+            {},
+            [&](Account const&, Account const& a2, ApplyContext& ac) {
+                auto const pseudo = vaultPseudo(ac);
+                return pseudo && pinCredential(*pseudo, a2.id(), ac);
+            },
+            XRPAmount{},
+            STTx{ttACCOUNT_SET, [](STObject&) {}},
+            {tesSUCCESS, tesSUCCESS},
+            createVault);
+    }
+
+    void
+    testLoanBrokerOwnership()
+    {
+        using namespace jtx;
+
+        testcase << "loan broker pseudo-account pinned by a credential";
+        std::optional<Keylet> brokerKeylet;
+        doInvariantCheck(
+            {"may not own an object of type Credential"},
+            [&](Account const&, Account const& a2, ApplyContext& ac) {
+                if (!brokerKeylet)
+                    return false;
+                auto const sleBroker = ac.view().read(*brokerKeylet);
+                if (!sleBroker)
+                    return false;
+                AccountID const pseudo = sleBroker->at(sfAccount);
+                return pinCredential(pseudo, a2.id(), ac);
+            },
+            XRPAmount{},
+            STTx{ttACCOUNT_SET, [](STObject&) {}},
+            {tecINVARIANT_FAILED, tefINVARIANT_FAILED},
+            [&, this](Account const& a1, Account const&, Env& env) -> bool {
+                PrettyAsset const xrpAsset{xrpIssue(), 1'000'000};
+                brokerKeylet = createLoanBroker(a1, env, xrpAsset);
+                return brokerKeylet.has_value();
+            });
+    }
+
+    void
+    testAMMOwnership()
+    {
+        using namespace jtx;
+
+        testcase << "AMM pseudo-account pinned by a credential";
+        std::optional<AccountID> ammAccount;
+        doInvariantCheck(
+            {"may not own an object of type Credential"},
+            [&](Account const&, Account const& a2, ApplyContext& ac) {
+                return ammAccount && pinCredential(*ammAccount, a2.id(), ac);
+            },
+            XRPAmount{},
+            STTx{ttACCOUNT_SET, [](STObject&) {}},
+            {tecINVARIANT_FAILED, tefINVARIANT_FAILED},
+            [&](Account const& a1, Account const&, Env& env) -> bool {
+                AMM const amm(env, a1, XRP(100), a1["USD"](100));
+                ammAccount = amm.ammAccount();
+                return true;
+            });
+    }
+
     void
     run() override
     {
         testValidPseudoAccounts();
         testValidLoanBroker();
+        testVaultOwnership();
+        testLoanBrokerOwnership();
+        testAMMOwnership();
     }
 };
 


### PR DESCRIPTION
## High Level Overview of Change
New invariant `ValidPseudoAccountOwnership`, gated behind `fixCleanup3_5_0`. For each pseudo-account kind (AMM, Vault, LoanBroker), it fixes the set of ledger entry types allowed in that pseudo-account's owner directory. Any other type linked in there fails the transaction with `tecINVARIANT_FAILED`/`tefINVARIANT_FAILED`.

## Context of Change
A pseudo-account can't sign transactions, so any object type its per-kind guards don't expect ends up permanently pinned in its owner directory: nothing can remove it, and it blocks deleting the object that owns the pseudo-account. Several transactors already refuse to create such links (TrustSet, EscrowCreate, CheckCreate, PaymentChannelCreate, DelegateSet, SponsorshipSet, DepositPreauth, CredentialCreate, Payment). This invariant is the backstop for that whole class of guard: it checks once against whatever actually lands in the directory, instead of relying on every current and future transactor getting it right. It follows a Sherlock audit finding that a related pseudo-account cleanup mechanism was itself exploitable and got reverted in an earlier PR; this is the general replacement fix.

## API Impact
- [x] `libxrpl` change

## Test Plan
- `InvariantsPseudoAccount_test`: fabricates an object type each pseudo-account kind (AMM/Vault/LoanBroker) doesn't expect, the way a bug bypassing the transactor-level guard would, and checks the invariant rejects it, plus that it's a no-op with the amendment off.
- `Credentials_test`: updates the pre-fixCleanup3_3_0 pin scenario to expect `tecINVARIANT_FAILED` once `fixCleanup3_5_0` is enabled.

