### PR TITLE
feat: Support mirror key epochs in confidential MPT transactions for Key Rotation amendment

### DIFF
--- a/include/xrpl/protocol/ConfidentialTransfer.h
+++ b/include/xrpl/protocol/ConfidentialTransfer.h
@@ -6,6 +6,7 @@
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STInteger.h>  // IWYU pragma: keep
+#include <xrpl/protocol/STLedgerEntry.h>
 #include <xrpl/protocol/STObject.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/UintTypes.h>
@@ -314,7 +315,7 @@ checkEncryptedAmountFormat(STObject const& object);
  * @return true if the MPToken's issuer mirror is current. false if stale.
  */
 [[nodiscard]] bool
-isIssuerMirrorCurrent(STObject const& issuance, STObject const& mptoken);
+isIssuerMirrorCurrent(SLE const& issuance, SLE const& mptoken);
 
 /**
  * @brief Checks whether a holder's auditor mirror is encrypted under the
@@ -329,7 +330,7 @@ isIssuerMirrorCurrent(STObject const& issuance, STObject const& mptoken);
  * @return true if the auditor mirror is current or not required.
  */
 [[nodiscard]] bool
-isAuditorMirrorCurrent(STObject const& issuance, STObject const& mptoken);
+isAuditorMirrorCurrent(SLE const& issuance, SLE const& mptoken);
 
 /**
  * @brief Checks whether each mirror a holder is required to have is encrypted
@@ -344,7 +345,7 @@ isAuditorMirrorCurrent(STObject const& issuance, STObject const& mptoken);
  * @return true if the required mirrors are current.
  */
 [[nodiscard]] bool
-areMirrorsCurrent(STObject const& issuance, STObject const& mptoken);
+areMirrorsCurrent(SLE const& issuance, SLE const& mptoken);
 
 /**
  * @brief Set the holder's MPToken mirror epochs to match the issuance's current key epochs.
@@ -356,7 +357,7 @@ areMirrorsCurrent(STObject const& issuance, STObject const& mptoken);
  * @param mptoken  The holder's MPToken ledger entry to update.
  */
 void
-setMirrorEpochs(STObject const& issuance, STObject& mptoken);
+setMirrorEpochs(SLE const& issuance, SLE& mptoken);
 
 /**
  * @brief Verifies revealed amount encryptions for all recipients.

--- a/include/xrpl/protocol/ConfidentialTransfer.h
+++ b/include/xrpl/protocol/ConfidentialTransfer.h
@@ -302,12 +302,12 @@ NotTEC
 checkEncryptedAmountFormat(STObject const& object);
 
 /**
- * @brief Reports whether a holder's issuer mirror is encrypted under the
+ * @brief Checks whether a holder's issuer mirror is encrypted under the
  * issuance's currently registered issuer key.
  *
- * An absent mirror epoch means epoch 0, matching the issuance convention. A
- * holder with no issuer mirror at all is not current: there is nothing for a
- * later re-encryption to anchor on.
+ * Verifies that the holder's issuer mirror epoch matches the active issuer key
+ * epoch on the issuance. An absent mirror epoch defaults to epoch 0. A holder without an issuer
+ * mirror is considered stale, as there is no key anchor for future re-encryptions.
  *
  * @param issuance The MPTokenIssuance ledger object.
  * @param mptoken  The holder's MPToken ledger object.
@@ -317,13 +317,12 @@ checkEncryptedAmountFormat(STObject const& object);
 isIssuerMirrorCurrent(STObject const& issuance, STObject const& mptoken);
 
 /**
- * @brief Reports whether a holder's auditor mirror is encrypted under the
+ * @brief Checks whether a holder's auditor mirror is encrypted under the
  * issuance's currently registered auditor key.
  *
- * An issuance with no auditor key requires no auditor mirror, so the holder is
- * trivially current. Once an auditor key is configured the mirror must also be
- * present: a key registered after the holder initialized confidential state
- * leaves them with no auditor mirror at all.
+ * Verifies that the holder's auditor mirror epoch matches the active auditor key
+ * epoch on the issuance. An absent mirror epoch defaults to epoch 0. An issuance
+ * without an auditor key requires no auditor mirror and is considered current.
  *
  * @param issuance The MPTokenIssuance ledger object.
  * @param mptoken  The holder's MPToken ledger object.
@@ -333,13 +332,12 @@ isIssuerMirrorCurrent(STObject const& issuance, STObject const& mptoken);
 isAuditorMirrorCurrent(STObject const& issuance, STObject const& mptoken);
 
 /**
- * @brief Reports whether every mirror a holder is required to have is encrypted
+ * @brief Checks whether each mirror a holder is required to have is encrypted
  * under the issuance's currently registered ElGamal keys.
  *
- * A transaction that homomorphically combines a new ciphertext into an existing
- * mirror requires that mirror to be current. The new ciphertext is encrypted
- * under the registered key, so combining it into a mirror left behind by a key
- * rotation would produce a ciphertext that no party can decrypt.
+ * Verifies that both the issuer mirror and the auditor mirror (if required)
+ * are current. This serves as a combined check, ensuring all necessary
+ * holder mirror epochs match the active key epochs on the issuance.
  *
  * @param issuance The MPTokenIssuance ledger object.
  * @param mptoken  The holder's MPToken ledger object.
@@ -347,6 +345,18 @@ isAuditorMirrorCurrent(STObject const& issuance, STObject const& mptoken);
  */
 [[nodiscard]] bool
 areMirrorsCurrent(STObject const& issuance, STObject const& mptoken);
+
+/**
+ * @brief Set the holder's MPToken mirror epochs to match the issuance's current key epochs.
+ *
+ * Call this after writing mirror ciphertexts under the issuance's currently
+ * registered keys, so that the mirrors read as current afterwards.
+ *
+ * @param issuance The MPTokenIssuance ledger object.
+ * @param mptoken  The holder's MPToken ledger entry to update.
+ */
+void
+setMirrorEpochs(STObject const& issuance, STObject& mptoken);
 
 /**
  * @brief Verifies revealed amount encryptions for all recipients.

--- a/include/xrpl/protocol/ConfidentialTransfer.h
+++ b/include/xrpl/protocol/ConfidentialTransfer.h
@@ -302,6 +302,53 @@ NotTEC
 checkEncryptedAmountFormat(STObject const& object);
 
 /**
+ * @brief Reports whether a holder's issuer mirror is encrypted under the
+ * issuance's currently registered issuer key.
+ *
+ * An absent mirror epoch means epoch 0, matching the issuance convention. A
+ * holder with no issuer mirror at all is not current: there is nothing for a
+ * later re-encryption to anchor on.
+ *
+ * @param issuance The MPTokenIssuance ledger object.
+ * @param mptoken  The holder's MPToken ledger object.
+ * @return true if the MPToken's issuer mirror is current. false if stale.
+ */
+[[nodiscard]] bool
+isIssuerMirrorCurrent(STObject const& issuance, STObject const& mptoken);
+
+/**
+ * @brief Reports whether a holder's auditor mirror is encrypted under the
+ * issuance's currently registered auditor key.
+ *
+ * An issuance with no auditor key requires no auditor mirror, so the holder is
+ * trivially current. Once an auditor key is configured the mirror must also be
+ * present: a key registered after the holder initialized confidential state
+ * leaves them with no auditor mirror at all.
+ *
+ * @param issuance The MPTokenIssuance ledger object.
+ * @param mptoken  The holder's MPToken ledger object.
+ * @return true if the auditor mirror is current or not required.
+ */
+[[nodiscard]] bool
+isAuditorMirrorCurrent(STObject const& issuance, STObject const& mptoken);
+
+/**
+ * @brief Reports whether every mirror a holder is required to have is encrypted
+ * under the issuance's currently registered ElGamal keys.
+ *
+ * A transaction that homomorphically combines a new ciphertext into an existing
+ * mirror requires that mirror to be current. The new ciphertext is encrypted
+ * under the registered key, so combining it into a mirror left behind by a key
+ * rotation would produce a ciphertext that no party can decrypt.
+ *
+ * @param issuance The MPTokenIssuance ledger object.
+ * @param mptoken  The holder's MPToken ledger object.
+ * @return true if the required mirrors are current.
+ */
+[[nodiscard]] bool
+areMirrorsCurrent(STObject const& issuance, STObject const& mptoken);
+
+/**
  * @brief Verifies revealed amount encryptions for all recipients.
  *
  * Validates that the same amount was correctly encrypted for the holder,

--- a/include/xrpl/protocol/detail/ledger_entries.macro
+++ b/include/xrpl/protocol/detail/ledger_entries.macro
@@ -429,6 +429,8 @@ LEDGER_ENTRY(ltMPTOKEN, 0x007f, MPToken, mptoken, ({
     {sfConfidentialBalanceVersion,  SoeDefault},
     {sfIssuerEncryptedBalance,      SoeOptional},
     {sfAuditorEncryptedBalance,     SoeOptional},
+    {sfIssuerKeyMirrorEpoch,        SoeOptional},
+    {sfAuditorKeyMirrorEpoch,       SoeOptional},
     {sfHolderEncryptionKey,         SoeOptional},
 }))
 

--- a/include/xrpl/protocol_autogen/ledger_entries/MPToken.h
+++ b/include/xrpl/protocol_autogen/ledger_entries/MPToken.h
@@ -269,6 +269,54 @@ public:
     }
 
     /**
+     * @brief Get sfIssuerKeyMirrorEpoch (SoeOptional)
+     * @return The field value, or std::nullopt if not present.
+     */
+    [[nodiscard]]
+    protocol_autogen::Optional<SF_UINT32::type::value_type>
+    getIssuerKeyMirrorEpoch() const
+    {
+        if (hasIssuerKeyMirrorEpoch())
+            return this->sle_->at(sfIssuerKeyMirrorEpoch);
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Check if sfIssuerKeyMirrorEpoch is present.
+     * @return True if the field is present, false otherwise.
+     */
+    [[nodiscard]]
+    bool
+    hasIssuerKeyMirrorEpoch() const
+    {
+        return this->sle_->isFieldPresent(sfIssuerKeyMirrorEpoch);
+    }
+
+    /**
+     * @brief Get sfAuditorKeyMirrorEpoch (SoeOptional)
+     * @return The field value, or std::nullopt if not present.
+     */
+    [[nodiscard]]
+    protocol_autogen::Optional<SF_UINT32::type::value_type>
+    getAuditorKeyMirrorEpoch() const
+    {
+        if (hasAuditorKeyMirrorEpoch())
+            return this->sle_->at(sfAuditorKeyMirrorEpoch);
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Check if sfAuditorKeyMirrorEpoch is present.
+     * @return True if the field is present, false otherwise.
+     */
+    [[nodiscard]]
+    bool
+    hasAuditorKeyMirrorEpoch() const
+    {
+        return this->sle_->isFieldPresent(sfAuditorKeyMirrorEpoch);
+    }
+
+    /**
      * @brief Get sfHolderEncryptionKey (SoeOptional)
      * @return The field value, or std::nullopt if not present.
      */
@@ -468,6 +516,28 @@ public:
     setAuditorEncryptedBalance(std::decay_t<typename SF_VL::type::value_type> const& value)
     {
         object_[sfAuditorEncryptedBalance] = value;
+        return *this;
+    }
+
+    /**
+     * @brief Set sfIssuerKeyMirrorEpoch (SoeOptional)
+     * @return Reference to this builder for method chaining.
+     */
+    MPTokenBuilder&
+    setIssuerKeyMirrorEpoch(std::decay_t<typename SF_UINT32::type::value_type> const& value)
+    {
+        object_[sfIssuerKeyMirrorEpoch] = value;
+        return *this;
+    }
+
+    /**
+     * @brief Set sfAuditorKeyMirrorEpoch (SoeOptional)
+     * @return Reference to this builder for method chaining.
+     */
+    MPTokenBuilder&
+    setAuditorKeyMirrorEpoch(std::decay_t<typename SF_UINT32::type::value_type> const& value)
+    {
+        object_[sfAuditorKeyMirrorEpoch] = value;
         return *this;
     }
 

--- a/src/libxrpl/protocol/ConfidentialTransfer.cpp
+++ b/src/libxrpl/protocol/ConfidentialTransfer.cpp
@@ -421,9 +421,6 @@ isAuditorMirrorCurrent(SLE const& issuance, SLE const& mptoken)
     XRPL_ASSERT(
         mptoken.getType() == ltMPTOKEN, "xrpl::isAuditorMirrorCurrent : mptoken MPToken object");
 
-    // If the issuance registers the auditor key later, the holder's auditor mirror is considered
-    // stale. This is expected because the holder's mirror can be migrated through another
-    // transaction ConfidentialMPTMirrorUpdate, this will be in a separate PR.
     if (!issuance.isFieldPresent(sfAuditorEncryptionKey))
         return true;
 

--- a/src/libxrpl/protocol/ConfidentialTransfer.cpp
+++ b/src/libxrpl/protocol/ConfidentialTransfer.cpp
@@ -6,9 +6,11 @@
 #include <xrpl/basics/contract.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/Protocol.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STBlob.h>
+#include <xrpl/protocol/STLedgerEntry.h>
 #include <xrpl/protocol/STObject.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/UintTypes.h>
@@ -398,15 +400,27 @@ checkEncryptedAmountFormat(STObject const& object)
 }
 
 bool
-isIssuerMirrorCurrent(STObject const& issuance, STObject const& mptoken)
+isIssuerMirrorCurrent(SLE const& issuance, SLE const& mptoken)
 {
+    XRPL_ASSERT(
+        issuance.getType() == ltMPTOKEN_ISSUANCE,
+        "xrpl::isIssuerMirrorCurrent : issuance MPTokenIssuance object");
+    XRPL_ASSERT(
+        mptoken.getType() == ltMPTOKEN, "xrpl::isIssuerMirrorCurrent : mptoken MPToken object");
+
     return mptoken.isFieldPresent(sfIssuerEncryptedBalance) &&
         mptoken[~sfIssuerKeyMirrorEpoch].value_or(0) == issuance[~sfIssuerKeyEpoch].value_or(0);
 }
 
 bool
-isAuditorMirrorCurrent(STObject const& issuance, STObject const& mptoken)
+isAuditorMirrorCurrent(SLE const& issuance, SLE const& mptoken)
 {
+    XRPL_ASSERT(
+        issuance.getType() == ltMPTOKEN_ISSUANCE,
+        "xrpl::isAuditorMirrorCurrent : issuance MPTokenIssuance object");
+    XRPL_ASSERT(
+        mptoken.getType() == ltMPTOKEN, "xrpl::isAuditorMirrorCurrent : mptoken MPToken object");
+
     if (!issuance.isFieldPresent(sfAuditorEncryptionKey))
         return true;
 
@@ -415,14 +429,19 @@ isAuditorMirrorCurrent(STObject const& issuance, STObject const& mptoken)
 }
 
 bool
-areMirrorsCurrent(STObject const& issuance, STObject const& mptoken)
+areMirrorsCurrent(SLE const& issuance, SLE const& mptoken)
 {
     return isIssuerMirrorCurrent(issuance, mptoken) && isAuditorMirrorCurrent(issuance, mptoken);
 }
 
 void
-setMirrorEpochs(STObject const& issuance, STObject& mptoken)
+setMirrorEpochs(SLE const& issuance, SLE& mptoken)
 {
+    XRPL_ASSERT(
+        issuance.getType() == ltMPTOKEN_ISSUANCE,
+        "xrpl::setMirrorEpochs : issuance MPTokenIssuance object");
+    XRPL_ASSERT(mptoken.getType() == ltMPTOKEN, "xrpl::setMirrorEpochs : mptoken MPToken object");
+
     if (auto const epoch = issuance[~sfIssuerKeyEpoch].value_or(0); epoch != 0)
         mptoken[sfIssuerKeyMirrorEpoch] = epoch;
 

--- a/src/libxrpl/protocol/ConfidentialTransfer.cpp
+++ b/src/libxrpl/protocol/ConfidentialTransfer.cpp
@@ -421,6 +421,9 @@ isAuditorMirrorCurrent(SLE const& issuance, SLE const& mptoken)
     XRPL_ASSERT(
         mptoken.getType() == ltMPTOKEN, "xrpl::isAuditorMirrorCurrent : mptoken MPToken object");
 
+    // If the issuance registers the auditor key later, the holder's auditor mirror is considered
+    // stale. This is expected because the holder's mirror can be migrated through another
+    // transaction ConfidentialMPTMirrorUpdate, this will be in a separate PR.
     if (!issuance.isFieldPresent(sfAuditorEncryptionKey))
         return true;
 

--- a/src/libxrpl/protocol/ConfidentialTransfer.cpp
+++ b/src/libxrpl/protocol/ConfidentialTransfer.cpp
@@ -420,6 +420,19 @@ areMirrorsCurrent(STObject const& issuance, STObject const& mptoken)
     return isIssuerMirrorCurrent(issuance, mptoken) && isAuditorMirrorCurrent(issuance, mptoken);
 }
 
+void
+setMirrorEpochs(STObject const& issuance, STObject& mptoken)
+{
+    if (auto const epoch = issuance[~sfIssuerKeyEpoch].value_or(0); epoch != 0)
+        mptoken[sfIssuerKeyMirrorEpoch] = epoch;
+
+    if (mptoken.isFieldPresent(sfAuditorEncryptedBalance))
+    {
+        if (auto const epoch = issuance[~sfAuditorKeyEpoch].value_or(0); epoch != 0)
+            mptoken[sfAuditorKeyMirrorEpoch] = epoch;
+    }
+}
+
 TER
 verifySchnorrProof(Slice const& pubKeySlice, Slice const& proofSlice, uint256 const& contextHash)
 {

--- a/src/libxrpl/protocol/ConfidentialTransfer.cpp
+++ b/src/libxrpl/protocol/ConfidentialTransfer.cpp
@@ -397,6 +397,29 @@ checkEncryptedAmountFormat(STObject const& object)
     return tesSUCCESS;
 }
 
+bool
+isIssuerMirrorCurrent(STObject const& issuance, STObject const& mptoken)
+{
+    return mptoken.isFieldPresent(sfIssuerEncryptedBalance) &&
+        mptoken[~sfIssuerKeyMirrorEpoch].value_or(0) == issuance[~sfIssuerKeyEpoch].value_or(0);
+}
+
+bool
+isAuditorMirrorCurrent(STObject const& issuance, STObject const& mptoken)
+{
+    if (!issuance.isFieldPresent(sfAuditorEncryptionKey))
+        return true;
+
+    return mptoken.isFieldPresent(sfAuditorEncryptedBalance) &&
+        mptoken[~sfAuditorKeyMirrorEpoch].value_or(0) == issuance[~sfAuditorKeyEpoch].value_or(0);
+}
+
+bool
+areMirrorsCurrent(STObject const& issuance, STObject const& mptoken)
+{
+    return isIssuerMirrorCurrent(issuance, mptoken) && isAuditorMirrorCurrent(issuance, mptoken);
+}
+
 TER
 verifySchnorrProof(Slice const& pubKeySlice, Slice const& proofSlice, uint256 const& contextHash)
 {

--- a/src/libxrpl/tx/transactors/token/ConfidentialMPTClawback.cpp
+++ b/src/libxrpl/tx/transactors/token/ConfidentialMPTClawback.cpp
@@ -214,16 +214,7 @@ ConfidentialMPTClawback::doApply()
     // proof using the corresponding stale private key. The mirrors are updated
     // to the current epoch during execution.
     if (view().rules().enabled(featureConfidentialMPTKeyRotation))
-    {
-        if (auto const epoch = (*sleIssuance)[~sfIssuerKeyEpoch].valueOr(0); epoch != 0)
-            (*sleHolderMPToken)[sfIssuerKeyMirrorEpoch] = epoch;
-
-        if (sleHolderMPToken->isFieldPresent(sfAuditorEncryptedBalance))
-        {
-            if (auto const epoch = (*sleIssuance)[~sfAuditorKeyEpoch].valueOr(0); epoch != 0)
-                (*sleHolderMPToken)[sfAuditorKeyMirrorEpoch] = epoch;
-        }
-    }
+        setMirrorEpochs(*sleIssuance, *sleHolderMPToken);
 
     // Decrease Global Confidential Outstanding Amount
     auto const oldCOA = (*sleIssuance)[sfConfidentialOutstandingAmount];

--- a/src/libxrpl/tx/transactors/token/ConfidentialMPTClawback.cpp
+++ b/src/libxrpl/tx/transactors/token/ConfidentialMPTClawback.cpp
@@ -5,6 +5,7 @@
 #include <xrpl/core/ServiceRegistry.h>
 #include <xrpl/ledger/ReadView.h>
 #include <xrpl/protocol/ConfidentialTransfer.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/Protocol.h>
@@ -207,6 +208,21 @@ ConfidentialMPTClawback::doApply()
         }
 
         (*sleHolderMPToken)[sfAuditorEncryptedBalance] = std::move(*encZeroForAuditor);
+    }
+
+    // Allow clawback on stale mirrors since the issuer can still generate the
+    // proof using the corresponding stale private key. The mirrors are updated
+    // to the current epoch during execution.
+    if (view().rules().enabled(featureConfidentialMPTKeyRotation))
+    {
+        if (auto const epoch = (*sleIssuance)[~sfIssuerKeyEpoch].valueOr(0); epoch != 0)
+            (*sleHolderMPToken)[sfIssuerKeyMirrorEpoch] = epoch;
+
+        if (sleHolderMPToken->isFieldPresent(sfAuditorEncryptedBalance))
+        {
+            if (auto const epoch = (*sleIssuance)[~sfAuditorKeyEpoch].valueOr(0); epoch != 0)
+                (*sleHolderMPToken)[sfAuditorKeyMirrorEpoch] = epoch;
+        }
     }
 
     // Decrease Global Confidential Outstanding Amount

--- a/src/libxrpl/tx/transactors/token/ConfidentialMPTConvert.cpp
+++ b/src/libxrpl/tx/transactors/token/ConfidentialMPTConvert.cpp
@@ -345,16 +345,7 @@ ConfidentialMPTConvert::doApply()
 
         // Initialize key epochs when registering the keys.
         if (view().rules().enabled(featureConfidentialMPTKeyRotation))
-        {
-            if (auto const epoch = (*sleIssuance)[~sfIssuerKeyEpoch].valueOr(0); epoch != 0)
-                (*sleMptoken)[sfIssuerKeyMirrorEpoch] = epoch;
-
-            if (auditorEc)
-            {
-                if (auto const epoch = (*sleIssuance)[~sfAuditorKeyEpoch].valueOr(0); epoch != 0)
-                    (*sleMptoken)[sfAuditorKeyMirrorEpoch] = epoch;
-            }
-        }
+            setMirrorEpochs(*sleIssuance, *sleMptoken);
 
         // Spending balance starts at zero. Must use canonical zero encryption
         // (deterministic ciphertext) so the ledger state is reproducible.

--- a/src/libxrpl/tx/transactors/token/ConfidentialMPTConvert.cpp
+++ b/src/libxrpl/tx/transactors/token/ConfidentialMPTConvert.cpp
@@ -8,6 +8,7 @@
 #include <xrpl/ledger/ReadView.h>
 #include <xrpl/ledger/helpers/TokenHelpers.h>
 #include <xrpl/protocol/ConfidentialTransfer.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/MPTIssue.h>
@@ -110,6 +111,17 @@ ConfidentialMPTConvert::preclaim(PreclaimContext const& ctx)
     auto const sleMptoken = ctx.view.read(keylet::mptoken(issuanceID, account));
     if (!sleMptoken)
         return tecOBJECT_NOT_FOUND;
+
+    // An already-initialized holder has their new ciphertexts homomorphically
+    // added to their existing mirrors, so those mirrors must be encrypted under
+    // the currently registered keys. A first-time convert creates the mirrors
+    // under those keys instead, and has nothing to be stale.
+    if (ctx.view.rules().enabled(featureConfidentialMPTKeyRotation) &&
+        sleMptoken->isFieldPresent(sfIssuerEncryptedBalance) &&
+        !areMirrorsCurrent(*sleIssuance, *sleMptoken))
+    {
+        return tecNO_PERMISSION;
+    }
 
     auto const mptIssue = MPTIssue{issuanceID};
 
@@ -330,6 +342,19 @@ ConfidentialMPTConvert::doApply()
 
         if (auditorEc)
             (*sleMptoken)[sfAuditorEncryptedBalance] = *auditorEc;
+
+        // Initialize key epochs when registering the keys.
+        if (view().rules().enabled(featureConfidentialMPTKeyRotation))
+        {
+            if (auto const epoch = (*sleIssuance)[~sfIssuerKeyEpoch].valueOr(0); epoch != 0)
+                (*sleMptoken)[sfIssuerKeyMirrorEpoch] = epoch;
+
+            if (auditorEc)
+            {
+                if (auto const epoch = (*sleIssuance)[~sfAuditorKeyEpoch].valueOr(0); epoch != 0)
+                    (*sleMptoken)[sfAuditorKeyMirrorEpoch] = epoch;
+            }
+        }
 
         // Spending balance starts at zero. Must use canonical zero encryption
         // (deterministic ciphertext) so the ledger state is reproducible.

--- a/src/libxrpl/tx/transactors/token/ConfidentialMPTConvertBack.cpp
+++ b/src/libxrpl/tx/transactors/token/ConfidentialMPTConvertBack.cpp
@@ -7,6 +7,7 @@
 #include <xrpl/ledger/ReadView.h>
 #include <xrpl/ledger/helpers/TokenHelpers.h>
 #include <xrpl/protocol/ConfidentialTransfer.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/Protocol.h>
@@ -193,6 +194,14 @@ ConfidentialMPTConvertBack::preclaim(PreclaimContext const& ctx)
     if (!sleMptoken->isFieldPresent(sfHolderEncryptionKey) ||
         !sleMptoken->isFieldPresent(sfConfidentialBalanceSpending) ||
         !sleMptoken->isFieldPresent(sfIssuerEncryptedBalance))
+    {
+        return tecNO_PERMISSION;
+    }
+
+    // Converting back homomorphically subtracts from the holder's mirrors, so
+    // those mirrors must be current.
+    if (ctx.view.rules().enabled(featureConfidentialMPTKeyRotation) &&
+        !areMirrorsCurrent(*sleIssuance, *sleMptoken))
     {
         return tecNO_PERMISSION;
     }

--- a/src/libxrpl/tx/transactors/token/ConfidentialMPTSend.cpp
+++ b/src/libxrpl/tx/transactors/token/ConfidentialMPTSend.cpp
@@ -247,6 +247,15 @@ ConfidentialMPTSend::preclaim(PreclaimContext const& ctx)
         return tecNO_PERMISSION;
     }
 
+    // A send homomorphically updates the mirrors of both parties, so both must
+    // be current.
+    if (ctx.view.rules().enabled(featureConfidentialMPTKeyRotation) &&
+        (!areMirrorsCurrent(*sleIssuance, *sleSenderMPToken) ||
+         !areMirrorsCurrent(*sleIssuance, *sleDestinationMPToken)))
+    {
+        return tecNO_PERMISSION;
+    }
+
     // Sanity check: Both MPTokens' auditor fields must be present if auditing
     // is enabled
     if (requiresAuditor &&

--- a/src/test/app/ConfidentialMPTKeyRotation_test.cpp
+++ b/src/test/app/ConfidentialMPTKeyRotation_test.cpp
@@ -1198,6 +1198,32 @@ class ConfidentialMPTKeyRotation_test : public ConfidentialTransferTestBase
             BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, std::nullopt, 2u));
         }
 
+        // A holder who initialized after a rotation is clawed back successfully, and
+        // the issuer mirror is updated to the current epoch.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob}});
+            setupConfidentialIssuance(mptAlice, alice, {bob}, {}, clawbackFlags);
+            mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+
+            // Rotate the issuer key five times, issuance's issuer epoch is 5.
+            for (int i = 0; i < 5; ++i)
+            {
+                mptAlice.generateKeyPair(alice);
+                mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+            }
+
+            mptAlice.convert({
+                .account = bob,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(bob),
+            });
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, 5u, std::nullopt));
+
+            mptAlice.confidentialClaw({.account = alice, .holder = bob, .amt = 50});
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, 5u, std::nullopt));
+        }
+
         // Clawback is not blocked on
         // a stale issuer mirror. For now the proof cannot verify: it is checked
         // against the key registered on the issuance, while the mirror is still

--- a/src/test/app/ConfidentialMPTKeyRotation_test.cpp
+++ b/src/test/app/ConfidentialMPTKeyRotation_test.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <vector>
 
 namespace xrpl {
 
@@ -605,6 +606,635 @@ class ConfidentialMPTKeyRotation_test : public ConfidentialTransferTestBase
     }
 
     void
+    testConfidentialMPTConvertEpoch(FeatureBitset features)
+    {
+        testcase("ConfidentialMPTConvert mirror epoch");
+        using namespace test::jtx;
+
+        Account const alice("alice");
+        Account const bob("bob");
+        Account const carol("carol");
+        Account const auditor("auditor");
+
+        // A first-time convert with no rotation leaves both mirror
+        // epochs absent.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob}, .auditor = auditor});
+            setupConfidentialIssuance(mptAlice, alice, {bob}, {auditor});
+
+            mptAlice.set({
+                .account = alice,
+                .issuerPubKey = mptAlice.getPubKey(alice),
+                .auditorPubKey = mptAlice.getPubKey(auditor),
+            });
+
+            BEAST_EXPECT(mptAlice.checkKeyEpochs(std::nullopt, std::nullopt));
+
+            mptAlice.convert({
+                .account = bob,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(bob),
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, std::nullopt, std::nullopt));
+
+            // Both mirrors are current, so converting again is allowed and
+            // leaves the epochs untouched.
+            mptAlice.convert({
+                .account = bob,
+                .amt = 20,
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, std::nullopt, std::nullopt));
+        }
+
+        // Every remaining case needs key rotation to be enabled.
+        if (!features[featureConfidentialMPTKeyRotation])
+            return;
+
+        // A first-time convert stamps the mirrors with whatever epochs the
+        // issuance currently sits at. Only issuer key rotated in this case.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob, carol}, .auditor = auditor});
+            setupConfidentialIssuance(mptAlice, alice, {bob, carol}, {auditor});
+
+            mptAlice.set({
+                .account = alice,
+                .issuerPubKey = mptAlice.getPubKey(alice),
+                .auditorPubKey = mptAlice.getPubKey(auditor),
+            });
+
+            // Ten rotations, issuance's issuer epoch is 10.
+            for (int i = 0; i < 10; ++i)
+            {
+                mptAlice.generateKeyPair(alice);
+                mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+            }
+
+            BEAST_EXPECT(mptAlice.checkKeyEpochs(10u, std::nullopt));
+            BEAST_EXPECT(mptAlice.checkEncryptionKeys(alice, auditor));
+
+            // carol converts for the first time, and her mirrors are stamped with the current
+            // issuer epoch of 10.
+            mptAlice.convert({
+                .account = carol,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(carol),
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(carol, 10u, std::nullopt));
+        }
+
+        // A first-time convert stamps the mirrors with whatever epochs the
+        // issuance currently sits at. Both keys rotated in this case.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob, carol}, .auditor = auditor});
+            setupConfidentialIssuance(mptAlice, alice, {bob, carol}, {auditor});
+
+            mptAlice.set({
+                .account = alice,
+                .issuerPubKey = mptAlice.getPubKey(alice),
+                .auditorPubKey = mptAlice.getPubKey(auditor),
+            });
+
+            // 100 rotations of both keys, so both epochs are 100.
+            for (int i = 0; i < 100; ++i)
+            {
+                mptAlice.generateKeyPair(alice);
+                mptAlice.generateKeyPair(auditor);
+                mptAlice.set({
+                    .account = alice,
+                    .issuerPubKey = mptAlice.getPubKey(alice),
+                    .auditorPubKey = mptAlice.getPubKey(auditor),
+                });
+            }
+
+            // 5 more rotations of the auditor key alone, so the auditor epoch is 105 now.
+            for (int i = 0; i < 5; ++i)
+            {
+                mptAlice.generateKeyPair(auditor);
+                mptAlice.set({.account = alice, .auditorPubKey = mptAlice.getPubKey(auditor)});
+            }
+
+            BEAST_EXPECT(mptAlice.checkKeyEpochs(100u, 105u));
+            BEAST_EXPECT(mptAlice.checkEncryptionKeys(alice, auditor));
+
+            // carol converts for the first time, and each of her mirrors is stamped with the epoch
+            // of the key it was encrypted under.
+            mptAlice.convert({
+                .account = carol,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(carol),
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(carol, 100u, 105u));
+        }
+
+        // An issuer key rotation leaves an existing holder's issuer mirror
+        // behind, converting will be blocked until the holder's mirror is updated to the new epoch.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob, carol}, .auditor = auditor});
+            setupConfidentialIssuance(mptAlice, alice, {bob, carol}, {auditor});
+
+            mptAlice.set({
+                .account = alice,
+                .issuerPubKey = mptAlice.getPubKey(alice),
+                .auditorPubKey = mptAlice.getPubKey(auditor),
+            });
+
+            // carol initializes before any rotation, so her mirrors carry no epoch
+            // at all, the state every holder is in before the amendment.
+            mptAlice.convert({
+                .account = carol,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(carol),
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(carol, std::nullopt, std::nullopt));
+
+            // Rotate the issuer key to epoch 1.
+            mptAlice.generateKeyPair(alice);
+            mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+
+            BEAST_EXPECT(mptAlice.checkKeyEpochs(1u, std::nullopt));
+
+            // bob converts for the first time which is allowed when registering the key.
+            mptAlice.convert({
+                .account = bob,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(bob),
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, 1u, std::nullopt));
+
+            // carol's absent epoch reads as 0 which is stale.
+            mptAlice.convert({
+                .account = carol,
+                .amt = 20,
+                .err = tecNO_PERMISSION,
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(carol, std::nullopt, std::nullopt));
+
+            // Rotate the issuer key to epoch 2, leaving bob's issuer mirror stale.
+            mptAlice.generateKeyPair(alice);
+            mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+
+            BEAST_EXPECT(mptAlice.checkKeyEpochs(2u, std::nullopt));
+
+            // This is not the first time convert, and bob's issuer mirror is behind the current
+            // epoch, so the convert is rejected.
+            mptAlice.convert({
+                .account = bob,
+                .amt = 20,
+                .err = tecNO_PERMISSION,
+            });
+
+            // The rejected convert leaves bob's mirrors exactly as they were.
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, 1u, std::nullopt));
+
+            // carol still cannot convert.
+            mptAlice.convert({
+                .account = carol,
+                .amt = 20,
+                .err = tecNO_PERMISSION,
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(carol, std::nullopt, std::nullopt));
+        }
+
+        // The auditor mirror is checked the same way, so rotating only the
+        // auditor key blocks the convert on its own, with the issuer epoch
+        // untouched.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob, carol}, .auditor = auditor});
+            setupConfidentialIssuance(mptAlice, alice, {bob, carol}, {auditor});
+
+            mptAlice.set({
+                .account = alice,
+                .issuerPubKey = mptAlice.getPubKey(alice),
+                .auditorPubKey = mptAlice.getPubKey(auditor),
+            });
+
+            // bob initializes his confidential balance at epoch 0, so both of his
+            // mirrors are current.
+            mptAlice.convert({
+                .account = bob,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(bob),
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, std::nullopt, std::nullopt));
+
+            // Rotate the auditor key only, leaving bob's auditor mirror behind
+            // while his issuer mirror stays current.
+            mptAlice.generateKeyPair(auditor);
+            mptAlice.set({.account = alice, .auditorPubKey = mptAlice.getPubKey(auditor)});
+
+            BEAST_EXPECT(mptAlice.checkKeyEpochs(std::nullopt, 1u));
+            BEAST_EXPECT(mptAlice.checkEncryptionKeys(alice, auditor));
+
+            mptAlice.convert({
+                .account = bob,
+                .amt = 20,
+                .err = tecNO_PERMISSION,
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, std::nullopt, std::nullopt));
+
+            // Carol converts for the first time, and her auditor mirror is stamped with the current
+            // auditor epoch of 1.
+            mptAlice.convert({
+                .account = carol,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(carol),
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(carol, std::nullopt, 1u));
+        }
+
+        // A late auditor key registration bumps no epoch.
+        // Although both epochs are still zero, the convert is blocked
+        // because auditor mirror is missing.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob}, .auditor = auditor});
+            setupConfidentialIssuance(mptAlice, alice, {bob}, {auditor});
+
+            // Register the issuer key only.
+            mptAlice.set({
+                .account = alice,
+                .issuerPubKey = mptAlice.getPubKey(alice),
+            });
+
+            // The issuance has no auditor yet, so no auditor mirror is created.
+            mptAlice.convert({
+                .account = bob,
+                .amt = 50,
+                .fillAuditorEncryptedAmt = false,
+                .holderPubKey = mptAlice.getPubKey(bob),
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, std::nullopt, std::nullopt));
+
+            // Register the auditor key later, which bumps no epoch.
+            mptAlice.set({
+                .account = alice,
+                .auditorPubKey = mptAlice.getPubKey(auditor),
+            });
+
+            BEAST_EXPECT(mptAlice.checkKeyEpochs(std::nullopt, std::nullopt));
+
+            // bob's auditor mirror is still missing, so the convert is rejected.
+            mptAlice.convert({
+                .account = bob,
+                .amt = 20,
+                .err = tecNO_PERMISSION,
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, std::nullopt, std::nullopt));
+        }
+    }
+
+    void
+    testConfidentialMPTSendEpoch(FeatureBitset features)
+    {
+        testcase("ConfidentialMPTSend mirror epoch");
+        using namespace test::jtx;
+
+        Account const alice("alice");
+        Account const bob("bob");
+        Account const carol("carol");
+        Account const auditor("auditor");
+
+        // Two holders that both initialized after a rotation are current, so a
+        // send between them succeeds and leaves both mirrors untouched.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob, carol}});
+            setupConfidentialIssuance(mptAlice, alice, {bob, carol});
+            mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+
+            // Rotate the issuer key to epoch 1 before anyone holds a confidential
+            // balance.
+            mptAlice.generateKeyPair(alice);
+            mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+
+            BEAST_EXPECT(mptAlice.checkKeyEpochs(1u, std::nullopt));
+
+            for (auto const& holder : {bob, carol})
+            {
+                mptAlice.convert({
+                    .account = holder,
+                    .amt = 50,
+                    .holderPubKey = mptAlice.getPubKey(holder),
+                });
+                mptAlice.mergeInbox({.account = holder});
+            }
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, 1u, std::nullopt));
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(carol, 1u, std::nullopt));
+
+            mptAlice.send({.account = bob, .dest = carol, .amt = 10});
+
+            // The epochs are unchanged after send.
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, 1u, std::nullopt));
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(carol, 1u, std::nullopt));
+        }
+
+        // Either the sender or the destination being stale will be rejected.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob, carol}});
+            setupConfidentialIssuance(mptAlice, alice, {bob, carol});
+            mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+
+            // carol initializes at epoch 0.
+            mptAlice.convert({
+                .account = carol,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(carol),
+            });
+            mptAlice.mergeInbox({.account = carol});
+
+            // Rotate the issuer key to epoch 1, leaving carol behind.
+            mptAlice.generateKeyPair(alice);
+            mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+
+            // bob initializes after the rotation, so his mirrors are current.
+            mptAlice.convert({
+                .account = bob,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(bob),
+            });
+            mptAlice.mergeInbox({.account = bob});
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(carol, std::nullopt, std::nullopt));
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, 1u, std::nullopt));
+
+            // This is rejected because the sender is the stale even though the destination is
+            // current.
+            mptAlice.send({
+                .account = carol,
+                .dest = bob,
+                .amt = 10,
+                .err = tecNO_PERMISSION,
+            });
+
+            // This is rejected because the destination is the stale even though the sender is
+            // current.
+            mptAlice.send({
+                .account = bob,
+                .dest = carol,
+                .amt = 10,
+                .err = tecNO_PERMISSION,
+            });
+
+            // The rejected sends leave both mirrors as they were.
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(carol, std::nullopt, std::nullopt));
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, 1u, std::nullopt));
+        }
+
+        // Auditor mirror is stale, the send will be rejected.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob, carol}, .auditor = auditor});
+            setupConfidentialIssuance(mptAlice, alice, {bob, carol}, {auditor});
+            mptAlice.set({
+                .account = alice,
+                .issuerPubKey = mptAlice.getPubKey(alice),
+                .auditorPubKey = mptAlice.getPubKey(auditor),
+            });
+
+            for (auto const& holder : {bob, carol})
+            {
+                mptAlice.convert({
+                    .account = holder,
+                    .amt = 50,
+                    .holderPubKey = mptAlice.getPubKey(holder),
+                });
+                mptAlice.mergeInbox({.account = holder});
+            }
+
+            // Rotate the auditor key only
+            mptAlice.generateKeyPair(auditor);
+            mptAlice.set({.account = alice, .auditorPubKey = mptAlice.getPubKey(auditor)});
+
+            BEAST_EXPECT(mptAlice.checkKeyEpochs(std::nullopt, 1u));
+
+            mptAlice.send({
+                .account = bob,
+                .dest = carol,
+                .amt = 10,
+                .err = tecNO_PERMISSION,
+            });
+
+            mptAlice.send({
+                .account = carol,
+                .dest = bob,
+                .amt = 10,
+                .err = tecNO_PERMISSION,
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, std::nullopt, std::nullopt));
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(carol, std::nullopt, std::nullopt));
+        }
+    }
+
+    void
+    testConfidentialMPTConvertBackEpoch(FeatureBitset features)
+    {
+        testcase("ConfidentialMPTConvertBack mirror epoch");
+        using namespace test::jtx;
+
+        Account const alice("alice");
+        Account const bob("bob");
+        Account const auditor("auditor");
+
+        // A holder who initialized after a rotation is current, so converting
+        // back is allowed and leaves the epoch it was stamped with alone.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob}});
+            setupConfidentialIssuance(mptAlice, alice, {bob});
+            mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+
+            // Rotate the issuer key to epoch 1 before bob holds a confidential
+            // balance.
+            mptAlice.generateKeyPair(alice);
+            mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+
+            BEAST_EXPECT(mptAlice.checkKeyEpochs(1u, std::nullopt));
+
+            mptAlice.convert({
+                .account = bob,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(bob),
+            });
+            mptAlice.mergeInbox({.account = bob});
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, 1u, std::nullopt));
+
+            mptAlice.convertBack({.account = bob, .amt = 20});
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, 1u, std::nullopt));
+        }
+
+        // Converting back with stale mirrors is rejected.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob}});
+            setupConfidentialIssuance(mptAlice, alice, {bob});
+            mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+
+            // bob initializes at epoch 0.
+            mptAlice.convert({
+                .account = bob,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(bob),
+            });
+            mptAlice.mergeInbox({.account = bob});
+
+            // Converting back is allowed while his mirrors are still current.
+            mptAlice.convertBack({.account = bob, .amt = 20});
+
+            // Rotate the issuer key to epoch 1, leaving bob behind.
+            mptAlice.generateKeyPair(alice);
+            mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+
+            mptAlice.convertBack({
+                .account = bob,
+                .amt = 10,
+                .err = tecNO_PERMISSION,
+            });
+
+            // The rejected convert back leaves bob's mirrors as they were.
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, std::nullopt, std::nullopt));
+        }
+
+        // Converting back with a stale auditor mirror is rejected, even if the issuer mirror is
+        // current.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob}, .auditor = auditor});
+            setupConfidentialIssuance(mptAlice, alice, {bob}, {auditor});
+            mptAlice.set({
+                .account = alice,
+                .issuerPubKey = mptAlice.getPubKey(alice),
+                .auditorPubKey = mptAlice.getPubKey(auditor),
+            });
+
+            mptAlice.convert({
+                .account = bob,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(bob),
+            });
+            mptAlice.mergeInbox({.account = bob});
+
+            // Rotate the auditor key only, leaving bob behind on that mirror alone.
+            mptAlice.generateKeyPair(auditor);
+            mptAlice.set({.account = alice, .auditorPubKey = mptAlice.getPubKey(auditor)});
+
+            BEAST_EXPECT(mptAlice.checkKeyEpochs(std::nullopt, 1u));
+
+            mptAlice.convertBack({
+                .account = bob,
+                .amt = 10,
+                .err = tecNO_PERMISSION,
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, std::nullopt, std::nullopt));
+        }
+    }
+
+    void
+    testConfidentialMPTClawbackEpoch(FeatureBitset features)
+    {
+        testcase("ConfidentialMPTClawback mirror epoch");
+        using namespace test::jtx;
+
+        Account const alice("alice");
+        Account const bob("bob");
+        Account const auditor("auditor");
+
+        std::uint32_t const clawbackFlags =
+            tfMPTCanTransfer | tfMPTCanHoldConfidentialBalance | tfMPTCanClawback;
+
+        // Clawback is not blocked on
+        // a stale auditor mirror.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob}, .auditor = auditor});
+            setupConfidentialIssuance(mptAlice, alice, {bob}, {auditor}, clawbackFlags);
+            mptAlice.set({
+                .account = alice,
+                .issuerPubKey = mptAlice.getPubKey(alice),
+                .auditorPubKey = mptAlice.getPubKey(auditor),
+            });
+
+            // bob initializes both mirrors at epoch 0.
+            mptAlice.convert({
+                .account = bob,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(bob),
+            });
+
+            // Rotate the auditor key twice, leaving bob's auditor mirror behind.
+            for (int i = 0; i < 2; ++i)
+            {
+                mptAlice.generateKeyPair(auditor);
+                mptAlice.set({.account = alice, .auditorPubKey = mptAlice.getPubKey(auditor)});
+            }
+
+            BEAST_EXPECT(mptAlice.checkKeyEpochs(std::nullopt, 2u));
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, std::nullopt, std::nullopt));
+
+            mptAlice.confidentialClaw({.account = alice, .holder = bob, .amt = 50});
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, std::nullopt, 2u));
+        }
+
+        // Clawback is not blocked on
+        // a stale issuer mirror. For now the proof cannot verify: it is checked
+        // against the key registered on the issuance, while the mirror is still
+        // encrypted under the key it was written with, and that older key is
+        // nowhere on the ledger yet. This will be added in a separate PR.
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob}});
+            setupConfidentialIssuance(mptAlice, alice, {bob}, {}, clawbackFlags);
+            mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+
+            // bob initializes at epoch 0.
+            mptAlice.convert({
+                .account = bob,
+                .amt = 50,
+                .holderPubKey = mptAlice.getPubKey(bob),
+            });
+
+            // Rotate the issuer key to epoch 1, leaving bob behind.
+            mptAlice.generateKeyPair(alice);
+            mptAlice.set({.account = alice, .issuerPubKey = mptAlice.getPubKey(alice)});
+
+            BEAST_EXPECT(mptAlice.checkKeyEpochs(1u, std::nullopt));
+
+            mptAlice.confidentialClaw({
+                .account = alice,
+                .holder = bob,
+                .amt = 50,
+                .err = tecBAD_PROOF,
+            });
+
+            BEAST_EXPECT(mptAlice.checkMirrorEpochs(bob, std::nullopt, std::nullopt));
+        }
+    }
+
+public:
+    void
     testMPTokenIssuanceSetWithFeats(FeatureBitset features)
     {
         testMPTokenIssuanceSetRotateIssuerKey(features);
@@ -626,6 +1256,12 @@ public:
 
         testMPTokenIssuanceSetWithFeats(all);
         testMPTokenIssuanceSetWithFeats(all - featureConfidentialMPTKeyRotation);
+
+        testConfidentialMPTConvertEpoch(all);
+        testConfidentialMPTConvertEpoch(all - featureConfidentialMPTKeyRotation);
+        testConfidentialMPTSendEpoch(all);
+        testConfidentialMPTConvertBackEpoch(all);
+        testConfidentialMPTClawbackEpoch(all);
     }
 };
 

--- a/src/test/jtx/ConfidentialTransfer.h
+++ b/src/test/jtx/ConfidentialTransfer.h
@@ -422,7 +422,7 @@ protected:
     // holders funded and authorized, and a key pair generated for the issuer,
     // every holder, and every extra key owner. The keys are
     // generated but not registered.
-    static void
+    void
     setupConfidentialIssuance(
         test::jtx::MPTTester& mpt,
         test::jtx::Account const& issuer,

--- a/src/test/jtx/ConfidentialTransfer.h
+++ b/src/test/jtx/ConfidentialTransfer.h
@@ -420,34 +420,15 @@ protected:
 
     // Create an issuance that can hold confidential balances, with the listed
     // holders funded and authorized, and a key pair generated for the issuer,
-    // every holder, and every extra key owner (an auditor, say). The keys are
-    // generated but not registered on the issuance: callers that care about key
-    // epochs need to control when that happens.
+    // every holder, and every extra key owner. The keys are
+    // generated but not registered.
     static void
     setupConfidentialIssuance(
         test::jtx::MPTTester& mpt,
         test::jtx::Account const& issuer,
         std::vector<test::jtx::Account> const& holders,
         std::vector<test::jtx::Account> const& keyOwners = {},
-        std::uint32_t flags = tfMPTCanTransfer | tfMPTCanHoldConfidentialBalance)
-    {
-        using namespace test::jtx;
-        mpt.create({
-            .ownerCount = 1,
-            .flags = flags,
-        });
-
-        for (auto const& holder : holders)
-        {
-            mpt.authorize({.account = holder});
-            mpt.pay(issuer, holder, 100);
-            mpt.generateKeyPair(holder);
-        }
-
-        mpt.generateKeyPair(issuer);
-        for (auto const& keyOwner : keyOwners)
-            mpt.generateKeyPair(keyOwner);
-    }
+        std::uint32_t flags = tfMPTCanTransfer | tfMPTCanHoldConfidentialBalance);
 
     // Set up an MPT environment suitable for batch testing.
     // alice is issuer; bob has 'bobAmt' in confidential spending; carol has

--- a/src/test/jtx/ConfidentialTransfer.h
+++ b/src/test/jtx/ConfidentialTransfer.h
@@ -422,7 +422,7 @@ protected:
     // holders funded and authorized, and a key pair generated for the issuer,
     // every holder, and every extra key owner. The keys are
     // generated but not registered.
-    void
+    static void
     setupConfidentialIssuance(
         test::jtx::MPTTester& mpt,
         test::jtx::Account const& issuer,

--- a/src/test/jtx/ConfidentialTransfer.h
+++ b/src/test/jtx/ConfidentialTransfer.h
@@ -418,6 +418,37 @@ protected:
         }
     };
 
+    // Create an issuance that can hold confidential balances, with the listed
+    // holders funded and authorized, and a key pair generated for the issuer,
+    // every holder, and every extra key owner (an auditor, say). The keys are
+    // generated but not registered on the issuance: callers that care about key
+    // epochs need to control when that happens.
+    static void
+    setupConfidentialIssuance(
+        test::jtx::MPTTester& mpt,
+        test::jtx::Account const& issuer,
+        std::vector<test::jtx::Account> const& holders,
+        std::vector<test::jtx::Account> const& keyOwners = {},
+        std::uint32_t flags = tfMPTCanTransfer | tfMPTCanHoldConfidentialBalance)
+    {
+        using namespace test::jtx;
+        mpt.create({
+            .ownerCount = 1,
+            .flags = flags,
+        });
+
+        for (auto const& holder : holders)
+        {
+            mpt.authorize({.account = holder});
+            mpt.pay(issuer, holder, 100);
+            mpt.generateKeyPair(holder);
+        }
+
+        mpt.generateKeyPair(issuer);
+        for (auto const& keyOwner : keyOwners)
+            mpt.generateKeyPair(keyOwner);
+    }
+
     // Set up an MPT environment suitable for batch testing.
     // alice is issuer; bob has 'bobAmt' in confidential spending; carol has
     // 'carolAmt' in confidential spending; dave is initialised with pubkey but

--- a/src/test/jtx/impl/ConfidentialTransfer.cpp
+++ b/src/test/jtx/impl/ConfidentialTransfer.cpp
@@ -1,0 +1,39 @@
+#include <test/jtx/ConfidentialTransfer.h>
+
+#include <test/jtx/Account.h>
+#include <test/jtx/mpt.h>
+
+#include <xrpl/protocol/TxFlags.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace xrpl {
+
+void
+ConfidentialTransferTestBase::setupConfidentialIssuance(
+    test::jtx::MPTTester& mpt,
+    test::jtx::Account const& issuer,
+    std::vector<test::jtx::Account> const& holders,
+    std::vector<test::jtx::Account> const& keyOwners,
+    std::uint32_t flags)
+{
+    using namespace test::jtx;
+    mpt.create({
+        .ownerCount = 1,
+        .flags = flags,
+    });
+
+    for (auto const& holder : holders)
+    {
+        mpt.authorize({.account = holder});
+        mpt.pay(issuer, holder, 100);
+        mpt.generateKeyPair(holder);
+    }
+
+    mpt.generateKeyPair(issuer);
+    for (auto const& keyOwner : keyOwners)
+        mpt.generateKeyPair(keyOwner);
+}
+
+}  // namespace xrpl

--- a/src/test/jtx/impl/ConfidentialTransfer.cpp
+++ b/src/test/jtx/impl/ConfidentialTransfer.cpp
@@ -3,8 +3,6 @@
 #include <test/jtx/Account.h>
 #include <test/jtx/mpt.h>
 
-#include <xrpl/protocol/TxFlags.h>
-
 #include <cstdint>
 #include <vector>
 

--- a/src/test/jtx/impl/mpt.cpp
+++ b/src/test/jtx/impl/mpt.cpp
@@ -92,6 +92,33 @@ makePedersenParams(PedersenProofParams const& params)
     return res;
 }
 
+/**
+ * @brief Looks up an account's key at a given key epoch.
+ *
+ * @param keys accounts' history of keys, indexed by key epoch.
+ * @param account The account whose key is being looked up.
+ * @param epoch The key epoch, or std::nullopt for the account's latest key.
+ * @return The key, or std::nullopt if the account has no key at that epoch.
+ */
+[[nodiscard]] std::optional<Buffer>
+keyAtEpoch(
+    std::unordered_map<AccountID, std::vector<Buffer>> const& keys,
+    AccountID const& account,
+    std::optional<std::uint32_t> epoch)
+{
+    auto const it = keys.find(account);
+    if (it == keys.end() || it->second.empty())
+        return std::nullopt;
+
+    if (!epoch)
+        return it->second.back();
+
+    if (*epoch >= it->second.size())
+        return std::nullopt;
+
+    return it->second[*epoch];
+}
+
 }  // namespace
 
 void
@@ -660,6 +687,33 @@ MPTTester::checkKeyEpochs(
 }
 
 [[nodiscard]] bool
+MPTTester::checkMirrorEpochs(
+    Account const& holder,
+    std::optional<std::uint32_t> issuerKeyMirrorEpoch,
+    std::optional<std::uint32_t> auditorKeyMirrorEpoch) const
+{
+    return forObject(
+        [&](SLEP const& sle) -> bool {
+            return (*sle)[~sfIssuerKeyMirrorEpoch] == issuerKeyMirrorEpoch &&
+                (*sle)[~sfAuditorKeyMirrorEpoch] == auditorKeyMirrorEpoch;
+        },
+        holder);
+}
+
+[[nodiscard]] std::optional<std::uint32_t>
+MPTTester::getMirrorEpoch(Account const& holder, SF_UINT32 const& field) const
+{
+    std::optional<std::uint32_t> epoch;
+    forObject(
+        [&](SLEP const& sle) -> bool {
+            epoch = (*sle)[~field];
+            return true;
+        },
+        holder);
+    return epoch;
+}
+
+[[nodiscard]] bool
 MPTTester::checkEncryptionKeys(
     std::optional<Account> const& issuerKeyOwner,
     std::optional<Account> const& auditorKeyOwner) const
@@ -1172,8 +1226,13 @@ MPTTester::convert(MPTConvert const& arg)
     if (!prevInboxBalance || !prevSpendingBalance || !prevIssuerBalance)
         Throw<std::runtime_error>("Failed to get Pre-convert balance");
 
+    // The auditor mirror is only touched if the transaction carries an auditor
+    // ciphertext, which mirrors the condition convertJV fills it under.
+    bool const hasAuditorAmt =
+        arg.auditorEncryptedAmt || (auditor_ && arg.fillAuditorEncryptedAmt.value_or(false));
+
     std::optional<uint64_t> prevAuditorBalance;
-    if (arg.auditorEncryptedAmt || auditor_)
+    if (hasAuditorAmt)
     {
         prevAuditorBalance = getDecryptedBalance(*arg.account, auditorEncryptedBalance);
         if (!prevAuditorBalance)
@@ -1212,7 +1271,7 @@ MPTTester::convert(MPTConvert const& arg)
         if (!postInboxBalance || !postIssuerBalance || !postSpendingBalance)
             Throw<std::runtime_error>("Failed to get post-convert balance");
 
-        if (arg.auditorEncryptedAmt || auditor_)
+        if (hasAuditorAmt)
         {
             auto const postAuditorBalance =
                 getDecryptedBalance(*arg.account, auditorEncryptedBalance);
@@ -2039,7 +2098,7 @@ MPTTester::confidentialClaw(MPTConfidentialClawback const& arg)
     }
 }
 
-void
+std::uint32_t
 MPTTester::generateKeyPair(Account const& account)
 {
     unsigned char privKey[kEcPrivKeyLength];
@@ -2057,26 +2116,23 @@ MPTTester::generateKeyPair(Account const& account)
         Throw<std::runtime_error>("failed to serialize public key");
     }
 
-    pubKeys_.insert({account.id(), Buffer{compressedPubKey, kEcPubKeyLength}});
-    privKeys_.insert({account.id(), Buffer{privKey, kEcPrivKeyLength}});
+    auto& pubKeyEpochs = pubKeys_[account.id()];
+    pubKeyEpochs.emplace_back(compressedPubKey, kEcPubKeyLength);
+    privKeys_[account.id()].emplace_back(privKey, kEcPrivKeyLength);
+
+    return static_cast<std::uint32_t>(pubKeyEpochs.size() - 1);
 }
 
 std::optional<Buffer>
-MPTTester::getPubKey(Account const& account) const
+MPTTester::getPubKey(Account const& account, std::optional<std::uint32_t> epoch) const
 {
-    if (auto const it = pubKeys_.find(account.id()); it != pubKeys_.end())
-        return it->second;
-
-    return std::nullopt;
+    return keyAtEpoch(pubKeys_, account.id(), epoch);
 }
 
 std::optional<Buffer>
-MPTTester::getPrivKey(Account const& account) const
+MPTTester::getPrivKey(Account const& account, std::optional<std::uint32_t> epoch) const
 {
-    if (auto const it = privKeys_.find(account.id()); it != privKeys_.end())
-        return it->second;
-
-    return std::nullopt;
+    return keyAtEpoch(privKeys_, account.id(), epoch);
 }
 
 Buffer
@@ -2095,7 +2151,10 @@ MPTTester::encryptAmount(Account const& account, uint64_t const amt, Buffer cons
 }
 
 std::optional<uint64_t>
-MPTTester::decryptAmount(Account const& account, Buffer const& amt) const
+MPTTester::decryptAmount(
+    Account const& account,
+    Buffer const& amt,
+    std::optional<std::uint32_t> epoch) const
 {
     if (amt.size() != kEcGamalEncryptedTotalLength)
         return std::nullopt;
@@ -2104,7 +2163,7 @@ MPTTester::decryptAmount(Account const& account, Buffer const& amt) const
     if (!pair)
         return std::nullopt;
 
-    auto const privKey = getPrivKey(account);
+    auto const privKey = getPrivKey(account, epoch);
     if (!privKey || privKey->size() != kEcPrivKeyLength)
         return std::nullopt;
 
@@ -2136,18 +2195,24 @@ MPTTester::getDecryptedBalance(Account const& account, EncryptedBalanceType bala
 
     Account decryptor = account;
 
+    // A mirror stays encrypted under the key it was written with, so a rotation
+    // leaves it readable only by that generation of the key, not the latest one.
+    std::optional<std::uint32_t> epoch;
+
     if (balanceType == issuerEncryptedBalance)
     {
         decryptor = issuer_;
+        epoch = getMirrorEpoch(account, sfIssuerKeyMirrorEpoch).value_or(0);
     }
     else if (balanceType == auditorEncryptedBalance)
     {
         if (!auditor_)
             return std::nullopt;
         decryptor = *auditor_;
+        epoch = getMirrorEpoch(account, sfAuditorKeyMirrorEpoch).value_or(0);
     }
 
-    return decryptAmount(decryptor, *encryptedAmt);
+    return decryptAmount(decryptor, *encryptedAmt, epoch);
 };
 
 json::Value

--- a/src/test/jtx/mpt.h
+++ b/src/test/jtx/mpt.h
@@ -20,6 +20,7 @@
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Asset.h>
 #include <xrpl/protocol/ConfidentialTransfer.h>
+#include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/UintTypes.h>
@@ -451,8 +452,10 @@ class MPTTester
     std::optional<Account> const auditor_;
     std::optional<MPTID> id_;
     bool close_;
-    std::unordered_map<AccountID, Buffer> pubKeys_;
-    std::unordered_map<AccountID, Buffer> privKeys_;
+    // Keys generated for each account. Buffer vector's index is the key epoch: index 0 is
+    // the initial pair and each rotation appends.
+    std::unordered_map<AccountID, std::vector<Buffer>> pubKeys_;
+    std::unordered_map<AccountID, std::vector<Buffer>> privKeys_;
 
 public:
     enum class EncryptedBalanceType {
@@ -619,6 +622,15 @@ public:
         std::optional<std::uint32_t> issuerKeyEpoch,
         std::optional<std::uint32_t> auditorKeyEpoch) const;
 
+    // Checks both mirror epochs on a holder's MPToken. Pass std::nullopt for an
+    // epoch that is expected to be absent, which means the mirror was written
+    // under the issuance's epoch 0 key.
+    [[nodiscard]] bool
+    checkMirrorEpochs(
+        Account const& holder,
+        std::optional<std::uint32_t> issuerKeyMirrorEpoch,
+        std::optional<std::uint32_t> auditorKeyMirrorEpoch) const;
+
     // Checks that the issuance carries the encryption keys of the given
     // accounts. Pass std::nullopt for a key that is expected to be absent,
     // which means the key is never registered.
@@ -678,20 +690,31 @@ public:
 
     operator Asset() const;
 
-    void
+    // Generates the account's next key pair and returns the key epoch it landed
+    // at, leaving the earlier ones retrievable.
+    std::uint32_t
     generateKeyPair(Account const& account);
 
+    // Returns the account's public key at the given key epoch, or its latest key when
+    // no epoch is given.
     [[nodiscard]] std::optional<Buffer>
-    getPubKey(Account const& account) const;
+    getPubKey(Account const& account, std::optional<std::uint32_t> epoch = std::nullopt) const;
 
+    // Returns the account's private key at the given key epoch, or its latest key when
+    // no epoch is given.
     [[nodiscard]] std::optional<Buffer>
-    getPrivKey(Account const& account) const;
+    getPrivKey(Account const& account, std::optional<std::uint32_t> epoch = std::nullopt) const;
 
     [[nodiscard]] Buffer
     encryptAmount(Account const& account, uint64_t const amt, Buffer const& blindingFactor) const;
 
+    // Decrypts with the account's key at the given key epoch, or its latest key
+    // when no epoch is given.
     [[nodiscard]] std::optional<uint64_t>
-    decryptAmount(Account const& account, Buffer const& amt) const;
+    decryptAmount(
+        Account const& account,
+        Buffer const& amt,
+        std::optional<std::uint32_t> epoch = std::nullopt) const;
 
     [[nodiscard]] std::optional<uint64_t>
     getDecryptedBalance(Account const& account, EncryptedBalanceType balanceType) const;
@@ -744,6 +767,10 @@ private:
     forObject(
         std::function<bool(SLEP const& sle)> const& cb,
         std::optional<Account> const& holder = std::nullopt) const;
+
+    // Reads one of the holder's mirror key epochs off their MPToken.
+    [[nodiscard]] std::optional<std::uint32_t>
+    getMirrorEpoch(Account const& holder, SF_UINT32 const& field) const;
 
     template <typename A>
     TER

--- a/src/tests/libxrpl/protocol_autogen/ledger_entries/MPTokenTests.cpp
+++ b/src/tests/libxrpl/protocol_autogen/ledger_entries/MPTokenTests.cpp
@@ -32,6 +32,8 @@ TEST(MPTokenTests, BuilderSettersRoundTrip)
     auto const confidentialBalanceVersionValue = canonical_UINT32();
     auto const issuerEncryptedBalanceValue = canonical_VL();
     auto const auditorEncryptedBalanceValue = canonical_VL();
+    auto const issuerKeyMirrorEpochValue = canonical_UINT32();
+    auto const auditorKeyMirrorEpochValue = canonical_UINT32();
     auto const holderEncryptionKeyValue = canonical_VL();
 
     MPTokenBuilder builder{
@@ -49,6 +51,8 @@ TEST(MPTokenTests, BuilderSettersRoundTrip)
     builder.setConfidentialBalanceVersion(confidentialBalanceVersionValue);
     builder.setIssuerEncryptedBalance(issuerEncryptedBalanceValue);
     builder.setAuditorEncryptedBalance(auditorEncryptedBalanceValue);
+    builder.setIssuerKeyMirrorEpoch(issuerKeyMirrorEpochValue);
+    builder.setAuditorKeyMirrorEpoch(auditorKeyMirrorEpochValue);
     builder.setHolderEncryptionKey(holderEncryptionKeyValue);
 
     builder.setLedgerIndex(index);
@@ -147,6 +151,22 @@ TEST(MPTokenTests, BuilderSettersRoundTrip)
     }
 
     {
+        auto const& expected = issuerKeyMirrorEpochValue;
+        auto const actualOpt = entry.getIssuerKeyMirrorEpoch();
+        ASSERT_TRUE(actualOpt.has_value());
+        expectEqualField(expected, *actualOpt, "sfIssuerKeyMirrorEpoch");
+        EXPECT_TRUE(entry.hasIssuerKeyMirrorEpoch());
+    }
+
+    {
+        auto const& expected = auditorKeyMirrorEpochValue;
+        auto const actualOpt = entry.getAuditorKeyMirrorEpoch();
+        ASSERT_TRUE(actualOpt.has_value());
+        expectEqualField(expected, *actualOpt, "sfAuditorKeyMirrorEpoch");
+        EXPECT_TRUE(entry.hasAuditorKeyMirrorEpoch());
+    }
+
+    {
         auto const& expected = holderEncryptionKeyValue;
         auto const actualOpt = entry.getHolderEncryptionKey();
         ASSERT_TRUE(actualOpt.has_value());
@@ -179,6 +199,8 @@ TEST(MPTokenTests, BuilderFromSleRoundTrip)
     auto const confidentialBalanceVersionValue = canonical_UINT32();
     auto const issuerEncryptedBalanceValue = canonical_VL();
     auto const auditorEncryptedBalanceValue = canonical_VL();
+    auto const issuerKeyMirrorEpochValue = canonical_UINT32();
+    auto const auditorKeyMirrorEpochValue = canonical_UINT32();
     auto const holderEncryptionKeyValue = canonical_VL();
 
     auto sle = std::make_shared<SLE>(MPToken::entryType, index);
@@ -195,6 +217,8 @@ TEST(MPTokenTests, BuilderFromSleRoundTrip)
     sle->at(sfConfidentialBalanceVersion) = confidentialBalanceVersionValue;
     sle->at(sfIssuerEncryptedBalance) = issuerEncryptedBalanceValue;
     sle->at(sfAuditorEncryptedBalance) = auditorEncryptedBalanceValue;
+    sle->at(sfIssuerKeyMirrorEpoch) = issuerKeyMirrorEpochValue;
+    sle->at(sfAuditorKeyMirrorEpoch) = auditorKeyMirrorEpochValue;
     sle->at(sfHolderEncryptionKey) = holderEncryptionKeyValue;
 
     MPTokenBuilder builderFromSle{sle};
@@ -348,6 +372,32 @@ TEST(MPTokenTests, BuilderFromSleRoundTrip)
     }
 
     {
+        auto const& expected = issuerKeyMirrorEpochValue;
+
+        auto const fromSleOpt = entryFromSle.getIssuerKeyMirrorEpoch();
+        auto const fromBuilderOpt = entryFromBuilder.getIssuerKeyMirrorEpoch();
+
+        ASSERT_TRUE(fromSleOpt.has_value());
+        ASSERT_TRUE(fromBuilderOpt.has_value());
+
+        expectEqualField(expected, *fromSleOpt, "sfIssuerKeyMirrorEpoch");
+        expectEqualField(expected, *fromBuilderOpt, "sfIssuerKeyMirrorEpoch");
+    }
+
+    {
+        auto const& expected = auditorKeyMirrorEpochValue;
+
+        auto const fromSleOpt = entryFromSle.getAuditorKeyMirrorEpoch();
+        auto const fromBuilderOpt = entryFromBuilder.getAuditorKeyMirrorEpoch();
+
+        ASSERT_TRUE(fromSleOpt.has_value());
+        ASSERT_TRUE(fromBuilderOpt.has_value());
+
+        expectEqualField(expected, *fromSleOpt, "sfAuditorKeyMirrorEpoch");
+        expectEqualField(expected, *fromBuilderOpt, "sfAuditorKeyMirrorEpoch");
+    }
+
+    {
         auto const& expected = holderEncryptionKeyValue;
 
         auto const fromSleOpt = entryFromSle.getHolderEncryptionKey();
@@ -436,6 +486,10 @@ TEST(MPTokenTests, OptionalFieldsReturnNullopt)
     EXPECT_FALSE(entry.getIssuerEncryptedBalance().has_value());
     EXPECT_FALSE(entry.hasAuditorEncryptedBalance());
     EXPECT_FALSE(entry.getAuditorEncryptedBalance().has_value());
+    EXPECT_FALSE(entry.hasIssuerKeyMirrorEpoch());
+    EXPECT_FALSE(entry.getIssuerKeyMirrorEpoch().has_value());
+    EXPECT_FALSE(entry.hasAuditorKeyMirrorEpoch());
+    EXPECT_FALSE(entry.getAuditorKeyMirrorEpoch().has_value());
     EXPECT_FALSE(entry.hasHolderEncryptionKey());
     EXPECT_FALSE(entry.getHolderEncryptionKey().has_value());
 }


### PR DESCRIPTION
<!--
This PR template helps you write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR. This avoids redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

The changes are under ConfidentialMPTKeyRotation amendment:

1. `ConfidentialMPTConvert`: First time key registration: create the mirror epochs to match the issuance's epochs; If it is not first time registration (just convert amount to confidential): will be rejected with tecNO_PERMISSION if either epoch (issuer/auditor) is stale.
2. `ConfidentialMPTSend`: Will be rejected with tecNO_PERMISSION if either epoch (issuer/auditor) of sender or destination is stale.
3. `ConfidentialMPTConvertBack`: Will be rejected with tecNO_PERMISSION if either epoch (issuer/auditor) is stale.
4. `ConfidentialMPTClawback`: If epoch is stale, this is not blocked. It will update the mirror epochs once succeeded. But we still need to support ConfidentialMPTClawback to read from a historical private key.
5. The changes in test framework now support to retrieve public or private key from a specific epoch.

## Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

## API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
6. What behavior/functionality does the change impact?
7. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
8. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to this PR.
-->
