### PR TITLE
Decide the Smart Escrow fee limits from the ledger, and lower the default values of the limits

### DIFF
--- a/cfg/xrpld-example.cfg
+++ b/cfg/xrpld-example.cfg
@@ -1370,7 +1370,7 @@
 #       default. Don't change this without understanding the consequences.
 #
 #       Example:
-#           gas_limit = 1000000      # 1 million gas
+#           gas_limit = 400000       # 400 thousand gas
 #
 #   bytecode_size_limit = <bytes>
 #
@@ -1382,7 +1382,7 @@
 #       default. Don't change this without understanding the consequences.
 #
 #       Example:
-#           bytecode_size_limit = 100000      # 100 kb
+#           bytecode_size_limit = 50000       # 50 kb
 #
 #   gas_price = <micro-drops>
 #

--- a/include/xrpl/core/ServiceRegistry.h
+++ b/include/xrpl/core/ServiceRegistry.h
@@ -6,7 +6,6 @@
 #include <xrpl/basics/TaggedCache.h>
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/beast/utility/Journal.h>
-#include <xrpl/protocol/Fees.h>
 
 #include <boost/asio.hpp>
 
@@ -246,9 +245,6 @@ public:
      */
     virtual DatabaseCon&
     getWalletDB() = 0;
-
-    [[nodiscard]] virtual Fees
-    getFees() const = 0;
 
     // Temporary: Get the underlying Application for functions that haven't
     // been migrated yet. This should be removed once all code is migrated.

--- a/include/xrpl/ledger/helpers/EscrowHelpers.h
+++ b/include/xrpl/ledger/helpers/EscrowHelpers.h
@@ -12,6 +12,7 @@
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Concepts.h>
 #include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/Fees.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Issue.h>
 #include <xrpl/protocol/Keylet.h>
@@ -273,6 +274,27 @@ escrowUnlockApplyHelper<MPTIssue>(
         ctx.view.rules().enabled(fixTokenEscrowV1) ? amount : finalAmt,
         journal);
 }
+
+/**
+ * Smart escrow kill switches, driven by the voted FeeSettings.
+ *
+ * Zeroing `bytecodeSizeLimit` stops new uploads while leaving existing escrows
+ * finishable without forcing holders to wait for `CancelAfter`.
+ * Zeroing `gasLimit` stops both.
+ */
+/** @{ */
+inline bool
+isBytecodeUploadDisabled(Fees const& fees)
+{
+    return fees.bytecodeSizeLimit == 0 || fees.gasLimit == 0;
+}
+
+inline bool
+isBytecodeExecutionDisabled(Fees const& fees)
+{
+    return fees.gasLimit == 0;
+}
+/** @} */
 
 template <class T>
 static int32_t

--- a/include/xrpl/protocol/Fees.h
+++ b/include/xrpl/protocol/Fees.h
@@ -14,10 +14,18 @@ inline constexpr std::uint32_t kFeeUnitsDeprecated = 10;
 constexpr std::uint32_t microDropsPerDrop{1'000'000};
 
 /**
- * Maximum Feature Extension fee settings.
+ * Hard protocol ceilings on the Feature Extension fee settings. A voted value
+ * can never exceed these, so `preflight`, which has no view, may bound against
+ * them.
  */
 inline constexpr std::uint32_t kMaxGasLimit{2'000'000};
 inline constexpr std::uint32_t kMaxBytecodeSizeLimit{200'000};
+
+// The following default values of fee settings will seed into FeeSettings
+// and write to the ledger on featureSmartEscrow activation.
+inline constexpr std::uint32_t kDefaultGasLimit{1'000'000};
+inline constexpr std::uint32_t kDefaultBytecodeSizeLimit{100'000};
+inline constexpr std::uint32_t kDefaultGasPrice{1'000'000};
 
 /**
  * Reflects the fee settings for a particular ledger.
@@ -44,18 +52,21 @@ struct Fees
 
     /**
      * @brief Gas limit for Feature Extensions (instructions).
+     *
+     * This and the one below default to the protocol values rather than 0,
+     * because an explicit 0 is the voted kill switch.
      */
-    std::uint32_t gasLimit{0};
+    std::uint32_t gasLimit{kDefaultGasLimit};
 
     /**
      * @brief Bytecode size limit for Feature Extensions (bytes).
      */
-    std::uint32_t bytecodeSizeLimit{0};
+    std::uint32_t bytecodeSizeLimit{kDefaultBytecodeSizeLimit};
 
     /**
      * @brief Price of WASM gas (micro-drops).
      */
-    std::uint32_t gasPrice{0};
+    std::uint32_t gasPrice{kDefaultGasPrice};
 
     explicit Fees() = default;
     Fees(Fees const&) = default;

--- a/include/xrpl/protocol/Fees.h
+++ b/include/xrpl/protocol/Fees.h
@@ -14,12 +14,13 @@ inline constexpr std::uint32_t kFeeUnitsDeprecated = 10;
 constexpr std::uint32_t microDropsPerDrop{1'000'000};
 
 /**
- * Hard protocol ceilings on the Feature Extension fee settings. A voted value
- * can never exceed these, so `preflight`, which has no view, may bound against
- * them.
+ * Hard protocol ceilings and a floor on the Feature Extension fee settings.
+ * A voted value can never exceed these, so `preflight`, which has no view,
+ * may bound against them.
  */
 inline constexpr std::uint32_t kMaxGasLimit{2'000'000};
 inline constexpr std::uint32_t kMaxBytecodeSizeLimit{200'000};
+inline constexpr std::uint32_t kMinGasPrice{1'000};
 
 // The following default values of fee settings will seed into FeeSettings
 // and write to the ledger on featureSmartEscrow activation.

--- a/include/xrpl/protocol/Fees.h
+++ b/include/xrpl/protocol/Fees.h
@@ -62,8 +62,19 @@ struct Fees
     Fees&
     operator=(Fees const&) = default;
 
-    Fees(XRPAmount base, XRPAmount reserve, XRPAmount increment)
-        : base(base), reserve(reserve), increment(increment)
+    Fees(
+        XRPAmount base,
+        XRPAmount reserve,
+        XRPAmount increment,
+        std::uint32_t gasLimit,
+        std::uint32_t bytecodeSizeLimit,
+        std::uint32_t gasPrice)
+        : base(base)
+        , reserve(reserve)
+        , increment(increment)
+        , gasLimit(gasLimit)
+        , bytecodeSizeLimit(bytecodeSizeLimit)
+        , gasPrice(gasPrice)
     {
     }
 

--- a/include/xrpl/protocol/Fees.h
+++ b/include/xrpl/protocol/Fees.h
@@ -23,8 +23,8 @@ inline constexpr std::uint32_t kMaxBytecodeSizeLimit{200'000};
 
 // The following default values of fee settings will seed into FeeSettings
 // and write to the ledger on featureSmartEscrow activation.
-inline constexpr std::uint32_t kDefaultGasLimit{1'000'000};
-inline constexpr std::uint32_t kDefaultBytecodeSizeLimit{100'000};
+inline constexpr std::uint32_t kDefaultGasLimit{400'000};
+inline constexpr std::uint32_t kDefaultBytecodeSizeLimit{50'000};
 inline constexpr std::uint32_t kDefaultGasPrice{1'000'000};
 
 /**

--- a/include/xrpl/tx/transactors/escrow/EscrowCreate.h
+++ b/include/xrpl/tx/transactors/escrow/EscrowCreate.h
@@ -32,9 +32,6 @@ public:
     static NotTEC
     preflight(PreflightContext const& ctx);
 
-    static NotTEC
-    preflightSigValidated(PreflightContext const& ctx);
-
     static TER
     preclaim(PreclaimContext const& ctx);
 

--- a/include/xrpl/tx/transactors/system/Change.h
+++ b/include/xrpl/tx/transactors/system/Change.h
@@ -52,6 +52,13 @@ private:
     TER
     applyFee();
 
+    /**
+     * Seed the default Feature Extension fee settings on `featureSmartEscrow`
+     * activation.
+     */
+    void
+    seedExtensionFees();
+
     TER
     applyUNLModify();
 };

--- a/src/libxrpl/ledger/Ledger.cpp
+++ b/src/libxrpl/ledger/Ledger.cpp
@@ -611,15 +611,13 @@ Ledger::setup()
                 auto const bytecodeSizeLimit = sle->at(~sfBytecodeSizeLimit);
                 auto const gasPrice = sle->at(~sfGasPrice);
 
-                auto assign = [](std::uint32_t& dest, std::optional<std::uint32_t> const& src) {
-                    if (src)
-                    {
-                        dest = src.value();
-                    }
-                };
-                assign(fees_.gasLimit, gasLimit);
-                assign(fees_.bytecodeSizeLimit, bytecodeSizeLimit);
-                assign(fees_.gasPrice, gasPrice);
+                // Absent resolves to the protocol constants.
+                if (rules_.enabled(featureSmartEscrow))
+                {
+                    fees_.gasLimit = gasLimit.value_or(kDefaultGasLimit);
+                    fees_.bytecodeSizeLimit = bytecodeSizeLimit.value_or(kDefaultBytecodeSizeLimit);
+                    fees_.gasPrice = gasPrice.value_or(kDefaultGasPrice);
+                }
                 extensionFees = gasLimit || bytecodeSizeLimit || gasPrice;
             }
             if (oldFees && newFees)

--- a/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
@@ -4,7 +4,6 @@
 #include <xrpl/basics/chrono.h>
 #include <xrpl/beast/utility/Zero.h>
 #include <xrpl/conditions/Condition.h>
-#include <xrpl/core/ServiceRegistry.h>
 #include <xrpl/ledger/ApplyView.h>
 #include <xrpl/ledger/ReadView.h>
 #include <xrpl/ledger/View.h>
@@ -18,6 +17,7 @@
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Concepts.h>
 #include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/Fees.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Issue.h>
 #include <xrpl/protocol/LedgerFormats.h>
@@ -219,41 +219,15 @@ EscrowCreate::preflight(PreflightContext const& ctx)
         }
     }
 
+    // amendment was checked by checkExtraFeatures
     if (ctx.tx.isFieldPresent(sfBytecode))
     {
-        auto const fees(ctx.registry.get().getFees());
-        if (fees.bytecodeSizeLimit == 0 || fees.gasLimit == 0)
-        {
-            JLOG(ctx.j.debug()) << "WASM runtime deactivated by fee voting";
-            return temTEMP_DISABLED;
-        }
-
         auto const code = ctx.tx.getFieldVL(sfBytecode);
-        if (code.empty() || code.size() > fees.bytecodeSizeLimit)
+        // Protocol ceiling only; `preflight` has no view.
+        if (code.empty() || code.size() > kMaxBytecodeSizeLimit)
         {
             JLOG(ctx.j.debug()) << "EscrowCreate.Bytecode bad size " << code.size();
             return temMALFORMED;
-        }
-        // actual validity of WASM code happens in `preflightSigValidated`
-        // (after the signature is checked)
-    }
-
-    return tesSUCCESS;
-}
-
-NotTEC
-EscrowCreate::preflightSigValidated(PreflightContext const& ctx)
-{
-    if (ctx.tx.isFieldPresent(sfBytecode))
-    {
-        auto const code = ctx.tx.getFieldVL(sfBytecode);
-        // basic checks happen in `preflight`
-
-        auto const re = preflightEscrowWasm(code, ctx.j, escrowFunctionName);
-        if (!isTesSuccess(re))
-        {
-            JLOG(ctx.j.debug()) << "EscrowCreate.Bytecode bad WASM";
-            return re;
         }
     }
 
@@ -447,6 +421,30 @@ EscrowCreate::preclaim(PreclaimContext const& ctx)
             !isTesSuccess(ret))
             return ret;
     }
+
+    if (ctx.tx.isFieldPresent(sfBytecode))
+    {
+        auto const& fees = ctx.view.fees();
+        if (isBytecodeUploadDisabled(fees))
+        {
+            JLOG(ctx.j.debug()) << "WASM runtime deactivated by fee voting";
+            return temTEMP_DISABLED;
+        }
+
+        auto const code = ctx.tx.getFieldVL(sfBytecode);
+        if (code.size() > fees.bytecodeSizeLimit)
+        {
+            JLOG(ctx.j.debug()) << "EscrowCreate.Bytecode over voted limit " << code.size();
+            return temMALFORMED;
+        }
+
+        if (auto const re = preflightEscrowWasm(code, ctx.j, escrowFunctionName); !isTesSuccess(re))
+        {
+            JLOG(ctx.j.debug()) << "EscrowCreate.Bytecode bad WASM";
+            return re;
+        }
+    }
+
     return tesSUCCESS;
 }
 

--- a/src/libxrpl/tx/transactors/escrow/EscrowFinish.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowFinish.cpp
@@ -99,17 +99,12 @@ EscrowFinish::preflight(PreflightContext const& ctx)
 
     if (auto const allowance = ctx.tx[~sfGas]; allowance)
     {
-        auto const fees(ctx.registry.get().getFees());
-        if (fees.gasLimit == 0)
-        {
-            JLOG(ctx.j.debug()) << "WASM runtime deactivated by fee voting";
-            return temTEMP_DISABLED;
-        }
+        // Protocol ceiling only; `preflight` has no view.
         if (*allowance == 0)
         {
             return temBAD_LIMIT;
         }
-        if (*allowance > fees.gasLimit)
+        if (*allowance > kMaxGasLimit)
         {
             JLOG(ctx.j.debug()) << "Gas too large: " << *allowance;
             return temBAD_LIMIT;
@@ -265,6 +260,20 @@ EscrowFinish::preclaim(PreclaimContext const& ctx)
                 {
                     JLOG(ctx.j.debug()) << "Bytecode requires Gas";
                     return tefBYTECODE_NOT_INCLUDED;
+                }
+
+                // Earliest step with a view. A `tem` here still claims no fee.
+                auto const& fees = ctx.view.fees();
+                if (isBytecodeExecutionDisabled(fees))
+                {
+                    JLOG(ctx.j.debug()) << "WASM runtime deactivated by fee voting";
+                    return temTEMP_DISABLED;
+                }
+
+                if (ctx.tx[sfGas] > fees.gasLimit)
+                {
+                    JLOG(ctx.j.debug()) << "Gas over voted limit: " << ctx.tx[sfGas];
+                    return temBAD_LIMIT;
                 }
             }
             else

--- a/src/libxrpl/tx/transactors/system/Change.cpp
+++ b/src/libxrpl/tx/transactors/system/Change.cpp
@@ -131,7 +131,8 @@ Change::preclaim(PreclaimContext const& ctx)
                     !ctx.tx.isFieldPresent(sfGasPrice))
                     return temMALFORMED;
                 if (ctx.tx[sfGasLimit] > kMaxGasLimit ||
-                    ctx.tx[sfBytecodeSizeLimit] > kMaxBytecodeSizeLimit)
+                    ctx.tx[sfBytecodeSizeLimit] > kMaxBytecodeSizeLimit ||
+                    ctx.tx[sfGasPrice] < kMinGasPrice)
                     return temBAD_FEE;
             }
             else

--- a/src/libxrpl/tx/transactors/system/Change.cpp
+++ b/src/libxrpl/tx/transactors/system/Change.cpp
@@ -174,6 +174,30 @@ Change::preCompute()
     XRPL_ASSERT(accountID_ == beast::kZero, "xrpl::Change::preCompute : zero account");
 }
 
+void
+Change::seedExtensionFees()
+{
+    auto const k = keylet::feeSettings();
+
+    SLE::pointer feeObject = view().peek(k);
+
+    if (!feeObject)
+    {
+        feeObject = std::make_shared<SLE>(k);
+        view().insert(feeObject);
+    }
+
+    // Compile-time constants, never `FeeSetup`: every node applies this
+    // pseudo-transaction, so reading local config here would diverge.
+    feeObject->at(sfGasLimit) = kDefaultGasLimit;
+    feeObject->at(sfBytecodeSizeLimit) = kDefaultBytecodeSizeLimit;
+    feeObject->at(sfGasPrice) = kDefaultGasPrice;
+
+    view().update(feeObject);
+
+    JLOG(j_.info()) << "Feature Extension fees seeded on SmartEscrow activation";
+}
+
 TER
 Change::applyAmendment()
 {
@@ -252,6 +276,9 @@ Change::applyAmendment()
                              << " activated: server blocked.";
             ctx_.registry.get().getOPs().setAmendmentBlocked();
         }
+
+        if (amendment == featureSmartEscrow)
+            seedExtensionFees();
     }
 
     if (newMajorities.empty())

--- a/src/test/app/EscrowSmart_test.cpp
+++ b/src/test/app/EscrowSmart_test.cpp
@@ -14,7 +14,6 @@
 #include <test/jtx/fee.h>
 #include <test/jtx/mpt.h>
 #include <test/jtx/multisign.h>
-#include <test/jtx/noop.h>
 #include <test/jtx/offer.h>
 #include <test/jtx/pay.h>
 #include <test/jtx/permissioned_domains.h>
@@ -27,14 +26,12 @@
 
 #include <xrpld/core/Config.h>
 
-#include <xrpl/basics/StringUtilities.h>
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/basics/strHex.h>
 #include <xrpl/beast/unit_test/suite.h>
-#include <xrpl/beast/utility/Journal.h>
+#include <xrpl/config/Constants.h>
 #include <xrpl/core/ServiceRegistry.h>
 #include <xrpl/core/StartUpType.h>
-#include <xrpl/ledger/OpenView.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Fees.h>
 #include <xrpl/protocol/Indexes.h>
@@ -45,9 +42,11 @@
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <xrpl/tx/applySteps.h>
 
 #include <cstdint>
 #include <exception>
+#include <map>
 #include <memory>
 #include <optional>
 #include <source_location>
@@ -56,6 +55,21 @@
 #include <vector>
 
 namespace xrpl::test {
+
+// The limits live in FeeSettings, so a non-default value has to be voted in:
+// set [voting] (Config::fees would not work) and run past the flag ledger.
+static std::unique_ptr<Config>
+votingConfig(std::map<std::string, std::string> voting)
+{
+    return jtx::makeConfig({}, std::move(voting));
+}
+
+static void
+awaitFeeVote(jtx::Env& env)
+{
+    for (auto i = env.current()->seq(); i <= 257; ++i)
+        env.close();
+}
 
 struct EscrowSmart_test : public beast::unit_test::Suite
 {
@@ -97,13 +111,8 @@ struct EscrowSmart_test : public beast::unit_test::Suite
 
         {
             // Bytecode > max length
-            Env env(
-                *this,
-                envconfig([](std::unique_ptr<Config> cfg) {
-                    cfg->fees.bytecodeSizeLimit = 10;  // 10 bytes
-                    return cfg;
-                }),
-                features);
+            Env env(*this, votingConfig({{Keys::kBytecodeSizeLimit, "10"}}), features);
+            awaitFeeVote(env);
             XRPAmount const txnFees = env.current()->fees().base + 1000;
             // create escrow
             env.fund(XRP(5000), alice, carol);
@@ -121,57 +130,57 @@ struct EscrowSmart_test : public beast::unit_test::Suite
         }
 
         {
-            // compute limit set to 0
-            Env env(
-                *this,
-                envconfig([](std::unique_ptr<Config> cfg) {
-                    // WASM runtime disabled
-                    cfg->fees.gasLimit = 0;
-                    return cfg;
-                }),
-                features);
-            XRPAmount const txnFees = env.current()->fees().base + 1000;
-            // create escrow
+            // Gas is not a field of EscrowCreate: rejected by the format check
+            // before any limit is consulted.
+            Env env(*this, features);
             env.fund(XRP(5000), alice, carol);
 
-            auto const escrowCreate = escrow::create(alice, carol, XRP(500));
-
-            env(escrowCreate,
+            env(escrow::create(alice, carol, XRP(500)),
                 escrow::Bytecode(kLedgerSqnWasmHex),
                 escrow::kCancelTime(env.now() + 100s),
                 escrow::Gas(100),
-                Fee(txnFees),
+                Fee(XRP(1)),
                 Ter(temMALFORMED));
             env.close();
         }
 
         {
-            // size limit set to 0
-            Env env(
-                *this,
-                envconfig([](std::unique_ptr<Config> cfg) {
-                    cfg->fees.bytecodeSizeLimit = 0;  // WASM upload disabled
-                    return cfg;
-                }),
-                features);
-            XRPAmount const txnFees = env.current()->fees().base + 1000;
-            // create escrow
+            // The other half of isBytecodeUploadDisabled: zeroing the gas
+            // limit must stop new uploads too, not just execution.
+            Env env(*this, votingConfig({{Keys::kGasLimit, "0"}}), features);
+            awaitFeeVote(env);
+            env.fund(XRP(5000), alice, carol);
+
+            env(escrow::create(alice, carol, XRP(500)),
+                escrow::Bytecode(kLedgerSqnWasmHex),
+                escrow::kCancelTime(env.now() + 100s),
+                Fee(XRP(1)),
+                Ter(temTEMP_DISABLED));
+            env.close();
+        }
+
+        {
+            // Voting the size limit to zero stops new uploads.
+            Env env(*this, votingConfig({{Keys::kBytecodeSizeLimit, "0"}}), features);
+            awaitFeeVote(env);
             env.fund(XRP(5000), alice, carol);
 
             auto const escrowCreate = escrow::create(alice, carol, XRP(500));
 
-            // 2-byte string
+            // Not valid WASM: pins that the disabled check fires before the
+            // module is compiled.
             env(escrowCreate,
                 escrow::Bytecode("AA"),
                 escrow::kCancelTime(env.now() + 100s),
-                Fee(txnFees),
+                Fee(XRP(1)),
                 Ter(temTEMP_DISABLED));
             env.close();
 
+            // And a genuinely valid module is refused for the same reason.
             env(escrowCreate,
                 escrow::Bytecode(kLedgerSqnWasmHex),
                 escrow::kCancelTime(env.now() + 100s),
-                Fee(txnFees),
+                Fee(XRP(1)),
                 Ter(temTEMP_DISABLED));
             env.close();
         }
@@ -382,76 +391,72 @@ struct EscrowSmart_test : public beast::unit_test::Suite
         }
 
         {
-            // Gas > max compute limit
-            Env env(
-                *this,
-                envconfig([](std::unique_ptr<Config> cfg) {
-                    cfg->fees.gasLimit = 1'000;  // in gas
-                    return cfg;
-                }),
-                features);
+            // Above the protocol ceiling: preflight rejects it before the
+            // escrow is looked up, so no escrow, fee or vote is needed.
+            Env env(*this, features);
             env.fund(XRP(5000), alice, carol);
-            // Run past the flag ledger so that a Fee change vote occurs and
-            // updates FeeSettings. (It also activates all supported
-            // amendments.)
-            for (auto i = env.current()->seq(); i <= 257; ++i)
-                env.close();
 
-            auto const allowance = 1'001;
-            env(escrow::finish(carol, alice, 1),
-                Fee(env.current()->fees().base + allowance),
-                escrow::Gas(allowance),
+            env(escrow::finish(carol, alice, 1), escrow::Gas(kMaxGasLimit + 1), Ter(temBAD_LIMIT));
+        }
+
+        {
+            // Above the voted limit but under the ceiling. The escrow must exist,
+            // since preclaim reads it before checking the allowance.
+            Env env(*this, features);
+            env.fund(XRP(5000), alice, carol);
+
+            auto const seq = env.seq(alice);
+            auto const create = env.jt(
+                escrow::create(alice, carol, XRP(500)),
+                escrow::Bytecode(kLedgerSqnWasmHex),
+                escrow::kCancelTime(env.now() + 100s));
+            env(escrow::create(alice, carol, XRP(500)),
+                escrow::Bytecode(kLedgerSqnWasmHex),
+                escrow::kCancelTime(env.now() + 100s),
+                Fee(xrpl::calculateBaseFee(*env.current(), *create.stx)));
+            env.close();
+
+            env(escrow::finish(carol, alice, seq),
+                escrow::Gas(kDefaultGasLimit + 1),
+                Fee(XRP(1)),
                 Ter(temBAD_LIMIT));
         }
 
         {
-            // WASM compute disabled
-            using namespace test::jtx;
-            using namespace std::chrono;
-            Env env{*this, envconfig([](std::unique_ptr<Config> cfg) {
-                        cfg->fees.gasLimit = 0;
-                        return cfg;
-                    })};
+            // Both rungs of the kill switch from one starting state. Zeroing
+            // bytecodeSizeLimit stops uploads but must leave an existing escrow
+            // finishable -- a graceful drain. Zeroing gasLimit stops both.
+            auto runLadder = [&](char const* key, TER expected) {
+                Env env(*this, votingConfig({{key, "0"}}), features);
+                Account const alice{"alice"};
+                Account const carol{"carol"};
+                env.fund(XRP(5000), alice, carol);
+                env.close();
 
-            Account const alice{"alice"};
-            env.fund(XRP(1000), alice);
-            env.close();
+                // Create before the vote lands. CancelAfter must outlast
+                // awaitFeeVote, which advances a flag-ledger interval.
+                auto const seq = env.seq(alice);
+                env(escrow::create(alice, carol, XRP(500)),
+                    escrow::Bytecode(kLedgerSqnWasmHex),
+                    escrow::kCancelTime(env.now() + 100000s),
+                    Fee(XRP(1)));
+                env.close();
+                BEAST_EXPECT(env.ownerCount(alice) > 0);
 
-            auto const seq = env.seq(alice);
-            auto const keylet = keylet::escrow(alice.id(), SeqProxy::rawSequence(seq));
-            env(noop(alice));  // to align sequence numbers
+                awaitFeeVote(env);
 
-            // This adds the Escrow ledger object by hand, bypassing normal
-            // transaction processing This is necessary because the config
-            // cannot be updated in the middle of a test, and we cannot easily
-            // create a Smart Escrow while the compute limit is set to 0
-            env.app().getOpenLedger().modify([&](OpenView& view, beast::Journal j) {
-                auto sle = std::make_shared<SLE>(keylet);
+                env(escrow::finish(carol, alice, seq),
+                    escrow::Gas(1000),
+                    Fee(XRP(1)),
+                    Ter(expected));
+            };
 
-                sle->setAccountID(sfAccount, alice.id());
-                sle->setFieldAmount(sfAmount, XRP(100));
-                sle->setFieldU32(sfCancelAfter, 110);
-                sle->setAccountID(sfDestination, alice.id());
-                sle->setFieldVL(sfBytecode, strUnHex(kLedgerSqnWasmHex).value());
-                sle->setFieldU32(sfFlags, 0);
-                sle->setFieldU64(sfOwnerNode, 0);
-                uint256 tmp;
-                BEAST_EXPECT(tmp.parseHex(
-                    "F63D1A452A96C19EFD77901FB37D236C59EAA746771A6"
-                    "85D1BBA57A2238B9401"));
-                sle->setFieldH256(sfPreviousTxnID, tmp);
-                sle->setFieldU32(sfPreviousTxnLgrSeq, 4);
-                sle->setFieldU32(sfSequence, seq);
+            // Uploads off: the existing escrow still finishes. The contract
+            // returns success at this ledger height, so the escrow is removed.
+            runLadder(Keys::kBytecodeSizeLimit, tesSUCCESS);
 
-                view.rawInsert(sle);
-                return true;
-            });
-            BEAST_EXPECT(env.le(keylet));
-
-            env(escrow::finish(alice, alice, seq),
-                escrow::Gas(1000),
-                Fee(env.current()->fees().base + 1000),
-                Ter(temTEMP_DISABLED));
+            // Execution off: the same escrow cannot be finished at all.
+            runLadder(Keys::kGasLimit, temTEMP_DISABLED);
         }
 
         Env env(*this, features);
@@ -577,6 +582,8 @@ struct EscrowSmart_test : public beast::unit_test::Suite
         // getLedgerSqn() >= 5}
         std::uint32_t const allowance = 467;
         auto escrowCreate = escrow::create(alice, carol, XRP(1000));
+        // Ask production rather than mirroring the formula: a hand-copied one
+        // agrees with the implementation when it is wrong.
         auto [createFee, finishFee] = [&]() {
             Env const env(*this, features);
             auto createFee = env.current()->fees().base * 10 + kLedgerSqnWasmHex.size() / 2 * 5;
@@ -886,7 +893,9 @@ struct EscrowSmart_test : public beast::unit_test::Suite
 
             auto const allowance = 1420;
             XRPAmount const finishFee = env.current()->fees().base +
-                (allowance * env.current()->fees().gasPrice) / microDropsPerDrop + 1;
+                (static_cast<uint64_t>(allowance) * env.current()->fees().gasPrice) /
+                    microDropsPerDrop +
+                1;
 
             // FinishAfter time hasn't passed
             env(escrow::finish(alice, alice, seq),
@@ -936,19 +945,11 @@ struct EscrowSmart_test : public beast::unit_test::Suite
         }();
 
         {
-            // ensure fees don't overflow
+            // bigAllowance would wrap the drops charge in 32 bits, so vote the
+            // gas limit up to the ceiling.
             Env env(
-                *this,
-                envconfig([](std::unique_ptr<Config> cfg) {
-                    cfg->fees.gasPrice = 1'000'000;  // in gas
-                    return cfg;
-                }),
-                features);
-            // Run past the flag ledger so that a Fee change vote occurs and
-            // updates FeeSettings. (It also activates all supported
-            // amendments.)
-            for (auto i = env.current()->seq(); i <= 257; ++i)
-                env.close();
+                *this, votingConfig({{Keys::kGasLimit, std::to_string(kMaxGasLimit)}}), features);
+            awaitFeeVote(env);
 
             // create escrow
             env.fund(XRP(5000), alice, carol);
@@ -966,9 +967,13 @@ struct EscrowSmart_test : public beast::unit_test::Suite
                 env.require(Balance(carol, XRP(5000)));
                 env.close();
 
-                auto const bigAllowance = 996'433;
+                // Derived from the limit in force, so a repricing does not
+                // silently weaken the test.
+                auto const bigAllowance = env.current()->fees().gasLimit - 1;
                 uint64_t const partialFeeCalc =
-                    ((static_cast<uint64_t>(bigAllowance) * 1'000'000) / microDropsPerDrop) + 1;
+                    ((static_cast<uint64_t>(bigAllowance) * env.current()->fees().gasPrice) /
+                     microDropsPerDrop) +
+                    1;
                 auto finishFee = env.current()->fees().base + partialFeeCalc;
                 BEAST_EXPECT(finishFee.drops() > bigAllowance);
 
@@ -1021,7 +1026,11 @@ struct EscrowSmart_test : public beast::unit_test::Suite
         Account const carol{"carol"};
 
         {
-            Env env(*this, features);
+            // This contract exercises every host function, so it needs an
+            // allowance above the default limit; vote the limit up.
+            Env env(
+                *this, votingConfig({{Keys::kGasLimit, std::to_string(kMaxGasLimit)}}), features);
+            awaitFeeVote(env);
             // create escrow
             env.fund(XRP(5000), alice, carol);
             auto const seq = env.seq(alice);
@@ -1045,7 +1054,9 @@ struct EscrowSmart_test : public beast::unit_test::Suite
 
                 auto const allowance = 1'000'000;
                 XRPAmount const finishFee = env.current()->fees().base +
-                    (allowance * env.current()->fees().gasPrice) / microDropsPerDrop + 1;
+                    (static_cast<uint64_t>(allowance) * env.current()->fees().gasPrice) /
+                        microDropsPerDrop +
+                    1;
 
                 // FinishAfter time hasn't passed
                 env(escrow::finish(carol, alice, seq),
@@ -1168,7 +1179,9 @@ struct EscrowSmart_test : public beast::unit_test::Suite
 
                 auto const allowance = 184'375;
                 auto const finishFee = env.current()->fees().base +
-                    (allowance * env.current()->fees().gasPrice) / microDropsPerDrop + 1;
+                    (static_cast<uint64_t>(allowance) * env.current()->fees().gasPrice) /
+                        microDropsPerDrop +
+                    1;
                 env(escrow::finish(carol, alice, seq), escrow::Gas(allowance), Fee(finishFee));
                 env.close();
 
@@ -1192,26 +1205,27 @@ struct EscrowSmart_test : public beast::unit_test::Suite
         using namespace std::chrono;
         using namespace wasm_constants;
 
-        enum class ExpectedStatus { Success, Malformed, Crash };
+        enum class ExpectedStatus { Success, Malformed };
 
         auto runTest = [&](std::vector<uint8_t> const& wasm,
                            std::optional<uint32_t> sizeLimit,
                            ExpectedStatus expectedStatus,
                            std::source_location const& loc = std::source_location::current()) {
+            // No sizeLimit means "leave it at the default"; voting costs a
+            // flag ledger, so only vote when a case asks for a limit.
             auto makeEnv = [&]() -> Env {
                 if (sizeLimit)
                 {
                     return Env(
                         *this,
-                        envconfig([&sizeLimit](std::unique_ptr<Config> cfg) {
-                            cfg->fees.bytecodeSizeLimit = *sizeLimit;
-                            return cfg;
-                        }),
+                        votingConfig({{Keys::kBytecodeSizeLimit, std::to_string(*sizeLimit)}}),
                         features);
                 }
                 return Env(*this, features);
             };
             Env env = makeEnv();
+            if (sizeLimit)
+                awaitFeeVote(env);
 
             auto const alice = Account("alice");
             env.fund(XRP(1'000'000), alice);
@@ -1226,25 +1240,11 @@ struct EscrowSmart_test : public beast::unit_test::Suite
                     Fee(env.current()->fees().base * 10 + wasmHex.size() / 2 * 5),
                     Ter(expectedStatus == ExpectedStatus::Success ? TER{tesSUCCESS}
                                                                   : TER{temMALFORMED}));
-                if (expectedStatus == ExpectedStatus::Crash)
-                {
-                    fail("Expected crash", loc.file_name(), loc.line());
-                }
-                else
-                {
-                    pass();
-                }
+                pass();
             }
             catch (std::exception const& e)
             {
-                if (expectedStatus == ExpectedStatus::Crash)
-                {
-                    pass();
-                }
-                else
-                {
-                    fail(e.what(), loc.file_name(), loc.line());
-                }
+                fail(e.what(), loc.file_name(), loc.line());
             }
         };
 
@@ -1258,49 +1258,44 @@ struct EscrowSmart_test : public beast::unit_test::Suite
             ExpectedStatus expected;
         };
 
+        // Sizes straddle the two real bounds: the default voted limit
+        // (kDefaultBytecodeSizeLimit) when no sizeLimit is given, and the
+        // protocol ceiling (kMaxBytecodeSizeLimit) when one is.
         std::vector<TestCase> const testCases = {
             // Code blob tests
             {.type = TestCase::BlobType::Code,
-             .size = 99'950,
+             .size = kDefaultBytecodeSizeLimit - 50,
              .sizeLimit = std::nullopt,
-             .expected = ExpectedStatus::Success},  // just under 100kb
+             .expected = ExpectedStatus::Success},  // just under the default
             {.type = TestCase::BlobType::Code,
-             .size = 99'955,
+             .size = kDefaultBytecodeSizeLimit + 50,
              .sizeLimit = std::nullopt,
-             .expected = ExpectedStatus::Malformed},  // just over 100kb
+             .expected = ExpectedStatus::Malformed},  // just over the default
             {.type = TestCase::BlobType::Code,
-             .size = 200'000,
-             .sizeLimit = 10'000'000,
-             .expected = ExpectedStatus::Success},  // ~200kb
+             .size = kMaxBytecodeSizeLimit - 50,
+             .sizeLimit = kMaxBytecodeSizeLimit,
+             .expected = ExpectedStatus::Success},  // just under the ceiling
             {.type = TestCase::BlobType::Code,
-             .size = 490'000,
-             .sizeLimit = 10'000'000,
-             .expected = ExpectedStatus::Success},  // just under 1MB JSON
-            {.type = TestCase::BlobType::Code,
-             .size = 999'999,
-             .sizeLimit = 10'000'000,
-             .expected = ExpectedStatus::Crash},  // just over 1MB JSON
+             .size = kMaxBytecodeSizeLimit + 50,
+             .sizeLimit = kMaxBytecodeSizeLimit,
+             .expected = ExpectedStatus::Malformed},  // over the ceiling
             // Data blob tests
             {.type = TestCase::BlobType::Data,
-             .size = 99'939,
+             .size = kDefaultBytecodeSizeLimit - 61,
              .sizeLimit = std::nullopt,
-             .expected = ExpectedStatus::Success},  // just under 100kb
+             .expected = ExpectedStatus::Success},  // just under the default
             {.type = TestCase::BlobType::Data,
-             .size = 99'941,
+             .size = kDefaultBytecodeSizeLimit + 59,
              .sizeLimit = std::nullopt,
-             .expected = ExpectedStatus::Malformed},  // just over 100kb
+             .expected = ExpectedStatus::Malformed},  // just over the default
             {.type = TestCase::BlobType::Data,
-             .size = 200'000,
-             .sizeLimit = 10'000'000,
-             .expected = ExpectedStatus::Success},  // ~200kb
+             .size = kMaxBytecodeSizeLimit - 61,
+             .sizeLimit = kMaxBytecodeSizeLimit,
+             .expected = ExpectedStatus::Success},  // just under the ceiling
             {.type = TestCase::BlobType::Data,
-             .size = 490'000,
-             .sizeLimit = 10'000'000,
-             .expected = ExpectedStatus::Success},  // just under 1MB JSON
-            {.type = TestCase::BlobType::Data,
-             .size = 999'950,
-             .sizeLimit = 10'000'000,
-             .expected = ExpectedStatus::Crash},  // just over 1MB JSON
+             .size = kMaxBytecodeSizeLimit + 59,
+             .sizeLimit = kMaxBytecodeSizeLimit,
+             .expected = ExpectedStatus::Malformed},  // over the ceiling
         };
 
         for (auto const& tc : testCases)
@@ -1309,6 +1304,61 @@ struct EscrowSmart_test : public beast::unit_test::Suite
                                                                   : generateDataBlob(tc.size);
             runTest(wasm, tc.sizeLimit, tc.expected);
         }
+    }
+
+    // Admission must depend only on the ledger's voted FeeSettings. Both runs
+    // start from an identical genesis; one then sets a FeeSetup that would
+    // reject every transaction below, if anything still read it.
+    void
+    testLimitsIgnoreLocalConfig(FeatureBitset features)
+    {
+        testcase("Limits come from the ledger, not local config");
+
+        using namespace jtx;
+        using namespace std::chrono;
+
+        auto run = [&](bool hostile) {
+            Env env(*this, features);
+            if (hostile)
+            {
+                // A 1-byte module cap and a 1-gas compute cap: under the old
+                // config-driven checks every transaction below would have been
+                // rejected here and accepted by a stock node.
+                auto& cfgFees = env.app().config().fees;
+                cfgFees.gasLimit = 1;
+                cfgFees.bytecodeSizeLimit = 1;
+                cfgFees.gasPrice = 999'999'999;
+            }
+
+            Account const alice{"alice"};
+            Account const carol{"carol"};
+            env.fund(XRP(5000), alice, carol);
+            env.close();
+
+            // The module is arbitrary: any the engine accepts and that returns
+            // true will do, so both runs reach the same ledger.
+            // kTable0ElementsHex is simply the smallest such fixture.
+            auto const seq = env.seq(alice);
+            env(escrow::create(alice, carol, XRP(500)),
+                escrow::Bytecode(kTable0ElementsHex),
+                escrow::kCancelTime(env.now() + 100s),
+                Fee(env.current()->fees().base * 10 + 5 * (kTable0ElementsHex.size() / 2)));
+            env.close();
+
+            std::uint32_t const allowance = 100'000;
+            env(escrow::finish(carol, alice, seq), escrow::Gas(allowance), Fee(XRP(1)));
+            env.close();
+
+            return std::make_pair(env.closed()->header().hash, env.ownerCount(alice));
+        };
+
+        auto const hostile = run(true);
+        auto const stock = run(false);
+
+        BEAST_EXPECTS(
+            hostile.first == stock.first,
+            to_string(hostile.first) + " != " + to_string(stock.first));
+        BEAST_EXPECT(hostile.second == stock.second);
     }
 
     void
@@ -1343,6 +1393,7 @@ struct EscrowSmart_test : public beast::unit_test::Suite
         // be accepted. The >1MB cases also abort the run: the harness cannot carry
         // a log message that large (multi_runner.cpp:398, recvdSize == 1).
         // testLargeWasmModules(features);
+        testLimitsIgnoreLocalConfig(features);
     }
 
 public:

--- a/src/test/app/FeeVote_test.cpp
+++ b/src/test/app/FeeVote_test.cpp
@@ -435,7 +435,7 @@ class FeeVote_test : public beast::unit_test::Suite
                 .reserveIncrementDrops = XRPAmount{50000},
                 .gasLimit = 100,
                 .bytecodeSizeLimit = 200,
-                .gasPrice = 300};
+                .gasPrice = 3000};
             // Test successful fee transaction with new fields
             auto feeTx = createFeeTx(ledger->rules(), ledger->seq(), fields);
 
@@ -471,14 +471,29 @@ class FeeVote_test : public beast::unit_test::Suite
                  .reserveIncrementDrops = XRPAmount{50000},
                  .gasLimit = kMaxGasLimit + 1,
                  .bytecodeSizeLimit = kMaxBytecodeSizeLimit,
-                 .gasPrice = 300});
+                 .gasPrice = 3000});
             testBadFields(
                 {.baseFeeDrops = XRPAmount{10},
                  .reserveBaseDrops = XRPAmount{200000},
                  .reserveIncrementDrops = XRPAmount{50000},
                  .gasLimit = kMaxGasLimit,
                  .bytecodeSizeLimit = kMaxBytecodeSizeLimit + 1,
-                 .gasPrice = 300});
+                 .gasPrice = 3000});
+            // gasPrice has a floor rather than a ceiling.
+            testBadFields(
+                {.baseFeeDrops = XRPAmount{10},
+                 .reserveBaseDrops = XRPAmount{200000},
+                 .reserveIncrementDrops = XRPAmount{50000},
+                 .gasLimit = kMaxGasLimit,
+                 .bytecodeSizeLimit = kMaxBytecodeSizeLimit,
+                 .gasPrice = kMinGasPrice - 1});
+            testBadFields(
+                {.baseFeeDrops = XRPAmount{10},
+                 .reserveBaseDrops = XRPAmount{200000},
+                 .reserveIncrementDrops = XRPAmount{50000},
+                 .gasLimit = kMaxGasLimit,
+                 .bytecodeSizeLimit = kMaxBytecodeSizeLimit,
+                 .gasPrice = 0});
         }
 
         // Test that the Smart Escrow fields are rejected if the
@@ -501,7 +516,7 @@ class FeeVote_test : public beast::unit_test::Suite
                 .reserveIncrementDrops = XRPAmount{50000},
                 .gasLimit = 100,
                 .bytecodeSizeLimit = 200,
-                .gasPrice = 300};
+                .gasPrice = 3000};
             // Test successful fee transaction with new fields
             auto feeTx = createFeeTx(ledger->rules(), ledger->seq(), fields, true);
 
@@ -1050,7 +1065,7 @@ class FeeVote_test : public beast::unit_test::Suite
             setup.ownerReserve = 7654321;
             setup.gasLimit = 100;
             setup.bytecodeSizeLimit = 200;
-            setup.gasPrice = 300;
+            setup.gasPrice = 3000;
             auto const [feeTx, ledger] = createFeeTxFromVoting(setup);
 
             checkFeeTx(setup, feeTx, ledger);
@@ -1063,7 +1078,7 @@ class FeeVote_test : public beast::unit_test::Suite
             setup.ownerReserve = 7654321;
             setup.gasLimit = 0;
             setup.bytecodeSizeLimit = 0;
-            setup.gasPrice = 300;
+            setup.gasPrice = 3000;
             auto const [feeTx, ledger] = createFeeTxFromVoting(setup);
 
             checkFeeTx(setup, feeTx, ledger);
@@ -1076,7 +1091,7 @@ class FeeVote_test : public beast::unit_test::Suite
             setup.ownerReserve = 7654321;
             setup.gasLimit = kMaxGasLimit + 1;
             setup.bytecodeSizeLimit = kMaxBytecodeSizeLimit + 1;
-            setup.gasPrice = 300;
+            setup.gasPrice = 3000;
             auto const [feeTx, ledger] = createFeeTxFromVoting(setup);
 
             setup.gasLimit = ledger->fees().gasLimit;

--- a/src/test/app/FeeVote_test.cpp
+++ b/src/test/app/FeeVote_test.cpp
@@ -948,9 +948,9 @@ class FeeVote_test : public beast::unit_test::Suite
         BEAST_EXPECT(env.current()->fees().base == XRPAmount{UNIT_TEST_REFERENCE_FEE});
         BEAST_EXPECT(env.current()->fees().reserve == XRPAmount{200'000'000});
         BEAST_EXPECT(env.current()->fees().increment == XRPAmount{50'000'000});
-        BEAST_EXPECT(env.current()->fees().gasLimit == 0);
-        BEAST_EXPECT(env.current()->fees().bytecodeSizeLimit == 0);
-        BEAST_EXPECT(env.current()->fees().gasPrice == 0);
+        BEAST_EXPECT(env.current()->fees().gasLimit == kDefaultGasLimit);
+        BEAST_EXPECT(env.current()->fees().bytecodeSizeLimit == kDefaultBytecodeSizeLimit);
+        BEAST_EXPECT(env.current()->fees().gasPrice == kDefaultGasPrice);
 
         auto const createFeeTxFromVoting =
             [&](FeeSetup const& setup) -> std::pair<STTx, std::shared_ptr<Ledger>> {
@@ -1085,6 +1085,81 @@ class FeeVote_test : public beast::unit_test::Suite
         }
     }
 
+    // Activation cannot be driven through consensus here, so the ledger is
+    // built by hand and wrapped in an OpenView, which reports closed --
+    // Change::preclaim rejects pseudo-transactions against an open view.
+    void
+    testSeedingOnActivation()
+    {
+        testcase("Seeding on amendment activation");
+
+        using namespace jtx;
+
+        // env is only a factory for Rules, Fees, a family and a journal.
+        Env env(*this, testableAmendments() - featureSmartEscrow);
+
+        auto ledger = std::make_shared<Ledger>(
+            kCreateGenesis,
+            Rules{env.app().config().features},
+            env.app().config().fees.toFees(),
+            std::vector<uint256>{},
+            env.app().getNodeFamily());
+        // One successor, so the amendment is not applied to genesis itself.
+        ledger = std::make_shared<Ledger>(*ledger, env.app().getTimeKeeper().closeTime());
+
+        if (auto const before = ledger->read(keylet::feeSettings()); BEAST_EXPECT(before))
+        {
+            BEAST_EXPECT(!before->isFieldPresent(sfGasLimit));
+            BEAST_EXPECT(!before->isFieldPresent(sfBytecodeSizeLimit));
+            BEAST_EXPECT(!before->isFieldPresent(sfGasPrice));
+        }
+
+        STTx const amendTx(ttAMENDMENT, [&](auto& obj) {
+            obj.setAccountID(sfAccount, AccountID());
+            obj.setFieldH256(sfAmendment, featureSmartEscrow);
+            obj.setFieldU32(sfLedgerSequence, ledger->seq());
+        });
+
+        {
+            OpenView accum(ledger.get());
+            BEAST_EXPECT(!accum.open());
+
+            auto const result = apply(env.app(), accum, amendTx, ApplyFlags::TapNone, env.journal);
+            BEAST_EXPECTS(result.applied && isTesSuccess(result.ter), transToken(result.ter));
+            accum.apply(*ledger);
+        }
+
+        auto const after = ledger->read(keylet::feeSettings());
+        if (!BEAST_EXPECT(after))
+            return;
+
+        if (BEAST_EXPECT(after->isFieldPresent(sfGasLimit)))
+        {
+            BEAST_EXPECTS(
+                after->getFieldU32(sfGasLimit) == kDefaultGasLimit,
+                std::to_string(after->getFieldU32(sfGasLimit)));
+        }
+        if (BEAST_EXPECT(after->isFieldPresent(sfBytecodeSizeLimit)))
+        {
+            BEAST_EXPECTS(
+                after->getFieldU32(sfBytecodeSizeLimit) == kDefaultBytecodeSizeLimit,
+                std::to_string(after->getFieldU32(sfBytecodeSizeLimit)));
+        }
+        if (BEAST_EXPECT(after->isFieldPresent(sfGasPrice)))
+        {
+            BEAST_EXPECTS(
+                after->getFieldU32(sfGasPrice) == kDefaultGasPrice,
+                std::to_string(after->getFieldU32(sfGasPrice)));
+        }
+
+        // Also pins that the amendment is seen before the fee fields are read.
+        ledger->setImmutable();
+        BEAST_EXPECT(ledger->rules().enabled(featureSmartEscrow));
+        BEAST_EXPECT(ledger->fees().gasLimit == kDefaultGasLimit);
+        BEAST_EXPECT(ledger->fees().bytecodeSizeLimit == kDefaultBytecodeSizeLimit);
+        BEAST_EXPECT(ledger->fees().gasPrice == kDefaultGasPrice);
+    }
+
     void
     run() override
     {
@@ -1099,6 +1174,7 @@ class FeeVote_test : public beast::unit_test::Suite
         testDoValidation();
         testDoVoting();
         testDoVotingSmartEscrow();
+        testSeedingOnActivation();
     }
 };
 

--- a/src/test/core/Config_test.cpp
+++ b/src/test/core/Config_test.cpp
@@ -8,6 +8,7 @@
 #include <xrpl/config/BasicConfig.h>
 #include <xrpl/config/Constants.h>
 #include <xrpl/protocol/SystemParameters.h>  // IWYU pragma: keep
+#include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/server/Port.h>
 
 #include <boost/lexical_cast/bad_lexical_cast.hpp>
@@ -1658,6 +1659,30 @@ r.ripple.com:51235
     }
 
     void
+    testToFees()
+    {
+        testcase("toFees");
+
+        FeeSetup setup;
+
+        setup.referenceFee = XRPAmount{17};
+        setup.accountReserve = XRPAmount{3'000'017};
+        setup.ownerReserve = XRPAmount{700'017};
+        setup.gasLimit = 123'457;
+        setup.bytecodeSizeLimit = 23'457;
+        setup.gasPrice = 7'654'321;
+
+        auto const fees = setup.toFees();
+
+        BEAST_EXPECT(fees.base == setup.referenceFee);
+        BEAST_EXPECT(fees.reserve == setup.accountReserve);
+        BEAST_EXPECT(fees.increment == setup.ownerReserve);
+        BEAST_EXPECT(fees.gasLimit == setup.gasLimit);
+        BEAST_EXPECT(fees.bytecodeSizeLimit == setup.bytecodeSizeLimit);
+        BEAST_EXPECT(fees.gasPrice == setup.gasPrice);
+    }
+
+    void
     run() override
     {
         testLegacy();
@@ -1676,6 +1701,7 @@ r.ripple.com:51235
         testAmendment();
         testOverlay();
         testNetworkID();
+        testToFees();
     }
 };
 

--- a/src/test/jtx/impl/envconfig.cpp
+++ b/src/test/jtx/impl/envconfig.cpp
@@ -21,16 +21,12 @@ void
 setupConfigForUnitTests(Config& cfg)
 {
     using namespace jtx;
-    // Default fees to old values, so tests don't have to worry about changes in
-    // Config.h
-    // NOTE: For new `fees` fields, you need to wait for the first flag ledger
-    // to close for the values to be activated.
+    // Reserves held at pre-2021 mainnet values; many tests carry balance
+    // expectations built on them. Extension limits are deliberately unset --
+    // tests inherit the FeeSetup defaults, or set [voting].
     cfg.fees.referenceFee = UNIT_TEST_REFERENCE_FEE;
     cfg.fees.accountReserve = XRP(200).value().xrp().drops();
     cfg.fees.ownerReserve = XRP(50).value().xrp().drops();
-    cfg.fees.gasLimit = 1'000'000;
-    cfg.fees.bytecodeSizeLimit = 100'000;
-    cfg.fees.gasPrice = 1'000'000;  // 1 drop = 1,000,000 micro-drops
 
     // The Beta API (currently v2) is always available to tests
     cfg.betaRpcApi = true;

--- a/src/test/rpc/Subscribe_test.cpp
+++ b/src/test/rpc/Subscribe_test.cpp
@@ -29,6 +29,7 @@
 #include <xrpl/json/to_string.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/Fees.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/KeyType.h>
 #include <xrpl/protocol/PublicKey.h>
@@ -431,7 +432,19 @@ public:
     {
         using namespace jtx;
 
-        Env env{*this, singleThreadIo(envconfig(validator, "")), features};
+        // doValidation only writes a fee field when its target differs from the
+        // ledger's current value, so a node with nothing to change emits
+        // nothing. Vote for limits other than the ones already in force, so
+        // the extension fields actually appear on the flag ledger.
+        auto voteDifferentLimits = [](std::unique_ptr<Config> cfg) {
+            auto& voting = cfg->section(Sections::kVoting);
+            voting.set(Keys::kGasLimit, std::to_string(kDefaultGasLimit - 1000));
+            voting.set(Keys::kBytecodeSizeLimit, std::to_string(kDefaultBytecodeSizeLimit - 1000));
+            voting.set(Keys::kGasPrice, std::to_string(kDefaultGasPrice - 1000));
+
+            return cfg;
+        };
+        Env env{*this, singleThreadIo(voteDifferentLimits(envconfig(validator, ""))), features};
         auto& cfg = env.app().config();
         if (!BEAST_EXPECT(cfg.section(Sections::kValidationSeed).empty()))
             return;
@@ -521,6 +534,9 @@ public:
 
                     if (jv.isMember(jss::bytecode_size_limit) != isFlagLedger)
                         return false;
+
+                    if (jv.isMember(jss::gas_price) != isFlagLedger)
+                        return false;
                 }
                 else
                 {
@@ -528,6 +544,9 @@ public:
                         return false;
 
                     if (jv.isMember(jss::bytecode_size_limit))
+                        return false;
+
+                    if (jv.isMember(jss::gas_price))
                         return false;
                 }
                 return true;

--- a/src/tests/libxrpl/CMakeLists.txt
+++ b/src/tests/libxrpl/CMakeLists.txt
@@ -43,6 +43,7 @@ set(test_modules
     consensus
     crypto
     json
+    ledger
     nodestore
     peerfinder
     protocol

--- a/src/tests/libxrpl/helpers/TestServiceRegistry.h
+++ b/src/tests/libxrpl/helpers/TestServiceRegistry.h
@@ -17,7 +17,6 @@
 #include <xrpl/protocol/PublicKey.h>
 #include <xrpl/protocol/Rules.h>
 #include <xrpl/protocol/STValidation.h>
-#include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/server/LoadFeeTrack.h>
 
 #include <boost/asio/io_context.hpp>
@@ -179,22 +178,11 @@ private:
  */
 class TestServiceRegistry : public ServiceRegistry
 {
-    static Fees
-    defaultFees()
-    {
-        Fees fees{XRPAmount{10}, XRPAmount{10 * kDropsPerXrp}, XRPAmount{2 * kDropsPerXrp}};
-        fees.gasLimit = 1'000'000;
-        fees.bytecodeSizeLimit = 100'000;
-        fees.gasPrice = 1'000'000;
-        return fees;
-    }
-
     TestLogs logs_{beast::Severity::Warning};
     boost::asio::io_context ioContext_;
     TestFamily family_{logs_.journal("TestFamily")};
     LoadFeeTrack feeTrack_{logs_.journal("LoadFeeTrack")};
     TestNetworkIDService networkIDService_;
-    Fees fees_{defaultFees()};
     HashRouter hashRouter_{HashRouter::Setup{}, stopwatch()};
     NodeCache tempNodeCache_{
         "TempNodeCache",
@@ -492,12 +480,6 @@ public:
     getWalletDB() override
     {
         throw std::logic_error("TestServiceRegistry::getWalletDB() not implemented");
-    }
-
-    Fees
-    getFees() const override
-    {
-        return fees_;
     }
 
     // Temporary: Get the underlying Application

--- a/src/tests/libxrpl/helpers/TxTest.cpp
+++ b/src/tests/libxrpl/helpers/TxTest.cpp
@@ -73,9 +73,9 @@ TxTest::TxTest(std::optional<FeatureBitset> features)
         XRPAmount{10},
         XRPAmount{10000000},
         XRPAmount{2000000},
-        0,
-        0,
-        0};
+        kDefaultGasLimit,
+        kDefaultBytecodeSizeLimit,
+        kDefaultGasPrice};
 
     // Create a genesis ledger as the base
     closedLedger_ = std::make_shared<Ledger>(

--- a/src/tests/libxrpl/helpers/TxTest.cpp
+++ b/src/tests/libxrpl/helpers/TxTest.cpp
@@ -69,7 +69,13 @@ TxTest::TxTest(std::optional<FeatureBitset> features)
     rules_.emplace(featureSet_);
 
     // Default fees for testing
-    Fees const fees{XRPAmount{10}, XRPAmount{10000000}, XRPAmount{2000000}};
+    Fees const fees{
+        XRPAmount{10},
+        XRPAmount{10000000},
+        XRPAmount{2000000},
+        0,
+        0,
+        0};
 
     // Create a genesis ledger as the base
     closedLedger_ = std::make_shared<Ledger>(

--- a/src/tests/libxrpl/ledger/ExtensionFees.cpp
+++ b/src/tests/libxrpl/ledger/ExtensionFees.cpp
@@ -1,0 +1,144 @@
+#include <xrpl/basics/base_uint.h>
+#include <xrpl/basics/chrono.h>
+#include <xrpl/beast/hash/uhash.h>
+#include <xrpl/beast/utility/Journal.h>
+#include <xrpl/ledger/Ledger.h>
+#include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/Fees.h>
+#include <xrpl/protocol/Indexes.h>
+#include <xrpl/protocol/Rules.h>
+#include <xrpl/protocol/SField.h>
+#include <xrpl/protocol/STLedgerEntry.h>
+#include <xrpl/protocol/XRPAmount.h>
+
+#include <gtest/gtest.h>
+#include <helpers/TestFamily.h>
+
+#include <cstdint>
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+namespace xrpl::test {
+
+namespace {
+
+// Unlike every protocol constant, so an assertion cannot pass by chance.
+constexpr std::uint32_t kLocalGasLimit{123'457};
+constexpr std::uint32_t kLocalBytecodeSizeLimit{23'457};
+constexpr std::uint32_t kLocalGasPrice{7'654'321};
+
+// Stands in for FeeSetup::toFees(): local configuration.
+Fees
+localFees()
+{
+    return Fees{
+        XRPAmount{10},
+        XRPAmount{10'000'000},
+        XRPAmount{2'000'000},
+        kLocalGasLimit,
+        kLocalBytecodeSizeLimit,
+        kLocalGasPrice};
+}
+
+}  // namespace
+
+class ExtensionFees : public ::testing::Test
+{
+protected:
+    std::unordered_set<uint256, beast::Uhash<>> presets_;
+    TestFamily family_{beast::Journal{beast::Journal::getNullSink()}};
+
+    std::shared_ptr<Ledger>
+    makeGenesis(std::vector<uint256> const& amendments)
+    {
+        presets_.insert(amendments.begin(), amendments.end());
+        return std::make_shared<Ledger>(
+            kCreateGenesis, Rules{presets_}, localFees(), amendments, family_);
+    }
+
+    // Closed successor with FeeSettings rewritten by `edit`; setImmutable runs
+    // Ledger::setup, so fees() is what the resolution produced.
+    template <typename F>
+    std::shared_ptr<Ledger>
+    successorWithFeeSettings(Ledger const& parent, F&& edit)
+    {
+        auto ledger = std::make_shared<Ledger>(parent, NetClock::time_point{});
+        auto sle = std::make_shared<SLE>(*ledger->read(keylet::feeSettings()));
+        edit(*sle);
+        ledger->rawReplace(sle);
+        ledger->setImmutable();
+        return ledger;
+    }
+};
+
+// test how Ledger::setup decides the three extension fee fields
+
+// Genesis is the one place local configuration legitimately reaches the ledger.
+TEST_F(ExtensionFees, GenesisWritesTheConfiguredValues)
+{
+    auto const ledger = makeGenesis({featureSmartEscrow});
+
+    EXPECT_EQ(ledger->fees().gasLimit, kLocalGasLimit);
+    EXPECT_EQ(ledger->fees().bytecodeSizeLimit, kLocalBytecodeSizeLimit);
+    EXPECT_EQ(ledger->fees().gasPrice, kLocalGasPrice);
+}
+
+// Absent must resolve to the protocol constant, never to the constructed Fees,
+// which every caller builds from local configuration.
+TEST_F(ExtensionFees, AbsentFieldsResolveToTheProtocolConstants)
+{
+    auto const genesis = makeGenesis({featureSmartEscrow});
+
+    auto const ledger = successorWithFeeSettings(*genesis, [](SLE& sle) {
+        sle.makeFieldAbsent(sfGasLimit);
+        sle.makeFieldAbsent(sfBytecodeSizeLimit);
+        sle.makeFieldAbsent(sfGasPrice);
+    });
+
+    ASSERT_TRUE(ledger->rules().enabled(featureSmartEscrow));
+
+    EXPECT_EQ(ledger->fees().gasLimit, kDefaultGasLimit);
+    EXPECT_EQ(ledger->fees().bytecodeSizeLimit, kDefaultBytecodeSizeLimit);
+    EXPECT_EQ(ledger->fees().gasPrice, kDefaultGasPrice);
+
+    EXPECT_NE(ledger->fees().gasLimit, kLocalGasLimit);
+    EXPECT_NE(ledger->fees().bytecodeSizeLimit, kLocalBytecodeSizeLimit);
+    EXPECT_NE(ledger->fees().gasPrice, kLocalGasPrice);
+}
+
+// The fallback only fills gaps; a present field still governs.
+TEST_F(ExtensionFees, PresentFieldsAreTakenFromTheLedger)
+{
+    constexpr std::uint32_t kVotedGasLimit{987'654};
+    constexpr std::uint32_t kVotedBytecodeSizeLimit{87'654};
+    constexpr std::uint32_t kVotedGasPrice{76'543};
+
+    auto const genesis = makeGenesis({featureSmartEscrow});
+
+    auto const ledger = successorWithFeeSettings(*genesis, [&](SLE& sle) {
+        sle.at(sfGasLimit) = kVotedGasLimit;
+        sle.at(sfBytecodeSizeLimit) = kVotedBytecodeSizeLimit;
+        sle.at(sfGasPrice) = kVotedGasPrice;
+    });
+
+    EXPECT_EQ(ledger->fees().gasLimit, kVotedGasLimit);
+    EXPECT_EQ(ledger->fees().bytecodeSizeLimit, kVotedBytecodeSizeLimit);
+    EXPECT_EQ(ledger->fees().gasPrice, kVotedGasPrice);
+}
+
+// An explicit zero is the kill switch, not absence.
+TEST_F(ExtensionFees, AnExplicitZeroIsNotTreatedAsAbsent)
+{
+    auto const genesis = makeGenesis({featureSmartEscrow});
+
+    auto const ledger = successorWithFeeSettings(*genesis, [](SLE& sle) {
+        sle.at(sfGasLimit) = 0u;
+        sle.at(sfBytecodeSizeLimit) = 0u;
+    });
+
+    EXPECT_EQ(ledger->fees().gasLimit, 0u);
+    EXPECT_EQ(ledger->fees().bytecodeSizeLimit, 0u);
+}
+
+}  // namespace xrpl::test

--- a/src/xrpld/app/main/Application.cpp
+++ b/src/xrpld/app/main/Application.cpp
@@ -826,24 +826,6 @@ public:
         return *walletDB_;
     }
 
-    Fees
-    getFees() const override
-    {
-        XRPL_ASSERT(config_, "xrpl::ApplicationImp::getFees : non-null config");
-
-        auto const& f1(config_->fees);
-
-        Fees f2;
-        f2.base = f1.referenceFee;
-        f2.reserve = f1.accountReserve;
-        f2.increment = f1.ownerReserve;
-        f2.gasLimit = f1.gasLimit;
-        f2.bytecodeSizeLimit = f1.bytecodeSizeLimit;
-        f2.gasPrice = f1.gasPrice;
-
-        return f2;
-    }
-
     bool
     serverOkay(std::string& reason) override;
 

--- a/src/xrpld/app/misc/FeeVoteImpl.cpp
+++ b/src/xrpld/app/misc/FeeVoteImpl.cpp
@@ -184,7 +184,10 @@ FeeVoteImpl::doValidation(Fees const& lastFees, Rules const& rules, STValidation
                 "bytecode size limit",
                 sfBytecodeSizeLimit);
         }
-        vote(lastFees.gasPrice, target_.gasPrice, "gas price", sfGasPrice);
+        if (target_.gasPrice >= kMinGasPrice)
+        {
+            vote(lastFees.gasPrice, target_.gasPrice, "gas price", sfGasPrice);
+        }
     }
 }
 
@@ -205,9 +208,10 @@ FeeVoteImpl::doVoting(
 
     detail::VotableValue incReserveVote(lastClosedLedger->fees().increment, target_.ownerReserve);
 
-    auto validOrCurrent = [](std::uint32_t target, std::uint32_t max, std::uint32_t current) {
-        return target <= max ? target : current;
-    };
+    auto validOrCurrent =
+        [](std::uint32_t target, std::uint32_t max, std::uint32_t current, std::uint32_t min = 0) {
+            return (target <= max && target >= min) ? target : current;
+        };
 
     detail::VotableValue gasLimitVote(
         lastClosedLedger->fees().gasLimit,
@@ -220,7 +224,13 @@ FeeVoteImpl::doVoting(
             kMaxBytecodeSizeLimit,
             lastClosedLedger->fees().bytecodeSizeLimit));
 
-    detail::VotableValue gasPriceVote(lastClosedLedger->fees().gasPrice, target_.gasPrice);
+    detail::VotableValue gasPriceVote(
+        lastClosedLedger->fees().gasPrice,
+        validOrCurrent(
+            target_.gasPrice,
+            std::numeric_limits<std::uint32_t>::max(),
+            lastClosedLedger->fees().gasPrice,
+            kMinGasPrice));
 
     auto const& rules = lastClosedLedger->rules();
     if (rules.enabled(featureXRPFees))
@@ -297,10 +307,11 @@ FeeVoteImpl::doVoting(
         auto doVote = [](std::shared_ptr<STValidation> const& val,
                          detail::VotableValue<std::uint32_t>& value,
                          SF_UINT32 const& sfield,
-                         std::uint32_t maxValue) {
+                         std::uint32_t maxValue,
+                         std::uint32_t minValue = 0) {
             if (auto const field = ~val->at(~sfield); field)
             {
-                if (field.value() <= maxValue)
+                if (field.value() <= maxValue && field.value() >= minValue)
                 {
                     value.addVote(field.value());
                 }
@@ -321,7 +332,12 @@ FeeVoteImpl::doVoting(
                 continue;
             doVote(val, gasLimitVote, sfGasLimit, kMaxGasLimit);
             doVote(val, bytecodeSizeLimitVote, sfBytecodeSizeLimit, kMaxBytecodeSizeLimit);
-            doVote(val, gasPriceVote, sfGasPrice, std::numeric_limits<std::uint32_t>::max());
+            doVote(
+                val,
+                gasPriceVote,
+                sfGasPrice,
+                std::numeric_limits<std::uint32_t>::max(),
+                kMinGasPrice);
         }
     }
 

--- a/src/xrpld/core/Config.h
+++ b/src/xrpld/core/Config.h
@@ -69,17 +69,17 @@ struct FeeSetup
     /**
      * The gas limit for Feature Extensions.
      */
-    std::uint32_t gasLimit{1'000'000};
+    std::uint32_t gasLimit{kDefaultGasLimit};
 
     /**
      * The bytecode size limit for Feature Extensions.
      */
-    std::uint32_t bytecodeSizeLimit{100'000};
+    std::uint32_t bytecodeSizeLimit{kDefaultBytecodeSizeLimit};
 
     /**
      * The price of 1 WASM gas, in micro-drops.
      */
-    std::uint32_t gasPrice{1'000'000};
+    std::uint32_t gasPrice{kDefaultGasPrice};
 
     /* (Remember to update the example cfg files when changing any of these
      * values.) */

--- a/src/xrpld/core/Config.h
+++ b/src/xrpld/core/Config.h
@@ -90,7 +90,8 @@ struct FeeSetup
     [[nodiscard]] Fees
     toFees() const
     {
-        return Fees{referenceFee, accountReserve, ownerReserve};
+        return Fees{
+            referenceFee, accountReserve, ownerReserve, gasLimit, bytecodeSizeLimit, gasPrice};
     }
 };
 


### PR DESCRIPTION
## The defect

`gasLimit`, `bytecodeSizeLimit` and `gasPrice` are network parameters: voted, and
carried in the `FeeSettings` ledger object. Two paths let a node's own config
decide them instead.

**Admission read the config file.** `EscrowCreate::preflight` and
`EscrowFinish::preflight` took their limits from `ServiceRegistry::getFees()`,
which returns this node's `FeeSetup`. So:

* **Nodes could disagree.** Two nodes with different limits configured admit
  different sets of transactions from the same ledger.
* **The kill switch did not work.** Voting a limit to `0` writes it to
  `FeeSettings`, which admission never read — so a successful vote to disable
  changed nothing.
* **Gas was nearly free after activation.** The charge is
  `allowance * gasPrice / microDropsPerDrop + 1`, and `gasPrice` came from the
  ledger, where it was absent and read as `0` — one drop for any allowance. The
  guard that would have refused execution read `gasLimit` from config, where it
  was non-zero. One value from each source; either source alone would have been
  safe. Transient: the first fee vote closes it.

**Absent fields inherited the config too.** `Ledger::setup` assigned a field only
when `FeeSettings` carried it, leaving an absent one at whatever `fees_` was
constructed with — and every `Ledger` is built from the local `FeeSetup`. Same
divergence, second route. (Genesis is the exception: there, reading config is
correct.)

## The fix

`preflight` has no view, so it bounds against the protocol ceilings
`kMaxGasLimit` / `kMaxBytecodeSizeLimit`; `preclaim` applies the voted values.

WASM validation moves to `preclaim` too — a cached `preflight` result outlives the
vote that invalidates it — and runs last, since compiling is the expensive step.

`isBytecodeUploadDisabled` / `isBytecodeExecutionDisabled` are two rungs on
purpose: zeroing `bytecodeSizeLimit` stops new uploads but leaves existing escrows
finishable, so the feature can be wound down without forcing holders to wait for
`CancelAfter`. Zeroing `gasLimit` stops both.

`Ledger::setup` now resolves an absent field to the protocol constants, so a
consensus value is either in the ledger or a compile-time constant. Amendment
gated.

`Change::applyAmendment` seeds the three fields on activation; without it they
read as `0` until the first post-activation `SetFee`. That makes the seeded values
consensus-critical, and it is why they are constants rather than `FeeSetup`.

`getFees()` is deleted rather than fixed: levelization already forbids `libxrpl`
from reaching config, and this accessor was the way around it.

## Commits

| | |
|---|---|
| `0d355925a6` | **Fix `FeeSetup::toFees` dropping the extension fee settings.** Pre-existing: it returned only the three base fields, unnoticed because nothing read them yet. The `Fees` constructor now requires every field, so the omission is a compile error. |
| `bc8109388c` | **The divergence fix**, end to end. |
| `5818dad4c1` | **Reduce the defaults** to 400,000 gas / 50,000 bytes. Policy, not part of the fix — separate so it is revertible on its own. |
| `6d14434fb8` | **Floor the voted gas price** at 1,000 micro-drops. `gasPrice` is a price, not a capability, so `0` means free rather than disabled. Enforced at the vote target and the `SetFee`, not at config parse time. |

## Why lower the defaults

Assuming building a ledger has ~1 s execution budget, 200 smart escrow txns running some handcrafted wasm code with 1M gas break this budget. 
Lowering to 400K keeps the execution time way below the budget. 50,000 bytes bounds module compile time, which scales with size and does not charge fuel.

Not restrictive: the largest module in the tree is 10,667 B, so 50 KB leaves
~4.7x headroom on code, and the heaviest contract we can measure
(`all_host_functions`) uses 48,433 gas, so 400K leaves ~8.3x on gas. That gas
figure is a single data point from a contract that calls each host function once
and does not loop, so it is not an upper bound on legitimate usage. Both limits
are voted, so either is one vote from correction.

## Tests

* **`ExtensionFees`** (new gtest) pins the resolution: absent yields the constants
  and *not* the configured values, present still governs, explicit `0` is the kill
  switch rather than absence.
* **`testLimitsIgnoreLocalConfig`** is the regression test — two runs, identical
  genesis, one with a hostile `FeeSetup`; identical results and ledger hash.
* **Kill-switch ladder** covers both rungs, including that zeroing
  `bytecodeSizeLimit` leaves an existing escrow finishable.
* Activation seeding in `FeeVote_test`; `toFees()` round-trip in `Config_test`;
  `gas_price` added to the validations stream test.
* The jtx config stops pinning the three limits — a second source of truth nothing
  read. Tests inherit the defaults and set `[voting]` when they need otherwise.

## Notes for reviewers

* `EscrowCreate::preclaim` returns `tem` codes that depend on ledger state
  (`temTEMP_DISABLED`, `temMALFORMED`). Unusual, but deliberate: these must not
  claim a fee, and `preflight` cannot see the voted values.
