### PR TITLE
fix: Assorted MPT/DEX offer related fixes

### DIFF
--- a/include/xrpl/ledger/helpers/MPTokenHelpers.h
+++ b/include/xrpl/ledger/helpers/MPTokenHelpers.h
@@ -312,12 +312,22 @@ checkCreateMPT(
 //
 //------------------------------------------------------------------------------
 
-// MaximumAmount doesn't exceed 2**63-1
+/**
+ * MaximumAmount doesn't exceed 2**63-1
+ */
 std::int64_t
 maxMPTAmount(SLE const& sleIssuance);
 
-// OutstandingAmount may overflow and available amount might be negative.
-// But available amount is always <= |MaximumAmount - OutstandingAmount|.
+/**
+ * std::nullopt if the issuance doesn't exist.
+ */
+std::optional<std::int64_t>
+maxMPTAmount(ReadView const& view, MPTID const& mptID);
+
+/**
+ * OutstandingAmount may overflow and available amount might be negative.
+ * But available amount is always <= |MaximumAmount - OutstandingAmount|.
+ */
 std::int64_t
 availableMPTAmount(SLE const& sleIssuance);
 
@@ -331,7 +341,12 @@ availableMPTAmount(ReadView const& view, MPTID const& mptID);
  * directSendNoFee transactions that bypass the payment engine.
  * 2.  **accountSend & Payment Engine (Overflow: Yes):** A temporary overflow
  * check when `OutstandingAmount > UINT64_MAX`. This higher threshold is used
- * for `accountSend` and payments processed via the payment engine.
+ * for `accountSend` and payments processed via the payment engine, whose
+ * reverse pass may issue before it redeems.
+ *
+ * In both cases a single `sendAmount > MaximumAmount` is rejected. Such a send
+ * can never settle: redemptions within the transaction are bounded by the
+ * outstanding amount, so the final OutstandingAmount would exceed the cap.
  */
 bool
 isMPTOverflow(

--- a/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
@@ -1047,6 +1047,14 @@ maxMPTAmount(SLE const& sleIssuance)
     return sleIssuance[~sfMaximumAmount].value_or(kMaxMpTokenAmount);
 }
 
+std::optional<std::int64_t>
+maxMPTAmount(ReadView const& view, MPTID const& mptID)
+{
+    if (auto const sle = view.read(keylet::mptokenIssuance(mptID)))
+        return maxMPTAmount(*sle);
+    return std::nullopt;
+}
+
 std::int64_t
 availableMPTAmount(SLE const& sleIssuance)
 {

--- a/src/libxrpl/protocol/STAmount.cpp
+++ b/src/libxrpl/protocol/STAmount.cpp
@@ -1541,11 +1541,19 @@ mulRoundImpl(STAmount const& v1, STAmount const& v2, Asset const& asset, bool ro
 
     bool const resultNegative = v1.negative() != v2.negative();
 
-    if (asset.holds<MPTIssue>() && isFeatureEnabled(featureMPTokensV2, false))
+    // The legacy path below assumes 16-digit mantissas. An MPT mantissa is the
+    // raw 63-bit balance, so any MPT operand (not just an MPT result) can
+    // overflow it: a large MPT amount times an IOU-shaped rate into an XRP or
+    // IOU result is the offer-crossing remainder and partial-fill case. Use
+    // Number arithmetic under MPTokensV2 whenever an MPT is involved.
+    //
+    // Outside a transaction (no current rules, e.g. pathfinding) default to
+    // the Number path: an MPT operand can only reach here through MPT
+    // offers or AMMs, which require MPTokensV2, so this keeps RPC quotes on
+    // the same arithmetic as the transaction they describe.
+    if (isFeatureEnabled(featureMPTokensV2, /*resultIfNoRules*/ true) &&
+        (asset.holds<MPTIssue>() || v1.holds<MPTIssue>() || v2.holds<MPTIssue>()))
     {
-        // MPT DEX can combine 63-bit MPT amounts with IOU-shaped transfer
-        // rates. Use Number arithmetic under MPTokensV2 so the rounded
-        // operation is not limited by the legacy uint64_t scaled mantissa.
         Number result;
         {
             NumberRoundModeGuard const operationRound(roundMode(resultNegative, roundUp));
@@ -1643,7 +1651,10 @@ divRoundImpl(STAmount const& num, STAmount const& den, Asset const& asset, bool 
 
     bool const resultNegative = (num.negative() != den.negative());
 
-    if (asset.holds<MPTIssue>() && isFeatureEnabled(featureMPTokensV2, false))
+    // See mulRoundImpl: any MPT operand, not just an MPT result, and the
+    // Number path when there are no current rules.
+    if (isFeatureEnabled(featureMPTokensV2, /*resultIfNoRules*/ true) &&
+        (asset.holds<MPTIssue>() || num.holds<MPTIssue>() || den.holds<MPTIssue>()))
     {
         // Match the multiply path above: Number performs the rounded
         // operation, then STAmount materializes the final MPT amount using the

--- a/src/libxrpl/tx/paths/BookStep.cpp
+++ b/src/libxrpl/tx/paths/BookStep.cpp
@@ -83,6 +83,11 @@ protected:
     std::optional<AMMLiquidity<TIn, TOut>> ammLiquidity_;
     beast::Journal const j_;
     Asset const strandDeliver_;
+    // MaximumAmount of book_.in if it is an MPT. Taking an MPT offer has the
+    // issuer send TakerPays to the owner, and a send above the cap is rejected
+    // (isMPTOverflow). forEachOffer limits the offer's input to the cap so it
+    // fills partially instead of failing the strand.
+    std::optional<TIn> maxIn_;
 
     struct Cache
     {
@@ -106,6 +111,12 @@ private:
         , j_(ctx.j)
         , strandDeliver_(ctx.strandDeliver)
     {
+        if constexpr (std::is_same_v<TIn, MPTAmount>)
+        {
+            if (auto const max = maxMPTAmount(ctx.view, in.get<MPTIssue>().getMptID()))
+                maxIn_.emplace(*max);
+        }
+
         if (auto const ammSle = ctx.view.read(keylet::amm(in, out));
             ammSle && ammSle->getFieldAmount(sfLPTokenBalance) != beast::kZero)
         {
@@ -819,29 +830,43 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
                 stpAmt.in = mulRatio(ofrAmt.in, ofrInRate, QUALITY_ONE, /*roundUp*/ true);
             }
 
-            // Limit offer's input if MPT, BookStep is the first step (an issuer
-            // is making a cross-currency payment), and this offer is not owned
-            // by the issuer. Otherwise, OutstandingAmount may overflow.
+            // Limit offer's input if MPT and the offer is not owned by the
+            // issuer (an issuer's send to itself is a no-op).
+            bool inLimited = false;
+            std::optional<TIn> limitIn;
             auto const& issuer = assetIn.getIssuer();
-            if (isAssetInMPT && !prevStep_ && offer.owner() != issuer)
+            if (isAssetInMPT && offer.owner() != issuer)
             {
-                // Funds available to issue
-                auto const available = toAmount<TIn>(accountFunds(
-                    sb,
-                    issuer,
-                    assetIn,  // STAmount{0}, but the default is not used
-                    FreezeHandling::IgnoreFreeze,
-                    AuthHandling::IgnoreAuth,
-                    j_));
-                if (stpAmt.in > available)
+                if (!prevStep_)
                 {
-                    limitStepIn(
-                        offer, ofrAmt, stpAmt, ownerGives, ofrInRate, ofrOutRate, available);
+                    // BookStep is the first step (an issuer is making a
+                    // cross-currency payment). Limit to the funds available to
+                    // issue, otherwise OutstandingAmount may overflow.
+                    auto const available = toAmount<TIn>(accountFunds(
+                        sb,
+                        issuer,
+                        assetIn,  // STAmount{0}, but the default is not used
+                        FreezeHandling::IgnoreFreeze,
+                        AuthHandling::IgnoreAuth,
+                        j_));
+                    if (stpAmt.in > available)
+                        limitIn = available;
+                }
+                else if (maxIn_ && ofrAmt.in > *maxIn_)
+                {
+                    // Limit to MaximumAmount (see maxIn_). The remainder is
+                    // still funded, so the callback keeps the offer instead of
+                    // consuming it. The grossed-up cap can't overflow since
+                    // ofrAmt.in > maxIn_ did not.
+                    inLimited = true;
+                    limitIn = mulRatio(*maxIn_, ofrInRate, QUALITY_ONE, /*roundUp*/ true);
                 }
             }
+            if (limitIn)
+                limitStepIn(offer, ofrAmt, stpAmt, ownerGives, ofrInRate, ofrOutRate, *limitIn);
 
             offerAttempted = true;
-            return callback(offer, ofrAmt, stpAmt, ownerGives, ofrInRate, ofrOutRate);
+            return callback(offer, ofrAmt, stpAmt, ownerGives, ofrInRate, ofrOutRate, inLimited);
         }
         catch (std::overflow_error const&)
         {
@@ -1091,7 +1116,8 @@ BookStep<TIn, TOut, TDerived>::revImp(
                          TAmounts<TIn, TOut> const& stpAmt,
                          TOut const& ownerGives,
                          std::uint32_t transferRateIn,
-                         std::uint32_t transferRateOut) mutable -> bool {
+                         std::uint32_t transferRateOut,
+                         bool inLimited) mutable -> bool {
         if (remainingOut <= beast::kZero)
             return false;
 
@@ -1103,8 +1129,10 @@ BookStep<TIn, TOut, TDerived>::revImp(
             remainingOut = out - result.out;
             this->consumeOffer(sb, offer, ofrAmt, stpAmt, ownerGives);
             // return true b/c even if the payment is satisfied,
-            // we need to consume the offer
-            return true;
+            // we need to consume the offer. An offer limited to the issuance
+            // cap is not consumed, though: its remainder is still funded, and
+            // no more of that MPT can flow through this step anyway.
+            return !inLimited;
         }
 
         auto ofrAdjAmt = ofrAmt;
@@ -1207,7 +1235,8 @@ BookStep<TIn, TOut, TDerived>::fwdImp(
                          TAmounts<TIn, TOut> const& stpAmt,
                          TOut const& ownerGives,
                          std::uint32_t transferRateIn,
-                         std::uint32_t transferRateOut) mutable -> bool {
+                         std::uint32_t transferRateOut,
+                         bool inLimited) mutable -> bool {
         XRPL_ASSERT(cache_, "xrpl::BookStep::fwdImp::eachOffer : cache is set");
 
         if (remainingIn <= beast::kZero)
@@ -1237,8 +1266,10 @@ BookStep<TIn, TOut, TDerived>::fwdImp(
             savedInsAdj.insert(stpAmt.in);
             lastOut = savedOutsAdj.insert(stpAmt.out);
             resultAdj = TAmounts<TIn, TOut>(sum(savedInsAdj), sum(savedOutsAdj));
-            // consume the offer even if stepAmt.in == remainingIn
-            processMore = true;
+            // consume the offer even if stepAmt.in == remainingIn, unless it
+            // was limited to the issuance cap: its remainder is still funded
+            // and must stay on the book.
+            processMore = !inLimited;
         }
         else
         {

--- a/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
+++ b/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
@@ -25,6 +25,7 @@
 #include <xrpl/protocol/Issue.h>
 #include <xrpl/protocol/Keylet.h>
 #include <xrpl/protocol/LedgerFormats.h>
+#include <xrpl/protocol/MPTAmount.h>
 #include <xrpl/protocol/MPTIssue.h>
 #include <xrpl/protocol/Protocol.h>
 #include <xrpl/protocol/Quality.h>
@@ -51,6 +52,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <tuple>
 #include <utility>
 
@@ -414,19 +416,47 @@ OfferCreate::flowCross(
         // offer taker.  Set sendMax to allow for the gateway's cut.
         Rate gatewayXferRate{QUALITY_ONE};
         STAmount sendMax = takerAmount.in;
+        // Payment flow code compares quality after the transfer rate is
+        // included, so the threshold is computed from the grossed-up input.
+        STAmount thresholdIn = sendMax;
         if (!sendMax.native() && (accountID_ != sendMax.getIssuer()))
         {
             gatewayXferRate = transferRate(psb, sendMax);
             if (gatewayXferRate.value != QUALITY_ONE)
             {
-                sendMax =
-                    multiplyRound(takerAmount.in, gatewayXferRate, takerAmount.in.asset(), true);
+                try
+                {
+                    sendMax = multiplyRound(
+                        takerAmount.in, gatewayXferRate, takerAmount.in.asset(), true);
+                    thresholdIn = sendMax;
+                }
+                catch (std::overflow_error const&)
+                {
+                    // Only an MPT amount can overflow here (IOU rescales and
+                    // XRP has no transfer rate), and MPT offers require
+                    // featureMPTokensV2 at preflight, so this legacy re-throw
+                    // is unreachable in practice.
+                    // LCOV_EXCL_START
+                    if (!takerAmount.in.holds<MPTIssue>() ||
+                        !psb.rules().enabled(featureMPTokensV2))
+                        throw;
+                    // LCOV_EXCL_STOP
+
+                    // The grossed-up MPT amount exceeds 2^63-1. The taker can't
+                    // send more than its balance anyway. The threshold only
+                    // needs the ratio, so compute it as an IOU, which can't
+                    // overflow.
+                    sendMax = inStartBalance;
+                    thresholdIn = multiplyRound(
+                        STAmount{noIssue(), takerAmount.in.mantissa()},
+                        gatewayXferRate,
+                        noIssue(),
+                        true);
+                }
             }
         }
 
-        // Payment flow code compares quality after the transfer rate is
-        // included.  Since transfer rate is incorporated compute threshold.
-        Quality threshold{takerAmount.out, sendMax};
+        Quality threshold{takerAmount.out, thresholdIn};
 
         // If we're creating a passive offer adjust the threshold so we only
         // cross offers that have a better quality than this one.
@@ -871,15 +901,30 @@ OfferCreate::applyGuts(Sandbox& sb, Sandbox& sbCancel)
         return {tesSUCCESS, true};
     }
 
+    // A taker redeeming an MPT into this offer pays the transfer fee, and
+    // BookStep grosses up TakerPays by the rate for the whole offer before
+    // anything else. If that doesn't fit in an MPT amount, no taker can take
+    // the offer and BookStep would remove it on the first attempt. Checked on
+    // the remainder: it may fit even if the original amount didn't.
+    bool cannotRest = false;
+    if (mptV2 && saTakerPays.holds<MPTIssue>())
+    {
+        auto const rate = transferRate(sb, saTakerPays);
+        cannotRest = rate != kParityRate &&
+            !tryMulRatio(saTakerPays.mpt(), rate.value, QUALITY_ONE, /*roundUp*/ true);
+    }
+
     // The remainder rests at uRate, the original pre-crossing rate. A zero
     // rate (quality not representable) puts it in the directory whose index
     // equals getBookBase(book), and BookTip scans keys strictly greater, so it
-    // could never be crossed while holding the owner's reserve. Don't place
-    // it; anything that crossed is kept, and a fully crossed offer has already
-    // returned above. Gated to preserve pre-amendment behavior.
-    if (mptV2 && uRate == 0)
+    // could never be crossed while holding the owner's reserve. Likewise, a
+    // bid whose fee-grossed TakerPays doesn't fit would be removed by BookStep
+    // on the first take. Don't place it; anything that crossed is kept, and a
+    // fully crossed offer has already returned above. Gated to preserve
+    // pre-amendment behavior.
+    if ((mptV2 && uRate == 0) || cannotRest)
     {
-        JLOG(j_.debug()) << "Unrepresentable quality: remainder not placed";
+        JLOG(j_.debug()) << "Unrepresentable quality or fee: remainder not placed";
         if (!crossed)
             return {tecKILLED, false};
         return {tesSUCCESS, true};

--- a/src/test/app/FlowMPT_test.cpp
+++ b/src/test/app/FlowMPT_test.cpp
@@ -41,9 +41,11 @@
 #include <xrpl/tx/paths/detail/Steps.h>
 
 #include <cstdint>
+#include <initializer_list>
 #include <optional>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace xrpl::test {
@@ -780,6 +782,335 @@ struct FlowMPT_test : public beast::unit_test::Suite
         // that scaling it by the transfer rate is not representable, so the
         // reverse pass takes the limiting branch and overflows on the maximum
         test(maxRepresentable + 1, kMaxMpTokenAmount, "limiting");
+    }
+
+    void
+    testBookStepInputAboveMaximumAmount(FeatureBitset features)
+    {
+        // OfferCreate doesn't compare TakerPays with the MPT's MaximumAmount,
+        // so a bid for more than the cap rests. Taking it has the issuer send
+        // TakerPays to the owner, and isMPTOverflow() rejects a single send
+        // above the cap. BookStep now limits the offer's input to the cap so
+        // the bid fills partially, like an underfunded offer, instead of
+        // throwing out of consumeOffer() and drying the strand (which left the
+        // bid on the book to dead-end every payment that crossed it).
+        //
+        // XRP -> x -> y. carol asks the whole 1,000 x supply for XRP(1,000);
+        // mallory bids x for 2,000 y; alice pays dave y.
+        testcase("BookStep input above MaximumAmount");
+
+        using namespace jtx;
+
+        Account const gwX("gwX");
+        Account const gwY("gwY");
+        Account const alice("alice");
+        Account const carol("carol");
+        Account const mallory("mallory");
+        Account const dave("dave");
+
+        std::int64_t constexpr cap = 1'000;
+        std::int64_t constexpr bidGets = 2'000;
+        // A bid above the cap at a non-unit price.
+        std::int64_t constexpr unevenBidPays = (3 * cap) + 100;
+
+        auto test = [&](Account const& bidder,
+                        std::int64_t bidPays,
+                        std::int64_t deliver,
+                        bool partial,
+                        std::int64_t delivered,
+                        std::optional<TER> const& ter = std::nullopt) {
+            Env env(*this, features);
+            env.fund(XRP(100'000), gwX, gwY, alice, carol, mallory, dave);
+            env.close();
+
+            MPT const x = MPTTester(
+                {.env = env, .issuer = gwX, .holders = {carol, mallory, dave}, .maxAmt = cap});
+            MPT const y = MPTTester({.env = env, .issuer = gwY, .holders = {mallory, dave, gwX}});
+            env(pay(gwX, carol, x(cap)));
+            env(pay(gwY, bidder, y(bidGets)));
+            env.close();
+
+            env(offer(carol, XRP(cap), x(cap)));
+            auto const bidSeq = env.seq(bidder);
+            env(offer(bidder, x(bidPays), y(bidGets)));
+            env.close();
+            auto const bidKeylet = keylet::offer(bidder.id(), SeqProxy::rawSequence(bidSeq));
+            BEAST_EXPECT(env.le(bidKeylet) != nullptr);
+
+            auto const flags = partial ? tfNoRippleDirect | tfPartialPayment : tfNoRippleDirect;
+            env(pay(alice, dave, y(deliver)),
+                Path(~x, ~y),
+                Sendmax(XRP(5'000)),
+                Txflags(flags),
+                ter ? Ter(*ter) : Ter(tesSUCCESS));
+            env.close();
+
+            BEAST_EXPECT(env.balance(dave, y) == y(delivered));
+            // Each x delivered through the bid costs bidGets/bidPays y.
+            std::int64_t const xTaken = delivered * bidPays / bidGets;
+            if (bidder != gwX)
+                BEAST_EXPECT(env.balance(bidder, x) == x(xTaken));
+            BEAST_EXPECT(env.balance(carol, x) == x(cap - xTaken));
+
+            auto const sle = env.le(bidKeylet);
+            if (xTaken == bidPays)
+            {
+                BEAST_EXPECT(!sle);
+            }
+            else if (BEAST_EXPECT(sle))
+            {
+                BEAST_EXPECT((*sle)[sfTakerPays] == x(bidPays - xTaken));
+                BEAST_EXPECT((*sle)[sfTakerGets] == y(bidGets - delivered));
+            }
+
+            auto const issuance = env.le(keylet::mptokenIssuance(x.mpt()));
+            if (BEAST_EXPECT(issuance))
+            {
+                // x taken by the issuer's own bid is redeemed.
+                std::int64_t const outstanding = bidder == gwX ? cap - xTaken : cap;
+                BEAST_EXPECT(
+                    (*issuance)[sfOutstandingAmount] == static_cast<std::uint64_t>(outstanding));
+            }
+        };
+
+        // Bid above the cap: the input is limited to the cap, so at most
+        // 1,000 x (= 1,000 y at this bid's price) can flow through it.
+        test(mallory, 2 * cap, 1'001, true, cap);
+        test(mallory, 2 * cap, bidGets, true, cap);
+        // Not partial: the strand no longer throws, but 1,001 y can't be
+        // delivered.
+        test(mallory, 2 * cap, 1'001, false, 0, tecPATH_PARTIAL);
+        // Controls: a request within the cap, and a bid at the cap.
+        test(mallory, 2 * cap, 500, true, 500);
+        test(mallory, cap, bidGets, true, bidGets);
+        // The issuer's own bid above the cap isn't limited: the issuer's send
+        // to itself is a no-op, so upstream supply bounds the fill as usual.
+        test(gwX, 2 * cap, 1'001, true, cap);
+
+        // A bid above the cap at a non-unit price, crossed repeatedly. Each
+        // crossing is limited to the cap and the output is rounded down, so
+        // the remainder's quality is no worse than the original's. The
+        // remainder stays on the book and is eventually consumed.
+        {
+            Env env(*this, features);
+            env.fund(XRP(100'000), gwX, gwY, alice, carol, mallory, dave);
+            env.close();
+
+            MPT const x = MPTTester(
+                {.env = env, .issuer = gwX, .holders = {carol, mallory, dave}, .maxAmt = cap});
+            MPT const y = MPTTester({.env = env, .issuer = gwY, .holders = {mallory, dave}});
+            env(pay(gwX, carol, x(cap)));
+            env(pay(gwY, mallory, y(bidGets)));
+            env.close();
+
+            auto const bidSeq = env.seq(mallory);
+            env(offer(mallory, x(unevenBidPays), y(bidGets)));
+            env.close();
+            auto const bidKeylet = keylet::offer(mallory.id(), SeqProxy::rawSequence(bidSeq));
+
+            // {x taken, y delivered} per round; the first three are capped.
+            // 1,000 x buys floor(1,000 * gets / pays) y at the remainder's
+            // price: 2,000/3,100, 1,355/2,100, 710/1,100. The last 100 x buy
+            // the remaining 65 y and consume the bid.
+            std::int64_t totalY = 0;
+            std::int64_t bidPays = unevenBidPays;
+            std::int64_t bidGetsLeft = bidGets;
+            for (auto const& [xTaken, yDelivered] :
+                 std::initializer_list<std::pair<std::int64_t, std::int64_t>>{
+                     {cap, 645}, {cap, 645}, {cap, 645}, {100, 65}})
+            {
+                auto const askSeq = env.seq(carol);
+                env(offer(carol, XRP(cap), x(cap)));
+                env.close();
+                env(pay(alice, dave, y(1'001)),
+                    Path(~x, ~y),
+                    Sendmax(XRP(5'000)),
+                    Txflags(tfNoRippleDirect | tfPartialPayment));
+                env.close();
+
+                totalY += yDelivered;
+                bidPays -= xTaken;
+                bidGetsLeft -= yDelivered;
+                BEAST_EXPECT(env.balance(dave, y) == y(totalY));
+                BEAST_EXPECT(env.balance(mallory, x) == x(xTaken));
+                BEAST_EXPECT(env.balance(carol, x) == x(cap - xTaken));
+                auto const sle = env.le(bidKeylet);
+                if (bidPays == 0)
+                {
+                    BEAST_EXPECT(!sle);
+                }
+                else if (BEAST_EXPECT(sle))
+                {
+                    BEAST_EXPECT((*sle)[sfTakerPays] == x(bidPays));
+                    BEAST_EXPECT((*sle)[sfTakerGets] == y(bidGetsLeft));
+                    // The remainder's quality is no worse than the original's.
+                    BEAST_EXPECT(bidGetsLeft * unevenBidPays >= bidGets * bidPays);
+                }
+
+                // Return x to carol for the next round, and cancel her unfilled
+                // ask remainder.
+                env(pay(mallory, carol, x(xTaken)));
+                env(offerCancel(carol, askSeq));
+                env.close();
+            }
+            BEAST_EXPECT(totalY == bidGets);
+        }
+
+        // A transfer fee on x: the cap is grossed up by the rate when limiting
+        // the taker's input, and the owner receives exactly the cap. The
+        // previous step must redeem for the fee to apply, so alice pays with
+        // x directly (MPTEndpoint alice -> gwX, then the x/y book). alice can
+        // hold at most the cap, so upstream still bounds the fill: she pays
+        // 1,000 gross, mallory receives floor(1,000 / 1.1) = 909 x, dave gets
+        // floor(909 * 2,000 / 3,100) = 586 y.
+        {
+            Env env(*this, features);
+            env.fund(XRP(100'000), gwX, gwY, alice, mallory, dave);
+            env.close();
+
+            MPT const x = MPTTester(
+                {.env = env,
+                 .issuer = gwX,
+                 .holders = {alice, mallory, dave},
+                 .transferFee = 10'000,
+                 .maxAmt = cap});
+            MPT const y = MPTTester({.env = env, .issuer = gwY, .holders = {mallory, dave}});
+            env(pay(gwX, alice, x(cap)));
+            env(pay(gwY, mallory, y(bidGets)));
+            env.close();
+
+            auto const bidSeq = env.seq(mallory);
+            env(offer(mallory, x(unevenBidPays), y(bidGets)));
+            env.close();
+            auto const bidKeylet = keylet::offer(mallory.id(), SeqProxy::rawSequence(bidSeq));
+
+            env(pay(alice, dave, y(1'001)),
+                Path(~y),
+                Sendmax(x(cap)),
+                Txflags(tfNoRippleDirect | tfPartialPayment));
+            env.close();
+
+            BEAST_EXPECT(env.balance(dave, y) == y(586));
+            BEAST_EXPECT(env.balance(mallory, x) == x(909));
+            BEAST_EXPECT(env.balance(alice, x) == x(0));
+            auto const sle = env.le(bidKeylet);
+            if (BEAST_EXPECT(sle))
+            {
+                BEAST_EXPECT((*sle)[sfTakerPays] == x(unevenBidPays - 909));
+                BEAST_EXPECT((*sle)[sfTakerGets] == y(bidGets - 586));
+            }
+            auto const issuance = env.le(keylet::mptokenIssuance(x.mpt()));
+            if (BEAST_EXPECT(issuance))
+                BEAST_EXPECT((*issuance)[sfOutstandingAmount] == 909);
+        }
+
+        // Two bids above the cap at the same quality, mallory's ahead of
+        // bob's. Stopping after a cap-limited bid doesn't strand bob's: the
+        // step's input is already at the cap, which is all carol can supply,
+        // so delivery equals the single-bid case. If mallory's bid is
+        // underfunded below the cap instead, it isn't cap-limited: it is
+        // consumed, removed, and bob's bid is crossed in the same pass.
+        auto twoBids = [&](std::int64_t malloryY,
+                           std::int64_t delivered,
+                           std::int64_t malloryX,
+                           std::int64_t malloryYSold,
+                           std::int64_t bobX,
+                           std::int64_t bobYSold,
+                           std::optional<std::pair<std::int64_t, std::int64_t>> malloryBid) {
+            Env env(*this, features);
+            Account const bob("bob");
+            env.fund(XRP(100'000), gwX, gwY, alice, bob, carol, mallory, dave);
+            env.close();
+
+            MPT const x = MPTTester(
+                {.env = env, .issuer = gwX, .holders = {bob, carol, mallory, dave}, .maxAmt = cap});
+            MPT const y = MPTTester({.env = env, .issuer = gwY, .holders = {bob, mallory, dave}});
+            env(pay(gwX, carol, x(cap)));
+            env(pay(gwY, mallory, y(malloryY)));
+            env(pay(gwY, bob, y(bidGets)));
+            env.close();
+
+            env(offer(carol, XRP(cap), x(cap)));
+            // Close between the bids: within one ledger, transactions apply in
+            // canonical order, and mallory's bid must be ahead of bob's.
+            auto const mallorySeq = env.seq(mallory);
+            env(offer(mallory, x(unevenBidPays), y(bidGets)));
+            env.close();
+            auto const bobSeq = env.seq(bob);
+            env(offer(bob, x(unevenBidPays), y(bidGets)));
+            env.close();
+
+            env(pay(alice, dave, y(bidGets)),
+                Path(~x, ~y),
+                Sendmax(XRP(5'000)),
+                Txflags(tfNoRippleDirect | tfPartialPayment));
+            env.close();
+
+            BEAST_EXPECT(env.balance(dave, y) == y(delivered));
+            BEAST_EXPECT(env.balance(mallory, x) == x(malloryX));
+            BEAST_EXPECT(env.balance(mallory, y) == y(malloryY - malloryYSold));
+            BEAST_EXPECT(env.balance(bob, x) == x(bobX));
+            BEAST_EXPECT(env.balance(bob, y) == y(bidGets - bobYSold));
+            BEAST_EXPECT(env.balance(carol, x) == x(cap - malloryX - bobX));
+
+            auto const mallorySle =
+                env.le(keylet::offer(mallory.id(), SeqProxy::rawSequence(mallorySeq)));
+            if (!malloryBid)
+            {
+                BEAST_EXPECT(!mallorySle);
+            }
+            else if (BEAST_EXPECT(mallorySle))
+            {
+                BEAST_EXPECT((*mallorySle)[sfTakerPays] == x(malloryBid->first));
+                BEAST_EXPECT((*mallorySle)[sfTakerGets] == y(malloryBid->second));
+            }
+            auto const bobSle = env.le(keylet::offer(bob.id(), SeqProxy::rawSequence(bobSeq)));
+            if (BEAST_EXPECT(bobSle))
+            {
+                BEAST_EXPECT((*bobSle)[sfTakerPays] == x(unevenBidPays - bobX));
+                BEAST_EXPECT((*bobSle)[sfTakerGets] == y(bidGets - bobYSold));
+            }
+            auto const issuance = env.le(keylet::mptokenIssuance(x.mpt()));
+            if (BEAST_EXPECT(issuance))
+                BEAST_EXPECT((*issuance)[sfOutstandingAmount] == static_cast<std::uint64_t>(cap));
+        };
+        // Both funded: mallory's bid takes the cap for 645 y and rests at
+        // 2,100/1,355; bob's is untouched.
+        twoBids(bidGets, 645, cap, 645, 0, 0, std::pair{unevenBidPays - cap, bidGets - 645});
+        // mallory holds 500 y: funds limit her bid to 775 x, under the cap, so
+        // it is consumed and removed; bob's bid takes the remaining 225 x for
+        // 145 y in the same pass. Same 645 y total.
+        twoBids(500, 645, 775, 500, 225, 145, std::nullopt);
+    }
+
+    void
+    testBookStepMissingIssuance(FeatureBitset features)
+    {
+        // A path through a book whose MPT issuance doesn't exist. BookStep's
+        // constructor looks the issuance up for MaximumAmount before check()
+        // rejects the step, so the lookup must tolerate a missing entry.
+        testcase("BookStep on a missing MPT issuance");
+
+        using namespace jtx;
+
+        Env env(*this, features);
+        Account const gw("gw");
+        Account const alice("alice");
+        Account const bob("bob");
+        env.fund(XRP(10'000), gw, alice, bob);
+        env.close();
+
+        MPT const y = MPTTester({.env = env, .issuer = gw, .holders = {alice, bob}});
+        MPT const missing{"missing", makeMptID(99, gw)};
+        BEAST_EXPECT(!env.le(keylet::mptokenIssuance(missing.mpt())));
+
+        env(pay(alice, bob, y(10)),
+            Path(~missing, ~y),
+            Sendmax(XRP(100)),
+            Txflags(tfNoRippleDirect),
+            Ter(tecOBJECT_NOT_FOUND));
+        env.close();
+        BEAST_EXPECT(env.balance(bob, y) == y(0));
     }
 
     void
@@ -2525,6 +2856,8 @@ struct FlowMPT_test : public beast::unit_test::Suite
         testTransferRate(features);
         testMPTEndpointTransferRateOverflow(features);
         testMPTEndpointRipplingInputOverflow(features);
+        testBookStepInputAboveMaximumAmount(features);
+        testBookStepMissingIssuance(features);
         testSelfPayment1(features);
         testSelfPayment2(features);
         testSelfFundedXRPEndpoint(false, features);

--- a/src/test/app/OfferMPT_test.cpp
+++ b/src/test/app/OfferMPT_test.cpp
@@ -3684,31 +3684,20 @@ public:
 
         {
             // Companion to the transfer-rate overflow cases above. The taker
-            // sells TakerPays=MPT(~1.84e18) for TakerGets=XRP(1) against a
-            // same-magnitude poison offer, forcing BookStep::revImp()'s
-            // limitStepOut() to strictly reduce and overflow.
-            //
-            // The taker's own quality is also unrepresentable here
-            // (getRate(TakerGets, TakerPays) == 0: a large MPT numerator over
-            // a small XRP denominator overflows the rate mantissa), but that
-            // no longer short-circuits the transaction -- crossing is
-            // attempted, and only a residual that would REST is stopped. So
-            // this exercises the deeper safety net:
-            // BookStep::forEachOffer's catch(std::overflow_error), which under
-            // featureMPTokensV2 removes the offending offer rather than
-            // propagating.
-            //
-            // Net effect: the poison offer is consumed off the book instead of
-            // being left to poison the next taker, nothing crosses, and the
-            // taker's own offer is not placed because its rate is
-            // unrepresentable -- so tecKILLED, which charges a fee and
-            // advances the sequence.
+            // buys ~1.84e18 MPT for XRP(1) against a same-magnitude issuer
+            // ask, so BookStep::revImp()'s limitStepOut() reduces the ask by
+            // one unit: mulRound(MPT limit, rate, XRP) with a 63-bit MPT
+            // operand and an XRP result. That used to take the legacy
+            // 16-digit path and overflow; forEachOffer's catch then removed
+            // the ask and the taker got tecKILLED (its own rate is
+            // unrepresentable, so nothing rested). With Number arithmetic for
+            // any MPT operand the ask is crossed like any other offer.
             Env env{*this, features};
             env.fund(XRP(10'000), issuer, taker);
             env.close();
 
-            MPTTester const token{
-                {.env = env, .issuer = issuer, .holders = {taker}, .maxAmt = kMaxMpTokenAmount}};
+            MPT const token = MPTTester(
+                {.env = env, .issuer = issuer, .holders = {taker}, .maxAmt = kMaxMpTokenAmount});
 
             env(pay(issuer, taker, token(1)));
             env.close();
@@ -3716,73 +3705,81 @@ public:
             auto const funded = 1'844'674'407'370'955'162LL;
             auto const offerOut = funded + 1;
 
-            auto const poisonSeq = env.seq(issuer);
+            auto const askSeq = env.seq(issuer);
             env(offer(issuer, XRP(1), token(offerOut)));
             env.close();
 
-            auto const poisonKeylet = keylet::offer(issuer.id(), SeqProxy::rawSequence(poisonSeq));
-            BEAST_EXPECT(env.le(poisonKeylet) != nullptr);
+            auto const askKeylet = keylet::offer(issuer.id(), SeqProxy::rawSequence(askSeq));
+            BEAST_EXPECT(env.le(askKeylet) != nullptr);
 
             auto const issuerXRPBefore = env.balance(issuer, XRP);
             auto const takerXRPBefore = env.balance(taker, XRP);
-            auto const takerMPTBefore = env.balance(taker, token);
-            auto const takerSeqBefore = env.seq(taker);
-
-            auto const takerSeq = takerSeqBefore;
+            auto const takerSeq = env.seq(taker);
             auto const fee = env.current()->fees().base;
-            env(offer(taker, token(funded), XRP(1)), Ter(tecKILLED));
+            env(offer(taker, token(funded), XRP(1)));
             env.close();
 
-            // The overflowing poison offer is removed by BookStep. Nothing
-            // crossed, so no asset changes hands and the taker's offer is not
-            // placed; the fee is burned and the sequence advances.
-            BEAST_EXPECT(env.le(poisonKeylet) == nullptr);
+            // The taker's bid is filled in full at the ask's price:
+            // funded / (funded + 1) XRP rounds up to the whole XRP(1), so the
+            // ask is consumed and nothing rests on either side.
+            BEAST_EXPECT(env.le(askKeylet) == nullptr);
             BEAST_EXPECT(
                 env.le(keylet::offer(taker.id(), SeqProxy::rawSequence(takerSeq))) == nullptr);
-            BEAST_EXPECT(env.balance(issuer, XRP) == issuerXRPBefore);
-            BEAST_EXPECT(env.balance(taker, XRP) == takerXRPBefore - fee);
-            BEAST_EXPECT(env.balance(taker, token) == takerMPTBefore);
-            BEAST_EXPECT(env.seq(taker) == takerSeqBefore + 1);
+            BEAST_EXPECT(env.balance(issuer, XRP) == issuerXRPBefore + XRP(1));
+            BEAST_EXPECT(env.balance(taker, XRP) == takerXRPBefore - XRP(1) - fee);
+            BEAST_EXPECT(env.balance(taker, token) == token(1 + funded));
+            BEAST_EXPECT(env.seq(taker) == takerSeq + 1);
         }
 
         {
-            auto const poisonMaker = Account("poisonMaker");
+            auto const maker = Account("maker");
 
             Env env{*this, features};
-            env.fund(XRP(10'000), issuer, poisonMaker, taker);
+            env.fund(XRP(10'000), issuer, maker, taker);
             env.close();
 
-            MPTTester const token{
+            MPT const token = MPTTester(
                 {.env = env,
                  .issuer = issuer,
-                 .holders = {poisonMaker, taker},
-                 .maxAmt = kMaxMpTokenAmount}};
+                 .holders = {maker, taker},
+                 .maxAmt = kMaxMpTokenAmount});
 
-            // Covers OfferStream::step() filtering. The offer is mostly
-            // funded, but reducing it to the actual owner funds inside
-            // shouldRmSmallIncreasedQOffer() used to overflow before BookStep
-            // saw the offer.
+            // Covers OfferStream::step() filtering. The ask is mostly funded;
+            // reducing it to the owner's actual funds inside
+            // shouldRmSmallIncreasedQOffer() (an MPT operand with an XRP
+            // result) used to overflow and remove the ask before BookStep saw
+            // it. It is now a normal partially funded offer.
             auto const funded = 1'844'674'407'370'955'162LL;
             auto const offerOut = funded + 1;
-            env(pay(issuer, poisonMaker, token(funded)));
+            env(pay(issuer, maker, token(funded)));
 
-            auto const poisonSeq = env.seq(poisonMaker);
-            env(offer(poisonMaker, XRP(1), token(offerOut)));
+            auto const askSeq = env.seq(maker);
+            env(offer(maker, XRP(1), token(offerOut)));
             env.close();
 
-            auto const poisonKeylet =
-                keylet::offer(poisonMaker.id(), SeqProxy::rawSequence(poisonSeq));
-            BEAST_EXPECT(env.le(poisonKeylet) != nullptr);
+            auto const askKeylet = keylet::offer(maker.id(), SeqProxy::rawSequence(askSeq));
+            BEAST_EXPECT(env.le(askKeylet) != nullptr);
 
             auto const takerSeq = env.seq(taker);
+            auto const takerXRPBefore = env.balance(taker, XRP);
+            auto const fee = env.current()->fees().base;
             env(offer(taker, token(1), XRP(1)));
             env.close();
 
-            BEAST_EXPECT(env.le(poisonKeylet) == nullptr);
+            // One token at the ask's price is a fraction of a drop, rounded up
+            // to one drop. The taker's bid is filled and the ask rests reduced
+            // by that token and that drop.
             BEAST_EXPECT(
-                env.le(keylet::offer(taker.id(), SeqProxy::rawSequence(takerSeq))) != nullptr);
-            BEAST_EXPECT(env.balance(poisonMaker, token) == token(funded));
-            BEAST_EXPECT(env.balance(taker, token) == token(0));
+                env.le(keylet::offer(taker.id(), SeqProxy::rawSequence(takerSeq))) == nullptr);
+            auto const ask = env.le(askKeylet);
+            if (BEAST_EXPECT(ask))
+            {
+                BEAST_EXPECT((*ask)[sfTakerPays] == XRP(1) - drops(1));
+                BEAST_EXPECT((*ask)[sfTakerGets] == token(offerOut - 1));
+            }
+            BEAST_EXPECT(env.balance(maker, token) == token(funded - 1));
+            BEAST_EXPECT(env.balance(taker, token) == token(1));
+            BEAST_EXPECT(env.balance(taker, XRP) == takerXRPBefore - drops(1) - fee);
         }
 
         {
@@ -6192,6 +6189,82 @@ public:
     }
 
     void
+    testMPTOfferLargeRemainderCross(FeatureBitset features)
+    {
+        // A bid for a large MPT amount paid in IOU partially crosses a small
+        // ask. flowCross then recomputes the remainder with
+        // mulRound(afterCross.out [MPT], rate, IOU): an MPT operand with a
+        // non-MPT result. That took the legacy 16-digit path and overflowed
+        // once TakerPays * rateMantissa exceeded ~1.8e33, failing the
+        // transaction with tecINTERNAL (fee charged, cross rolled back,
+        // nothing placed). Any MPT operand now uses Number arithmetic, so the
+        // cross settles.
+        testcase("MPT Offer large remainder after partial cross");
+
+        using namespace jtx;
+
+        // alice bids `pays` MPT for `gets` USD; bob asks 1,000 MPT at the same
+        // price. `remainderRests` says whether alice's remainder can be placed:
+        // its book rate is getRate(gets, pays) = divide(pays, gets), which
+        // itself overflows for an MPT numerator above ~1.8e18 and returns 0,
+        // and a zero rate is not placed (#7334). That is a separate defect.
+        auto test = [&](std::int64_t pays,
+                        std::int64_t gets,
+                        std::int64_t askGets,
+                        std::optional<std::int64_t> remainderGets) {
+            Env env{*this, features};
+            Account const gw{"gw"};
+            Account const alice{"alice"};
+            Account const bob{"bob"};
+            env.fund(XRP(10'000), gw, alice, bob);
+            env.close();
+
+            auto const usd = gw["USD"];
+            env(trust(alice, usd(2 * gets)));
+            env(trust(bob, usd(2 * gets)));
+            env(pay(gw, alice, usd(2 * gets)));
+
+            MPT const mpt = MPTTester(
+                {.env = env, .issuer = gw, .holders = {alice, bob}, .maxAmt = kMaxMpTokenAmount});
+            env(pay(gw, bob, mpt(1'000)));
+            auto const askSeq = env.seq(bob);
+            env(offer(bob, usd(askGets), mpt(1'000)));
+            env.close();
+
+            auto const bidSeq = env.seq(alice);
+            env(offer(alice, mpt(pays), usd(gets)));
+            env.close();
+
+            BEAST_EXPECT(env.balance(alice, mpt) == mpt(1'000));
+            BEAST_EXPECT(env.balance(bob, mpt) == mpt(0));
+            BEAST_EXPECT(env.balance(bob, usd) == usd(askGets));
+            BEAST_EXPECT(env.le(keylet::offer(bob.id(), SeqProxy::rawSequence(askSeq))) == nullptr);
+            auto const bid = env.le(keylet::offer(alice.id(), SeqProxy::rawSequence(bidSeq)));
+            if (!remainderGets)
+            {
+                BEAST_EXPECT(!bid);
+            }
+            else if (BEAST_EXPECT(bid))
+            {
+                BEAST_EXPECT((*bid)[sfTakerPays] == mpt(pays - 1'000));
+                BEAST_EXPECT((*bid)[sfTakerGets] == usd(*remainderGets));
+            }
+        };
+
+        // 1e18 MPT at 9e-3 USD per unit: the remainder's mulRound overflowed
+        // the legacy path (1e18 * 9e15 > 1.8e33) but its rate is
+        // representable, so it rests. At an exact 9e-3 the remainder would
+        // be 8,999,999,999,999,991 USD; it is 50 more because divide()'s +5
+        // rounding nudge assumes 16-digit mantissas and lands at the 15th
+        // digit for an unscaled MPT operand, so the stored rate is
+        // 0.00900000000000005 (pre-existing, see DEFI-1071 follow-ups).
+        test(1'000'000'000'000'000'000LL, 9'000'000'000'000'000LL, 9, 9'000'000'000'000'041LL);
+        // 5e18 MPT at 1e-3 USD per unit: the cross settles, but the
+        // remainder's rate is not representable and it is not placed.
+        test(5'000'000'000'000'000'000LL, 5'000'000'000'000'000LL, 1, std::nullopt);
+    }
+
+    void
     testBookOffersMPTFunding(FeatureBitset features)
     {
         testcase("book_offers uses MPT issuer capacity, transfer fees, and locks");
@@ -6891,6 +6964,7 @@ public:
         testMPTOfferZeroRateCrossable(features);
         testMPTOfferZeroRatePartialCross(features);
         testMPTOfferZeroRateTickSizeCross(features);
+        testMPTOfferLargeRemainderCross(features);
         testMPTOfferZeroRateFlags(features);
         testZeroRateXrpIouOffer(features);
         testBookOffersMPTFunding(features);

--- a/src/test/app/OfferMPT_test.cpp
+++ b/src/test/app/OfferMPT_test.cpp
@@ -3659,17 +3659,19 @@ public:
             // Covers BookStep::forEachOffer() offer preparation, where
             // stpAmt.in = mulRatio(ofrAmt.in, transferRateIn) overflowed.
             // The MPT/MPT amounts keep the offer quality reachable while
-            // applying tokenA's transfer rate overflows the input side.
+            // applying tokenA's transfer rate overflows the input side. Such
+            // an offer can no longer rest (see the fee gross-up scenarios
+            // below), so with nothing to cross it is tecKILLED.
             std::int64_t const poisonPays = 6'148'914'691'236'517'205LL;
             std::int64_t const poisonGets = 34'000'000'000'000'000LL;
             env(pay(gwB, mallory, tokenB(poisonGets)));
 
             auto const poisonSeq = env.seq(mallory);
-            env(offer(mallory, tokenA(poisonPays), tokenB(poisonGets)));
+            env(offer(mallory, tokenA(poisonPays), tokenB(poisonGets)), Ter(tecKILLED));
             env.close();
 
             auto const poisonKeylet = keylet::offer(mallory.id(), SeqProxy::rawSequence(poisonSeq));
-            BEAST_EXPECT(env.le(poisonKeylet) != nullptr);
+            BEAST_EXPECT(env.le(poisonKeylet) == nullptr);
 
             auto const aliceSeq = env.seq(alice);
             env(offer(alice, tokenB(1), tokenA(100)));
@@ -3821,6 +3823,382 @@ public:
                     env.le(keylet::offer(taker.id(), SeqProxy::rawSequence(takerSeq))) != nullptr);
             }
             BEAST_EXPECT(logs.contains("Removing offer with overflowing amount calculation"));
+        }
+
+        auto const maxAmt = static_cast<std::int64_t>(kMaxMpTokenAmount);
+        // floor(maxAmt / 1.1): the largest amount whose 10% fee gross-up fits.
+        std::int64_t const maxGross = 8'384'883'669'867'978'006LL;
+
+        // An MPT amount grossed up by its transfer fee may not fit in an MPT
+        // amount.
+        //
+        // TakerGets: flowCross() grosses up the taker's own TakerGets for
+        // sendMax, and that multiply used to throw (tecINTERNAL). It is now
+        // capped at the balance and the offer rests. A Payment consumes such an
+        // offer normally (the owner's side isn't grossed up there); an
+        // OfferCreate taker removes it when BookStep grosses up ownerGives.
+        //
+        // TakerPays: every redeeming taker grosses up the bid's whole TakerPays
+        // in BookStep, so no taker can take it and it would be removed on the
+        // first attempt. Such a bid may still cross, but its remainder isn't
+        // placed: tecKILLED if nothing crossed, like an offer with an
+        // unrepresentable quality.
+        {
+            // The reported case: alice holds the whole supply and sells it for
+            // a little XRP or USD. The offers rest.
+            auto const gw = Account("gw");
+            auto const usd = gw["USD"];
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+
+            Env env{*this, features};
+            env.fund(XRP(100'000), issuer, alice, bob, gw);
+            env.close();
+
+            MPTTester const token{
+                {.env = env,
+                 .issuer = issuer,
+                 .holders = {alice, bob},
+                 .transferFee = 10'000,
+                 .maxAmt = kMaxMpTokenAmount}};
+            env(pay(issuer, alice, token(maxAmt)));
+            env.close();
+
+            // A bid for the whole supply can't rest: the taker would pay the
+            // fee on top of it. Nothing to cross yet, so tecKILLED.
+            env(offer(bob, token(maxAmt), XRP(1)), Ter(tecKILLED));
+            env(offer(bob, token(maxGross + 1), XRP(1)), Ter(tecKILLED));
+            env.close();
+            BEAST_EXPECT(env.ownerCount(bob) == 1);
+
+            auto const seq1 = env.seq(alice);
+            env(offer(alice, XRP(1), token(maxAmt)));
+            auto const seq2 = env.seq(alice);
+            env(offer(alice, usd(1), token(maxAmt)));
+            auto const seq3 = env.seq(alice);
+            env(offer(alice, XRP(1), token(maxGross + 1)));
+            env.close();
+            for (auto const seq : {seq1, seq2, seq3})
+            {
+                BEAST_EXPECT(
+                    env.le(keylet::offer(alice.id(), SeqProxy::rawSequence(seq))) != nullptr);
+            }
+            BEAST_EXPECT(env.balance(alice, token) == token(maxAmt));
+            BEAST_EXPECT(env.ownerCount(alice) == 4);
+        }
+
+        {
+            // The resting whole-supply ask is consumed by a Payment (the fee
+            // is charged in the endpoint step, not on the owner's side) and
+            // removed by an OfferCreate taker (BookStep grosses up ownerGives
+            // for the whole offer, which overflows; see the poison scenarios
+            // above).
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+            auto const carol = Account("carol");
+
+            Env env{*this, features};
+            env.fund(XRP(100'000), issuer, alice, bob, carol);
+            env.close();
+
+            MPTTester const token{
+                {.env = env,
+                 .issuer = issuer,
+                 .holders = {alice, bob, carol},
+                 .transferFee = 10'000,
+                 .maxAmt = kMaxMpTokenAmount}};
+            MPT const mpt = token;
+            env(pay(issuer, alice, token(maxAmt)));
+            env.close();
+
+            // One drop buys 1e9 units.
+            auto const askSeq = env.seq(alice);
+            env(offer(alice, drops(9'223'372'036), token(maxAmt)));
+            env.close();
+            auto const askKeylet = keylet::offer(alice.id(), SeqProxy::rawSequence(askSeq));
+            BEAST_EXPECT(env.le(askKeylet) != nullptr);
+
+            std::int64_t const small = 1'000'000'000LL;
+            env(pay(bob, carol, token(small)),
+                Path(~mpt),
+                Sendmax(XRP(100)),
+                Txflags(tfNoRippleDirect | tfPartialPayment));
+            env.close();
+            BEAST_EXPECT(env.balance(carol, token) == token(small));
+            BEAST_EXPECT(env.balance(alice, token) == token(maxAmt - small - (small / 10)));
+            {
+                auto const sle = env.le(askKeylet);
+                if (BEAST_EXPECT(sle))
+                    BEAST_EXPECT((*sle)[sfTakerGets] == token(maxAmt - small - (small / 10)));
+            }
+
+            auto const bidSeq = env.seq(bob);
+            env(offer(bob, token(small), drops(2)));
+            env.close();
+            BEAST_EXPECT(env.le(askKeylet) == nullptr);
+            BEAST_EXPECT(env.balance(bob, token) == token(0));
+            BEAST_EXPECT(env.le(keylet::offer(bob.id(), SeqProxy::rawSequence(bidSeq))) != nullptr);
+        }
+
+        {
+            // Control: an ask at the largest amount whose gross-up fits is
+            // taken normally. bob buys 1e9 for a couple of drops and alice
+            // pays 1e9 plus the 1e8 fee.
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+
+            Env env{*this, features};
+            env.fund(XRP(100'000), issuer, alice, bob);
+            env.close();
+
+            MPTTester const token{
+                {.env = env,
+                 .issuer = issuer,
+                 .holders = {alice, bob},
+                 .transferFee = 10'000,
+                 .maxAmt = kMaxMpTokenAmount}};
+            env(pay(issuer, alice, token(maxAmt)));
+            env.close();
+
+            auto const okSeq = env.seq(alice);
+            env(offer(alice, drops(maxGross / 1'000'000'000), token(maxGross)));
+            env.close();
+            auto const okKeylet = keylet::offer(alice.id(), SeqProxy::rawSequence(okSeq));
+            BEAST_EXPECT(env.le(okKeylet) != nullptr);
+
+            std::int64_t const small = 1'000'000'000LL;
+            env(offer(bob, token(small), drops(2)));
+            env.close();
+            BEAST_EXPECT(env.balance(bob, token) == token(small));
+            BEAST_EXPECT(env.balance(alice, token) == token(maxAmt - small - (small / 10)));
+            auto const sle = env.le(okKeylet);
+            if (BEAST_EXPECT(sle))
+                BEAST_EXPECT((*sle)[sfTakerGets] == token(maxGross - small));
+        }
+
+        {
+            // With a resting bid, the whole-supply ask crosses it and the
+            // remainder rests. MPT/MPT so the remainder's quality is
+            // representable (a 63-bit MPT over a few drops is not).
+            auto const gwA = Account("gatewayA");
+            auto const gwB = Account("gatewayB");
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+
+            Env env{*this, features};
+            env.fund(XRP(10'000), gwA, gwB, alice, bob);
+            env.close();
+
+            MPTTester const tokenA{
+                {.env = env,
+                 .issuer = gwA,
+                 .holders = {alice, bob},
+                 .transferFee = 10'000,
+                 .maxAmt = kMaxMpTokenAmount}};
+            MPTTester const tokenB{{.env = env, .issuer = gwB, .holders = {alice, bob}}};
+
+            std::int64_t const small = 1'000'000'000LL;
+            std::int64_t const bobPays = 20'000'000LL;
+            std::int64_t const alicePays = 110'000'000'000'000'000LL;
+            env(pay(gwA, alice, tokenA(maxAmt)));
+            env(pay(gwB, bob, tokenB(bobPays)));
+            env.close();
+
+            env(offer(bob, tokenA(small), tokenB(bobPays)));
+            env.close();
+
+            auto const aliceSeq = env.seq(alice);
+            env(offer(alice, tokenB(alicePays), tokenA(maxAmt)));
+            env.close();
+            BEAST_EXPECT(env.balance(bob, tokenA) == tokenA(small));
+            BEAST_EXPECT(env.balance(alice, tokenA) == tokenA(maxAmt - small - (small / 10)));
+            BEAST_EXPECT(env.balance(alice, tokenB) == tokenB(bobPays));
+            auto const sle = env.le(keylet::offer(alice.id(), SeqProxy::rawSequence(aliceSeq)));
+            if (BEAST_EXPECT(sle))
+            {
+                BEAST_EXPECT((*sle)[sfTakerPays] == tokenB(alicePays - bobPays));
+                // TakerGets is scaled by the offer's own quality (about 83.85
+                // tokenA per tokenB), so it drops by about 1.68e9.
+                auto const gets = (*sle)[sfTakerGets].mpt().value();
+                BEAST_EXPECT(gets > maxAmt - (2 * small) && gets <= maxAmt - small);
+            }
+        }
+
+        {
+            // The issuer's ask for the whole supply rests too; flowCross()
+            // doesn't gross up the issuer's own sendMax at all.
+            Env env{*this, features};
+            env.fund(XRP(10'000), issuer, taker);
+            env.close();
+
+            MPTTester const token{
+                {.env = env,
+                 .issuer = issuer,
+                 .holders = {taker},
+                 .transferFee = 10'000,
+                 .maxAmt = kMaxMpTokenAmount}};
+
+            auto const issuerSeq = env.seq(issuer);
+            env(offer(issuer, XRP(1), token(maxAmt)));
+            env.close();
+            BEAST_EXPECT(
+                env.le(keylet::offer(issuer.id(), SeqProxy::rawSequence(issuerSeq))) != nullptr);
+        }
+
+        {
+            // An issuer offer above MaximumAmount is not rejected either. It
+            // is a partially funded offer, and fills up to the remaining
+            // issuance capacity.
+            Env env{*this, features};
+            env.fund(XRP(10'000), issuer, taker);
+            env.close();
+
+            MPTTester const token{
+                {.env = env, .issuer = issuer, .holders = {taker}, .maxAmt = 1'000}};
+
+            auto const issuerSeq = env.seq(issuer);
+            env(offer(issuer, XRP(2), token(2'000)));
+            env.close();
+            auto const issuerKeylet = keylet::offer(issuer.id(), SeqProxy::rawSequence(issuerSeq));
+            BEAST_EXPECT(env.le(issuerKeylet) != nullptr);
+
+            auto const takerXRPBefore = env.balance(taker, XRP);
+            auto const fee = env.current()->fees().base;
+            auto const takerSeq = env.seq(taker);
+            env(offer(taker, token(2'000), XRP(2)));
+            env.close();
+
+            // 1,000 units for XRP(1); the exhausted issuer offer is removed and
+            // the taker's remainder rests.
+            BEAST_EXPECT(env.balance(taker, token) == token(1'000));
+            BEAST_EXPECT(env.balance(taker, XRP) == takerXRPBefore - fee - XRP(1));
+            BEAST_EXPECT(env.le(issuerKeylet) == nullptr);
+            auto const sle = env.le(keylet::offer(taker.id(), SeqProxy::rawSequence(takerSeq)));
+            if (BEAST_EXPECT(sle))
+                BEAST_EXPECT((*sle)[sfTakerPays] == token(1'000));
+        }
+
+        {
+            // No fee: the whole supply can be offered.
+            Env env{*this, features};
+            env.fund(XRP(10'000), issuer, taker);
+            env.close();
+
+            MPTTester const token{
+                {.env = env,
+                 .issuer = issuer,
+                 .holders = {taker},
+                 .pay = kMaxMpTokenAmount,
+                 .maxAmt = kMaxMpTokenAmount}};
+
+            auto const takerSeq = env.seq(taker);
+            env(offer(taker, XRP(1), token(maxAmt)));
+            env.close();
+            BEAST_EXPECT(
+                env.le(keylet::offer(taker.id(), SeqProxy::rawSequence(takerSeq))) != nullptr);
+        }
+
+        {
+            // TakerPays side, MPT/MPT book: bob buys the whole tokenA supply
+            // (10% fee) for tokenB. Rejected; the largest amount that fits is
+            // accepted.
+            auto const gwA = Account("gatewayA");
+            auto const gwB = Account("gatewayB");
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+
+            Env env{*this, features};
+            env.fund(XRP(10'000), gwA, gwB, alice, bob);
+            env.close();
+
+            MPTTester const tokenA{
+                {.env = env,
+                 .issuer = gwA,
+                 .holders = {alice, bob},
+                 .transferFee = 10'000,
+                 .maxAmt = kMaxMpTokenAmount}};
+            MPTTester const tokenB{{.env = env, .issuer = gwB, .holders = {alice, bob}}};
+
+            std::int64_t const bobGets = 100'000'000'000'000'000LL;
+            env(pay(gwB, bob, tokenB(bobGets)));
+            env.close();
+
+            env(offer(bob, tokenA(maxAmt), tokenB(bobGets)), Ter(tecKILLED));
+            env(offer(bob, tokenA(maxGross + 1), tokenB(bobGets)), Ter(tecKILLED));
+            auto const bobSeq = env.seq(bob);
+            env(offer(bob, tokenA(maxGross), tokenB(bobGets)));
+            env.close();
+            BEAST_EXPECT(env.le(keylet::offer(bob.id(), SeqProxy::rawSequence(bobSeq))) != nullptr);
+            env(offerCancel(bob, bobSeq));
+            env.close();
+
+            // With a resting ask the rejected bid crosses it (bob pays no fee
+            // as the buyer; alice, the seller, pays 10% on top), and bob's
+            // remainder isn't placed.
+            env(pay(gwA, alice, tokenA(1'100)));
+            env.close();
+            env(offer(alice, tokenB(1), tokenA(1'000)));
+            env.close();
+            auto const crossSeq = env.seq(bob);
+            env(offer(bob, tokenA(maxAmt), tokenB(bobGets)));
+            env.close();
+            BEAST_EXPECT(env.balance(bob, tokenA) == tokenA(1'000));
+            BEAST_EXPECT(env.balance(bob, tokenB) == tokenB(bobGets - 1));
+            BEAST_EXPECT(env.balance(alice, tokenA) == tokenA(0));
+            BEAST_EXPECT(env.balance(alice, tokenB) == tokenB(1));
+            BEAST_EXPECT(
+                env.le(keylet::offer(bob.id(), SeqProxy::rawSequence(crossSeq))) == nullptr);
+        }
+
+        {
+            // If the crossing consumes enough of the bid, the remainder's
+            // gross-up fits and the remainder rests.
+            auto const gwA = Account("gatewayA");
+            auto const gwB = Account("gatewayB");
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+
+            Env env{*this, features};
+            env.fund(XRP(10'000), gwA, gwB, alice, bob);
+            env.close();
+
+            MPTTester const tokenA{
+                {.env = env,
+                 .issuer = gwA,
+                 .holders = {alice, bob},
+                 .transferFee = 10'000,
+                 .maxAmt = kMaxMpTokenAmount}};
+            MPTTester const tokenB{{.env = env, .issuer = gwB, .holders = {alice, bob}}};
+
+            // bob bids the whole tokenA supply at about 83.85 tokenA per
+            // tokenB. alice asks 1.5e18 tokenA at 100 per tokenB.
+            std::int64_t const bobGets = 110'000'000'000'000'000LL;
+            std::int64_t const aliceGets = 1'500'000'000'000'000'000LL;
+            std::int64_t const alicePays = 15'000'000'000'000'000LL;
+            env(pay(gwA, alice, tokenA(maxAmt)));
+            env(pay(gwB, bob, tokenB(bobGets)));
+            env.close();
+
+            env(offer(alice, tokenB(alicePays), tokenA(aliceGets)));
+            env.close();
+
+            auto const bobSeq = env.seq(bob);
+            env(offer(bob, tokenA(maxAmt), tokenB(bobGets)));
+            env.close();
+            BEAST_EXPECT(env.balance(bob, tokenA) == tokenA(aliceGets));
+            BEAST_EXPECT(
+                env.balance(alice, tokenA) == tokenA(maxAmt - aliceGets - (aliceGets / 10)));
+            BEAST_EXPECT(env.balance(alice, tokenB) == tokenB(alicePays));
+            // Remainder: TakerPays drops by what bob received, to 7.72e18,
+            // whose 10% gross-up fits; TakerGets is rescaled by the bid's
+            // quality to about 9.21e16.
+            auto const sle = env.le(keylet::offer(bob.id(), SeqProxy::rawSequence(bobSeq)));
+            if (BEAST_EXPECT(sle))
+            {
+                BEAST_EXPECT((*sle)[sfTakerPays] == tokenA(maxAmt - aliceGets));
+                auto const gets = (*sle)[sfTakerGets].mpt().value();
+                BEAST_EXPECT(gets > 92'000'000'000'000'000LL && gets < 92'200'000'000'000'000LL);
+            }
         }
     }
 

--- a/src/test/protocol/STAmount_test.cpp
+++ b/src/test/protocol/STAmount_test.cpp
@@ -1072,6 +1072,39 @@ public:
             BEAST_EXPECT(down.signum() > 0);
             BEAST_EXPECT(up >= down);
         }
+
+        {
+            // An MPT operand with a non-MPT result. The legacy path assumes
+            // 16-digit mantissas and overflows on a 63-bit MPT mantissa; under
+            // MPTokensV2 any MPT operand, not only an MPT result, takes the
+            // Number path. This is OfferCreate::flowCross recomputing the
+            // remainder of a partially crossed large MPT offer, and
+            // Quality::ceilIn/ceilOut partially filling one.
+            Issue const usd{Currency(0x5553440000000000), AccountID(0x4985601)};
+            STAmount const bigMpt{asset, UINT64_C(5'000'000'000'000'000'000)};
+            STAmount const milli{noIssue(), UINT64_C(1'000'000'000'000'000), -18};     // 1e-3
+            STAmount const kilo{noIssue(), UINT64_C(1'000'000'000'000'000), -12};      // 1e3
+            STAmount const tenMicro{noIssue(), UINT64_C(1'000'000'000'000'000), -20};  // 1e-5
+            STAmount const usdResult{usd, UINT64_C(5'000'000'000'000'000)};
+            XRPAmount const xrpResult{50'000'000'000'000};
+
+            {
+                CurrentTransactionRulesGuard const rg(rules(false));
+                throwsOverflow([&] { (void)mulRound(bigMpt, milli, usd, true); });
+                throwsOverflow([&] { (void)mulRound(bigMpt, tenMicro, xrpIssue(), true); });
+                throwsOverflow([&] { (void)divRound(bigMpt, kilo, usd, true); });
+                throwsOverflow([&] { (void)divRoundStrict(bigMpt, kilo, usd, false); });
+            }
+
+            {
+                CurrentTransactionRulesGuard const rg(rules(true));
+                BEAST_EXPECT(mulRound(bigMpt, milli, usd, true) == usdResult);
+                BEAST_EXPECT(mulRound(bigMpt, milli, usd, false) == usdResult);
+                BEAST_EXPECT(mulRound(bigMpt, tenMicro, xrpIssue(), true) == STAmount{xrpResult});
+                BEAST_EXPECT(divRound(bigMpt, kilo, usd, true) == usdResult);
+                BEAST_EXPECT(divRoundStrict(bigMpt, kilo, usd, false) == usdResult);
+            }
+        }
     }
 
     void


### PR DESCRIPTION
## High Level Overview of Change

- Handle MPT offers whose fee gross-up exceeds the maximum
- Limit MPT offer input to MaximumAmount in BookStep
- Use Number arithmetic for any MPT operand in mulRound/divRound
- Remove MPT offers whose fee-adjusted output rounds to zero

## API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

## Test Plan

Updated OfferMPT_test
