### PR TITLE
fix: Mask secrets in batch RPC errors

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -10,6 +10,12 @@ The [commandline](https://xrpl.org/docs/references/http-websocket-apis/api-conve
 
 For a log of breaking changes, see the **API Version [number]** headings. In general, breaking changes are associated with a particular API Version number. For non-breaking changes, scroll to the **XRP Ledger version [x.y.z]** headings. Non-breaking changes are associated with a particular XRP Ledger (`xrpld`) release.
 
+## Unreleased
+
+### Bugfixes
+
+- HTTP batch RPC requests rejected before handler execution now mask `secret`, `seed`, `seed_hex`, and `passphrase` fields in echoed request data, including nested objects and arrays. This also prevents those echoed values from appearing in debug reply logs. ([#7461](https://github.com/XRPLF/rippled/issues/7461))
+
 ## API Version 3 (Beta)
 
 API version 3 is currently a beta API. It requires enabling `[beta_rpc_api]` in the xrpld configuration to use. See [API-VERSION-3.md](API-VERSION-3.md) for the full list of changes in API version 3.

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -6,6 +6,7 @@
 #include <xrpld/app/ledger/LedgerMaster.h>
 
 #include <xrpl/basics/base64.h>
+#include <xrpl/beast/net/IPEndpoint.h>
 #include <xrpl/beast/test/yield_to.h>
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/config/Constants.h>
@@ -14,6 +15,10 @@
 #include <xrpl/json/to_string.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/jss.h>
+#include <xrpl/resource/Charge.h>
+#include <xrpl/resource/Consumer.h>
+#include <xrpl/resource/ResourceManager.h>
+#include <xrpl/resource/detail/Tuning.h>
 #include <xrpl/server/LoadFeeTrack.h>
 #include <xrpl/server/NetworkOPs.h>
 
@@ -1124,6 +1129,198 @@ class ServerStatus_test : public beast::unit_test::Suite, public beast::test::En
     }
 
     void
+    testBatchErrorMasking(boost::asio::yield_context& yield)
+    {
+        testcase("HTTP batch errors mask echoed secrets");
+
+        jtx::Env env{*this};
+        json::Value sensitive;
+        sensitive[jss::secret] = "batch-secret-sentinel";
+        sensitive[jss::seed] = "batch-seed-sentinel";
+        sensitive[jss::seed_hex] = "batch-hex-sentinel";
+        sensitive[jss::passphrase] = "batch-passphrase-sentinel";
+        sensitive["keep"] = "visible";
+
+        json::Value masked;
+        masked[jss::secret] = "<masked>";
+        masked[jss::seed] = "<masked>";
+        masked[jss::seed_hex] = "<masked>";
+        masked[jss::passphrase] = "<masked>";
+        masked["keep"] = "visible";
+
+        auto check = [&](char const* scenario,
+                         jtx::Env& testEnv,
+                         json::Value const& item,
+                         json::Value expected,
+                         int code,
+                         char const* message) {
+            testcase << "HTTP batch error masking: " << scenario;
+            json::Value request;
+            request[jss::method] = "batch";
+            request[jss::params].append(item);
+            // A following valid item must still execute normally.
+            json::Value ping;
+            ping[jss::method] = "ping";
+            request[jss::params].append(ping);
+
+            boost::system::error_code ec;
+            boost::beast::http::response<boost::beast::http::string_body> resp;
+            doHTTPRequest(testEnv, yield, false, resp, ec, to_string(request));
+            if (!BEAST_EXPECTS(!ec, ec.message()))
+                return;
+            BEAST_EXPECT(resp.result() == boost::beast::http::status::ok);
+            json::Value reply;
+            json::Reader reader;
+            if (!BEAST_EXPECT(reader.parse(resp.body(), reply)) ||
+                !BEAST_EXPECT(reply.isArray() && reply.size() == 2))
+                return;
+            expected[jss::error][jss::error]["code"] = code;
+            expected[jss::error][jss::error]["message"] = message;
+            BEAST_EXPECTS(reply[0u] == expected, to_string(reply[0u]));
+            if (code == -32604)
+            {
+                BEAST_EXPECT(reply[1u][jss::error][jss::error]["code"] == code);
+            }
+            else
+            {
+                BEAST_EXPECT(reply[1u][jss::result][jss::status] == jss::success);
+            }
+            BEAST_EXPECT(!resp.body().contains("-sentinel"));
+        };
+
+        // Early errors can echo both flat parameters and nested request data.
+        auto item = sensitive;
+        auto expected = masked;
+        item[jss::params].append(sensitive);
+        expected[jss::params].append(masked);
+        item[jss::id] = expected[jss::id] = 42;
+
+        check("missing method", env, item, expected, -32601, "Null method");
+        for (auto const& [scenario, value] : {
+                 std::pair{"null sensitive values", json::Value{}},
+                 std::pair{"boolean sensitive values", json::Value{true}},
+                 std::pair{"numeric sensitive values", json::Value{42}},
+                 std::pair{"object sensitive values", sensitive},
+                 std::pair{"array sensitive values", item[jss::params]},
+             })
+        {
+            auto malformed = item;
+            for (auto const& field : {jss::secret, jss::seed, jss::seed_hex, jss::passphrase})
+                malformed[field] = value;
+            check(scenario, env, malformed, expected, -32601, "Null method");
+        }
+        for (auto const& [message, method] : {
+                 std::pair{"Null method", json::Value{}},
+                 std::pair{"method is not string", json::Value{1}},
+                 std::pair{"method is empty", json::Value{""}},
+             })
+        {
+            item[jss::method] = expected[jss::method] = method;
+            check(message, env, item, expected, -32601, message);
+        }
+
+        item[jss::method] = expected[jss::method] = "ping";
+        item[jss::ripplerpc] = expected[jss::ripplerpc] = 1;
+        check("invalid ripplerpc", env, item, expected, -32601, "ripplerpc is not a string");
+        item.removeMember(jss::ripplerpc);
+        expected.removeMember(jss::ripplerpc);
+
+        item[jss::api_version] = expected[jss::api_version] = "invalid";
+        json::Value wrapped;
+        wrapped[jss::request] = expected;
+        check("invalid API version", env, item, wrapped, -32606, "invalid_API_version");
+
+        // Even an invalid array item can contain objects with sensitive fields.
+        json::Value array(json::ValueType::Array);
+        array.append(sensitive);
+        wrapped[jss::request] = json::ValueType::Array;
+        wrapped[jss::request].append(masked);
+        check("array item", env, array, wrapped, -32601, "Method not found");
+
+        // Preserve ordinary data while masking through object and array chains.
+        auto nested = sensitive;
+        auto nestedMasked = masked;
+        nested["ordinary"].append(true);
+        nested["ordinary"].append(42);
+        nestedMasked["ordinary"] = nested["ordinary"];
+        for (int depth = 0; depth < 16; ++depth)
+        {
+            json::Value parent;
+            json::Value maskedParent;
+            if (depth % 2 == 0)
+            {
+                parent["child"] = nested;
+                maskedParent["child"] = nestedMasked;
+            }
+            else
+            {
+                parent.append(nested);
+                maskedParent.append(nestedMasked);
+            }
+            nested = std::move(parent);
+            nestedMasked = std::move(maskedParent);
+        }
+        wrapped[jss::request] = nestedMasked;
+        check("deeply nested array item", env, nested, wrapped, -32601, "Method not found");
+
+        for (auto const& [scenario, value] : {
+                 std::pair{"null item", json::Value{}},
+                 std::pair{"boolean item", json::Value{true}},
+                 std::pair{"numeric item", json::Value{42}},
+                 std::pair{"string item", json::Value{"invalid"}},
+                 std::pair{"empty array item", json::Value{json::ValueType::Array}},
+             })
+        {
+            wrapped[jss::request] = value;
+            check(scenario, env, value, wrapped, -32601, "Method not found");
+        }
+
+        // A valid handler must receive the original passphrase even when the
+        // preceding batch item echoes a masked copy of it. Use the public test seed.
+        testcase("HTTP batch masking preserves valid wallet parameters");
+        json::Value wallet;
+        wallet[jss::method] = "wallet_propose";
+        wallet[jss::passphrase] = "masterpassphrase";
+        auto invalidWallet = wallet;
+        invalidWallet[jss::api_version] = "invalid";
+        json::Value request;
+        request[jss::method] = "batch";
+        request[jss::params].append(invalidWallet);
+        request[jss::params].append(wallet);
+        boost::system::error_code ec;
+        boost::beast::http::response<boost::beast::http::string_body> resp;
+        doHTTPRequest(env, yield, false, resp, ec, to_string(request));
+        if (!BEAST_EXPECTS(!ec, ec.message()))
+            return;
+        BEAST_EXPECT(resp.result() == boost::beast::http::status::ok);
+        json::Value reply;
+        json::Reader reader;
+        if (!BEAST_EXPECT(reader.parse(resp.body(), reply)) ||
+            !BEAST_EXPECT(reply.isArray() && reply.size() == 2))
+            return;
+        BEAST_EXPECT(reply[0u][jss::request][jss::passphrase] == "<masked>");
+        BEAST_EXPECT(reply[1u][jss::result][jss::status] == jss::success);
+        BEAST_EXPECT(reply[1u][jss::result][jss::master_seed] == "snoPBrXtMeMyMHUVTgbuqAfg1SUTb");
+        BEAST_EXPECT(
+            reply[1u][jss::result][jss::account_id] == "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh");
+
+        jtx::Env publicEnv{*this, makeConfig("http", false)};
+        item.removeMember(jss::api_version);
+        expected.removeMember(jss::api_version);
+        item[jss::method] = expected[jss::method] = "stop";
+        check("forbidden", publicEnv, item, expected, -32605, "Forbidden");
+
+        auto consumer = publicEnv.app().getResourceManager().newInboundEndpoint(
+            beast::ip::Endpoint::fromString(getEnvLocalhostAddr()));
+        // Charges are normalized by the decay window. Start at four times the
+        // drop threshold to allow for decay while the batch runs.
+        consumer.charge(
+            resource::Charge{resource::kDropThreshold * resource::kDecayWindowSeconds * 4});
+        item[jss::method] = expected[jss::method] = "ping";
+        check("overloaded", publicEnv, item, expected, -32604, "Server is overloaded");
+    }
+
+    void
     testStatusNotOkay(boost::asio::yield_context& yield)
     {
         testcase("Server status not okay");
@@ -1180,6 +1377,7 @@ public:
             testNoRPC(yield);
             testWSRequests(yield);
             testRPCRequests(yield);
+            testBatchErrorMasking(yield);
             testStatusNotOkay(yield);
         });
     }

--- a/src/xrpld/rpc/detail/ServerHandler.cpp
+++ b/src/xrpld/rpc/detail/ServerHandler.cpp
@@ -581,6 +581,27 @@ ServerHandler::processSession(
     }
 }
 
+// Only apply to request copies being echoed, not to handler results that may
+// intentionally contain generated secrets. The JSON reader bounds nesting depth.
+static void
+maskSensitiveFields(json::Value& request)
+{
+    if (request.isObject())
+    {
+        for (auto const& field : {jss::passphrase, jss::secret, jss::seed, jss::seed_hex})
+        {
+            if (request.isMember(field))
+                request[field] = "<masked>";
+        }
+    }
+
+    if (request.isObject() || request.isArray())
+    {
+        for (auto& child : request)
+            maskSensitiveFields(child);
+    }
+}
+
 static json::Value
 makeJsonError(json::Int code, json::Value&& message)
 {
@@ -647,6 +668,7 @@ ServerHandler::processRequest(
         {
             json::Value r(json::ValueType::Object);
             r[jss::request] = jsonRPC;
+            maskSensitiveFields(r[jss::request]);
             r[jss::error] = makeJsonError(kMethodNotFound, "Method not found");
             reply.append(r);
             continue;
@@ -675,6 +697,7 @@ ServerHandler::processRequest(
             }
             json::Value r(json::ValueType::Object);
             r[jss::request] = jsonRPC;
+            maskSensitiveFields(r[jss::request]);
             r[jss::error] = makeJsonError(kWrongVersion, jss::invalid_API_version.cStr());
             reply.append(r);
             continue;
@@ -717,6 +740,7 @@ ServerHandler::processRequest(
                     return;
                 }
                 json::Value r = jsonRPC;
+                maskSensitiveFields(r);
                 r[jss::error] = makeJsonError(kServerOverloaded, "Server is overloaded");
                 reply.append(r);
                 continue;
@@ -732,6 +756,7 @@ ServerHandler::processRequest(
                 return;
             }
             json::Value r = jsonRPC;
+            maskSensitiveFields(r);
             r[jss::error] = makeJsonError(kForbidden, "Forbidden");
             reply.append(r);
             continue;
@@ -746,6 +771,7 @@ ServerHandler::processRequest(
                 return;
             }
             json::Value r = jsonRPC;
+            maskSensitiveFields(r);
             r[jss::error] = makeJsonError(kMethodNotFound, "Null method");
             reply.append(r);
             continue;
@@ -761,6 +787,7 @@ ServerHandler::processRequest(
                 return;
             }
             json::Value r = jsonRPC;
+            maskSensitiveFields(r);
             r[jss::error] = makeJsonError(kMethodNotFound, "method is not string");
             reply.append(r);
             continue;
@@ -776,6 +803,7 @@ ServerHandler::processRequest(
                 return;
             }
             json::Value r = jsonRPC;
+            maskSensitiveFields(r);
             r[jss::error] = makeJsonError(kMethodNotFound, "method is empty");
             reply.append(r);
             continue;
@@ -830,6 +858,7 @@ ServerHandler::processRequest(
                 }
 
                 json::Value r = jsonRPC;
+                maskSensitiveFields(r);
                 r[jss::error] = makeJsonError(kMethodNotFound, "ripplerpc is not a string");
                 reply.append(r);
                 continue;


### PR DESCRIPTION
## High Level Overview of Change

Mask `secret`, `seed`, `seed_hex`, and `passphrase` fields when HTTP batch RPC requests are rejected before handler execution. Masking traverses nested objects and arrays so sensitive values are not echoed in error responses or debug reply logs.

Closes #7461.

## Context of Change

The normal RPC handler-error path masks sensitive fields before attaching request data to an error response. Eight early-error paths in HTTP batch processing instead copied the request item directly into the response, bypassing that masking.

This change applies masking only to the copied request data used by those error paths. It leaves the original request available to subsequent processing and does not sanitize successful handler output, which can legitimately contain generated wallet credentials.

## API Impact

This is a non-breaking public API bug fix. The affected error responses preserve their existing structure, codes, messages, IDs, and non-sensitive request fields; only sensitive field values are replaced with `<masked>`. `API-CHANGELOG.md` documents the change.

## Before / After

Before, an early failure such as an invalid `api_version`, forbidden method, overload, malformed method, malformed `ripplerpc`, or non-object batch item could echo sensitive request values verbatim.

After, sensitive fields in the echoed request copy are masked recursively. Other batch items continue to execute normally unless the client is already over the resource limit.

## Test Plan

- Verified the regression tests fail against the original handler with the sensitive sentinels present.
- Built the standard `xrpld` target in the repository's Nix CI environment with GCC 15.2.
- Ran all automatic RPC and server suites: 51 suites, 341 cases, 78,050 assertions, zero failures.
- Ran explicit `clang-tidy` on the changed C++ files.
- Ran applicable pre-commit checks, including the pinned formatter, include-style checks, spelling, and Markdown formatting.

Drafted by GPT 6 Astra: Light, Reviewed by GPT 6 Astra: High
