### PR TITLE
feat: Register featureLendingProtocolV1_2 amendment

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -15,6 +15,7 @@
 // Add new amendments to the top of this list.
 // Keep it sorted in reverse chronological order.
 
+XRPL_FEATURE(LendingProtocolV1_2,         Supported::No,  VoteBehavior::DefaultNo)
 XRPL_FIX    (Cleanup3_5_0,                Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(ConfidentialMPTKeyRotation,  Supported::No,  VoteBehavior::DefaultNo)
 XRPL_FIX    (Cleanup3_4_0,                Supported::Yes, VoteBehavior::DefaultNo)


### PR DESCRIPTION
## Summary
- Register `featureLendingProtocolV1_2` in `features.macro` as `Supported::No` / `VoteBehavior::DefaultNo`.
- No protocol behavior is gated yet. The amendment is not in `testableAmendments()`.

## Test plan
- Confirm `featureLendingProtocolV1_2` is declared after a compile.
- Confirm existing tests are unchanged (unsupported amendment is not enabled by default).