### PR TITLE
fix: Enforce asset authorization on LoanBrokerDelete

### DIFF
--- a/src/libxrpl/tx/transactors/lending/LoanBrokerDelete.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanBrokerDelete.cpp
@@ -94,21 +94,37 @@ LoanBrokerDelete::preclaim(PreclaimContext const& ctx)
 
     auto const coverAvailable = STAmount{asset, sleBroker->at(sfCoverAvailable)};
     // If there are assets in the cover, broker will receive them on deletion.
-    // So we need to check if the broker owner is deep frozen for that asset.
     if (coverAvailable > beast::kZero)
     {
+        auto const brokerPseudo = sleBroker->at(sfAccount);
+
+        // Pre-fixCleanup3_4_0: only freeze checks apply to the cover payout.
+        // Post-fixCleanup3_4_0: apply the cover-withdraw transfer and authorization checks too.
+        if (ctx.view.rules().enabled(fixCleanup3_4_0))
+        {
+            auto const waive = ctx.view.rules().enabled(fixCleanup3_2_0) ? WaiveMPTCanTransfer::Yes
+                                                                         : WaiveMPTCanTransfer::No;
+            if (auto const ret = canTransfer(ctx.view, asset, brokerPseudo, brokerOwner, waive))
+                return ret;
+
+            if (auto const ret = requireAuth(ctx.view, asset, brokerOwner, AuthType::WeakAuth))
+                return ret;
+
+            if (!holdingExists(ctx.view, brokerOwner, asset))
+            {
+                if (auto const ret = canAddHolding(ctx.view, asset); !isTesSuccess(ret))
+                    return ret;
+            }
+        }
+
         if (auto const ret = checkDeepFrozen(ctx.view, brokerOwner, asset))
         {
             JLOG(ctx.j.warn()) << "Broker owner account is frozen.";
             return ret;
         }
-    }
 
-    if (ctx.view.rules().enabled(fixCleanup3_2_0))
-    {
-        if (coverAvailable > beast::kZero)
+        if (ctx.view.rules().enabled(fixCleanup3_2_0))
         {
-            auto const brokerPseudo = sleBroker->at(sfAccount);
             if (auto const ret = checkFrozen(ctx.view, brokerPseudo, asset))
             {
                 JLOG(ctx.j.warn()) << "Broker pseudo-account is frozen/locked.";

--- a/src/test/app/lending/LoanBroker_test.cpp
+++ b/src/test/app/lending/LoanBroker_test.cpp
@@ -1917,6 +1917,68 @@ class LoanBroker_test : public beast::unit_test::Suite
     }
 
     void
+    testLoanBrokerDeleteDeletedLineIOU(
+        FeatureBitset features,
+        bool clearDefaultRipple,
+        TER expected)
+    {
+        testcase << "LoanBrokerDelete - IOU line deleted before payout, issuer "
+                 << (clearDefaultRipple ? "without" : "with") << " DefaultRipple "
+                 << (features[fixCleanup3_4_0] ? "post-fix" : "pre-fix");
+        using namespace jtx;
+        using namespace loan_broker;
+
+        Account const issuer{"issuer"};
+        Account const alice{"alice"};
+
+        Env env(*this, features);
+        env.fund(XRP(10'000), issuer, alice);
+        env.close();
+        env(fset(issuer, asfDefaultRipple));
+        env.close();
+
+        PrettyAsset const usd{issuer["USD"]};
+        Issue const usdIssue = usd.raw().get<Issue>();
+        env(trust(alice, usd(10'000)));
+        env.close();
+        env(pay(issuer, alice, usd(600)));
+        env.close();
+
+        Vault const vault{env};
+        auto const [createTx, vaultKeylet] = vault.create({.owner = alice, .asset = usd});
+        env(createTx);
+        env.close();
+        env(vault.deposit({.depositor = alice, .id = vaultKeylet.key, .amount = usd(500)}));
+        env.close();
+
+        auto const brokerKeylet =
+            keylet::loanBroker(alice.id(), SeqProxy::rawSequence(env.seq(alice)));
+        env(set(alice, vaultKeylet.key));
+        env.close();
+        env(coverDeposit(alice, brokerKeylet.key, usd(100).value()));
+        env.close();
+
+        // Alice spent her whole balance, so zeroing the limit deletes her line.
+        // The cover payout would have to recreate it.
+        env(trust(alice, usd(0)));
+        env.close();
+        BEAST_EXPECT(!env.le(keylet::trustLine(alice.id(), usdIssue)));
+
+        if (clearDefaultRipple)
+        {
+            env(fclear(issuer, asfDefaultRipple));
+            env.close();
+        }
+
+        env(del(alice, brokerKeylet.key), Ter(expected));
+        env.close();
+
+        BEAST_EXPECT((env.le(brokerKeylet) == nullptr) == isTesSuccess(expected));
+        if (isTesSuccess(expected))
+            BEAST_EXPECT(env.balance(alice, usd) == usd(100));
+    }
+
+    void
     testLoanBrokerDeleteRequireAuthMPT(FeatureBitset features, bool ownerAuthorized)
     {
         testcase << "LoanBrokerDelete - auth-required broker pseudo-account MPT "
@@ -3101,6 +3163,10 @@ public:
 
         testLoanBrokerDeleteNoRippleIOU(all_);
         testLoanBrokerDeleteNoRippleIOU(all_ - fixCleanup3_4_0);
+
+        testLoanBrokerDeleteDeletedLineIOU(all_, true, terNO_RIPPLE);
+        testLoanBrokerDeleteDeletedLineIOU(all_ - fixCleanup3_4_0, true, tesSUCCESS);
+        testLoanBrokerDeleteDeletedLineIOU(all_, false, tesSUCCESS);
 
         // featureMPTokensV2 independently makes ValidMPTTransfer enforcing,
         // but it's Supported::No (never enabled on real networks); exclude

--- a/src/test/app/lending/LoanBroker_test.cpp
+++ b/src/test/app/lending/LoanBroker_test.cpp
@@ -1850,10 +1850,78 @@ class LoanBroker_test : public beast::unit_test::Suite
     }
 
     void
-    testLoanBrokerDeleteRequireAuthMPT(FeatureBitset features)
+    testLoanBrokerDeleteNoRippleIOU(FeatureBitset features)
+    {
+        testcase << "LoanBrokerDelete - non-rippling IOU "
+                 << (features[fixCleanup3_4_0] ? "post-fix" : "pre-fix");
+        using namespace jtx;
+        using namespace loan_broker;
+
+        Account const issuer{"issuer"};
+        Account const alice{"alice"};
+
+        Env env(*this, features);
+        env.fund(XRP(100'000), issuer, alice);
+        env.close();
+
+        auto const iou = issuer["IOU"];
+        env(trust(alice, iou(15'000)));
+        env(pay(issuer, alice, iou(15'000)));
+        env.close();
+
+        Vault const vault{env};
+        auto const [tx, vaultKeylet] = vault.create({.owner = alice, .asset = iou.asset()});
+        env(tx);
+        env.close();
+        env(vault.deposit({.depositor = alice, .id = vaultKeylet.key, .amount = iou(10'000)}));
+        env.close();
+
+        auto const brokerKeylet =
+            keylet::loanBroker(alice.id(), SeqProxy::rawSequence(env.seq(alice)));
+        env(set(alice, vaultKeylet.key));
+        env.close();
+
+        auto const broker = env.le(brokerKeylet);
+        if (!BEAST_EXPECT(broker))
+            return;
+        Account const brokerPseudo{"BrokerPseudo", broker->at(sfAccount)};
+
+        // Block rippling on the empty pseudo-account line before funding it.
+        env(trust(issuer, brokerPseudo["IOU"](0), tfSetNoRipple));
+        env.close();
+        env(coverDeposit(alice, brokerKeylet.key, iou(5'000)));
+        env.close();
+
+        BEAST_EXPECT(env.balance(alice, iou) == beast::kZero);
+
+        // Alice's line can become non-rippling after the cover deposit leaves it empty.
+        env(trust(issuer, alice["IOU"](0), tfSetNoRipple));
+        env.close();
+
+        if (features[fixCleanup3_4_0])
+        {
+            env(del(alice, brokerKeylet.key), Ter(terNO_RIPPLE));
+            env.close();
+
+            BEAST_EXPECT(env.le(brokerKeylet) != nullptr);
+            BEAST_EXPECT(env.balance(alice, iou) == beast::kZero);
+        }
+        else
+        {
+            env(del(alice, brokerKeylet.key));
+            env.close();
+
+            BEAST_EXPECT(env.le(brokerKeylet) == nullptr);
+            BEAST_EXPECT(env.balance(alice, iou) > beast::kZero);
+        }
+    }
+
+    void
+    testLoanBrokerDeleteRequireAuthMPT(FeatureBitset features, bool ownerAuthorized)
     {
         testcase << "LoanBrokerDelete - auth-required broker pseudo-account MPT "
-                 << (features[fixCleanup3_4_0] ? "post-fix" : "pre-fix");
+                 << (features[fixCleanup3_4_0] ? "post-fix" : "pre-fix") << ", owner "
+                 << (ownerAuthorized ? "authorized" : "unauthorized");
         using namespace jtx;
         using namespace loan_broker;
 
@@ -1874,7 +1942,7 @@ class LoanBroker_test : public beast::unit_test::Suite
              .issuer = issuer,
              .holders = {alice},
              .pay = 20'000,
-             .flags = tfMPTRequireAuth | tfMPTCanTransfer,
+             .flags = tfMPTRequireAuth | tfMPTCanTransfer | tfMPTCanClawback,
              .authHolder = true});
 
         PrettyAsset const mpt{tester.issuanceID()};
@@ -1917,8 +1985,35 @@ class LoanBroker_test : public beast::unit_test::Suite
             return;
         BEAST_EXPECT(!pseudoMpt->isFlag(lsfMPTAuthorized));
 
+        if (!ownerAuthorized)
+        {
+            tester.authorize({.account = issuer, .holder = alice, .flags = tfMPTUnauthorize});
+        }
+
         // Record alice's balance before deletion
         auto const aliceBalanceBefore = env.balance(alice, mpt);
+
+        if (features[fixCleanup3_4_0] && !ownerAuthorized)
+        {
+            env(del(alice, brokerKeylet.key), Ter(tecNO_AUTH));
+            env.close();
+
+            BEAST_EXPECT(env.le(brokerKeylet) != nullptr);
+            BEAST_EXPECT(env.le(pseudoMptKey) != nullptr);
+            BEAST_EXPECT(env.balance(alice, mpt) == aliceBalanceBefore);
+
+            env(coverClawback(issuer), kLoanBrokerId(brokerKeylet.key), kAmount(mpt(5'000)));
+            env.close();
+            auto const brokerAfterClawback = env.le(brokerKeylet);
+            if (!BEAST_EXPECT(brokerAfterClawback))
+                return;
+            BEAST_EXPECT(brokerAfterClawback->at(sfCoverAvailable) == beast::kZero);
+
+            env(del(alice, brokerKeylet.key));
+            env.close();
+            BEAST_EXPECT(env.le(brokerKeylet) == nullptr);
+            return;
+        }
 
         // LoanBrokerDelete sends the remaining cover out of the broker pseudo-account, deletes its
         // now-empty MPToken, and erases the pseudo AccountRoot. Before the fix,
@@ -3004,12 +3099,17 @@ public:
         testLoanBrokerDeleteFrozenIOU(all_);
         testLoanBrokerDeleteFrozenIOU(all_ - fixCleanup3_2_0);
 
+        testLoanBrokerDeleteNoRippleIOU(all_);
+        testLoanBrokerDeleteNoRippleIOU(all_ - fixCleanup3_4_0);
+
         // featureMPTokensV2 independently makes ValidMPTTransfer enforcing,
         // but it's Supported::No (never enabled on real networks); exclude
         // it here so fixCleanup3_4_0 alone is the deciding amendment, as it
         // would be on mainnet.
-        testLoanBrokerDeleteRequireAuthMPT(all_ - featureMPTokensV2);
-        testLoanBrokerDeleteRequireAuthMPT(all_ - featureMPTokensV2 - fixCleanup3_4_0);
+        testLoanBrokerDeleteRequireAuthMPT(all_ - featureMPTokensV2, true);
+        testLoanBrokerDeleteRequireAuthMPT(all_ - featureMPTokensV2 - fixCleanup3_4_0, true);
+        testLoanBrokerDeleteRequireAuthMPT(all_ - featureMPTokensV2, false);
+        testLoanBrokerDeleteRequireAuthMPT(all_ - featureMPTokensV2 - fixCleanup3_4_0, false);
         // TODO: Write clawback failure tests with an issuer / MPT that doesn't
         // have the right flags set.
     }


### PR DESCRIPTION
## High Level Overview of Change

LoanBrokerDelete now checks asset transfer restrictions and owner authorization before returning nonzero broker cover.

## Context of Change

LoanBrokerDelete checked freeze state but returned cover through accountSend without the checks LoanBrokerCoverWithdraw uses. Under fixCleanup3_5_0, deletion follows the same self-withdrawal policy. If the owner has deleted its MPToken, deletion is rejected in preclaim with `tecNO_AUTH`. The payout can't recreate the MPToken, because the transaction already deletes the broker pseudo-account's one, so the owner has to authorize the MPT again first. Pre-amendment and zero-cover behavior stay the same.

## API Impact

- [x] `libxrpl` change

## Test Plan

LoanBroker tests cover, with the amendment on and off:
- an authorized MPT owner
- an MPT owner whose authorization was revoked, including the case where neither fixCleanup3_5_0 nor fixCleanup3_4_0 is enabled
- zero cover after clawback
- an owner who deleted its MPToken
- IOU NoRipple
- an IOU trust line deleted before the payout
