### PR TITLE
docs: Codify recurring PR review feedback into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,13 @@ This file provides guidance to AI coding agents (Claude Code, and other AGENTS.m
 
 ## Build
 
-Required on Linux/macOS: use the Nix devshell, which sets up the compiler, Conan, ccache, and (optionally) Rust automatically.
+Recommended on Linux/macOS: the Nix devshell sets up the compiler, Conan, ccache, and (optionally) Rust automatically.
 
 ```bash
 nix develop
 ```
 
-For alternate devshell variants (specific compiler, no-compiler, coverage), see [docs/build/nix.md](./docs/build/nix.md). For the manual build steps, CMake options, and protocol codegen commands, see [BUILD.md](./BUILD.md) (`## Steps`, `## Options`, `## Code generation`).
+Not required — contributors can use their own toolchain/build flow instead. For alternate devshell variants (specific compiler, no-compiler, coverage), see [docs/build/nix.md](./docs/build/nix.md). For manual (non-Nix) build steps, CMake options, and protocol codegen commands, see [BUILD.md](./BUILD.md) (`## Steps`, `## Options`, `## Code generation`).
 
 Rust crate tests (independent of the CMake build): `cargo test --manifest-path crates/Cargo.toml --workspace` (CI uses `cargo nextest`).
 
@@ -33,10 +33,8 @@ New file placement and header levelization: see [CONTRIBUTING.md](./CONTRIBUTING
 
 ## Architecture
 
-Paths below reflect the current layout; update this section if modularization moves a subsystem to a different directory.
+See [ARCHITECTURE.md](./ARCHITECTURE.md) for the directory-by-directory map of the codebase.
 
-- `include/xrpl/` + `src/libxrpl/` — the core protocol library: ledger, shamap, consensus, crypto, json, resource, nodestore, rdb, peerfinder, and `tx/` (transaction application: `Transactor.cpp`, `applySteps.cpp`, invariants, payment paths — see [src/libxrpl/tx/AGENTS.md](./src/libxrpl/tx/AGENTS.md) for amendment-gating conventions). `tx/transactors/` has one file per transaction type, grouped by subsystem: `escrow/`, `vault/`, `lending/`, `sponsor/`, `nft/`, `token/` (MPT), `payment_channel/`, `permissioned_domain/`, `dex/`, `oracle/`, `did/`, `credentials/`, `bridge/`, `check/`, `delegate/`, `account/`, `system/`.
-- `src/xrpld/` — the server application built on top of `libxrpl`: `app`, `core`, `overlay` (P2P networking), `peerfinder`, `perflog`, `rpc`, `shamap`. `main` builds an `ApplicationImp` implementing `Application`; most components hold a reference to it (`app_`), giving broad cross-component access — expect to trace call chains through `Application&`.
-- `src/test/` — unit tests mirroring the subsystems above, plus `jtx/` (the transaction-building test DSL — e.g. `jtx/escrow.h`, `jtx/vault.h`, `jtx/sponsor.h`, `jtx/permissioned_dex.h`) and `unit_test/` (the custom test framework itself, derived from Beast).
-- `src/tests/` — unit tests for `libxrpl` written in `gtest`, gradually replacing the `src/test` equivalents.
-- `crates/` — a Rust workspace (only built with `-Dxrpld -Drust=ON`) bridged into C++ via `cxxbridge`/the `cxx` crate; currently just a `hello_world` interop scaffold. Requires the Rust toolchain pinned in `rust-toolchain.toml` (the Nix devshell provides it automatically).
+## Keeping docs current
+
+When you add or change a convention, or touch a subsystem that has its own `AGENTS.md`, `README.md`, or `ARCHITECTURE.md`, update that documentation in the same change rather than leaving it stale.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,7 @@ Unit tests are a custom framework built into the `xrpld` binary itself (not Boos
 - A suite's `--unittest` name is built from the arguments to its `BEAST_DEFINE_TESTSUITE`/`BEAST_DEFINE_TESTSUITE_PRIO` macro (usually at the bottom of the test file), in reverse order and joined with `.`: `BEAST_DEFINE_TESTSUITE(Credentials, app, xrpl)` → `xrpl.app.Credentials`.
 - `--unittest-arg` does nothing — don't use it.
 - Tests that run offline in under a minute should be automatic `--unittest` suites; anything else is a manual/integration test.
-- New tests should be written using `gtest` under `src/tests/` unless that isn't possible, in which case fall back to the legacy Beast framework under `src/test/`. `tests/` (top-level) holds integration tests exercised against `libxrpl`/`xrpld`.
-- Shared test setup/helper code used by more than one test file belongs in `jtx/` (`src/test/jtx/`), not copy-pasted across test files.
+- New tests should be written using `gtest` under `src/tests/` unless that isn't possible, in which case fall back to the legacy Beast framework under `src/test/` (see [src/test/AGENTS.md](./src/test/AGENTS.md) for conventions specific to that directory). `tests/` (top-level) holds integration tests exercised against `libxrpl`/`xrpld`.
 
 ## Lint/Format
 
@@ -32,15 +31,11 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md#pre-commit-hooks) for `pre-commit` setup
 
 New file placement and header levelization: see [CONTRIBUTING.md](./CONTRIBUTING.md#before-making-a-pull-request). Braces, whitespace, member order, and other conventions: see [docs/CodingStyle.md](./docs/CodingStyle.md). `XRPL_ASSERT`/`UNREACHABLE` contracts: see [CONTRIBUTING.md](./CONTRIBUTING.md#contracts-and-instrumentation). Commit messages: see [CONTRIBUTING.md](./CONTRIBUTING.md#good-commit-messages). New public functions/methods need a Doxygen-style comment.
 
-## API Changelog
-
-Any change to publicly-visible API behavior — RPC/WebSocket fields, parameters, or error conditions, or transaction/signing behavior surfaced through the API — needs an entry in [API-CHANGELOG.md](./API-CHANGELOG.md) under `## Unreleased`, regardless of which directory the change lives in.
-
 ## Architecture
 
 Paths below reflect the current layout; update this section if modularization moves a subsystem to a different directory.
 
-- `include/xrpl/` + `src/libxrpl/` — the core protocol library: ledger, shamap, consensus, crypto, json, resource, nodestore, rdb, peerfinder, and `tx/` (transaction application: `Transactor.cpp`, `applySteps.cpp`, invariants, payment paths). `tx/transactors/` has one file per transaction type, grouped by subsystem: `escrow/`, `vault/`, `lending/`, `sponsor/`, `nft/`, `token/` (MPT), `payment_channel/`, `permissioned_domain/`, `dex/`, `oracle/`, `did/`, `credentials/`, `bridge/`, `check/`, `delegate/`, `account/`, `system/`. Any change to transaction-processing behavior must be gated behind an Amendment.
+- `include/xrpl/` + `src/libxrpl/` — the core protocol library: ledger, shamap, consensus, crypto, json, resource, nodestore, rdb, peerfinder, and `tx/` (transaction application: `Transactor.cpp`, `applySteps.cpp`, invariants, payment paths — see [src/libxrpl/tx/AGENTS.md](./src/libxrpl/tx/AGENTS.md) for amendment-gating conventions). `tx/transactors/` has one file per transaction type, grouped by subsystem: `escrow/`, `vault/`, `lending/`, `sponsor/`, `nft/`, `token/` (MPT), `payment_channel/`, `permissioned_domain/`, `dex/`, `oracle/`, `did/`, `credentials/`, `bridge/`, `check/`, `delegate/`, `account/`, `system/`.
 - `src/xrpld/` — the server application built on top of `libxrpl`: `app`, `core`, `overlay` (P2P networking), `peerfinder`, `perflog`, `rpc`, `shamap`. `main` builds an `ApplicationImp` implementing `Application`; most components hold a reference to it (`app_`), giving broad cross-component access — expect to trace call chains through `Application&`.
 - `src/test/` — unit tests mirroring the subsystems above, plus `jtx/` (the transaction-building test DSL — e.g. `jtx/escrow.h`, `jtx/vault.h`, `jtx/sponsor.h`, `jtx/permissioned_dex.h`) and `unit_test/` (the custom test framework itself, derived from Beast).
 - `src/tests/` — unit tests for `libxrpl` written in `gtest`, gradually replacing the `src/test` equivalents.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,7 @@ This file provides guidance to AI coding agents (Claude Code, and other AGENTS.m
 
 ## Build
 
-Recommended on Linux/macOS: the Nix devshell sets up the compiler, Conan, ccache, and (optionally) Rust automatically.
-
-```bash
-nix develop
-```
-
-Not required — contributors can use their own toolchain/build flow instead. For alternate devshell variants (specific compiler, no-compiler, coverage), see [docs/build/nix.md](./docs/build/nix.md). For manual (non-Nix) build steps, CMake options, and protocol codegen commands, see [BUILD.md](./BUILD.md) (`## Steps`, `## Options`, `## Code generation`).
+For the build steps, CMake options, and protocol codegen commands, see [BUILD.md](./BUILD.md) (`## Steps`, `## Options`, `## Code generation`). Nix development shells are available in the repo (not required) — see [docs/build/nix.md](./docs/build/nix.md) for setup and variants.
 
 Rust crate tests (independent of the CMake build): `cargo test --manifest-path crates/Cargo.toml --workspace` (CI uses `cargo nextest`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Unit tests are a custom framework built into the `xrpld` binary itself (not Boos
 - `--unittest-arg` does nothing — don't use it.
 - Tests that run offline in under a minute should be automatic `--unittest` suites; anything else is a manual/integration test.
 - New tests should be written using `gtest` under `src/tests/` unless that isn't possible, in which case fall back to the legacy Beast framework under `src/test/`. `tests/` (top-level) holds integration tests exercised against `libxrpl`/`xrpld`.
+- Shared test setup/helper code used by more than one test file belongs in `jtx/` (`src/test/jtx/`), not copy-pasted across test files.
 
 ## Lint/Format
 
@@ -29,7 +30,11 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md#pre-commit-hooks) for `pre-commit` setup
 
 ## Code Style
 
-New file placement and header levelization: see [CONTRIBUTING.md](./CONTRIBUTING.md#before-making-a-pull-request). Braces, whitespace, member order, and other conventions: see [docs/CodingStyle.md](./docs/CodingStyle.md). `XRPL_ASSERT`/`UNREACHABLE` contracts: see [CONTRIBUTING.md](./CONTRIBUTING.md#contracts-and-instrumentation). Commit messages: see [CONTRIBUTING.md](./CONTRIBUTING.md#good-commit-messages).
+New file placement and header levelization: see [CONTRIBUTING.md](./CONTRIBUTING.md#before-making-a-pull-request). Braces, whitespace, member order, and other conventions: see [docs/CodingStyle.md](./docs/CodingStyle.md). `XRPL_ASSERT`/`UNREACHABLE` contracts: see [CONTRIBUTING.md](./CONTRIBUTING.md#contracts-and-instrumentation). Commit messages: see [CONTRIBUTING.md](./CONTRIBUTING.md#good-commit-messages). New public functions/methods need a Doxygen-style comment.
+
+## API Changelog
+
+Any change to publicly-visible API behavior — RPC/WebSocket fields, parameters, or error conditions, or transaction/signing behavior surfaced through the API — needs an entry in [API-CHANGELOG.md](./API-CHANGELOG.md) under `## Unreleased`, regardless of which directory the change lives in.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md#pre-commit-hooks) for `pre-commit` setup
 
 New file placement and header levelization: see [CONTRIBUTING.md](./CONTRIBUTING.md#before-making-a-pull-request). Braces, whitespace, member order, and other conventions: see [docs/CodingStyle.md](./docs/CodingStyle.md). `XRPL_ASSERT`/`UNREACHABLE` contracts: see [CONTRIBUTING.md](./CONTRIBUTING.md#contracts-and-instrumentation). Commit messages: see [CONTRIBUTING.md](./CONTRIBUTING.md#good-commit-messages). New public functions/methods need a Doxygen-style comment.
 
+Comments should explain _why_, not _what_/_how_ — the code already shows that. Only describe what/how when the code itself would otherwise be confusing (a non-obvious workaround, a subtle invariant, a surprising constraint).
+
 ## Architecture
 
 See [ARCHITECTURE.md](./ARCHITECTURE.md) for the directory-by-directory map of the codebase.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,9 @@
+# Architecture
+
+Paths below reflect the current layout; update this doc if modularization moves a subsystem to a different directory.
+
+- `include/xrpl/` + `src/libxrpl/` — the core protocol library: ledger, shamap, consensus, crypto, json, resource, nodestore, rdb, peerfinder, and `tx/` (transaction application: `Transactor.cpp`, `applySteps.cpp`, invariants, payment paths — see [src/libxrpl/tx/AGENTS.md](./src/libxrpl/tx/AGENTS.md) for amendment-gating conventions). `tx/transactors/` has one file per transaction type, grouped by subsystem: `escrow/`, `vault/`, `lending/`, `sponsor/`, `nft/`, `token/` (MPT), `payment_channel/`, `permissioned_domain/`, `dex/`, `oracle/`, `did/`, `credentials/`, `bridge/`, `check/`, `delegate/`, `account/`, `system/`.
+- `src/xrpld/` — the server application built on top of `libxrpl`: `app`, `core`, `overlay` (P2P networking), `peerfinder`, `perflog`, `rpc`, `shamap`. `main` builds an `ApplicationImp` implementing `Application`; most components hold a reference to it (`app_`), giving broad cross-component access — expect to trace call chains through `Application&`.
+- `src/test/` — unit tests mirroring the subsystems above, plus `jtx/` (the transaction-building test DSL — e.g. `jtx/escrow.h`, `jtx/vault.h`, `jtx/sponsor.h`, `jtx/permissioned_dex.h`) and `unit_test/` (the custom test framework itself, derived from Beast).
+- `src/tests/` — unit tests for `libxrpl` written in `gtest`, gradually replacing the `src/test` equivalents.
+- `crates/` — a Rust workspace (only built with `-Dxrpld -Drust=ON`) bridged into C++ via `cxxbridge`/the `cxx` crate; currently just a `hello_world` interop scaffold. Requires the Rust toolchain pinned in `rust-toolchain.toml` (the Nix devshell provides it automatically).

--- a/include/xrpl/consensus/AGENTS.md
+++ b/include/xrpl/consensus/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — consensus
+
+See the repo-level [AGENTS.md](../../../AGENTS.md) for general guidance. See [README.md](./README.md) for a short pointer, and [docs/consensus.md](../../../docs/consensus.md) for the full consensus design.

--- a/include/xrpl/consensus/AGENTS.md
+++ b/include/xrpl/consensus/AGENTS.md
@@ -1,3 +1,3 @@
 # AGENTS.md — consensus
 
-See the repo-level [AGENTS.md](../../../AGENTS.md) for general guidance. See [README.md](./README.md) for a short pointer, and [docs/consensus.md](../../../docs/consensus.md) for the full consensus design.
+See [README.md](./README.md) for a short pointer, and [docs/consensus.md](../../../docs/consensus.md) for the full consensus design.

--- a/include/xrpl/consensus/CLAUDE.md
+++ b/include/xrpl/consensus/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/include/xrpl/nodestore/AGENTS.md
+++ b/include/xrpl/nodestore/AGENTS.md
@@ -1,3 +1,3 @@
 # AGENTS.md — nodestore
 
-See the repo-level [AGENTS.md](../../../AGENTS.md) for general guidance and [README.md](./README.md) for backend and benchmark design.
+See [README.md](./README.md) for backend and benchmark design.

--- a/include/xrpl/nodestore/AGENTS.md
+++ b/include/xrpl/nodestore/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — nodestore
+
+See the repo-level [AGENTS.md](../../../AGENTS.md) for general guidance and [README.md](./README.md) for backend and benchmark design.

--- a/include/xrpl/nodestore/CLAUDE.md
+++ b/include/xrpl/nodestore/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/include/xrpl/shamap/AGENTS.md
+++ b/include/xrpl/shamap/AGENTS.md
@@ -1,3 +1,3 @@
 # AGENTS.md — shamap
 
-See the repo-level [AGENTS.md](../../../AGENTS.md) for general guidance and [README.md](./README.md) for the SHAMap design.
+See [README.md](./README.md) for the SHAMap design.

--- a/include/xrpl/shamap/AGENTS.md
+++ b/include/xrpl/shamap/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — shamap
+
+See the repo-level [AGENTS.md](../../../AGENTS.md) for general guidance and [README.md](./README.md) for the SHAMap design.

--- a/include/xrpl/shamap/CLAUDE.md
+++ b/include/xrpl/shamap/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/libxrpl/ledger/helpers/AGENTS.md
+++ b/src/libxrpl/ledger/helpers/AGENTS.md
@@ -3,3 +3,7 @@
 See the repo-level [AGENTS.md](../../../../AGENTS.md) for general guidance.
 
 A helper that takes an `SLE`/`std::shared_ptr<SLE const>` should `XRPL_ASSERT` that it's non-null and of the expected ledger-entry type at entry, and keep a real runtime check/error-return alongside the assert (asserts compile out in release builds). Don't invent a new error-handling idiom for this (e.g. `std::unexpected`) — return the existing `tec`/`ter`/`tef` code used elsewhere in the codebase.
+
+Prefer a single amendment-enabled block and a single disabled block over scattering `rules.enabled(...)` checks through a function, even if the two blocks are similar. When a file or function checks more than one amendment, name local enablement booleans per-amendment (e.g. `fix340Enabled` for `fixCleanup3_4_0`), not a generic `fixEnabled`.
+
+Only use `UNREACHABLE` for genuinely impossible paths, not to avoid writing a test for one that's reachable but rare. When a branch marked `UNREACHABLE` is excluded from coverage, wrap it in `LCOV_EXCL_START`/`LCOV_EXCL_STOP`.

--- a/src/libxrpl/ledger/helpers/AGENTS.md
+++ b/src/libxrpl/ledger/helpers/AGENTS.md
@@ -2,7 +2,7 @@
 
 See the repo-level [AGENTS.md](../../../../AGENTS.md) for general guidance.
 
-A helper that takes an `SLE`/`std::shared_ptr<SLE const>` should `XRPL_ASSERT` that it's non-null and of the expected ledger-entry type at entry, and keep a real runtime check/error-return alongside the assert (asserts compile out in release builds). Don't invent a new error-handling idiom for this (e.g. `std::unexpected`) — return the existing `tec`/`ter`/`tef` code used elsewhere in the codebase.
+A helper that takes an `SLE`/`std::shared_ptr<SLE const>` should `XRPL_ASSERT` that it's non-null and of the expected ledger-entry type at entry, and keep a real runtime check/error-return alongside the assert (asserts compile out in release builds) — the established idiom in this directory is `std::expected<..., TER>`, returning `std::unexpected(tec*)` on failure. Don't invent a new error-handling idiom for this.
 
 Prefer a single amendment-enabled block and a single disabled block over scattering `rules.enabled(...)` checks through a function, even if the two blocks are similar. When a file or function checks more than one amendment, name local enablement booleans per-amendment (e.g. `fix340Enabled` for `fixCleanup3_4_0`), not a generic `fixEnabled`.
 

--- a/src/libxrpl/ledger/helpers/AGENTS.md
+++ b/src/libxrpl/ledger/helpers/AGENTS.md
@@ -1,7 +1,5 @@
 # AGENTS.md — ledger/helpers
 
-See the repo-level [AGENTS.md](../../../../AGENTS.md) for general guidance.
-
 A helper that takes an `SLE`/`std::shared_ptr<SLE const>` should `XRPL_ASSERT` that it's non-null and of the expected ledger-entry type at entry, and keep a real runtime check/error-return alongside the assert (asserts compile out in release builds) — the established idiom in this directory is `std::expected<..., TER>`, returning `std::unexpected(tec*)` on failure. Don't invent a new error-handling idiom for this.
 
 Prefer a single amendment-enabled block and a single disabled block over scattering `rules.enabled(...)` checks through a function, even if the two blocks are similar. When a file or function checks more than one amendment, name local enablement booleans per-amendment (e.g. `fix340Enabled` for `fixCleanup3_4_0`), not a generic `fixEnabled`.

--- a/src/libxrpl/ledger/helpers/AGENTS.md
+++ b/src/libxrpl/ledger/helpers/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md — ledger/helpers
+
+See the repo-level [AGENTS.md](../../../../AGENTS.md) for general guidance.
+
+A helper that takes an `SLE`/`std::shared_ptr<SLE const>` should `XRPL_ASSERT` that it's non-null and of the expected ledger-entry type at entry, and keep a real runtime check/error-return alongside the assert (asserts compile out in release builds). Don't invent a new error-handling idiom for this (e.g. `std::unexpected`) — return the existing `tec`/`ter`/`tef` code used elsewhere in the codebase.

--- a/src/libxrpl/ledger/helpers/CLAUDE.md
+++ b/src/libxrpl/ledger/helpers/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/libxrpl/tx/AGENTS.md
+++ b/src/libxrpl/tx/AGENTS.md
@@ -1,7 +1,5 @@
 # AGENTS.md — tx
 
-See the repo-level [AGENTS.md](../../../AGENTS.md) for general build/test/style guidance.
-
 ## When an amendment is required
 
 A change needs an amendment if it affects transaction processing, ledger objects, or anything else about the binary format or hash of the ledger. An amendment is optional if a change only affects what transactions get proposed for consensus (e.g. fee escalation). Otherwise, don't use one.

--- a/src/libxrpl/tx/AGENTS.md
+++ b/src/libxrpl/tx/AGENTS.md
@@ -12,10 +12,6 @@ When adding a new amendment or transaction type, check its interaction with: inv
 
 New (or deleted) invariant checks must be amendment-gated: they introduce (or remove) a way for a transaction to fail, and an un-gated change risks validators disagreeing on a transaction's result, i.e. a network fork.
 
-## Gating amendment-dependent code
+See [transactors/AGENTS.md](./transactors/AGENTS.md) for conventions on writing the amendment-gated code itself.
 
-Prefer a single amendment-enabled block and a single disabled block over scattering `rules.enabled(...)` checks through a function, even if the two blocks are similar.
-
-When a file or function checks more than one amendment, name local enablement booleans per-amendment (e.g. `fix340Enabled` for `fixCleanup3_4_0`), not a generic `fixEnabled` — it becomes ambiguous once a second amendment is checked in the same scope.
-
-Only use `UNREACHABLE` for genuinely impossible paths, not to avoid writing a test for one that's reachable but rare. When a branch marked `UNREACHABLE` is excluded from coverage, wrap it in `LCOV_EXCL_START`/`LCOV_EXCL_STOP`.
+A change to transaction/signing behavior that's visible through the public API also needs an `API-CHANGELOG.md` entry — see [../../xrpld/rpc/AGENTS.md](../../xrpld/rpc/AGENTS.md) for the full rule.

--- a/src/libxrpl/tx/AGENTS.md
+++ b/src/libxrpl/tx/AGENTS.md
@@ -2,4 +2,20 @@
 
 See the repo-level [AGENTS.md](../../../AGENTS.md) for general build/test/style guidance.
 
-Any change to transaction-processing behavior must be gated behind an amendment. New amendments (and fixes, i.e. `fix*` amendments) are added to [`include/xrpl/protocol/detail/features.macro`](../../../include/xrpl/protocol/detail/features.macro), as an `XRPL_FEATURE(...)` or `XRPL_FIX(...)` entry added to the top of the list (the list is kept in reverse chronological order). Once the pre-amendment code path for a retired amendment is removed, move its entry to `XRPL_RETIRE_FEATURE(...)`/`XRPL_RETIRE_FIX(...)` instead of deleting it.
+## When an amendment is required
+
+A change needs an amendment if it affects transaction processing, ledger objects, or anything else about the binary format or hash of the ledger. An amendment is optional if a change only affects what transactions get proposed for consensus (e.g. fee escalation). Otherwise, don't use one.
+
+New amendments (and fixes, i.e. `fix*` amendments) are added to [`include/xrpl/protocol/detail/features.macro`](../../../include/xrpl/protocol/detail/features.macro), as an `XRPL_FEATURE(...)` or `XRPL_FIX(...)` entry added to the top of the list (the list is kept in reverse chronological order). Once the pre-amendment code path for a retired amendment is removed, move its entry to `XRPL_RETIRE_FEATURE(...)`/`XRPL_RETIRE_FIX(...)` instead of deleting it.
+
+When adding a new amendment or transaction type, check its interaction with: invariants, fees, Deposit Auth, Batch transaction inclusion/exclusion, Permission Delegation inclusion/exclusion, Freeze/Deep Freeze (IOU) and Lock (MPT), Clawback, Credentials and Permissioned Domain, the case where the submitting account is the asset's issuer, and numeric over/underflow. Stick to existing paradigms rather than inventing new ones — consistency between features matters more than a locally "better" design.
+
+New (or deleted) invariant checks must be amendment-gated: they introduce (or remove) a way for a transaction to fail, and an un-gated change risks validators disagreeing on a transaction's result, i.e. a network fork.
+
+## Gating amendment-dependent code
+
+Prefer a single amendment-enabled block and a single disabled block over scattering `rules.enabled(...)` checks through a function, even if the two blocks are similar.
+
+When a file or function checks more than one amendment, name local enablement booleans per-amendment (e.g. `fix340Enabled` for `fixCleanup3_4_0`), not a generic `fixEnabled` — it becomes ambiguous once a second amendment is checked in the same scope.
+
+Only use `UNREACHABLE` for genuinely impossible paths, not to avoid writing a test for one that's reachable but rare. When a branch marked `UNREACHABLE` is excluded from coverage, wrap it in `LCOV_EXCL_START`/`LCOV_EXCL_STOP`.

--- a/src/libxrpl/tx/transactors/AGENTS.md
+++ b/src/libxrpl/tx/transactors/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS.md — transactors
+
+See [tx/AGENTS.md](../AGENTS.md) for amendment-gating conventions that apply to all transactors, and the repo-level [AGENTS.md](../../../../AGENTS.md) for general guidance.
+
+Pseudo-accounts (Vault, LoanBroker, AMM, ...) are exempt from `requireAuth` and freeze/deep-freeze checks as a class, not on a per-asset-type basis. Code that touches a pseudo-account (deposits, withdrawals, clawback, deletion, credential checks) must preserve that exemption rather than re-deriving it for each asset type.
+
+Prefer a single object-level invariant over duplicating the same delta/balance check in every transactor that touches an object — e.g. one invariant asserting a Vault's pseudo-account balance and `assetsAvailable` always move together, rather than repeating that check in `VaultDeposit`, `VaultWithdraw`, `VaultClawback`, `LoanSet`, etc.

--- a/src/libxrpl/tx/transactors/AGENTS.md
+++ b/src/libxrpl/tx/transactors/AGENTS.md
@@ -1,7 +1,5 @@
 # AGENTS.md — transactors
 
-See [tx/AGENTS.md](../AGENTS.md) for amendment-gating conventions that apply to all transactors, and the repo-level [AGENTS.md](../../../../AGENTS.md) for general guidance.
-
 Prefer a single object-level invariant over duplicating the same delta/balance check in every transactor that touches an object — e.g. one invariant asserting a Vault's pseudo-account balance and `assetsAvailable` always move together, rather than repeating that check in `VaultDeposit`, `VaultWithdraw`, `VaultClawback`, `LoanSet`, etc.
 
 ## Gating amendment-dependent code

--- a/src/libxrpl/tx/transactors/AGENTS.md
+++ b/src/libxrpl/tx/transactors/AGENTS.md
@@ -5,3 +5,11 @@ See [tx/AGENTS.md](../AGENTS.md) for amendment-gating conventions that apply to 
 Pseudo-accounts (Vault, LoanBroker, AMM, ...) are exempt from `requireAuth` and freeze/deep-freeze checks as a class, not on a per-asset-type basis. Code that touches a pseudo-account (deposits, withdrawals, clawback, deletion, credential checks) must preserve that exemption rather than re-deriving it for each asset type.
 
 Prefer a single object-level invariant over duplicating the same delta/balance check in every transactor that touches an object — e.g. one invariant asserting a Vault's pseudo-account balance and `assetsAvailable` always move together, rather than repeating that check in `VaultDeposit`, `VaultWithdraw`, `VaultClawback`, `LoanSet`, etc.
+
+## Gating amendment-dependent code
+
+Prefer a single amendment-enabled block and a single disabled block over scattering `rules.enabled(...)` checks through a function, even if the two blocks are similar.
+
+When a file or function checks more than one amendment, name local enablement booleans per-amendment (e.g. `fix340Enabled` for `fixCleanup3_4_0`), not a generic `fixEnabled` — it becomes ambiguous once a second amendment is checked in the same scope.
+
+Only use `UNREACHABLE` for genuinely impossible paths, not to avoid writing a test for one that's reachable but rare. When a branch marked `UNREACHABLE` is excluded from coverage, wrap it in `LCOV_EXCL_START`/`LCOV_EXCL_STOP`.

--- a/src/libxrpl/tx/transactors/AGENTS.md
+++ b/src/libxrpl/tx/transactors/AGENTS.md
@@ -2,8 +2,6 @@
 
 See [tx/AGENTS.md](../AGENTS.md) for amendment-gating conventions that apply to all transactors, and the repo-level [AGENTS.md](../../../../AGENTS.md) for general guidance.
 
-Pseudo-accounts (Vault, LoanBroker, AMM, ...) are exempt from `requireAuth` and freeze/deep-freeze checks as a class, not on a per-asset-type basis. Code that touches a pseudo-account (deposits, withdrawals, clawback, deletion, credential checks) must preserve that exemption rather than re-deriving it for each asset type.
-
 Prefer a single object-level invariant over duplicating the same delta/balance check in every transactor that touches an object — e.g. one invariant asserting a Vault's pseudo-account balance and `assetsAvailable` always move together, rather than repeating that check in `VaultDeposit`, `VaultWithdraw`, `VaultClawback`, `LoanSet`, etc.
 
 ## Gating amendment-dependent code
@@ -11,5 +9,7 @@ Prefer a single object-level invariant over duplicating the same delta/balance c
 Prefer a single amendment-enabled block and a single disabled block over scattering `rules.enabled(...)` checks through a function, even if the two blocks are similar.
 
 When a file or function checks more than one amendment, name local enablement booleans per-amendment (e.g. `fix340Enabled` for `fixCleanup3_4_0`), not a generic `fixEnabled` — it becomes ambiguous once a second amendment is checked in the same scope.
+
+## `UNREACHABLE` and test coverage
 
 Only use `UNREACHABLE` for genuinely impossible paths, not to avoid writing a test for one that's reachable but rare. When a branch marked `UNREACHABLE` is excluded from coverage, wrap it in `LCOV_EXCL_START`/`LCOV_EXCL_STOP`.

--- a/src/libxrpl/tx/transactors/CLAUDE.md
+++ b/src/libxrpl/tx/transactors/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/test/AGENTS.md
+++ b/src/test/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md — test
 
-See the repo-level [AGENTS.md](../../AGENTS.md) for general build/test/style guidance, and [README.md](./README.md) for basic `--unittest` invocation.
+See [README.md](./README.md) for basic `--unittest` invocation.
 
 Shared test setup/helper code used by more than one test file belongs in `jtx/`, not copy-pasted across test files.

--- a/src/test/AGENTS.md
+++ b/src/test/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md — test
+
+See the repo-level [AGENTS.md](../../AGENTS.md) for general build/test/style guidance, and [README.md](./README.md) for basic `--unittest` invocation.
+
+Shared test setup/helper code used by more than one test file belongs in `jtx/`, not copy-pasted across test files.

--- a/src/test/CLAUDE.md
+++ b/src/test/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/xrpld/app/consensus/AGENTS.md
+++ b/src/xrpld/app/consensus/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — consensus
+
+See the repo-level [AGENTS.md](../../../../AGENTS.md) for general guidance. See [README.md](./README.md) for a short pointer, and [docs/consensus.md](../../../../docs/consensus.md) for the full consensus design.

--- a/src/xrpld/app/consensus/AGENTS.md
+++ b/src/xrpld/app/consensus/AGENTS.md
@@ -1,3 +1,3 @@
 # AGENTS.md — consensus
 
-See the repo-level [AGENTS.md](../../../../AGENTS.md) for general guidance. See [README.md](./README.md) for a short pointer, and [docs/consensus.md](../../../../docs/consensus.md) for the full consensus design.
+See [README.md](./README.md) for a short pointer, and [docs/consensus.md](../../../../docs/consensus.md) for the full consensus design.

--- a/src/xrpld/app/consensus/CLAUDE.md
+++ b/src/xrpld/app/consensus/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/xrpld/app/ledger/AGENTS.md
+++ b/src/xrpld/app/ledger/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — ledger
+
+See the repo-level [AGENTS.md](../../../../AGENTS.md) for general guidance and [README.md](./README.md) for ledger lifecycle and fetch-pack design.

--- a/src/xrpld/app/ledger/AGENTS.md
+++ b/src/xrpld/app/ledger/AGENTS.md
@@ -1,3 +1,3 @@
 # AGENTS.md — ledger
 
-See the repo-level [AGENTS.md](../../../../AGENTS.md) for general guidance and [README.md](./README.md) for ledger lifecycle and fetch-pack design.
+See [README.md](./README.md) for ledger lifecycle and fetch-pack design.

--- a/src/xrpld/app/ledger/CLAUDE.md
+++ b/src/xrpld/app/ledger/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/xrpld/overlay/AGENTS.md
+++ b/src/xrpld/overlay/AGENTS.md
@@ -1,3 +1,3 @@
 # AGENTS.md — overlay
 
-See the repo-level [AGENTS.md](../../../AGENTS.md) for general guidance and [README.md](./README.md) for the peer-protocol handshake, clustering, gossip, and monitoring design.
+See [README.md](./README.md) for the peer-protocol handshake, clustering, gossip, and monitoring design.

--- a/src/xrpld/overlay/AGENTS.md
+++ b/src/xrpld/overlay/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — overlay
+
+See the repo-level [AGENTS.md](../../../AGENTS.md) for general guidance and [README.md](./README.md) for the peer-protocol handshake, clustering, gossip, and monitoring design.

--- a/src/xrpld/overlay/CLAUDE.md
+++ b/src/xrpld/overlay/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/xrpld/peerfinder/AGENTS.md
+++ b/src/xrpld/peerfinder/AGENTS.md
@@ -1,3 +1,3 @@
 # AGENTS.md — peerfinder
 
-See the repo-level [AGENTS.md](../../../AGENTS.md) for general guidance and [README.md](./README.md) for the peer-discovery design.
+See [README.md](./README.md) for the peer-discovery design.

--- a/src/xrpld/peerfinder/AGENTS.md
+++ b/src/xrpld/peerfinder/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — peerfinder
+
+See the repo-level [AGENTS.md](../../../AGENTS.md) for general guidance and [README.md](./README.md) for the peer-discovery design.

--- a/src/xrpld/peerfinder/CLAUDE.md
+++ b/src/xrpld/peerfinder/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/xrpld/rpc/AGENTS.md
+++ b/src/xrpld/rpc/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md — rpc
 
-See the repo-level [AGENTS.md](../../../AGENTS.md) for general build/test/style guidance.
+See the repo-level [AGENTS.md](../../../AGENTS.md) for general build/test/style guidance, including the [API Changelog](../../../AGENTS.md#api-changelog) rule.
 
-Any change to a public RPC method's behavior (new/changed/removed fields, parameters, or error conditions) needs a corresponding entry in [`API-CHANGELOG.md`](../../../API-CHANGELOG.md), under the `## Unreleased` section (`### Additions`, `### Deprecations`, etc. as appropriate).
+A change to a public RPC method's behavior (new/changed/removed fields, parameters, or error conditions) is exactly the kind of API-visible change that rule covers — use `### Additions`, `### Deprecations`, etc. under `## Unreleased` as appropriate.

--- a/src/xrpld/rpc/AGENTS.md
+++ b/src/xrpld/rpc/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md — rpc
 
-See the repo-level [AGENTS.md](../../../AGENTS.md) for general build/test/style guidance, including the [API Changelog](../../../AGENTS.md#api-changelog) rule, and [README.md](./README.md) for the RPC subsystem design.
+See the repo-level [AGENTS.md](../../../AGENTS.md) for general build/test/style guidance, and [README.md](./README.md) for the RPC subsystem design.
 
-A change to a public RPC method's behavior (new/changed/removed fields, parameters, or error conditions) is exactly the kind of API-visible change that rule covers — use `### Additions`, `### Deprecations`, etc. under `## Unreleased` as appropriate.
+Any change to publicly-visible API behavior — RPC/WebSocket fields, parameters, or error conditions, or transaction/signing behavior surfaced through the API even from outside this directory — needs an entry in [`API-CHANGELOG.md`](../../../API-CHANGELOG.md) under `## Unreleased` (`### Additions`, `### Deprecations`, etc. as appropriate).

--- a/src/xrpld/rpc/AGENTS.md
+++ b/src/xrpld/rpc/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md — rpc
 
-See the repo-level [AGENTS.md](../../../AGENTS.md) for general build/test/style guidance, including the [API Changelog](../../../AGENTS.md#api-changelog) rule.
+See the repo-level [AGENTS.md](../../../AGENTS.md) for general build/test/style guidance, including the [API Changelog](../../../AGENTS.md#api-changelog) rule, and [README.md](./README.md) for the RPC subsystem design.
 
 A change to a public RPC method's behavior (new/changed/removed fields, parameters, or error conditions) is exactly the kind of API-visible change that rule covers — use `### Additions`, `### Deprecations`, etc. under `## Unreleased` as appropriate.

--- a/src/xrpld/rpc/AGENTS.md
+++ b/src/xrpld/rpc/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md — rpc
 
-See the repo-level [AGENTS.md](../../../AGENTS.md) for general build/test/style guidance, and [README.md](./README.md) for the RPC subsystem design.
+See [README.md](./README.md) for the RPC subsystem design.
 
 Any change to publicly-visible API behavior — RPC/WebSocket fields, parameters, or error conditions, or transaction/signing behavior surfaced through the API even from outside this directory — needs an entry in [`API-CHANGELOG.md`](../../../API-CHANGELOG.md) under `## Unreleased` (`### Additions`, `### Deprecations`, etc. as appropriate).


### PR DESCRIPTION
## High Level Overview of Change

Mines the last 6 months of merged-PR human review comments (bots excluded) for conventions that recur across multiple PRs/reviewers but aren't already documented in CONTRIBUTING.md/docs/CodingStyle.md, and folds them into `AGENTS.md` files so AI coding agents pick them up automatically. Each rule lives in the narrowest directory it applies to (not root), so agents working elsewhere don't load irrelevant context.

## Context of Change

- Root `AGENTS.md`: Doxygen comments on new public functions/methods (genuinely repo-wide); trimmed the Architecture section's amendment mention to a pointer, since the detail now lives in `tx/AGENTS.md`.
- `src/libxrpl/tx/AGENTS.md`: a precise "when is an amendment required" test and a design-considerations checklist (sourced from an internal amendment-writer doc); new/deleted invariant checks must be amendment-gated (consensus-safety, since an un-gated invariant risks validators disagreeing on a transaction's result).
- `src/libxrpl/tx/transactors/AGENTS.md` (new): amendment-gating code shape (single enabled/disabled block, not scattered checks), per-amendment flag naming (`fix340Enabled` not `fixEnabled`), `UNREACHABLE`/`LCOV_EXCL_START`/`STOP` pairing, pseudo-accounts (Vault/LoanBroker/AMM) being exempt from `requireAuth`/freeze checks as a class, and preferring one object-level invariant over duplicating a delta check per transactor. All evidenced in vault/lending transactor PR reviews specifically, so scoped here rather than the parent `tx/AGENTS.md`.
- `src/libxrpl/ledger/helpers/AGENTS.md` (new): helpers should assert the SLE type they're handed rather than inventing a new error-handling idiom.
- `src/xrpld/rpc/AGENTS.md`: the `API-CHANGELOG.md` requirement lives here (its natural home) rather than at root, since it's the primary place API-visible changes happen; `tx/AGENTS.md` has a one-line pointer to it for the signing-behavior case.
- `src/test/AGENTS.md` (new): shared test setup/helpers belong in `jtx/`, not copy-pasted across test files.
- Thin pointer `AGENTS.md` files (with `CLAUDE.md` symlinks, matching the existing convention) for subsystems that already have a substantial `README.md` but no `AGENTS.md` — `overlay/`, `app/ledger/`, `shamap/`, `peerfinder/`, `nodestore/`, `app/consensus/`, `include/xrpl/consensus/`, and `rpc/`. Agent tooling auto-loads `AGENTS.md` when working in a directory but not `README.md`, so those existing design docs were otherwise easy for an agent to miss.

Every added rule cites the specific PR(s) where it recurred; I cross-checked each against CONTRIBUTING.md/docs/CodingStyle.md first to avoid duplicating what's already documented there.

## API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)